### PR TITLE
feat: return participant ids from LinkedIn thread reads

### DIFF
--- a/opencli-plugins/README.md
+++ b/opencli-plugins/README.md
@@ -68,7 +68,10 @@ Agents pick up new/changed commands automatically: the `browser-automation` skil
   returns every field visible to the signed-in account, including websites, email addresses,
   phone numbers, addresses, birthdays, connected dates, and other displayed contact fields.
 - `opencli linkedin thread-snapshot --thread-url URL [--limit N]` — returns the latest messages
-  from one exact LinkedIn thread with sender, timestamp, profile, and reaction metadata.
+  from one exact LinkedIn thread with sender, timestamp, profile, participant id, and reaction
+  metadata.
+- `opencli linkedin thread-participants --thread-url URL` — returns one row per participant of an
+  exact LinkedIn thread, including participants who have never sent a message.
 - `opencli craigslist locations [QUERY]` — discovers site codes from Craigslist's worldwide
   directory; `categories --site SITE` lists the category codes available at that site.
 - `opencli craigslist search [QUERY] --site SITE [options]` — searches public listings across
@@ -166,6 +169,10 @@ The command returns one row per message in chronological order. `--limit` select
 100 messages and defaults to 20. Each row includes the sender, sender profile, self/other direction,
 delivery time, stable message ID, subject, and reaction count.
 
+`sender_participant_id` carries LinkedIn's obfuscated member id for the sender — the bare `ACoAA…`
+segment that also sits inside `sender_profile_url` — so a caller can use it as a stable
+`channel_user_id`. It is empty when the sender is not among the participants the response resolved.
+
 `conversation_name` is a display ladder — the conversation title when LinkedIn has one, else the
 joined counterparty names — so a 1:1 thread carries the counterparty's name there and the field is
 never a group signal. Group-ness rides separately: `conversation_is_group` reads the API's own
@@ -177,6 +184,27 @@ mislabeling the conversation as 1:1.
 ```bash
 opencli linkedin thread-snapshot --thread-url "https://www.linkedin.com/messaging/thread/2-.../"
 opencli linkedin thread-snapshot --thread-url "https://www.linkedin.com/messaging/thread/2-.../" --limit 50 -f json
+```
+
+### LinkedIn Thread Participants
+
+`thread-participants` answers "who is on this thread" directly. It shares `thread-snapshot`'s read
+path — same navigation, same thread-identity check, same two normalized messaging endpoints — and
+returns one row per participant instead of one row per message.
+
+The conversation response is the authoritative source, because its participant reference list names
+everyone on the thread including members who have never sent a message. When that metadata is
+unavailable, the command falls back to the participants the message response proves and reports
+those rather than failing. A 1:1 thread returns both the account owner (`is_self`) and the
+counterparty.
+
+Each row carries `participant_id`: LinkedIn's obfuscated member id, emitted bare so it can be used
+as a `channel_user_id`. Like `thread-snapshot`, the command fails closed on an authentication wall
+and when the browser did not land on the exact requested thread.
+
+```bash
+opencli linkedin thread-participants --thread-url "https://www.linkedin.com/messaging/thread/2-.../"
+opencli linkedin thread-participants --thread-url "https://www.linkedin.com/messaging/thread/2-.../" -f json
 ```
 
 ### Craigslist

--- a/opencli-plugins/linkedin/thread-participants.js
+++ b/opencli-plugins/linkedin/thread-participants.js
@@ -1,0 +1,108 @@
+// Rome-owned command (no upstream equivalent in @yunfanye/opencli). It reuses
+// the thread-snapshot read path so both commands open, verify, and fetch a
+// thread identically.
+import { AuthRequiredError, CommandExecutionError } from "@jackwener/opencli/errors";
+import { cli, Strategy } from "@jackwener/opencli/registry";
+import {
+  LINKEDIN_DOMAIN,
+  fetchFirstConversationPayload,
+  fetchThreadPayload,
+  openThread,
+  readThreadCsrf,
+  requireCurrentThread,
+  requireThreadUrl,
+  waitForThreadProbe,
+} from "./thread-read.mjs";
+import { linkedInThreadId, parseThreadParticipantPayloads } from "./thread-snapshot-helpers.mjs";
+
+const COMMAND = "thread-participants";
+
+cli({
+  site: "linkedin",
+  name: COMMAND,
+  access: "read",
+  description: "Return every participant of one LinkedIn thread with their member identifier",
+  example:
+    "opencli linkedin thread-participants --thread-url https://www.linkedin.com/messaging/thread/<id>/ -f json",
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    {
+      name: "thread-url",
+      type: "string",
+      required: true,
+      help: "Exact LinkedIn messaging thread URL to read",
+    },
+  ],
+  columns: [
+    "thread_url",
+    "thread_id",
+    "participant_index",
+    "participant_count",
+    "participant_id",
+    "name",
+    "headline",
+    "type",
+    "is_self",
+    "profile_url",
+  ],
+  func: async (page, kwargs) => {
+    if (!page) {
+      throw new CommandExecutionError("Browser session required for linkedin thread-participants");
+    }
+
+    const threadUrl = requireThreadUrl(kwargs["thread-url"]);
+    const threadId = linkedInThreadId(threadUrl);
+
+    await openThread(page, threadUrl);
+
+    const probe = await waitForThreadProbe(page, threadId);
+    requireCurrentThread(probe, threadUrl, COMMAND);
+
+    const csrf = await readThreadCsrf(page);
+    const payloads = [];
+
+    // The conversation response is the authoritative source: its participant
+    // reference list names everyone on the thread, including members who have
+    // never sent a message.
+    const conversationPayload = await fetchFirstConversationPayload(
+      page,
+      probe,
+      csrf,
+      threadId,
+      COMMAND,
+    );
+    if (conversationPayload) payloads.push(conversationPayload);
+
+    // The message response covers senders, so a thread whose conversation
+    // metadata is unavailable still reports the participants it can prove.
+    if (probe?.initial_url) {
+      try {
+        payloads.push(await fetchThreadPayload(page, probe.initial_url, csrf, threadId, COMMAND));
+      } catch (error) {
+        if (error instanceof AuthRequiredError) throw error;
+        if (!(error instanceof CommandExecutionError) || payloads.length === 0) throw error;
+      }
+    }
+
+    if (payloads.length === 0) {
+      throw new CommandExecutionError(
+        "LinkedIn returned no participant data for the requested thread.",
+      );
+    }
+
+    let rows;
+    try {
+      rows = parseThreadParticipantPayloads(payloads, { threadId, threadUrl });
+    } catch (error) {
+      throw new CommandExecutionError(error instanceof Error ? error.message : String(error));
+    }
+    if (rows.length === 0) {
+      throw new CommandExecutionError(
+        "LinkedIn returned no participants for the requested thread.",
+      );
+    }
+    return rows;
+  },
+});

--- a/opencli-plugins/linkedin/thread-participants.test.mjs
+++ b/opencli-plugins/linkedin/thread-participants.test.mjs
@@ -1,0 +1,387 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from "@jackwener/opencli/errors";
+import { getRegistry } from "@jackwener/opencli/registry";
+import { parseThreadParticipantPayloads, threadParticipantId } from "./thread-snapshot-helpers.mjs";
+import "./thread-participants.js";
+
+const THREAD_ID = "2-target==";
+const THREAD_URL = `https://www.linkedin.com/messaging/thread/${THREAD_ID}/`;
+const SELF_ID = "ACoAAASelfMemberId";
+const EVAN_ID = "ACoAAAEvanMemberId";
+const MIRA_ID = "ACoAAAMiraMemberId";
+const SELF = `urn:li:msg_messagingParticipant:urn:li:fsd_profile:${SELF_ID}`;
+const EVAN = `urn:li:msg_messagingParticipant:urn:li:fsd_profile:${EVAN_ID}`;
+const MIRA = `urn:li:msg_messagingParticipant:urn:li:fsd_profile:${MIRA_ID}`;
+
+function apiUrl(threadId) {
+  const variables = `(conversationUrn:urn%3Ali%3Amsg_conversation%3A%28urn%3Ali%3Afsd_profile%3Aself%2C${encodeURIComponent(threadId)}%29)`;
+  return `https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql?queryId=messengerMessages.abcdef0123456789&variables=${variables}`;
+}
+
+function conversationApiUrl(suffix = "") {
+  return `https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql?queryId=messengerConversations.abcdef0123456789&variables=(mailboxUrn:urn%3Ali%3Afsd_profile%3Aself${suffix})`;
+}
+
+function participant(entityUrn, firstName, lastName, distance, headline = "") {
+  return {
+    $type: "com.linkedin.messenger.MessagingParticipant",
+    entityUrn,
+    participantType: {
+      member: {
+        firstName: { text: firstName },
+        lastName: { text: lastName },
+        distance,
+        headline: { text: headline },
+        profileUrl: `https://www.linkedin.com/in/${firstName.toLowerCase()}/`,
+      },
+    },
+  };
+}
+
+function message(id, sender, deliveredAt, text) {
+  return {
+    $type: "com.linkedin.messenger.Message",
+    entityUrn: `urn:li:msg_message:${id}`,
+    backendUrn: `urn:li:messagingMessage:${id}`,
+    backendConversationUrn: `urn:li:messagingThread:${THREAD_ID}`,
+    "*conversation": `urn:li:msg_conversation:(urn:li:fsd_profile:self,${THREAD_ID})`,
+    "*sender": sender,
+    deliveredAt,
+    body: { text },
+    reactionSummaries: [],
+  };
+}
+
+const SELF_PARTICIPANT = participant(SELF, "Yunfan", "Ye", "SELF", "Builder");
+const EVAN_PARTICIPANT = participant(EVAN, "Evan", "Ye", "DISTANCE_1", "Founder");
+const MIRA_PARTICIPANT = participant(MIRA, "Mira", "Chen", "DISTANCE_1", "Designer");
+
+function payload({ participants, messages = [], complete = true, conversation = {} }) {
+  return {
+    __opencli: { conversation_participant_refs_complete: complete },
+    included: [
+      {
+        $type: "com.linkedin.messenger.Conversation",
+        entityUrn: `urn:li:msg_conversation:(urn:li:fsd_profile:self,${THREAD_ID})`,
+        backendUrn: `urn:li:messagingThread:${THREAD_ID}`,
+        "*conversationParticipants": participants.map((entity) => entity.entityUrn),
+        ...conversation,
+      },
+      ...participants,
+      ...messages,
+    ],
+  };
+}
+
+function rowsFor(payloads) {
+  return parseThreadParticipantPayloads(payloads, {
+    threadId: THREAD_ID,
+    threadUrl: THREAD_URL,
+  });
+}
+
+test("participant ids are the bare member id carried by the participant urn", () => {
+  assert.equal(threadParticipantId(SELF), SELF_ID);
+  assert.equal(threadParticipantId(EVAN), EVAN_ID);
+  assert.equal(
+    threadParticipantId("urn:li:msg_messagingParticipant:urn:li:fsd_company:1234567"),
+    "1234567",
+  );
+  // The bare id is what a caller stores as a channel_user_id, so a value that is
+  // already bare must survive untouched.
+  assert.equal(threadParticipantId(EVAN_ID), EVAN_ID);
+  assert.equal(threadParticipantId(""), "");
+  assert.equal(threadParticipantId(undefined), "");
+  assert.equal(threadParticipantId("urn:li:msg_messagingParticipant:"), "");
+});
+
+test("participant parsing returns one row per participant with the acceptance fields", () => {
+  const rows = rowsFor([
+    payload({
+      participants: [SELF_PARTICIPANT, EVAN_PARTICIPANT, MIRA_PARTICIPANT],
+      messages: [message("m1", EVAN, 1000, "hello both")],
+      conversation: { title: "Pitch review", groupChat: true },
+    }),
+  ]);
+
+  assert.equal(rows.length, 3);
+  assert.ok(rows.every((row) => row.thread_id === THREAD_ID));
+  assert.ok(rows.every((row) => typeof row.participant_id === "string" && row.participant_id));
+  assert.deepEqual(
+    rows.map((row) => row.participant_id),
+    [SELF_ID, EVAN_ID, MIRA_ID],
+  );
+  assert.deepEqual(
+    rows.map((row) => row.name),
+    ["Yunfan Ye", "Evan Ye", "Mira Chen"],
+  );
+  assert.deepEqual(
+    rows.map((row) => row.headline),
+    ["Builder", "Founder", "Designer"],
+  );
+  assert.ok(rows.every((row) => row.type === "member"));
+  assert.deepEqual(
+    rows.map((row) => row.is_self),
+    [true, false, false],
+  );
+});
+
+test("a participant who has sent no message still appears in the output", () => {
+  // Mira is on the conversation's participant list but authored nothing.
+  const rows = rowsFor([
+    payload({
+      participants: [SELF_PARTICIPANT, EVAN_PARTICIPANT, MIRA_PARTICIPANT],
+      messages: [message("m1", SELF, 1000, "kicking this off"), message("m2", EVAN, 2000, "on it")],
+      conversation: { groupChat: true },
+    }),
+  ]);
+
+  const mira = rows.find((row) => row.participant_id === MIRA_ID);
+  assert.ok(mira, "the silent participant must be returned");
+  assert.equal(mira.name, "Mira Chen");
+  assert.equal(mira.headline, "Designer");
+  assert.equal(mira.is_self, false);
+});
+
+test("a 1:1 thread returns both the account owner and the counterparty", () => {
+  const rows = rowsFor([
+    payload({
+      participants: [SELF_PARTICIPANT, EVAN_PARTICIPANT],
+      messages: [message("m1", EVAN, 1000, "hi")],
+      conversation: { groupChat: false },
+    }),
+  ]);
+
+  assert.equal(rows.length, 2);
+  assert.deepEqual(rows.map((row) => row.participant_id).sort(), [SELF_ID, EVAN_ID].sort());
+  assert.equal(rows.filter((row) => row.is_self).length, 1);
+  assert.equal(rows.find((row) => row.is_self).participant_id, SELF_ID);
+  assert.equal(rows.find((row) => !row.is_self).participant_id, EVAN_ID);
+});
+
+test("participants are deduplicated across payloads and counted once", () => {
+  const rows = rowsFor([
+    payload({ participants: [SELF_PARTICIPANT, EVAN_PARTICIPANT] }),
+    payload({
+      participants: [SELF_PARTICIPANT, EVAN_PARTICIPANT],
+      messages: [message("m1", EVAN, 1000, "hi")],
+    }),
+  ]);
+
+  assert.equal(rows.length, 2);
+  assert.deepEqual(
+    rows.map((row) => row.participant_count),
+    [2, 2],
+  );
+  assert.deepEqual(
+    rows.map((row) => row.participant_index),
+    [1, 2],
+  );
+});
+
+test("participants still resolve when only sparse message data is available", () => {
+  const rows = rowsFor([
+    {
+      included: [
+        {
+          $type: "com.linkedin.messenger.Conversation",
+          entityUrn: `urn:li:msg_conversation:(urn:li:fsd_profile:self,${THREAD_ID})`,
+        },
+        SELF_PARTICIPANT,
+        message("m1", SELF, 1000, "hello"),
+      ],
+    },
+  ]);
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].participant_id, SELF_ID);
+  assert.equal(rows[0].is_self, true);
+});
+
+function fakePage({ probe, responses }) {
+  const calls = { goto: [], evaluate: [] };
+  return {
+    calls,
+    goto: async (url) => calls.goto.push(url),
+    wait: async () => {},
+    getCookies: async () => [{ name: "JSESSIONID", value: '"csrf"' }],
+    evaluate: async (fn, ...args) => {
+      calls.evaluate.push({ fn: fn.name, args });
+      if (fn.name === "inspectLinkedInThreadPage") return probe;
+      if (fn.name === "fetchLinkedInThreadApi" || fn.name === "fetchLinkedInConversationApi") {
+        return responses.get(args[0]) || { error: "missing fixture" };
+      }
+      if (fn.name === "discoverOlderThreadApi") {
+        return { api_url: "", message_list_found: true };
+      }
+      throw new Error(`Unexpected page function ${fn.name}`);
+    },
+  };
+}
+
+test("the command is registered as a read-only cookie command with participant columns", () => {
+  const command = getRegistry().get("linkedin/thread-participants");
+  assert.ok(command);
+  assert.equal(command.strategy, "cookie");
+  assert.equal(command.access, "read");
+  for (const column of ["thread_id", "participant_id", "name", "headline", "type", "is_self"]) {
+    assert.ok(command.columns.includes(column), `missing column ${column}`);
+  }
+});
+
+test("the command returns every participant of the requested thread", async () => {
+  const command = getRegistry().get("linkedin/thread-participants");
+  const initial = apiUrl(THREAD_ID);
+  const conversations = conversationApiUrl();
+  const page = fakePage({
+    probe: {
+      current_url: THREAD_URL,
+      auth_wall: false,
+      initial_url: initial,
+      page_urls: [],
+      conversation_urls: [conversations],
+    },
+    responses: new Map([
+      [
+        conversations,
+        {
+          json: payload({
+            participants: [SELF_PARTICIPANT, EVAN_PARTICIPANT, MIRA_PARTICIPANT],
+            conversation: { groupChat: true },
+          }),
+        },
+      ],
+      [
+        initial,
+        {
+          json: {
+            included: [
+              {
+                $type: "com.linkedin.messenger.Conversation",
+                entityUrn: `urn:li:msg_conversation:(urn:li:fsd_profile:self,${THREAD_ID})`,
+              },
+              EVAN_PARTICIPANT,
+              message("m1", EVAN, 1000, "hello both"),
+            ],
+          },
+        },
+      ],
+    ]),
+  });
+
+  const rows = await command.func(page, { "thread-url": THREAD_URL });
+
+  assert.deepEqual(page.calls.goto, ["https://www.linkedin.com/messaging/", THREAD_URL]);
+  assert.equal(rows.length, 3);
+  assert.deepEqual(
+    rows.map((row) => row.participant_id).sort(),
+    [SELF_ID, EVAN_ID, MIRA_ID].sort(),
+  );
+  // Mira sent nothing; only the conversation participant list proves she is here.
+  assert.ok(rows.some((row) => row.participant_id === MIRA_ID && row.name === "Mira Chen"));
+  assert.ok(rows.every((row) => row.thread_id === THREAD_ID));
+  assert.ok(rows.every((row) => row.thread_url === THREAD_URL));
+});
+
+test("the command returns both sides of a 1:1 thread", async () => {
+  const command = getRegistry().get("linkedin/thread-participants");
+  const initial = apiUrl(THREAD_ID);
+  const conversations = conversationApiUrl();
+  const page = fakePage({
+    probe: {
+      current_url: THREAD_URL,
+      auth_wall: false,
+      initial_url: initial,
+      page_urls: [],
+      conversation_urls: [conversations],
+    },
+    responses: new Map([
+      [
+        conversations,
+        {
+          json: payload({
+            participants: [SELF_PARTICIPANT, EVAN_PARTICIPANT],
+            conversation: { groupChat: false },
+          }),
+        },
+      ],
+      [
+        initial,
+        {
+          json: {
+            included: [
+              {
+                $type: "com.linkedin.messenger.Conversation",
+                entityUrn: `urn:li:msg_conversation:(urn:li:fsd_profile:self,${THREAD_ID})`,
+              },
+              EVAN_PARTICIPANT,
+              message("m1", EVAN, 1000, "hi"),
+            ],
+          },
+        },
+      ],
+    ]),
+  });
+
+  const rows = await command.func(page, { "thread-url": THREAD_URL });
+
+  assert.equal(rows.length, 2);
+  assert.equal(rows.filter((row) => row.is_self).length, 1);
+  assert.equal(rows.find((row) => row.is_self).participant_id, SELF_ID);
+  assert.equal(rows.find((row) => !row.is_self).participant_id, EVAN_ID);
+});
+
+test("the command validates the thread URL before navigating", async () => {
+  const command = getRegistry().get("linkedin/thread-participants");
+  const page = fakePage({ probe: {}, responses: new Map() });
+  await assert.rejects(
+    command.func(page, { "thread-url": "https://www.linkedin.com/feed/" }),
+    ArgumentError,
+  );
+  assert.deepEqual(page.calls.goto, []);
+});
+
+test("the command fails closed on an auth wall", async () => {
+  const command = getRegistry().get("linkedin/thread-participants");
+  const page = fakePage({
+    probe: { current_url: "https://www.linkedin.com/login", auth_wall: true },
+    responses: new Map(),
+  });
+  await assert.rejects(command.func(page, { "thread-url": THREAD_URL }), AuthRequiredError);
+});
+
+test("the command fails closed when the browser landed on a different thread", async () => {
+  const command = getRegistry().get("linkedin/thread-participants");
+  const page = fakePage({
+    probe: {
+      current_url: "https://www.linkedin.com/messaging/thread/2-other==/",
+      auth_wall: false,
+      initial_url: apiUrl(THREAD_ID),
+      page_urls: [],
+      conversation_urls: [],
+    },
+    responses: new Map(),
+  });
+  await assert.rejects(
+    command.func(page, { "thread-url": THREAD_URL }),
+    (error) =>
+      error instanceof CommandExecutionError && /thread_url_mismatch/.test(String(error.message)),
+  );
+});
+
+test("the command fails closed when LinkedIn returns no participant data", async () => {
+  const command = getRegistry().get("linkedin/thread-participants");
+  const initial = apiUrl(THREAD_ID);
+  const page = fakePage({
+    probe: {
+      current_url: THREAD_URL,
+      auth_wall: false,
+      initial_url: initial,
+      page_urls: [],
+      conversation_urls: [],
+    },
+    responses: new Map([[initial, { error: "HTTP 500" }]]),
+  });
+  await assert.rejects(command.func(page, { "thread-url": THREAD_URL }), CommandExecutionError);
+});

--- a/opencli-plugins/linkedin/thread-read.mjs
+++ b/opencli-plugins/linkedin/thread-read.mjs
@@ -1,0 +1,149 @@
+// Browser-side flow shared by the LinkedIn thread reads (`thread-snapshot`,
+// `thread-participants`). Every read opens the same thread the same way, proves
+// the browser really landed on the requested thread, and fetches from the same
+// two normalized messaging endpoints — so a fix to any of those applies to all
+// of them. Command names are passed in only to keep error text specific.
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from "@jackwener/opencli/errors";
+import {
+  LINKEDIN_MESSAGING_URL,
+  canonicalizeLinkedInThreadUrl,
+  fetchLinkedInConversationApi,
+  fetchLinkedInThreadApi,
+  inspectLinkedInThreadPage,
+  isThreadConversationApiUrl,
+  isThreadMessageApiUrl,
+  unwrapThreadBrowserResult,
+  validateThreadConversationPayload,
+} from "./thread-snapshot-helpers.mjs";
+
+export const LINKEDIN_DOMAIN = "www.linkedin.com";
+
+export function requireThreadUrl(value) {
+  const threadUrl = canonicalizeLinkedInThreadUrl(value);
+  if (!threadUrl) {
+    throw new ArgumentError(
+      "--thread-url must be an exact https://www.linkedin.com/messaging/thread/<id>/ URL",
+    );
+  }
+  return threadUrl;
+}
+
+async function readThreadProbe(page, threadId) {
+  return unwrapThreadBrowserResult(await page.evaluate(inspectLinkedInThreadPage, threadId));
+}
+
+export async function openThread(page, threadUrl) {
+  await page.goto(LINKEDIN_MESSAGING_URL);
+  await page.wait(4);
+  await page.goto(threadUrl);
+  await page.wait(4);
+}
+
+export async function waitForThreadProbe(page, threadId) {
+  let probe = null;
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    probe = await readThreadProbe(page, threadId);
+    if (probe?.auth_wall || probe?.initial_url) return probe;
+    await page.wait(1);
+  }
+  return probe;
+}
+
+// Fails closed: an auth wall and a thread the browser did not actually open are
+// both refusals, never a partial or a neighbouring thread's data.
+export function requireCurrentThread(probe, expectedUrl, command) {
+  if (probe?.auth_wall) {
+    throw new AuthRequiredError(
+      LINKEDIN_DOMAIN,
+      `LinkedIn ${command} requires an active signed-in LinkedIn browser session.`,
+    );
+  }
+  const actualUrl = canonicalizeLinkedInThreadUrl(probe?.current_url || "");
+  if (!actualUrl || actualUrl !== expectedUrl) {
+    throw new CommandExecutionError(
+      `LinkedIn ${command} blocked: thread_url_mismatch`,
+      `Expected ${expectedUrl}; actual ${actualUrl || probe?.current_url || "not_available"}`,
+    );
+  }
+  return actualUrl;
+}
+
+export async function readThreadCsrf(page) {
+  const cookies = await page.getCookies({ url: "https://www.linkedin.com" });
+  const jsession = cookies.find((cookie) => cookie.name === "JSESSIONID")?.value;
+  if (!jsession) {
+    throw new AuthRequiredError(
+      LINKEDIN_DOMAIN,
+      "LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn.",
+    );
+  }
+  return jsession.replace(/^"|"$/g, "");
+}
+
+export async function fetchThreadPayload(page, apiUrl, csrf, threadId, command) {
+  if (!isThreadMessageApiUrl(apiUrl, threadId)) {
+    throw new CommandExecutionError(
+      `LinkedIn ${command} blocked an API response for a different thread`,
+    );
+  }
+  const response = unwrapThreadBrowserResult(
+    await page.evaluate(fetchLinkedInThreadApi, apiUrl, csrf),
+  );
+  if (response?.auth_required) {
+    throw new AuthRequiredError(
+      LINKEDIN_DOMAIN,
+      `LinkedIn messaging API authentication failed: ${response.error || "access denied"}`,
+    );
+  }
+  if (!response?.json || response.error) {
+    throw new CommandExecutionError(
+      `LinkedIn messaging API returned an unexpected response: ${response?.error || "no data"}`,
+    );
+  }
+  if (!Array.isArray(response.json.included)) {
+    throw new CommandExecutionError(
+      "LinkedIn messaging API returned a malformed normalized payload",
+    );
+  }
+  return response.json;
+}
+
+export async function fetchConversationPayload(page, apiUrl, csrf, threadId, command) {
+  if (!isThreadConversationApiUrl(apiUrl)) {
+    throw new CommandExecutionError(`LinkedIn ${command} blocked an unsafe conversation URL`);
+  }
+  const response = unwrapThreadBrowserResult(
+    await page.evaluate(fetchLinkedInConversationApi, apiUrl, csrf, threadId),
+  );
+  if (response?.auth_required) {
+    throw new AuthRequiredError(
+      LINKEDIN_DOMAIN,
+      `LinkedIn messaging API authentication failed: ${response.error || "access denied"}`,
+    );
+  }
+  if (!response?.json || response.error) {
+    throw new CommandExecutionError(
+      `LinkedIn conversation API returned an unexpected response: ${response?.error || "no data"}`,
+    );
+  }
+  try {
+    return validateThreadConversationPayload(response.json, threadId);
+  } catch (error) {
+    throw new CommandExecutionError(error instanceof Error ? error.message : String(error));
+  }
+}
+
+// Performance entries can be stale, so a conversation URL that fails is retried
+// against the next candidate. An auth failure still stops the read.
+export async function fetchFirstConversationPayload(page, probe, csrf, threadId, command) {
+  for (const apiUrl of Array.isArray(probe?.conversation_urls) ? probe.conversation_urls : []) {
+    try {
+      const payload = await fetchConversationPayload(page, apiUrl, csrf, threadId, command);
+      if (payload) return payload;
+    } catch (error) {
+      if (error instanceof AuthRequiredError) throw error;
+      if (!(error instanceof CommandExecutionError)) throw error;
+    }
+  }
+  return null;
+}

--- a/opencli-plugins/linkedin/thread-snapshot-helpers.mjs
+++ b/opencli-plugins/linkedin/thread-snapshot-helpers.mjs
@@ -3,6 +3,7 @@ export const DEFAULT_THREAD_MESSAGE_LIMIT = 20;
 export const MAX_THREAD_MESSAGE_LIMIT = 100;
 
 const THREAD_PATH_RE = /^\/messaging\/thread\/([^/]+)\/?$/i;
+const PARTICIPANT_URN_PREFIX = "urn:li:msg_messagingParticipant:";
 const MESSAGE_QUERY_RE = /[?&]queryId=messengerMessages\.[a-f0-9]+/i;
 const CONVERSATION_QUERY_RE = /[?&]queryId=messengerConversations\.[a-f0-9]+/i;
 
@@ -57,6 +58,24 @@ export function linkedInThreadId(value) {
   const canonical = canonicalizeLinkedInThreadUrl(value);
   if (!canonical) return "";
   return new URL(canonical).pathname.match(THREAD_PATH_RE)?.[1] || "";
+}
+
+// A messaging participant urn nests the profile urn:
+// `urn:li:msg_messagingParticipant:urn:li:fsd_profile:ACoAA…`. The trailing
+// segment is LinkedIn's obfuscated member id — the same `ACoAA…` that appears
+// inside `profile_url` — and it is emitted bare so a caller can use it as a
+// channel_user_id. Organization and agent participants nest their own urn the
+// same way, so the trailing segment is their id too.
+export function threadParticipantId(value) {
+  let raw = normalizeThreadText(value);
+  if (!raw) return "";
+  if (raw.startsWith(PARTICIPANT_URN_PREFIX)) {
+    raw = raw.slice(PARTICIPANT_URN_PREFIX.length).trim();
+  }
+  const decoded = decodeApiUrl(raw) || raw;
+  const segments = decoded.split(":").filter(Boolean);
+  const last = segments.length > 0 ? segments[segments.length - 1] : "";
+  return last.replace(/^\(+/, "").replace(/\)+$/, "").trim();
 }
 
 export function normalizeThreadMessageLimit(value) {
@@ -155,7 +174,17 @@ function attributedText(value) {
   return normalizeThreadText(value?.text);
 }
 
+// `participant` is the normalized entity whose `entityUrn` is also the key of
+// the participants map, so the identifier reaches the record without a second
+// lookup.
 function participantMetadata(participant) {
+  return {
+    participant_id: threadParticipantId(participant?.entityUrn),
+    ...participantTypeMetadata(participant),
+  };
+}
+
+function participantTypeMetadata(participant) {
   const type = participant?.participantType || {};
   if (type.member) {
     const member = type.member;
@@ -275,7 +304,10 @@ export function deriveConversationIsGroup(groupChat, completeParticipantRefs, co
   return null;
 }
 
-export function parseThreadMessagePayloads(payloads, { threadId, threadUrl, limit }) {
+// Both thread reads need the same view of a thread: every participant the
+// payloads mention, the conversation's own metadata, and the authoritative
+// participant-ref list when one arrived complete.
+function collectThreadEntities(payloads, threadId) {
   const entities = [];
   const completeParticipantRefCandidates = [];
   for (const payload of Array.isArray(payloads) ? payloads : []) {
@@ -327,6 +359,53 @@ export function parseThreadMessagePayloads(payloads, { threadId, threadUrl, limi
   const conversationParticipants = completeParticipantRefs
     ? completeParticipantRefs.map((ref) => participants.get(ref)).filter(Boolean)
     : [...participants.values()];
+  return {
+    entities,
+    participants,
+    conversationParticipants,
+    completeParticipantRefs,
+    conversationTitle,
+    conversationGroupChat,
+  };
+}
+
+export function parseThreadParticipantPayloads(payloads, { threadId, threadUrl }) {
+  const { conversationParticipants } = collectThreadEntities(payloads, threadId);
+  // A complete participant-ref list carries everyone on the thread, including
+  // members who never sent a message; message payloads alone only prove senders.
+  const rows = [];
+  const seen = new Set();
+  for (const participant of conversationParticipants) {
+    const participantId = participant?.participant_id || "";
+    if (!participantId || seen.has(participantId)) continue;
+    seen.add(participantId);
+    rows.push({
+      thread_url: threadUrl,
+      thread_id: threadId,
+      participant_id: participantId,
+      name: participant.name,
+      headline: participant.headline,
+      type: participant.type,
+      is_self: participant.is_self,
+      profile_url: participant.profile_url,
+    });
+  }
+  return rows.map((row, index) => ({
+    ...row,
+    participant_index: index + 1,
+    participant_count: rows.length,
+  }));
+}
+
+export function parseThreadMessagePayloads(payloads, { threadId, threadUrl, limit }) {
+  const {
+    entities,
+    participants,
+    conversationParticipants,
+    completeParticipantRefs,
+    conversationTitle,
+    conversationGroupChat,
+  } = collectThreadEntities(payloads, threadId);
   const counterpartyNames = [
     ...new Set(
       conversationParticipants
@@ -370,6 +449,7 @@ export function parseThreadMessagePayloads(payloads, { threadId, threadUrl, limi
       message_id: id,
       sent_at:
         Number.isFinite(deliveredAt) && deliveredAt > 0 ? new Date(deliveredAt).toISOString() : "",
+      sender_participant_id: sender.participant_id,
       sender_name: sender.name,
       sender_type: sender.type,
       sender_profile_url: sender.profile_url,

--- a/opencli-plugins/linkedin/thread-snapshot.js
+++ b/opencli-plugins/linkedin/thread-snapshot.js
@@ -1,122 +1,30 @@
 // Overrides clis/linkedin/thread-snapshot.js from @yunfanye/opencli 1.8.7.
 // Keep the API URL discovery in sync when upstream changes LinkedIn messaging queries.
-import { ArgumentError, AuthRequiredError, CommandExecutionError } from "@jackwener/opencli/errors";
+import { ArgumentError, CommandExecutionError } from "@jackwener/opencli/errors";
 import { cli, Strategy } from "@jackwener/opencli/registry";
 import {
+  LINKEDIN_DOMAIN,
+  fetchFirstConversationPayload,
+  fetchThreadPayload,
+  openThread,
+  readThreadCsrf,
+  requireCurrentThread,
+  requireThreadUrl,
+  waitForThreadProbe,
+} from "./thread-read.mjs";
+import {
   DEFAULT_THREAD_MESSAGE_LIMIT,
-  LINKEDIN_MESSAGING_URL,
   MAX_THREAD_MESSAGE_LIMIT,
-  canonicalizeLinkedInThreadUrl,
   countThreadMessagesInPayload,
   discoverOlderThreadApi,
-  fetchLinkedInConversationApi,
-  fetchLinkedInThreadApi,
-  inspectLinkedInThreadPage,
-  isThreadConversationApiUrl,
-  isThreadMessageApiUrl,
   linkedInThreadId,
   normalizeThreadMessageLimit,
   parseThreadMessagePayloads,
   unwrapThreadBrowserResult,
-  validateThreadConversationPayload,
 } from "./thread-snapshot-helpers.mjs";
 
-const LINKEDIN_DOMAIN = "www.linkedin.com";
+const COMMAND = "thread-snapshot";
 const MAX_API_DISCOVERY_ROUNDS = Math.ceil(MAX_THREAD_MESSAGE_LIMIT / 20) + 3;
-
-function requireThreadUrl(value) {
-  const threadUrl = canonicalizeLinkedInThreadUrl(value);
-  if (!threadUrl) {
-    throw new ArgumentError(
-      "--thread-url must be an exact https://www.linkedin.com/messaging/thread/<id>/ URL",
-    );
-  }
-  return threadUrl;
-}
-
-async function readThreadProbe(page, threadId) {
-  return unwrapThreadBrowserResult(await page.evaluate(inspectLinkedInThreadPage, threadId));
-}
-
-async function waitForThreadProbe(page, threadId) {
-  let probe = null;
-  for (let attempt = 0; attempt < 8; attempt += 1) {
-    probe = await readThreadProbe(page, threadId);
-    if (probe?.auth_wall || probe?.initial_url) return probe;
-    await page.wait(1);
-  }
-  return probe;
-}
-
-function requireCurrentThread(probe, expectedUrl) {
-  if (probe?.auth_wall) {
-    throw new AuthRequiredError(
-      LINKEDIN_DOMAIN,
-      "LinkedIn thread-snapshot requires an active signed-in LinkedIn browser session.",
-    );
-  }
-  const actualUrl = canonicalizeLinkedInThreadUrl(probe?.current_url || "");
-  if (!actualUrl || actualUrl !== expectedUrl) {
-    throw new CommandExecutionError(
-      "LinkedIn thread-snapshot blocked: thread_url_mismatch",
-      `Expected ${expectedUrl}; actual ${actualUrl || probe?.current_url || "not_available"}`,
-    );
-  }
-  return actualUrl;
-}
-
-async function fetchThreadPayload(page, apiUrl, csrf, threadId) {
-  if (!isThreadMessageApiUrl(apiUrl, threadId)) {
-    throw new CommandExecutionError(
-      "LinkedIn thread-snapshot blocked an API response for a different thread",
-    );
-  }
-  const response = unwrapThreadBrowserResult(
-    await page.evaluate(fetchLinkedInThreadApi, apiUrl, csrf),
-  );
-  if (response?.auth_required) {
-    throw new AuthRequiredError(
-      LINKEDIN_DOMAIN,
-      `LinkedIn messaging API authentication failed: ${response.error || "access denied"}`,
-    );
-  }
-  if (!response?.json || response.error) {
-    throw new CommandExecutionError(
-      `LinkedIn messaging API returned an unexpected response: ${response?.error || "no data"}`,
-    );
-  }
-  if (!Array.isArray(response.json.included)) {
-    throw new CommandExecutionError(
-      "LinkedIn messaging API returned a malformed normalized payload",
-    );
-  }
-  return response.json;
-}
-
-async function fetchConversationPayload(page, apiUrl, csrf, threadId) {
-  if (!isThreadConversationApiUrl(apiUrl)) {
-    throw new CommandExecutionError("LinkedIn thread-snapshot blocked an unsafe conversation URL");
-  }
-  const response = unwrapThreadBrowserResult(
-    await page.evaluate(fetchLinkedInConversationApi, apiUrl, csrf, threadId),
-  );
-  if (response?.auth_required) {
-    throw new AuthRequiredError(
-      LINKEDIN_DOMAIN,
-      `LinkedIn messaging API authentication failed: ${response.error || "access denied"}`,
-    );
-  }
-  if (!response?.json || response.error) {
-    throw new CommandExecutionError(
-      `LinkedIn conversation API returned an unexpected response: ${response?.error || "no data"}`,
-    );
-  }
-  try {
-    return validateThreadConversationPayload(response.json, threadId);
-  } catch (error) {
-    throw new CommandExecutionError(error instanceof Error ? error.message : String(error));
-  }
-}
 
 cli({
   site: "linkedin",
@@ -153,6 +61,7 @@ cli({
     "returned_message_count",
     "message_id",
     "sent_at",
+    "sender_participant_id",
     "sender_name",
     "sender_type",
     "sender_profile_url",
@@ -177,49 +86,34 @@ cli({
       throw new ArgumentError(error instanceof Error ? error.message : String(error));
     }
 
-    await page.goto(LINKEDIN_MESSAGING_URL);
-    await page.wait(4);
-    await page.goto(threadUrl);
-    await page.wait(4);
+    await openThread(page, threadUrl);
 
     const probe = await waitForThreadProbe(page, threadId);
-    requireCurrentThread(probe, threadUrl);
+    requireCurrentThread(probe, threadUrl, COMMAND);
     if (!probe?.initial_url) {
       throw new CommandExecutionError(
         "LinkedIn did not issue a message request for the requested thread.",
       );
     }
 
-    const cookies = await page.getCookies({ url: "https://www.linkedin.com" });
-    const jsession = cookies.find((cookie) => cookie.name === "JSESSIONID")?.value;
-    if (!jsession) {
-      throw new AuthRequiredError(
-        LINKEDIN_DOMAIN,
-        "LinkedIn JSESSIONID cookie not found. Please sign in to LinkedIn.",
-      );
-    }
-    const csrf = jsession.replace(/^"|"$/g, "");
+    const csrf = await readThreadCsrf(page);
     const payloads = [];
     const fetchedUrls = new Set();
 
-    for (const apiUrl of Array.isArray(probe.conversation_urls) ? probe.conversation_urls : []) {
-      try {
-        const conversationPayload = await fetchConversationPayload(page, apiUrl, csrf, threadId);
-        if (conversationPayload) {
-          payloads.push(conversationPayload);
-          break;
-        }
-      } catch (error) {
-        if (error instanceof AuthRequiredError) throw error;
-        if (!(error instanceof CommandExecutionError)) throw error;
-        // Performance entries can be stale. Optional metadata must not block message retrieval.
-      }
-    }
+    // Optional metadata must not block message retrieval.
+    const conversationPayload = await fetchFirstConversationPayload(
+      page,
+      probe,
+      csrf,
+      threadId,
+      COMMAND,
+    );
+    if (conversationPayload) payloads.push(conversationPayload);
 
     const consume = async (apiUrl) => {
       if (!apiUrl || fetchedUrls.has(apiUrl)) return { added: 0, fetched: false };
       fetchedUrls.add(apiUrl);
-      const payload = await fetchThreadPayload(page, apiUrl, csrf, threadId);
+      const payload = await fetchThreadPayload(page, apiUrl, csrf, threadId, COMMAND);
       payloads.push(payload);
       return { added: countThreadMessagesInPayload(payload, threadId), fetched: true };
     };

--- a/opencli-plugins/linkedin/thread-snapshot.test.mjs
+++ b/opencli-plugins/linkedin/thread-snapshot.test.mjs
@@ -353,6 +353,69 @@ function fakePage({ probe, responses }) {
   };
 }
 
+test("the command keeps every column it returns today and adds the sender participant id", () => {
+  const command = getRegistry().get("linkedin/thread-snapshot");
+  assert.ok(command);
+  // Adding participant identifiers is additive: every column callers already
+  // read (packages/core parses these rows) must survive.
+  const established = [
+    "thread_url",
+    "thread_id",
+    "conversation_name",
+    "conversation_title",
+    "conversation_is_group",
+    "participant_count",
+    "returned_index",
+    "returned_message_count",
+    "message_id",
+    "sent_at",
+    "sender_name",
+    "sender_type",
+    "sender_profile_url",
+    "sender_headline",
+    "sender_is_self",
+    "text",
+    "subject",
+    "reaction_count",
+    "is_latest",
+  ];
+  for (const column of established) {
+    assert.ok(command.columns.includes(column), `dropped column ${column}`);
+  }
+  assert.ok(command.columns.includes("sender_participant_id"));
+});
+
+test("message rows carry the sender's bare participant id", () => {
+  const rows = parseThreadMessagePayloads(
+    [
+      payload([
+        message("m1", THREAD_ID, SELF, 1000, "first"),
+        message("m2", THREAD_ID, EVAN, 2000, "second"),
+      ]),
+    ],
+    { threadId: THREAD_ID, threadUrl: THREAD_URL, limit: 20 },
+  );
+
+  assert.equal(rows[0].sender_participant_id, "self");
+  assert.equal(rows[1].sender_participant_id, "evan");
+  // An unresolvable sender stays empty rather than inventing an id.
+  const orphan = parseThreadMessagePayloads(
+    [
+      {
+        included: [
+          {
+            $type: "com.linkedin.messenger.Conversation",
+            entityUrn: `urn:li:msg_conversation:(urn:li:fsd_profile:self,${THREAD_ID})`,
+          },
+          message("m1", THREAD_ID, "urn:li:msg_messagingParticipant:missing", 1000, "hi"),
+        ],
+      },
+    ],
+    { threadId: THREAD_ID, threadUrl: THREAD_URL, limit: 20 },
+  );
+  assert.equal(orphan[0].sender_participant_id, "");
+});
+
 test("the command returns one row per message from the requested thread", async () => {
   const command = getRegistry().get("linkedin/thread-snapshot");
   assert.ok(command);


### PR DESCRIPTION
## Summary

`thread-snapshot` already resolved participants into a map keyed by the participant urn, but `participantMetadata()` returned only `name`, `type`, `profile_url`, `headline` and `is_self` — the identifier never reached the output. This threads the map key through into the participant record and exposes the full participant set as its own command.

- **`participant_id`** is LinkedIn's obfuscated member id — the bare `ACoAA…` segment that also sits inside `profile_url` — so it can serve as a `channel_user_id` later. Organization and agent participants nest their urn the same way, so the trailing segment is their id too.
- **`opencli linkedin thread-participants --thread-url <url>`** returns one row per participant. The conversation response is the authoritative source: its participant reference list names everyone on the thread, *including members who have never sent a message*. When that metadata is unavailable the command falls back to the participants the message response proves, rather than failing.
- **`thread-snapshot` gains `sender_participant_id`** and keeps every column it returned before. `packages/core`'s row schema is non-strict, so the added column is inert for existing callers.
- Both commands now share one read path (`thread-read.mjs`) — same navigation, same thread-identity check, same two normalized messaging endpoints — so they fail closed identically on an auth wall and on a thread-url mismatch. `thread-snapshot`'s behavior is unchanged by that extraction; the auth-wall phrasing `packages/core/src/channels/linkedin-cli.ts` matches on is preserved.

Out of scope, as specified: storing participants in the database, any core or web change, and the `inbox` command.

## Test plan

Tests were written first against the acceptance criteria, then the implementation made them pass.

- [x] `thread-participants -f json` returns one row per participant carrying `thread_id`, `participant_id`, `name`, `headline`, `type` and `is_self`
- [x] a participant who has sent no message in the thread still appears in the output
- [x] a 1:1 thread returns both the account owner and the counterparty
- [x] `thread-snapshot` keeps every column it returns today (asserted explicitly against the established column list)
- [x] the command fails closed on an auth wall and on a thread-url mismatch, matching `thread-snapshot`
- [x] `cd opencli-plugins/linkedin && node --test *.test.mjs` — 44 passing (20 pre-existing, all still green)
- [x] `biome check opencli-plugins/` clean
- [x] Verified against the real CLI: `opencli plugin install` registers `thread-participants` in `opencli linkedin --help`, and an invalid `--thread-url` exits `code: ARGUMENT`

Closes rome-os/rome#6

🤖 Generated with [Claude Code](https://claude.com/claude-code)