### PR TITLE
feat(scripts): star the repo via gh when the quickstart CTA gets a yes

### DIFF
--- a/scripts/quickstart-docker.sh
+++ b/scripts/quickstart-docker.sh
@@ -308,7 +308,9 @@ if [[ -t 1 && -r /dev/tty ]]; then
     [Nn]*) ;;
     *)
       if [[ "$gh_ready" == "true" ]]; then
-        if gh api --method PUT "user/starred/${repo_slug}" >/dev/null 2>&1; then
+        # Pin the host: gh api honors GH_HOST, and the readiness check above
+        # validated the github.com login specifically.
+        if gh api --hostname github.com --method PUT "user/starred/${repo_slug}" >/dev/null 2>&1; then
           echo "Starred ${repo_slug} — thank you!"
         else
           # auth status passes on tokens that lack the starring scope.

--- a/scripts/quickstart-docker.sh
+++ b/scripts/quickstart-docker.sh
@@ -287,17 +287,37 @@ echo "  Dashboard : http://localhost:${host_port}"
 echo "  Logs      : docker logs -f ${container_name}"
 echo "  Stop      : docker stop ${container_name}"
 echo ""
-echo "If Rome looks useful, a GitHub star helps other people find it:"
+echo "If it looks good, could you star the repo so more people can find it?"
 echo "  ${ROME_REPO_URL}"
 # /dev/tty, not stdin: under `curl | bash` stdin is the script itself. Skip
 # the prompt entirely when no terminal is attached.
 if [[ -t 1 && -r /dev/tty ]]; then
+  repo_slug="${ROME_REPO_URL#https://github.com/}"
+  gh_ready="false"
+  if command -v gh >/dev/null 2>&1 && gh auth status --hostname github.com >/dev/null 2>&1; then
+    gh_ready="true"
+  fi
+  if [[ "$gh_ready" == "true" ]]; then
+    prompt="Star ${repo_slug} now? [Y/n] "
+  else
+    prompt="Open ${ROME_REPO_URL} in your browser to leave a star? [Y/n] "
+  fi
   reply=""
-  read -r -p "Open ${ROME_REPO_URL} in your browser to leave a star? [Y/n] " reply </dev/tty || reply="n"
+  read -r -p "$prompt" reply </dev/tty || reply="n"
   case "$reply" in
     [Nn]*) ;;
     *)
-      open_url "$ROME_REPO_URL"
+      if [[ "$gh_ready" == "true" ]]; then
+        if gh api --method PUT "user/starred/${repo_slug}" >/dev/null 2>&1; then
+          echo "Starred ${repo_slug} — thank you!"
+        else
+          # auth status passes on tokens that lack the starring scope.
+          echo "quickstart-docker: gh could not star ${repo_slug} — opening it in your browser instead." >&2
+          open_url "$ROME_REPO_URL"
+        fi
+      else
+        open_url "$ROME_REPO_URL"
+      fi
       ;;
   esac
 fi

--- a/scripts/quickstart-docker.sh
+++ b/scripts/quickstart-docker.sh
@@ -294,7 +294,9 @@ echo "  ${ROME_REPO_URL}"
 if [[ -t 1 && -r /dev/tty ]]; then
   repo_slug="${ROME_REPO_URL#https://github.com/}"
   gh_ready="false"
-  if command -v gh >/dev/null 2>&1 && gh auth status --hostname github.com >/dev/null 2>&1; then
+  # Probe the credential the PUT will use: gh auth status exits 1 when any
+  # known github.com account is stale, even while the active account works.
+  if command -v gh >/dev/null 2>&1 && gh api --hostname github.com user >/dev/null 2>&1; then
     gh_ready="true"
   fi
   if [[ "$gh_ready" == "true" ]]; then


### PR DESCRIPTION
## What this PR does

The quickstart's closing CTA could only open the repo page, so a user who already lives in the terminal with an authenticated gh still had to click through the browser to leave a star. The script now detects an installed gh with a github.com login and adapts the prompt: on yes it stars the repo in place via `gh api PUT /user/starred/<slug>`, and every other path keeps the browser flow. The CTA copy reads "If it looks good, could you star the repo so more people can find it?".

## Design & Invariants

- The prompt states what a yes does before the user answers: the gh path asks "Star <slug> now?", the browser path asks to open the page. A yes never does something the prompt did not name.
- `gh auth status` passing does not guarantee the token can star (a scoped `GH_TOKEN` can fail the PUT), so a failed star falls back to opening the page with a notice rather than exiting — the script has already booted Rome by this point and must not die on the courtesy step.
- The non-interactive contract is unchanged: without a terminal the script prints the URL and never prompts, gh or not.

## Test plan

- [x] `bash -n scripts/quickstart-docker.sh`
- [x] Extracted the CTA block verbatim and drove it under a pty with a stubbed `gh` and `open_url`: authorized gh + yes issues `gh api --method PUT user/starred/rome-os/rome` and thanks the user; a failing PUT prints the notice and opens the page; no gh on PATH shows the browser prompt and opens the page on yes; `n` does nothing in both modes.
- [x] Verified the endpoint shape read-only against the real API (`gh api user/starred/rome-os/rome` → starred).
- [ ] Full `curl | bash` run of the script end-to-end (boots a container; unchanged apart from the CTA block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)