### PR TITLE
feat: populate LinkedIn participants from the thread poller

### DIFF
--- a/packages/core/drizzle/system/0058_wet_rockslide.sql
+++ b/packages/core/drizzle/system/0058_wet_rockslide.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `linkedin_threads` ADD `participants_last_read_at` integer;

--- a/packages/core/drizzle/system/meta/0058_snapshot.json
+++ b/packages/core/drizzle/system/meta/0058_snapshot.json
@@ -1,0 +1,3044 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5c0e421e-5a69-4146-97a5-085ab1af7d71",
+  "prevId": "5709b720-f644-4d1a-a32b-cb6f5b80db5a",
+  "tables": {
+    "action_executions": {
+      "name": "action_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initiator": {
+          "name": "initiator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "approvals": {
+      "name": "approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_state": {
+          "name": "execution_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_error": {
+          "name": "execution_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_mappings": {
+      "name": "channel_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_channel_mappings_identity": {
+          "name": "idx_channel_mappings_identity",
+          "columns": [
+            "channel",
+            "channel_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_mappings_person_id_persons_id_fk": {
+          "name": "channel_mappings_person_id_persons_id_fk",
+          "tableFrom": "channel_mappings",
+          "tableTo": "persons",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connection_grants": {
+      "name": "connection_grants",
+      "columns": {
+        "custody": {
+          "name": "custody",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential": {
+          "name": "credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conferred_at": {
+          "name": "conferred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_at": {
+          "name": "degraded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_reason": {
+          "name": "degraded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connection_grants_custody_name_pk": {
+          "columns": [
+            "custody",
+            "name"
+          ],
+          "name": "connection_grants_custody_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connections": {
+      "name": "connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connections_service_unique": {
+          "name": "connections_service_unique",
+          "columns": [
+            "service"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tzid": {
+          "name": "tzid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_time": {
+          "name": "local_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rrule": {
+          "name": "rrule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "execution_journal": {
+      "name": "execution_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_hash": {
+          "name": "args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expected_action_name": {
+          "name": "expected_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expected_args_hash": {
+          "name": "expected_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_action_name": {
+          "name": "actual_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_args_hash": {
+          "name": "actual_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ej_root_execution_id": {
+          "name": "idx_ej_root_execution_id",
+          "columns": [
+            "root_execution_id"
+          ],
+          "isUnique": false
+        },
+        "idx_ej_created_at": {
+          "name": "idx_ej_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardian_auth": {
+      "name": "guardian_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guardian_auth_user_id_unique": {
+          "name": "guardian_auth_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_messages": {
+      "name": "linkedin_messages",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_profile_url": {
+          "name": "sender_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_headline": {
+          "name": "sender_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_is_self": {
+          "name": "sender_is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_messages_thread_sent": {
+          "name": "idx_linkedin_messages_thread_sent",
+          "columns": [
+            "thread_id",
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_messages_thread_id_message_id_pk": {
+          "columns": [
+            "thread_id",
+            "message_id"
+          ],
+          "name": "linkedin_messages_thread_id_message_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_participants": {
+      "name": "linkedin_participants",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_self": {
+          "name": "is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_thread_participants": {
+      "name": "linkedin_thread_participants",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_thread_participants_participant": {
+          "name": "idx_linkedin_thread_participants_participant",
+          "columns": [
+            "participant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_thread_participants_thread_id_participant_id_pk": {
+          "columns": [
+            "thread_id",
+            "participant_id"
+          ],
+          "name": "linkedin_thread_participants_thread_id_participant_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_threads": {
+      "name": "linkedin_threads",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_url": {
+          "name": "thread_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_name": {
+          "name": "person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_name": {
+          "name": "conversation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread": {
+          "name": "unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "counterparty_type": {
+          "name": "counterparty_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "participants_last_read_at": {
+          "name": "participants_last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_pending_attempts": {
+      "name": "oauth_pending_attempts",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_origin": {
+          "name": "callback_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_pending_attempts_expires_at": {
+          "name": "idx_oauth_pending_attempts_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persons": {
+      "name": "persons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bond_level": {
+          "name": "bond_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_path": {
+          "name": "profile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_value": {
+          "name": "scope_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sync_links": {
+      "name": "project_sync_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_type": {
+          "name": "project_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_extra": {
+          "name": "project_link_extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sync_links_project_path_unique": {
+          "name": "project_sync_links_project_path_unique",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_accounts": {
+      "name": "provider_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "provider_accounts_provider_unique": {
+          "name": "provider_accounts_provider_unique",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_messages": {
+      "name": "rome_agent_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_platform_message_id": {
+          "name": "reply_to_platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_injected_turn_id": {
+          "name": "context_injected_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_messages_session_id": {
+          "name": "idx_rome_agent_messages_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_turn_id": {
+          "name": "idx_rome_agent_messages_turn_id",
+          "columns": [
+            "turn_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_role_created_at": {
+          "name": "idx_rome_agent_messages_role_created_at",
+          "columns": [
+            "role",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_platform_message": {
+          "name": "idx_rome_agent_messages_platform_message",
+          "columns": [
+            "session_id",
+            "platform_message_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_agent_messages\".\"platform_message_id\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_trace_blocks": {
+      "name": "rome_agent_trace_blocks",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_trace_blocks_session_id": {
+          "name": "idx_rome_agent_trace_blocks_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_trace_blocks_terminal_message": {
+          "name": "idx_rome_agent_trace_blocks_terminal_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') IN ('result', 'error')"
+        },
+        "idx_rome_agent_trace_blocks_turn_end_message": {
+          "name": "idx_rome_agent_trace_blocks_turn_end_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') = 'turn_end'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rome_agent_trace_blocks_message_id_seq_pk": {
+          "columns": [
+            "message_id",
+            "seq"
+          ],
+          "name": "rome_agent_trace_blocks_message_id_seq_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_sessions": {
+      "name": "rome_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "large_model_selection": {
+          "name": "large_model_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webchat'"
+        },
+        "source_channel": {
+          "name": "source_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_name": {
+          "name": "source_thread_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_type": {
+          "name": "source_thread_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_settings": {
+          "name": "channel_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_turn_id": {
+          "name": "parent_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handoff_spec": {
+          "name": "handoff_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_activity_at": {
+          "name": "last_seen_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_sessions_project_path": {
+          "name": "idx_rome_sessions_project_path",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_sidebar_activity": {
+          "name": "idx_rome_sessions_sidebar_activity",
+          "columns": [
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_project_activity": {
+          "name": "idx_rome_sessions_project_activity",
+          "columns": [
+            "project_path",
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_channel": {
+          "name": "idx_rome_sessions_source_channel",
+          "columns": [
+            "source_channel"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_thread": {
+          "name": "idx_rome_sessions_source_thread",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_channel_address": {
+          "name": "idx_rome_sessions_channel_address",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_sessions\".\"type\" = 'channel' AND \"rome_sessions\".\"source_channel\" IS NOT NULL AND \"rome_sessions\".\"source_thread_id\" IS NOT NULL"
+        },
+        "idx_rome_sessions_parent_session": {
+          "name": "idx_rome_sessions_parent_session",
+          "columns": [
+            "parent_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routine_runs": {
+      "name": "routine_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_routine_runs_routine_id": {
+          "name": "idx_routine_runs_routine_id",
+          "columns": [
+            "routine_id"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_fired_at": {
+          "name": "idx_routine_runs_fired_at",
+          "columns": [
+            "fired_at"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_status": {
+          "name": "idx_routine_runs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "routine_runs_routine_id_routines_id_fk": {
+          "name": "routine_runs_routine_id_routines_id_fk",
+          "tableFrom": "routine_runs",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routines": {
+      "name": "routines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed_by": {
+          "name": "managed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "routines_key_unique": {
+          "name": "routines_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sentinel_log": {
+      "name": "sentinel_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_turn_checkpoints": {
+      "name": "session_turn_checkpoints",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_turn_checkpoints_session_id_sessions_id_fk": {
+          "name": "session_turn_checkpoints_session_id_sessions_id_fk",
+          "tableFrom": "session_turn_checkpoints",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_turn_checkpoints_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "session_turn_checkpoints_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_thread_key": {
+          "name": "channel_thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shared_chats": {
+      "name": "shared_chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_shared_chats_session_id": {
+          "name": "idx_shared_chats_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_chats": {
+      "name": "wa_chats",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_contacts": {
+      "name": "wa_contacts",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify": {
+          "name": "notify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "img_url": {
+          "name": "img_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_messages": {
+      "name": "wa_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_jid": {
+          "name": "chat_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_jid": {
+          "name": "sender_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_me": {
+          "name": "from_me",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_media": {
+          "name": "has_media",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "push_name": {
+          "name": "push_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reacts_to_id": {
+          "name": "reacts_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_chat_ts": {
+          "name": "idx_wa_messages_chat_ts",
+          "columns": [
+            "chat_jid",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wa_messages_chat_jid_id_pk": {
+          "columns": [
+            "chat_jid",
+            "id"
+          ],
+          "name": "wa_messages_chat_jid_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_projects": {
+      "name": "webchat_projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webchat_projects_path_unique": {
+          "name": "webchat_projects_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_turn_feedback": {
+      "name": "webchat_turn_feedback",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webchat_turn_feedback_session_id": {
+          "name": "idx_webchat_turn_feedback_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webchat_turn_feedback_session_id_rome_sessions_id_fk": {
+          "name": "webchat_turn_feedback_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_turn_feedback",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webchat_turn_feedback_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "webchat_turn_feedback_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_workspace_layouts": {
+      "name": "webchat_workspace_layouts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webchat_workspace_layouts_session_id_rome_sessions_id_fk": {
+          "name": "webchat_workspace_layouts_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_workspace_layouts",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_invocations": {
+      "name": "webhook_invocations",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_url": {
+          "name": "callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_status": {
+          "name": "callback_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_attempted_at": {
+          "name": "callback_attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_delivered_at": {
+          "name": "callback_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_response_status": {
+          "name": "callback_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_error": {
+          "name": "callback_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webhook_invocations_created_at": {
+          "name": "idx_webhook_invocations_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_webhook_invocations_action_name": {
+          "name": "idx_webhook_invocations_action_name",
+          "columns": [
+            "action_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/system/meta/_journal.json
+++ b/packages/core/drizzle/system/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1787559677614,
       "tag": "0057_omniscient_living_lightning",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "6",
+      "when": 1787563091626,
+      "tag": "0058_wet_rockslide",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/channels/linkedin-cli.test.ts
+++ b/packages/core/src/channels/linkedin-cli.test.ts
@@ -4,8 +4,10 @@ import {
   OpencliCommandError,
   parseInbox,
   parseSafeSend,
+  parseThreadParticipants,
   parseThreadSnapshot,
   parseWhoami,
+  readLinkedInThreadParticipants,
   safeSendLinkedInReply,
   type OpencliResult,
 } from "./linkedin-cli.js";
@@ -259,5 +261,137 @@ describe("safeSendLinkedInReply", () => {
         ),
       ),
     ).toThrow(OpencliCommandError);
+  });
+});
+
+describe("parseThreadParticipants", () => {
+  const row = (overrides: Record<string, unknown> = {}) => ({
+    thread_url: "https://www.linkedin.com/messaging/thread/2-abc==/",
+    thread_id: "2-abc==",
+    participant_index: 1,
+    participant_count: 2,
+    participant_id: "ACoAAAda0001",
+    name: "Ada Lovelace",
+    headline: "Engineer",
+    type: "member",
+    is_self: false,
+    profile_url: "https://www.linkedin.com/in/ACoAAAda0001/",
+    ...overrides,
+  });
+
+  it("returns one record per participant, member id first", () => {
+    const participants = parseThreadParticipants(
+      ok(
+        JSON.stringify([
+          row(),
+          row({
+            participant_index: 2,
+            participant_id: "ACoAASelf0003",
+            name: "Jane Doe",
+            headline: "",
+            is_self: true,
+          }),
+        ]),
+      ),
+    );
+
+    expect(participants).toEqual([
+      {
+        threadId: "2-abc==",
+        participantId: "ACoAAAda0001",
+        name: "Ada Lovelace",
+        headline: "Engineer",
+        type: "member",
+        isSelf: false,
+        profileUrl: "https://www.linkedin.com/in/ACoAAAda0001/",
+      },
+      {
+        threadId: "2-abc==",
+        participantId: "ACoAASelf0003",
+        name: "Jane Doe",
+        // The plugin writes "" for a field it could not read; the mirror stores
+        // "not known" as null so a later read can still fill it in.
+        headline: null,
+        type: "member",
+        isSelf: true,
+        profileUrl: "https://www.linkedin.com/in/ACoAAAda0001/",
+      },
+    ]);
+  });
+
+  it("keeps a participant who has sent no message in the thread", () => {
+    // The conversation payload names everyone; a lurker only ever appears here.
+    const participants = parseThreadParticipants(
+      ok(JSON.stringify([row(), row({ participant_index: 2, participant_id: "ACoAALurk0002" })])),
+    );
+    expect(participants.map((p) => p.participantId)).toEqual(["ACoAAAda0001", "ACoAALurk0002"]);
+  });
+
+  it("drops rows with no member id rather than storing a blank identity", () => {
+    const participants = parseThreadParticipants(
+      ok(JSON.stringify([row(), row({ participant_index: 2, participant_id: "" })])),
+    );
+    expect(participants.map((p) => p.participantId)).toEqual(["ACoAAAda0001"]);
+  });
+
+  it("fails closed on an auth wall, matching thread-snapshot", () => {
+    expect(() =>
+      parseThreadParticipants({
+        code: 1,
+        stdout: "",
+        stderr: "AuthRequiredError: authwall — sign in to LinkedIn",
+      }),
+    ).toThrow(OpencliAuthError);
+  });
+
+  it("fails on an unexpected output shape", () => {
+    expect(() => parseThreadParticipants(ok(JSON.stringify([{ name: "Ada" }])))).toThrow(
+      OpencliCommandError,
+    );
+  });
+
+  it("fails when the thread reports no participants at all", () => {
+    // An empty read must never reach the store: the store treats an empty set
+    // as "everyone left" and would wipe the thread's membership.
+    expect(() => parseThreadParticipants(ok(JSON.stringify([])))).toThrow(OpencliCommandError);
+  });
+});
+
+describe("readLinkedInThreadParticipants", () => {
+  it("invokes the thread-participants command for the requested thread", async () => {
+    const run = vi.fn(async () =>
+      ok(
+        JSON.stringify([
+          {
+            thread_url: "https://www.linkedin.com/messaging/thread/2-abc==/",
+            thread_id: "2-abc==",
+            participant_index: 1,
+            participant_count: 1,
+            participant_id: "ACoAAAda0001",
+            name: "Ada Lovelace",
+            headline: "Engineer",
+            type: "member",
+            is_self: false,
+            profile_url: "https://www.linkedin.com/in/ACoAAAda0001/",
+          },
+        ]),
+      ),
+    );
+
+    const participants = await readLinkedInThreadParticipants(
+      { threadUrl: "https://www.linkedin.com/messaging/thread/2-abc==/" },
+      run,
+    );
+
+    expect(run).toHaveBeenCalledWith(
+      [
+        "linkedin",
+        "thread-participants",
+        "--thread-url",
+        "https://www.linkedin.com/messaging/thread/2-abc==/",
+      ],
+      {},
+    );
+    expect(participants.map((p) => p.participantId)).toEqual(["ACoAAAda0001"]);
   });
 });

--- a/packages/core/src/channels/linkedin-cli.ts
+++ b/packages/core/src/channels/linkedin-cli.ts
@@ -293,6 +293,87 @@ export function parseThreadSnapshot(result: OpencliResult): LinkedInSnapshotMess
   }));
 }
 
+// ── thread-participants ───────────────────────────────────────────────────
+// The Rome-owned command (opencli-plugins/linkedin/thread-participants.js).
+// It reads the conversation's participant reference list, so it names everyone
+// on the thread — including members who have never sent a message, who are
+// invisible in `thread-snapshot`'s per-message rows.
+
+const participantRowSchema = z.object({
+  thread_id: z.string().min(1),
+  participant_id: z.string(),
+  name: z.string().nullish(),
+  headline: z.string().nullish(),
+  type: z.string().nullish(),
+  is_self: z.boolean(),
+  profile_url: z.string().nullish(),
+});
+
+export interface LinkedInThreadParticipant {
+  threadId: string;
+  /** LinkedIn's obfuscated member id, bare (`ACoAA…`). */
+  participantId: string;
+  name: string | null;
+  headline: string | null;
+  /** `member` | `organization` | `agent` | `custom`. */
+  type: string | null;
+  /** True for the account owner's own row in the participant list. */
+  isSelf: boolean;
+  profileUrl: string | null;
+}
+
+/** The plugin writes "" for a field it could not read; the mirror stores "not
+ *  known" as null so a later read can still fill it in. */
+function emptyToNull(value: string | null | undefined): string | null {
+  const trimmed = (value ?? "").trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
+ * Parse `linkedin thread-participants`. Rows without a member id are dropped
+ * rather than stored as a blank identity — `participant_id` is the primary key
+ * of `linkedin_participants` and has to match `channel_mappings.channel_user_id`.
+ *
+ * An empty result is a failure, not an empty thread: the store reads an empty
+ * participant set as "everyone left" and would wipe the thread's membership,
+ * so a read that proved nothing must never reach it.
+ */
+export function parseThreadParticipants(result: OpencliResult): LinkedInThreadParticipant[] {
+  const raw = parseJsonOutput("linkedin thread-participants", result);
+  const rows = z.array(participantRowSchema).safeParse(raw);
+  if (!rows.success) {
+    throw new OpencliCommandError("linkedin thread-participants", "unexpected output shape");
+  }
+  const participants = rows.data
+    .filter((row) => row.participant_id.trim() !== "")
+    .map((row) => ({
+      threadId: row.thread_id,
+      participantId: row.participant_id.trim(),
+      name: emptyToNull(row.name),
+      headline: emptyToNull(row.headline),
+      type: emptyToNull(row.type),
+      isSelf: row.is_self,
+      profileUrl: emptyToNull(row.profile_url),
+    }));
+  if (participants.length === 0) {
+    throw new OpencliCommandError("linkedin thread-participants", "reported no participants");
+  }
+  return participants;
+}
+
+/** Read one thread's full participant list through opencli. */
+export async function readLinkedInThreadParticipants(
+  input: { threadUrl: string },
+  run: RunOpencli = runOpencli,
+  opts: RunOpencliOptions = {},
+): Promise<LinkedInThreadParticipant[]> {
+  const result = await run(
+    ["linkedin", "thread-participants", "--thread-url", input.threadUrl],
+    opts,
+  );
+  return parseThreadParticipants(result);
+}
+
 // ── safe-send ────────────────────────────────────────────────────────────
 
 const safeSendRowSchema = z.object({

--- a/packages/core/src/channels/linkedin-sync.ts
+++ b/packages/core/src/channels/linkedin-sync.ts
@@ -113,10 +113,19 @@ export interface LinkedInSyncSink {
   fetchHistory?(threadId: string | null, since: Date): Promise<LinkedInHistoryMessage[]>;
   /**
    * Replace a thread's membership with exactly `participants` (an empty array
-   * empties the thread). Optional: no poller writes participants yet.
+   * empties the thread) and record that the membership was read just now.
+   *
+   * Optional, and the poller treats it as a capability probe: a sink that
+   * cannot store membership is never made to pay for the crawl that produces
+   * it.
    */
   upsertThreadParticipants?(
     threadId: string,
     participants: LinkedInParticipantInput[],
   ): Promise<void>;
+  /**
+   * Seed participants from messages the sink already holds — no opencli call.
+   * The poller runs this once per start, before it crawls anything.
+   */
+  backfillParticipantsFromMessages?(): Promise<unknown>;
 }

--- a/packages/core/src/channels/linkedin.test.ts
+++ b/packages/core/src/channels/linkedin.test.ts
@@ -5,9 +5,10 @@ import {
   threadNeedsSnapshot,
   type LinkedInPollerOptions,
 } from "./linkedin.js";
-import type { OpencliResult } from "./linkedin-cli.js";
+import { OpencliAuthError, type OpencliResult } from "./linkedin-cli.js";
 import type {
   LinkedInMessageInput,
+  LinkedInParticipantInput,
   LinkedInSyncSink,
   LinkedInThreadCursor,
   LinkedInThreadInput,
@@ -70,6 +71,41 @@ class FakeSink implements LinkedInSyncSink {
   ): Promise<void> {
     this.synced.push(threadId);
     this.syncedMeta.set(threadId, opts);
+  }
+}
+
+function participantRow(threadId: string, participantId: string, overrides = {}) {
+  return {
+    thread_url: `https://www.linkedin.com/messaging/thread/${threadId}/`,
+    thread_id: threadId,
+    participant_index: 1,
+    participant_count: 2,
+    participant_id: participantId,
+    name: "Ada",
+    headline: "Engineer",
+    type: "member",
+    is_self: false,
+    profile_url: `https://www.linkedin.com/in/${participantId}/`,
+    ...overrides,
+  };
+}
+
+/** A sink that can hold membership, unlike {@link FakeSink}. */
+class ParticipantSink extends FakeSink {
+  participantSets = new Map<string, LinkedInParticipantInput[]>();
+  participantWrites: string[] = [];
+  backfills = 0;
+
+  async upsertThreadParticipants(
+    threadId: string,
+    participants: LinkedInParticipantInput[],
+  ): Promise<void> {
+    this.participantWrites.push(threadId);
+    this.participantSets.set(threadId, participants);
+  }
+
+  async backfillParticipantsFromMessages(): Promise<void> {
+    this.backfills++;
   }
 }
 
@@ -202,6 +238,153 @@ describe("LinkedInInboxPoller.pollOnce", () => {
 
     expect(snapshotted).toEqual(["t1", "t2"]);
     expect(sink.synced).toEqual(["t1", "t2"]);
+  });
+});
+
+describe("LinkedInInboxPoller participant sync", () => {
+  /** inbox → snapshot → thread-participants, with the participant payload swappable. */
+  function participantRun(payloads: () => unknown[]) {
+    return vi.fn(async (args: string[]) => {
+      if (args[1] === "inbox") return ok([inboxRow("t1", "2026-08-19T20:00:00.000Z")]);
+      if (args[1] === "thread-participants") return ok(payloads());
+      return ok([snapshotRow("t1", "m1")]);
+    });
+  }
+
+  it("stores a polled thread's participants, readable after the tick", async () => {
+    const sink = new ParticipantSink();
+    const run = participantRun(() => [
+      participantRow("t1", "ACoAAAda0001"),
+      participantRow("t1", "ACoAASelf0003", {
+        participant_index: 2,
+        name: "Jane Doe",
+        is_self: true,
+      }),
+    ]);
+
+    await makePoller(sink, run).pollOnce();
+
+    expect(run).toHaveBeenCalledWith(
+      ["linkedin", "thread-participants", "--thread-url", inboxRow("t1", "").thread_url],
+      expect.anything(),
+    );
+    expect(sink.participantSets.get("t1")).toEqual([
+      {
+        participantId: "ACoAAAda0001",
+        name: "Ada",
+        headline: "Engineer",
+        type: "member",
+        isSelf: false,
+      },
+      {
+        participantId: "ACoAASelf0003",
+        name: "Jane Doe",
+        headline: "Engineer",
+        type: "member",
+        isSelf: true,
+      },
+    ]);
+  });
+
+  it("stores a participant who has sent no message in the thread", async () => {
+    const sink = new ParticipantSink();
+    // The snapshot only proves m1's sender; the participant read names a
+    // second member who has never posted.
+    const run = participantRun(() => [
+      participantRow("t1", "ACoAAAda0001"),
+      participantRow("t1", "ACoAALurk0002", { participant_index: 2, name: "Quiet One" }),
+    ]);
+
+    await makePoller(sink, run).pollOnce();
+
+    expect(sink.messages.map((m) => m.messageId)).toEqual(["m1"]);
+    expect(sink.participantSets.get("t1")?.map((p) => p.participantId)).toEqual([
+      "ACoAAAda0001",
+      "ACoAALurk0002",
+    ]);
+  });
+
+  it("a re-poll of a thread whose membership changed stores the latest read", async () => {
+    const sink = new ParticipantSink();
+    let members = [
+      participantRow("t1", "ACoAAAda0001"),
+      participantRow("t1", "ACoAAGrace002", { participant_index: 2 }),
+    ];
+    const run = participantRun(() => members);
+    const poller = makePoller(sink, run);
+
+    await poller.pollOnce();
+    // Grace left, someone new joined; the thread is stale again next tick.
+    members = [
+      participantRow("t1", "ACoAAAda0001"),
+      participantRow("t1", "ACoAANew00004", { participant_index: 2 }),
+    ];
+    await poller.pollOnce();
+
+    expect(sink.participantWrites).toEqual(["t1", "t1"]);
+    expect(sink.participantSets.get("t1")?.map((p) => p.participantId)).toEqual([
+      "ACoAAAda0001",
+      "ACoAANew00004",
+    ]);
+  });
+
+  it("does not crawl participants a sink cannot store", async () => {
+    const sink = new FakeSink();
+    const run = participantRun(() => [participantRow("t1", "ACoAAAda0001")]);
+
+    await makePoller(sink, run).pollOnce();
+
+    expect(run.mock.calls.map((c) => c[0][1])).toEqual(["inbox", "thread-snapshot"]);
+  });
+
+  it("a failed participant read leaves the message snapshot standing", async () => {
+    const sink = new ParticipantSink();
+    const run = vi.fn(async (args: string[]): Promise<OpencliResult> => {
+      if (args[1] === "inbox") return ok([inboxRow("t1", "2026-08-19T20:00:00.000Z")]);
+      if (args[1] === "thread-participants") {
+        return { code: 1, stdout: "", stderr: "LinkedIn returned no participant data" };
+      }
+      return ok([snapshotRow("t1", "m1")]);
+    });
+
+    // Membership is a cache: a read that failed simply is not recorded, and it
+    // must not cost the tick the messages it already mirrored.
+    await expect(makePoller(sink, run).pollOnce()).resolves.toBeUndefined();
+
+    expect(sink.messages.map((m) => m.messageId)).toEqual(["m1"]);
+    expect(sink.synced).toEqual(["t1"]);
+    expect(sink.participantWrites).toEqual([]);
+  });
+
+  it("an auth wall during the participant read still fails the tick", async () => {
+    const sink = new ParticipantSink();
+    const run = vi.fn(async (args: string[]): Promise<OpencliResult> => {
+      if (args[1] === "inbox") return ok([inboxRow("t1", "2026-08-19T20:00:00.000Z")]);
+      if (args[1] === "thread-participants") {
+        return { code: 69, stdout: "ok: false\nerror:\n  code: AUTH_REQUIRED", stderr: "" };
+      }
+      return ok([snapshotRow("t1", "m1")]);
+    });
+
+    // A signed-out session is not a per-thread hiccup — the grant owner has to
+    // hear about it.
+    await expect(makePoller(sink, run).pollOnce()).rejects.toBeInstanceOf(OpencliAuthError);
+  });
+
+  it("seeds participants from stored messages once, without calling opencli", async () => {
+    const sink = new ParticipantSink();
+    const run = participantRun(() => [participantRow("t1", "ACoAAAda0001")]);
+    const poller = makePoller(sink, run);
+
+    await poller.pollOnce();
+    await poller.pollOnce();
+
+    expect(sink.backfills).toBe(1);
+    // The seed reads rows already on disk; every opencli call in the tick
+    // belongs to the normal poll path.
+    expect(new Set(run.mock.calls.map((c) => c[0][1]))).toEqual(
+      new Set(["inbox", "thread-snapshot", "thread-participants"]),
+    );
   });
 });
 

--- a/packages/core/src/channels/linkedin.ts
+++ b/packages/core/src/channels/linkedin.ts
@@ -20,6 +20,7 @@ import { createLogger } from "../logger.js";
 import {
   OpencliAuthError,
   parseInbox,
+  parseThreadParticipants,
   parseThreadSnapshot,
   type LinkedInInboxRow,
   type RunOpencli,
@@ -95,6 +96,8 @@ export class LinkedInInboxPoller {
    *  in-flight tick's snapshot loop and suppresses rescheduling. */
   private stopped = false;
   private ticking = false;
+  /** The message-derived participant seed is a one-shot, not a per-tick cost. */
+  private participantsSeeded = false;
   private consecutiveFailures = 0;
   private lastFailureMessage: string | null = null;
   private nextRunAt: Date | null = null;
@@ -148,6 +151,7 @@ export class LinkedInInboxPoller {
    *  Public as the unit-test entry point; production ticks come off the timer. */
   async pollOnce(): Promise<void> {
     const signal = this.abort?.signal;
+    await this.seedParticipantsOnce();
     const inboxResult = await this.run(
       ["linkedin", "inbox", "--limit", String(this.inboxLimit)],
       signal ? { signal } : {},
@@ -224,6 +228,74 @@ export class LinkedInInboxPoller {
       isGroup: messages.find((m) => m.conversationIsGroup != null)?.conversationIsGroup ?? null,
       participantCount: messages.find((m) => m.participantCount != null)?.participantCount ?? null,
     });
+    await this.syncThreadParticipants(row, signal);
+  }
+
+  /**
+   * Read the thread's membership and replace the stored set with it. Runs
+   * after the snapshot rather than inside it: the snapshot's per-message rows
+   * only prove senders, while this command reads the conversation's own
+   * participant list and so also names members who have never posted.
+   *
+   * A failed read is not fatal. Membership is a cache of a pull-only mirror,
+   * so the honest response to a failure is to record nothing — the thread's
+   * `participants_last_read_at` simply does not advance and the previous set
+   * stays visibly stale — rather than to throw away the messages this tick
+   * already mirrored. A signed-out session is the exception: that is not a
+   * per-thread hiccup, and the grant owner has to hear about it.
+   */
+  private async syncThreadParticipants(row: LinkedInInboxRow, signal?: AbortSignal): Promise<void> {
+    const upsert = this.sink.upsertThreadParticipants?.bind(this.sink);
+    // No point paying for a crawl whose result nothing can store.
+    if (!upsert) return;
+
+    let participants: ReturnType<typeof parseThreadParticipants>;
+    try {
+      const result = await this.run(
+        ["linkedin", "thread-participants", "--thread-url", row.threadUrl],
+        { timeoutMs: SNAPSHOT_TIMEOUT_MS, ...(signal ? { signal } : {}) },
+      );
+      participants = parseThreadParticipants(result);
+    } catch (err) {
+      if (err instanceof OpencliAuthError) throw err;
+      log.warn("linkedin participant read failed; membership left as-is", {
+        threadId: row.threadId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    await upsert(
+      row.threadId,
+      participants.map((p) => ({
+        participantId: p.participantId,
+        name: p.name,
+        headline: p.headline,
+        type: p.type,
+        isSelf: p.isSelf,
+      })),
+    );
+  }
+
+  /**
+   * Seed the participant tables from messages the mirror already holds, once
+   * per process. Every sender already recorded carries their member id, so an
+   * inbox polled before participants existed knows most of its membership
+   * without a single new page load. Best-effort: a failed seed must not cost
+   * the poll that follows it.
+   */
+  private async seedParticipantsOnce(): Promise<void> {
+    if (this.participantsSeeded) return;
+    this.participantsSeeded = true;
+    const backfill = this.sink.backfillParticipantsFromMessages?.bind(this.sink);
+    if (!backfill) return;
+    try {
+      await backfill();
+    } catch (err) {
+      log.warn("linkedin participant backfill failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   private async tick(): Promise<void> {

--- a/packages/core/src/db/repositories/linkedin-store.test.ts
+++ b/packages/core/src/db/repositories/linkedin-store.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { sql } from "drizzle-orm";
 import { createTestDb, type TestDb } from "../../test/helpers.js";
-import { LinkedInStoreRepository } from "./linkedin-store.js";
+import { LinkedInStoreRepository, linkedInMemberIdFromProfileUrl } from "./linkedin-store.js";
 
 describe("LinkedInStoreRepository", () => {
   let testDb: TestDb;
@@ -266,6 +266,13 @@ describe("LinkedInStoreRepository", () => {
       expect(byName.get("idx_linkedin_thread_participants_participant")).toBe("index");
     });
 
+    it("the migrations add the per-thread membership read timestamp", () => {
+      const columns = testDb.db.all(
+        sql`SELECT name FROM pragma_table_info('linkedin_threads')`,
+      ) as Array<{ name: string }>;
+      expect(columns.map((c) => c.name)).toContain("participants_last_read_at");
+    });
+
     it("upserting the same participant set twice leaves one row per participant", async () => {
       await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
       await repo.upsertThreadParticipants("t1", [ada, grace, self]);
@@ -407,5 +414,218 @@ describe("LinkedInStoreRepository", () => {
       ]);
       expect(await repo.getParticipantThreadIds(ada.participantId)).toEqual(["t1"]);
     });
+
+    // These tables are a cache of a pull-only mirror, so a read of them has to
+    // say when it was taken. `getThreadParticipantSet` pairs the membership
+    // with that timestamp; a null one means "never authoritatively read".
+    describe("membership freshness", () => {
+      it("a thread that has never been read reports a null last-read time", async () => {
+        await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
+
+        const set = await repo.getThreadParticipantSet("t1");
+        expect(set.participants).toEqual([]);
+        expect(set.lastReadAt).toBeNull();
+      });
+
+      it("replacing a thread's participants records when the membership was read", async () => {
+        await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
+        const before = Date.now();
+        await repo.upsertThreadParticipants("t1", [ada, self]);
+        const after = Date.now();
+
+        const set = await repo.getThreadParticipantSet("t1");
+        expect(set.participants.map((p) => p.participantId)).toEqual([
+          ada.participantId,
+          self.participantId,
+        ]);
+        const readAt = set.lastReadAt?.getTime() ?? 0;
+        // Second-resolution storage: floor the window so a read taken at
+        // x.9s and stored as x.0s still lands inside it.
+        expect(readAt).toBeGreaterThanOrEqual(Math.floor(before / 1000) * 1000);
+        expect(readAt).toBeLessThanOrEqual(after);
+      });
+
+      it("a later read advances the last-read time", async () => {
+        await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
+        await repo.upsertThreadParticipants("t1", [ada]);
+        // Backdate the first read so the second is unambiguously newer than it.
+        testDb.db.run(
+          sql`UPDATE linkedin_threads SET participants_last_read_at = 1000 WHERE thread_id = 't1'`,
+        );
+
+        await repo.upsertThreadParticipants("t1", [ada, grace]);
+
+        const set = await repo.getThreadParticipantSet("t1");
+        expect(set.lastReadAt?.getTime()).toBeGreaterThan(1000 * 1000);
+      });
+
+      it("a re-read whose membership changed leaves the stored set matching it", async () => {
+        await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
+        await repo.upsertThreadParticipants("t1", [ada, grace, self]);
+        // Grace left, a new member joined.
+        await repo.upsertThreadParticipants("t1", [
+          ada,
+          self,
+          { ...grace, participantId: "ACoAANew00004", name: "New Person" },
+        ]);
+
+        const set = await repo.getThreadParticipantSet("t1");
+        expect(set.participants.map((p) => p.participantId).sort()).toEqual([
+          ada.participantId,
+          "ACoAANew00004",
+          self.participantId,
+        ]);
+        expect(set.lastReadAt).not.toBeNull();
+      });
+    });
+
+    // Every sender the mirror already stored carries its member id inside
+    // `linkedin_messages.sender_profile_url`, so the tables can be seeded from
+    // data on disk rather than a fresh crawl.
+    describe("backfill from stored messages", () => {
+      const message = (
+        threadId: string,
+        messageId: string,
+        overrides: Record<string, unknown> = {},
+      ) => ({
+        messageId,
+        threadId,
+        sentAt: new Date("2026-08-19T19:00:00Z"),
+        senderName: "Ada Lovelace",
+        senderProfileUrl: "https://www.linkedin.com/in/ACoAAAda0001/",
+        senderHeadline: "Engineer",
+        senderType: "member",
+        senderIsSelf: false,
+        text: "hi",
+        subject: null,
+        reactionCount: null,
+        ...overrides,
+      });
+
+      it("seeds participants and membership from stored messages", async () => {
+        await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
+        await repo.upsertMessages([
+          message("t1", "m1"),
+          message("t1", "m2", {
+            senderName: "Me Myself",
+            senderProfileUrl: "https://www.linkedin.com/in/ACoAASelf0003/",
+            senderIsSelf: true,
+            senderHeadline: null,
+          }),
+        ]);
+
+        const result = await repo.backfillParticipantsFromMessages();
+        expect(result.threads).toBe(1);
+        expect(result.participants).toBe(2);
+
+        const set = await repo.getThreadParticipantSet("t1");
+        expect(set.participants.map((p) => p.participantId)).toEqual([
+          "ACoAAAda0001",
+          "ACoAASelf0003",
+        ]);
+        const seeded = set.participants.find((p) => p.participantId === "ACoAAAda0001");
+        expect(seeded?.name).toBe("Ada Lovelace");
+        expect(seeded?.headline).toBe("Engineer");
+        expect(seeded?.type).toBe("member");
+        expect(set.participants.find((p) => p.participantId === "ACoAASelf0003")?.isSelf).toBe(
+          true,
+        );
+      });
+
+      it("a seeded thread is not marked as read — the seed is not an authoritative read", async () => {
+        await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
+        await repo.upsertMessages([message("t1", "m1")]);
+
+        await repo.backfillParticipantsFromMessages();
+
+        // Senders alone cannot prove membership: a lurker is invisible here, so
+        // the set must not claim the authority of a real participant read.
+        expect((await repo.getThreadParticipantSet("t1")).lastReadAt).toBeNull();
+      });
+
+      it("skips a thread whose membership has already been read", async () => {
+        await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
+        // The authoritative read says Grace is the only member; Ada has since
+        // left, even though her messages are still mirrored.
+        await repo.upsertThreadParticipants("t1", [grace]);
+        await repo.upsertMessages([message("t1", "m1")]);
+
+        const result = await repo.backfillParticipantsFromMessages();
+        expect(result.threads).toBe(0);
+
+        expect((await repo.getThreadParticipants("t1")).map((p) => p.participantId)).toEqual([
+          grace.participantId,
+        ]);
+      });
+
+      it("is idempotent and never duplicates an identity across threads", async () => {
+        await repo.upsertThreads([
+          thread("t1", new Date("2026-08-19T20:00:00Z")),
+          thread("t2", new Date("2026-08-18T20:00:00Z")),
+        ]);
+        await repo.upsertMessages([message("t1", "m1"), message("t2", "m2")]);
+
+        await repo.backfillParticipantsFromMessages();
+        await repo.backfillParticipantsFromMessages();
+
+        const identities = testDb.db.all(
+          sql`SELECT participant_id FROM linkedin_participants`,
+        ) as Array<{ participant_id: string }>;
+        expect(identities.map((r) => r.participant_id)).toEqual(["ACoAAAda0001"]);
+        expect(await repo.getParticipantThreadIds("ACoAAAda0001")).toEqual(["t1", "t2"]);
+      });
+
+      it("keeps facts an authoritative read already learned", async () => {
+        await repo.upsertThreads([
+          thread("t1", new Date("2026-08-19T20:00:00Z")),
+          thread("t2", new Date("2026-08-18T20:00:00Z")),
+        ]);
+        // t1 was read properly and learned Ada's headline; t2 only has her
+        // messages, which report a stale headline.
+        await repo.upsertThreadParticipants("t1", [{ ...ada, headline: "Countess of Lovelace" }]);
+        await repo.upsertMessages([message("t2", "m1", { senderHeadline: "Engineer" })]);
+
+        await repo.backfillParticipantsFromMessages();
+
+        const t2 = await repo.getThreadParticipants("t2");
+        expect(t2[0]?.headline).toBe("Countess of Lovelace");
+      });
+
+      it("ignores senders whose profile URL carries no member id", async () => {
+        await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
+        await repo.upsertMessages([
+          // A vanity URL is a public handle, not the member id the participant
+          // tables key on, so it must not become a participant_id.
+          message("t1", "m1", { senderProfileUrl: "https://www.linkedin.com/in/ada-lovelace/" }),
+          message("t1", "m2", { senderProfileUrl: null }),
+          message("t1", "m3"),
+        ]);
+
+        const result = await repo.backfillParticipantsFromMessages();
+        expect(result.participants).toBe(1);
+        expect((await repo.getThreadParticipants("t1")).map((p) => p.participantId)).toEqual([
+          "ACoAAAda0001",
+        ]);
+      });
+    });
+  });
+});
+
+describe("linkedInMemberIdFromProfileUrl", () => {
+  it("extracts the member id from the stored profile URL forms", () => {
+    expect(linkedInMemberIdFromProfileUrl("https://www.linkedin.com/in/ACoAAAda0001/")).toBe(
+      "ACoAAAda0001",
+    );
+    expect(
+      linkedInMemberIdFromProfileUrl("https://www.linkedin.com/in/ACoAAAda0001?trk=messaging"),
+    ).toBe("ACoAAAda0001");
+    expect(linkedInMemberIdFromProfileUrl("/in/ACoAAAda0001/")).toBe("ACoAAAda0001");
+  });
+
+  it("returns null for anything that is not a member id", () => {
+    expect(linkedInMemberIdFromProfileUrl("https://www.linkedin.com/in/ada-lovelace/")).toBeNull();
+    expect(linkedInMemberIdFromProfileUrl("https://www.linkedin.com/company/acme/")).toBeNull();
+    expect(linkedInMemberIdFromProfileUrl(null)).toBeNull();
+    expect(linkedInMemberIdFromProfileUrl("")).toBeNull();
   });
 });

--- a/packages/core/src/db/repositories/linkedin-store.ts
+++ b/packages/core/src/db/repositories/linkedin-store.ts
@@ -53,6 +53,34 @@ export interface LinkedInMessageRow {
   reactionCount: number | null;
 }
 
+/** One thread's membership paired with the age of the read that produced it. */
+export interface LinkedInThreadParticipantSet {
+  participants: LinkedInParticipantRow[];
+  /** When the membership was last read from LinkedIn; null when never. */
+  lastReadAt: Date | null;
+}
+
+/** What one backfill pass touched. */
+export interface LinkedInParticipantBackfillResult {
+  /** Threads seeded — threads already read authoritatively are skipped. */
+  threads: number;
+  /** Distinct identities the seed proved. */
+  participants: number;
+}
+
+// The obfuscated member id inside a mirrored profile URL —
+// `https://www.linkedin.com/in/ACoAA…/`. A vanity handle (`/in/ada-lovelace`)
+// deliberately does not match: it is a public alias, not the member id these
+// tables key on, and storing one would break the correspondence with
+// `channel_mappings.channel_user_id`.
+const MEMBER_ID_IN_PROFILE_URL = /\/in\/(ACoAA[A-Za-z0-9_-]+)/;
+
+/** The bare LinkedIn member id inside a stored profile URL, or null. */
+export function linkedInMemberIdFromProfileUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  return MEMBER_ID_IN_PROFILE_URL.exec(url)?.[1] ?? null;
+}
+
 function chunked<T>(items: T[], size: number): T[][] {
   const out: T[][] = [];
   for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
@@ -279,6 +307,11 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
    *
    * Identity rows outlive membership: a person dropped from one thread keeps
    * their row for the other threads they are in.
+   *
+   * The same transaction stamps the thread's `participants_last_read_at`. Every
+   * call here IS an authoritative read of the membership, and recording it
+   * atomically with the set makes it impossible to claim a read that did not
+   * land — or to land a set that then looks like it was never read.
    */
   async upsertThreadParticipants(
     threadId: string,
@@ -347,7 +380,116 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
               ),
         )
         .run();
+
+      // The membership is only as good as the read it came from, so the age of
+      // that read is stored with it. A no-op when the listing has not created
+      // the thread row yet — the next listing will.
+      tx.update(linkedinThreads)
+        .set({ participantsLastReadAt: now, updatedAt: now })
+        .where(eq(linkedinThreads.threadId, threadId))
+        .run();
     });
+  }
+
+  /**
+   * One thread's membership together with when it was read. Prefer this over
+   * {@link getThreadParticipants} wherever the answer's authority matters: a
+   * null `lastReadAt` means nothing has ever read this thread's membership, so
+   * the rows are at best a seed inferred from stored messages.
+   */
+  async getThreadParticipantSet(threadId: string): Promise<LinkedInThreadParticipantSet> {
+    const [participants, rows] = await Promise.all([
+      this.getThreadParticipants(threadId),
+      this.db
+        .select({ participantsLastReadAt: linkedinThreads.participantsLastReadAt })
+        .from(linkedinThreads)
+        .where(eq(linkedinThreads.threadId, threadId))
+        .limit(1),
+    ]);
+    return { participants, lastReadAt: rows[0]?.participantsLastReadAt ?? null };
+  }
+
+  /**
+   * Seed the participant tables from messages already mirrored. Every sender
+   * the mirror recorded carries their member id inside
+   * `linkedin_messages.sender_profile_url`, so an inbox that has been polled
+   * for a while already knows most of its participants without a new crawl.
+   *
+   * Two properties keep the seed honest:
+   *   - it is additive (insert-or-ignore, never a delete), because senders
+   *     prove presence but their absence proves nothing; and
+   *   - it never stamps `participants_last_read_at`, and skips any thread that
+   *     already carries one. A real read is authoritative and must not be
+   *     re-polluted by a member who has since left but whose messages remain.
+   */
+  async backfillParticipantsFromMessages(): Promise<LinkedInParticipantBackfillResult> {
+    const now = new Date();
+    // Newest message last, so a later message's facts win for a given sender.
+    const rows = (await this.db.all(sql`
+      SELECT
+        m.thread_id AS threadId,
+        m.sender_profile_url AS senderProfileUrl,
+        m.sender_name AS senderName,
+        m.sender_headline AS senderHeadline,
+        m.sender_type AS senderType,
+        m.sender_is_self AS senderIsSelf
+      FROM linkedin_messages m
+      JOIN linkedin_threads t ON t.thread_id = m.thread_id
+      WHERE t.participants_last_read_at IS NULL
+        AND m.sender_profile_url IS NOT NULL
+      ORDER BY coalesce(m.sent_at, m.created_at) ASC, m.rowid ASC
+    `)) as Array<Record<string, unknown>>;
+
+    const identities = new Map<string, LinkedInParticipantInput>();
+    const memberships = new Map<string, { threadId: string; participantId: string }>();
+    for (const row of rows) {
+      const participantId = linkedInMemberIdFromProfileUrl(row.senderProfileUrl as string | null);
+      if (!participantId) continue;
+      const threadId = String(row.threadId);
+      identities.set(participantId, {
+        participantId,
+        name: (row.senderName as string | null) ?? null,
+        headline: (row.senderHeadline as string | null) ?? null,
+        type: (row.senderType as string | null) ?? null,
+        isSelf: Boolean(row.senderIsSelf),
+      });
+      memberships.set(`${threadId}\u0000${participantId}`, { threadId, participantId });
+    }
+    if (memberships.size === 0) return { threads: 0, participants: 0 };
+
+    await this.db.transaction((tx) => {
+      for (const chunk of chunked([...identities.values()], UPSERT_CHUNK)) {
+        tx.insert(linkedinParticipants)
+          .values(
+            chunk.map((p) => ({
+              participantId: p.participantId,
+              name: p.name ?? null,
+              headline: p.headline ?? null,
+              type: p.type ?? null,
+              isSelf: p.isSelf,
+              firstSyncedAt: now,
+              updatedAt: now,
+            })),
+          )
+          // A sender row is weaker evidence than a participant read, so it only
+          // fills gaps: an existing fact — including `is_self`, which a real
+          // read answers for the viewer — is left exactly as it was.
+          .onConflictDoNothing()
+          .run();
+      }
+
+      for (const chunk of chunked([...memberships.values()], UPSERT_CHUNK)) {
+        tx.insert(linkedinThreadParticipants)
+          .values(chunk.map((m) => ({ ...m, firstSyncedAt: now })))
+          .onConflictDoNothing()
+          .run();
+      }
+    });
+
+    return {
+      threads: new Set([...memberships.values()].map((m) => m.threadId)).size,
+      participants: identities.size,
+    };
   }
 
   /** One thread's participants with their person-level facts, by member id. */

--- a/packages/core/src/db/schema/system.ts
+++ b/packages/core/src/db/schema/system.ts
@@ -199,6 +199,12 @@ export const linkedinThreads = sqliteTable("linkedin_threads", {
   // LinkedIn inbox categories, e.g. 'INBOX,PRIMARY_INBOX'.
   category: text("category"),
   lastSyncedAt: integer("last_synced_at", { mode: "timestamp" }),
+  // When this thread's membership was last read from LinkedIn. The participant
+  // tables are a cache of a pull-only mirror, so a reader has to be able to
+  // tell how old the set is. Null means the membership has never been read
+  // authoritatively — including a thread seeded from stored messages, where
+  // senders alone cannot prove membership and a lurker is invisible.
+  participantsLastReadAt: integer("participants_last_read_at", { mode: "timestamp" }),
   firstSyncedAt: integer("first_synced_at", { mode: "timestamp" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });


### PR DESCRIPTION
## Summary

The participant tables shipped dormant in #14 and the opencli command that fills them landed in #13, so a thread's membership was knowable but never known. This wires the two together.

- **The poller fills the tables.** After a thread snapshot completes, `syncThreadParticipants` reads that thread's participant list via a new `readLinkedInThreadParticipants` wrapper (beside the existing snapshot and reply wrappers in `linkedin-cli.ts`) and replaces the stored set. It is a separate command rather than a by-product of the snapshot because snapshot rows only prove senders — `thread-participants` reads the conversation's own participant reference list, so a member who has never posted is stored too.
- **The cache says how old it is.** `linkedin_threads` gains `participants_last_read_at` (migration `0058`), stamped inside the same transaction as the replace, so it is impossible to claim a read that did not land or to store a set that then looks like it was never read. `getThreadParticipantSet` returns the membership together with the age of the read that produced it.
- **The backfill costs no crawl.** `backfillParticipantsFromMessages` seeds from rows already on disk — `linkedin_messages.sender_profile_url` holds the `.../in/ACoAA…` form, so every sender already mirrored is a participant. The seed stays deliberately weaker than a read: additive only, never stamping `participants_last_read_at`, and skipping any thread that already carries one. Senders prove presence but their absence proves nothing, so a seed must not re-add someone a real read saw leave. A vanity handle (`/in/ada-lovelace`) is rejected rather than stored as a member id.
- **Faults follow the existing split.** A failed participant read records nothing rather than costing the tick the messages it already mirrored; a signed-out session still fails the tick so the grant owner hears about it. A sink that cannot store membership is never made to pay for the crawl.

Out of scope, per the issue: promotion into `persons`, deriving the participant count, and any UI.

Closes rome-os/rome#8

## Test plan

Tests were written first from the issue's acceptance criteria, then the implementation made them pass.

- [x] `linkedin-cli.test.ts` — `parseThreadParticipants` returns one record per participant, keeps a participant who has sent no message, drops rows with no member id, normalizes the plugin's `""` to null, fails closed on an auth wall and on shape drift, and rejects an empty read (which the store would read as "everyone left")
- [x] `linkedin.test.ts` — a polled thread's participants are stored; a non-sender is stored; a re-poll whose membership changed stores the latest read; a failed participant read leaves the message snapshot standing; an auth wall still fails the tick; the seed runs once per start with no extra opencli call; a sink that cannot store membership is never crawled
- [x] `linkedin-store.test.ts` — the migration adds the column; a never-read thread reports a null last-read time; a replace records and advances it; a changed membership matches the latest read; the backfill seeds identities and membership, leaves the thread unread, skips already-read threads, is idempotent, keeps facts an authoritative read learned, and ignores senders with no member id
- [x] `pnpm typecheck` clean; `biome check` clean on all touched files
- [x] Core unit suite: 3828 tests pass (2 pre-existing suites — `terminal-server`, `auth-me` — fail only because `node-pty` has no native build in this sandbox, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)