### PR TITLE
docs: add Discord badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
   <a href="https://x.com/RomeAILab">
     <img alt="Follow Rome on X" src="https://img.shields.io/badge/follow-%40RomeAILab-black?logo=x&amp;logoColor=white" />
   </a>
+  <a href="https://discord.gg/g7EFmEtmqc">
+    <img alt="Join the Rome Discord server" src="https://img.shields.io/badge/chat-Discord-5865F2?logo=discord&amp;logoColor=white" />
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## What this PR does

The README did not link to the Rome Discord server. This adds a Discord badge beside the existing project badges and links it to the server invite.

## Test plan

- [x] Render the README through the GitHub Markdown API.
- [x] Confirm the Discord invite resolves successfully.
- [x] Confirm the badge URL returns an SVG image.
- [x] Run `git diff --check`.