### PR TITLE
fix(core): make addConversationMessage's write atomic

### DIFF
--- a/packages/core/src/db/repositories/webchat.test.ts
+++ b/packages/core/src/db/repositories/webchat.test.ts
@@ -1,8 +1,34 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { eq, sql } from "drizzle-orm";
 import { createTestDb, type TestDb } from "../../test/helpers.js";
+import type { DrizzleDb } from "../index.js";
 import { romeAgentMessages, romeSessions, romeAgentTraceBlocks } from "../schema.js";
 import { WebChatRepository, channelConversationId, validateTurnRecapAudioUrl } from "./webchat.js";
+
+// Records which statement entry points (`select`, `insert`, `update`, `delete`,
+// `transaction`) a repository reaches for on the connection itself, so a test
+// can assert a write goes through one transaction rather than as separate
+// autocommit statements.
+function trackStatements(db: DrizzleDb): { db: DrizzleDb; statements: string[] } {
+  const statements: string[] = [];
+  const tracked = new Proxy(db as object, {
+    get(target, prop) {
+      const value = Reflect.get(target, prop);
+      if (typeof value !== "function") return value;
+      if (
+        prop === "select" ||
+        prop === "insert" ||
+        prop === "update" ||
+        prop === "delete" ||
+        prop === "transaction"
+      ) {
+        statements.push(prop);
+      }
+      return value.bind(target);
+    },
+  }) as DrizzleDb;
+  return { db: tracked, statements };
+}
 
 describe("WebChatRepository", () => {
   let testDb: TestDb;
@@ -115,6 +141,116 @@ describe("WebChatRepository", () => {
       await expect(
         repo.addConversationMessage({ ...message, sessionId: second.id }),
       ).resolves.toEqual({ inserted: true });
+    });
+
+    describe("addConversationMessage atomicity", () => {
+      it("writes the message and the session activity update through one transaction", async () => {
+        const conversation = await repo.ensureChannelConversation({
+          channel: "telegram",
+          threadId: "atomic-single-transaction",
+          agentName: "main",
+        });
+        const { db, statements } = trackStatements(testDb.db);
+        const trackedRepo = new WebChatRepository(db);
+
+        await expect(
+          trackedRepo.addConversationMessage({
+            sessionId: conversation.id,
+            role: "user",
+            content: textContent("hello"),
+            platformMessageId: "atomic-1",
+            createdAt: new Date("2026-08-03T09:00:00.000Z"),
+          }),
+        ).resolves.toEqual({ inserted: true });
+
+        expect(statements).toEqual(["transaction"]);
+      });
+
+      it("returns { inserted: false } for a duplicate platform message id without advancing session activity", async () => {
+        const conversation = await repo.ensureChannelConversation({
+          channel: "telegram",
+          threadId: "atomic-duplicate",
+          agentName: "main",
+        });
+        const message = {
+          sessionId: conversation.id,
+          role: "user" as const,
+          content: textContent("hello"),
+          platformMessageId: "atomic-duplicate-1",
+        };
+        await expect(
+          repo.addConversationMessage({
+            ...message,
+            createdAt: new Date("2026-08-03T09:00:00.000Z"),
+          }),
+        ).resolves.toEqual({ inserted: true });
+        const [afterInsert] = await testDb.db
+          .select()
+          .from(romeSessions)
+          .where(eq(romeSessions.id, conversation.id));
+
+        await expect(
+          repo.addConversationMessage({
+            ...message,
+            content: textContent("hello again"),
+            createdAt: new Date("2026-08-03T10:00:00.000Z"),
+          }),
+        ).resolves.toEqual({ inserted: false });
+
+        const [afterDuplicate] = await testDb.db
+          .select()
+          .from(romeSessions)
+          .where(eq(romeSessions.id, conversation.id));
+        expect(afterDuplicate.activityAt.getTime()).toBe(afterInsert.activityAt.getTime());
+        const rows = await testDb.db
+          .select({ content: romeAgentMessages.content })
+          .from(romeAgentMessages)
+          .where(eq(romeAgentMessages.sessionId, conversation.id));
+        expect(rows).toEqual([{ content: textContent("hello") }]);
+      });
+
+      it("leaves no message row behind when the session activity update fails", async () => {
+        const conversation = await repo.ensureChannelConversation({
+          channel: "telegram",
+          threadId: "atomic-rollback",
+          agentName: "main",
+        });
+        const [before] = await testDb.db
+          .select()
+          .from(romeSessions)
+          .where(eq(romeSessions.id, conversation.id));
+        // Fail the activity write at the database, the way a constraint or a
+        // disk error would, so the assertion is about the rollback and not
+        // about a stubbed repository method.
+        testDb.db.run(sql`
+          CREATE TRIGGER reject_session_activity_update
+          BEFORE UPDATE OF activity_at ON rome_sessions
+          BEGIN
+            SELECT RAISE(ABORT, 'session activity update failed');
+          END;
+        `);
+
+        await expect(
+          repo.addConversationMessage({
+            sessionId: conversation.id,
+            role: "user",
+            content: textContent("hello"),
+            platformMessageId: "atomic-rollback-1",
+            createdAt: new Date("2026-08-03T09:00:00.000Z"),
+          }),
+        ).rejects.toThrow(/session activity update failed/);
+
+        const rows = await testDb.db
+          .select()
+          .from(romeAgentMessages)
+          .where(eq(romeAgentMessages.sessionId, conversation.id));
+        expect(rows).toEqual([]);
+        const [after] = await testDb.db
+          .select()
+          .from(romeSessions)
+          .where(eq(romeSessions.id, conversation.id));
+        expect(after.activityAt.getTime()).toBe(before.activityAt.getTime());
+      });
     });
 
     it("loads pending notifications and the exact replied-to message, then marks only notifications injected", async () => {

--- a/packages/core/src/db/repositories/webchat.ts
+++ b/packages/core/src/db/repositories/webchat.ts
@@ -859,30 +859,37 @@ export class WebChatRepository {
     createdAt?: Date;
   }): Promise<{ inserted: boolean }> {
     const createdAt = input.createdAt ?? new Date();
-    const rows = await this.db
-      .insert(romeAgentMessages)
-      .values({
-        id: conversationPlatformMessageId(input.sessionId, input.platformMessageId),
-        sessionId: input.sessionId,
-        turnId: null,
-        role: input.role,
-        content: input.content,
-        platformMessageId: input.platformMessageId,
-        senderId: input.senderId ?? null,
-        senderName: input.senderName ?? null,
-        replyToPlatformMessageId: input.replyToPlatformMessageId ?? null,
-        contextInjectedTurnId: null,
-        createdAt,
-      })
-      .onConflictDoNothing()
-      .returning({ id: romeAgentMessages.id });
-    if (rows.length > 0) {
-      await this.db
-        .update(romeSessions)
+    // The row and the session activity it advances are one fact. Splitting them
+    // across two writes lets a failure in between store the message against
+    // stale activity, which sorts the conversation by the wrong timestamp.
+    return this.db.transaction((tx) => {
+      const rows = tx
+        .insert(romeAgentMessages)
+        .values({
+          id: conversationPlatformMessageId(input.sessionId, input.platformMessageId),
+          sessionId: input.sessionId,
+          turnId: null,
+          role: input.role,
+          content: input.content,
+          platformMessageId: input.platformMessageId,
+          senderId: input.senderId ?? null,
+          senderName: input.senderName ?? null,
+          replyToPlatformMessageId: input.replyToPlatformMessageId ?? null,
+          contextInjectedTurnId: null,
+          createdAt,
+        })
+        .onConflictDoNothing()
+        .returning({ id: romeAgentMessages.id })
+        .all();
+      // A platform message id we already stored is a redelivery, not new
+      // activity — leave the session's timestamp where it is.
+      if (rows.length === 0) return { inserted: false };
+      tx.update(romeSessions)
         .set(advanceSessionActivitySet(createdAt))
-        .where(eq(romeSessions.id, input.sessionId));
-    }
-    return { inserted: rows.length > 0 };
+        .where(eq(romeSessions.id, input.sessionId))
+        .run();
+      return { inserted: true };
+    });
   }
 
   async promoteConversationMessageToUser(


### PR DESCRIPTION
## Problem

`WebChatRepository.addConversationMessage` inserted the message, awaited it, then updated the session's activity columns as a separate write. A failure in between stores the row against stale session activity, so the conversation sorts by the wrong timestamp — and because the platform message id is de-duplicated, a redelivery returns `{ inserted: false }` and never repairs it.

Its siblings `addMessage` and `recordOutboundConversationMessage` already wrap the same pair in `this.db.transaction`.

## Change

- Wrap the insert and the activity update in one `this.db.transaction` call.
- The insert's `.returning()` gains the synchronous `.all()` terminal the better-sqlite3 transaction scope requires; the early return on an empty result keeps a duplicate platform message id from advancing session activity.
- `{ inserted: boolean }`, the `onConflictDoNothing` de-duplication, and every caller are unchanged. `promoteConversationMessageToUser` and `assignConversationMessageTurn` are untouched, per the issue.

## Tests

Written first, against the acceptance criteria, all three failing before the change:

- **one transaction** — a `Proxy` over the connection records which statement entry points the repository reaches for; the write must show up as `["transaction"]`, not `["insert", "update"]`.
- **duplicate is inert** — a repeated platform message id returns `{ inserted: false }`, leaves `activity_at` where it was, and does not overwrite the stored content.
- **rollback** — a `BEFORE UPDATE OF activity_at` trigger aborts the activity write at the database, the way a constraint or disk error would, and the message row must be absent afterward with session activity unmoved.

The duplicate case passed before the change too and stays as a regression guard, since the issue asks for that behavior to be preserved.

`packages/core` unit suite: 3836 passed. (`terminal-server` / `auth-me` fail to collect in this sandbox because `node-pty` has no prebuilt binary here — pre-existing and unrelated.) Typecheck and biome clean.

Closes rome-os/rome#17

🤖 Generated with [Claude Code](https://claude.com/claude-code)