### PR TITLE
docs: add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/rome-os/rome/actions/workflows/ci.yml">
+    <img alt="CI" src="https://github.com/rome-os/rome/actions/workflows/ci.yml/badge.svg" />
+  </a>
+  <a href="LICENSE">
+    <img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-blue.svg" />
+  </a>
+  <a href="https://x.com/RomeAILab">
+    <img alt="Follow Rome on X" src="https://img.shields.io/badge/follow-%40RomeAILab-black?logo=x&amp;logoColor=white" />
+  </a>
+</p>
+
+<p align="center">
   <a href="https://romeos.cc/">Website</a>
   ·
   <a href="https://romeos.cc/login">Try Rome Cloud</a>


### PR DESCRIPTION
## What this PR does

The README hero did not show project status, licensing, or Rome’s social channel at a glance. This adds badges for CI, the MIT license, and the official X profile.

## Test plan

- [x] Run `git diff --check`.
- [x] Render the README through the GitHub Markdown API and verify all three badges.
- [x] Check all 13 local README targets.
- [x] Confirm the badge and X endpoints return HTTP 200.