### PR TITLE
feat(welcome): localize onboarding flow

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
           packages = [
             pkgs.nodejs_24
             pkgs.pnpm
+            pkgs.git
             # node-gyp drives the build with python3 + make + a compiler. make
             # comes from stdenv and cc from mkShell; python3 has to be asked
             # for by name, and node-gyp checks for it first, so a missing

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test": "pnpm --filter @rome-os/libs test && pnpm --filter @rome/discord-cli test && pnpm --filter @rome/core test && pnpm --filter rome-web test && pnpm --filter @rome-os/ui test && pnpm test:ui:padding && pnpm test:ui:tokens && pnpm test:ui:contract && pnpm test:ui:radius",
     "test:watch": "pnpm --filter @rome/core test:watch",
     "test:unit": "pnpm test:unit:rest && pnpm test:unit:core && pnpm test:unit:web",
+    "test:welcome": "pnpm --filter @rome/core exec vitest run --config vitest.config.ts ../../rome_apps/welcome-to-rome/src/locale.test.ts ../../rome_apps/welcome-to-rome/src/api/index.test.ts ../../rome_apps/welcome-to-rome/src/hooks/turn-middleware/script.test.ts && pnpm --filter rome-web exec vitest run src/components/chat/blocks/QuestionCard.test.tsx",
     "test:unit:core": "pnpm --filter @rome/core test:unit",
     "test:unit:web": "pnpm --filter rome-web test && pnpm --filter @rome-os/ui test",
     "test:unit:rest": "pnpm --filter @rome-os/libs test && pnpm --filter @rome/discord-cli test && pnpm --filter rome-desktop test && pnpm test:ci:areas && pnpm test:obs:dashboards && pnpm test:ui:padding && pnpm test:ui:tokens && pnpm test:ui:contract && pnpm test:ui:radius",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "test": "pnpm --filter @rome-os/libs test && pnpm --filter @rome/discord-cli test && pnpm --filter @rome/core test && pnpm --filter rome-web test && pnpm --filter @rome-os/ui test && pnpm test:ui:padding && pnpm test:ui:tokens && pnpm test:ui:contract && pnpm test:ui:radius",
     "test:watch": "pnpm --filter @rome/core test:watch",
     "test:unit": "pnpm test:unit:rest && pnpm test:unit:core && pnpm test:unit:web",
-    "test:welcome": "pnpm --filter @rome/core exec vitest run --config vitest.config.ts ../../rome_apps/welcome-to-rome/src/locale.test.ts ../../rome_apps/welcome-to-rome/src/api/index.test.ts ../../rome_apps/welcome-to-rome/src/hooks/turn-middleware/script.test.ts && pnpm --filter rome-web exec vitest run src/components/chat/blocks/QuestionCard.test.tsx",
     "test:unit:core": "pnpm --filter @rome/core test:unit",
     "test:unit:web": "pnpm --filter rome-web test && pnpm --filter @rome-os/ui test",
     "test:unit:rest": "pnpm --filter @rome-os/libs test && pnpm --filter @rome/discord-cli test && pnpm --filter rome-desktop test && pnpm test:ci:areas && pnpm test:obs:dashboards && pnpm test:ui:padding && pnpm test:ui:tokens && pnpm test:ui:contract && pnpm test:ui:radius",

--- a/packages/web/src/components/chat/blocks/QuestionCard.test.tsx
+++ b/packages/web/src/components/chat/blocks/QuestionCard.test.tsx
@@ -3,10 +3,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QuestionCard } from "./QuestionCard";
+import i18n from "@/i18n";
 
-afterEach(() => {
+afterEach(async () => {
   cleanup();
   vi.restoreAllMocks();
+  await i18n.changeLanguage("en");
 });
 
 const MULTI_PROPS = {
@@ -54,6 +56,32 @@ describe("QuestionCard — multi-choice", () => {
       { answers: [{ questionId: "interests", value: "AI, Finance" }] },
       "AI, Finance",
     );
+  });
+
+  it("uses the active Rome language for the card controls", async () => {
+    await i18n.changeLanguage("zh-CN");
+    renderCard({
+      questions: [
+        {
+          id: "interests",
+          question: "你感兴趣什么？",
+          type: "multi",
+          options: ["人工智能"],
+          freeText: true,
+        },
+        {
+          id: "note",
+          question: "其他信息",
+          type: "text",
+          optional: true,
+        },
+      ],
+    });
+
+    expect(screen.getByText("可选")).toBeTruthy();
+    expect(screen.getByPlaceholderText("添加自己的选项…")).toBeTruthy();
+    expect(screen.getByPlaceholderText("输入你的答案…")).toBeTruthy();
+    expect(optionButton("发送")).toBeTruthy();
   });
 
   it("toggles an option off when tapped twice", async () => {

--- a/packages/web/src/components/chat/blocks/QuestionCard.tsx
+++ b/packages/web/src/components/chat/blocks/QuestionCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
@@ -88,6 +89,7 @@ export interface QuestionCardProps {
 }
 
 export function QuestionCard({ toolUseId, props, result, onSubmit, onDismiss }: QuestionCardProps) {
+  const { t } = useTranslation("chat");
   const questions = parseQuestions(props);
   const resolved = result !== undefined;
   // Dismissed (the guardian skipped the card — tapped Dismiss, or answered in
@@ -169,7 +171,9 @@ export function QuestionCard({ toolUseId, props, result, onSubmit, onDismiss }: 
               <FieldLabel>
                 {q.question}
                 {q.optional ? (
-                  <span className="ml-2 text-aux text-muted-foreground">optional</span>
+                  <span className="ml-2 text-aux text-muted-foreground">
+                    {t("questionCard.optional")}
+                  </span>
                 ) : null}
               </FieldLabel>
               {q.type === "single" || q.type === "multi" ? (
@@ -225,7 +229,7 @@ export function QuestionCard({ toolUseId, props, result, onSubmit, onDismiss }: 
                             multi || !options.includes(drafts[q.id]) ? (drafts[q.id] ?? "") : ""
                           }
                           onChange={(e) => setDrafts((d) => ({ ...d, [q.id]: e.target.value }))}
-                          placeholder={multi ? "Add your own…" : "Or type your own…"}
+                          placeholder={multi ? t("questionCard.addOwn") : t("questionCard.typeOwn")}
                           className={cn("text-ui", stacked ? "w-full" : "min-w-[10rem] flex-1")}
                         />
                       ) : null}
@@ -238,7 +242,7 @@ export function QuestionCard({ toolUseId, props, result, onSubmit, onDismiss }: 
                   onChange={(e) => setDrafts((d) => ({ ...d, [q.id]: e.target.value }))}
                   rows={2}
                   className="resize-none"
-                  placeholder="Type your answer…"
+                  placeholder={t("questionCard.typeAnswer")}
                 />
               )}
             </Field>
@@ -248,15 +252,19 @@ export function QuestionCard({ toolUseId, props, result, onSubmit, onDismiss }: 
 
       <div className="flex items-center justify-between gap-3 border-t border-border px-4 py-3">
         <span className="text-aux text-muted-foreground">
-          {locked ? (dismissed ? "Dismissed" : "Answered") : "Asked by Rome"}
+          {locked
+            ? dismissed
+              ? t("questionCard.dismissed")
+              : t("questionCard.answered")
+            : t("questionCard.askedByRome")}
         </span>
         {!locked && (
           <div className="flex gap-2">
             <Button type="button" variant="ghost" size="sm" onClick={() => onDismiss(toolUseId)}>
-              Dismiss
+              {t("questionCard.dismiss")}
             </Button>
             <Button type="button" size="sm" onClick={submit} disabled={!allAnswered}>
-              Send
+              {t("questionCard.send")}
             </Button>
           </div>
         )}

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -209,6 +209,17 @@
     "stop": "Stop",
     "stopGenerating": "Stop generating"
   },
+  "questionCard": {
+    "optional": "optional",
+    "addOwn": "Add your own…",
+    "typeOwn": "Or type your own…",
+    "typeAnswer": "Type your answer…",
+    "dismissed": "Dismissed",
+    "answered": "Answered",
+    "askedByRome": "Asked by Rome",
+    "dismiss": "Dismiss",
+    "send": "Send"
+  },
   "modelSelector": {
     "label": "Model",
     "saveFailed": "Failed to save model selection.",

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -209,6 +209,17 @@
     "stop": "停止",
     "stopGenerating": "停止生成"
   },
+  "questionCard": {
+    "optional": "可选",
+    "addOwn": "添加自己的选项…",
+    "typeOwn": "或输入自己的答案…",
+    "typeAnswer": "输入你的答案…",
+    "dismissed": "已跳过",
+    "answered": "已回答",
+    "askedByRome": "Rome 正在提问",
+    "dismiss": "跳过",
+    "send": "发送"
+  },
   "modelSelector": {
     "label": "模型",
     "saveFailed": "保存模型选择失败。",

--- a/rome_apps/welcome-to-rome/src/api/index.test.ts
+++ b/rome_apps/welcome-to-rome/src/api/index.test.ts
@@ -1,0 +1,59 @@
+import type { RomeAppApiRequest, RomeAppContext } from "@rome-os/app-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ reset: vi.fn() }));
+
+vi.mock("../db/repositories/progress.js", async (importActual) => ({
+  ...(await importActual<typeof import("../db/repositories/progress.js")>()),
+  createProgressRepository: () => ({ reset: mocks.reset }),
+}));
+
+import { createApiHandler } from "./index.js";
+
+function createContext(): RomeAppContext {
+  return {
+    app: { id: "welcome-to-rome", version: "0.1.0", description: "Welcome" },
+    controller: {},
+    db: {} as never,
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    repositories: { settings: { get: vi.fn(), set: vi.fn(async () => undefined) } },
+    runAction: vi.fn(),
+    listRoutines: vi.fn(),
+  };
+}
+
+function resetRequest(locale: unknown): RomeAppApiRequest {
+  return {
+    method: "POST",
+    path: ["reset"],
+    headers: {},
+    query: new URLSearchParams(),
+    caller: { kind: "guardian", userId: "u1", via: "cookie" },
+    body: new TextEncoder().encode(JSON.stringify({ locale })),
+  };
+}
+
+describe("welcome API", () => {
+  beforeEach(() => {
+    mocks.reset.mockReset();
+  });
+
+  it("persists the landing locale before resetting the scripted flow", async () => {
+    const ctx = createContext();
+
+    const response = await createApiHandler(ctx).handle(resetRequest("zh-CN"));
+
+    expect(response.status).toBe(200);
+    expect(ctx.repositories.settings.set).toHaveBeenCalledWith("guardianLanguage", "zh-CN");
+    expect(mocks.reset).toHaveBeenCalledOnce();
+  });
+
+  it("does not overwrite the language for an unsupported locale", async () => {
+    const ctx = createContext();
+
+    await createApiHandler(ctx).handle(resetRequest("zh-TW"));
+
+    expect(ctx.repositories.settings.set).not.toHaveBeenCalled();
+    expect(mocks.reset).toHaveBeenCalledOnce();
+  });
+});

--- a/rome_apps/welcome-to-rome/src/api/index.ts
+++ b/rome_apps/welcome-to-rome/src/api/index.ts
@@ -1,12 +1,25 @@
 import type { RomeAppApiHandler, RomeAppApiRequest, RomeAppContext } from "@rome-os/app-runtime";
 import { createProgressRepository } from "../db/repositories/progress.js";
+import { welcomeLocaleFromCode, type WelcomeLocale } from "../locale.js";
+
+function requestLocale(request: RomeAppApiRequest): WelcomeLocale | undefined {
+  if (!request.body || request.body.byteLength === 0) return undefined;
+  try {
+    const body = JSON.parse(new TextDecoder().decode(request.body));
+    if (!body || typeof body !== "object" || !("locale" in body)) return undefined;
+    return welcomeLocaleFromCode((body as { locale?: unknown }).locale);
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * welcome-to-rome app API. The only real route is `POST /reset`, which the
  * landing screen (src/web/App.tsx) calls before starting a chat so every entry
- * from the welcome screen replays the flow from a clean slate. Reset scope is
- * intentionally just the progress row — no memory, settings, or
- * transcript is touched.
+ * from the welcome screen replays the flow from a clean slate. When supplied,
+ * the locale is persisted as the guardian's language before the chat starts.
+ * Reset scope otherwise stays intentionally narrow: no memory or transcript is
+ * touched.
  */
 class WelcomeApiHandler implements RomeAppApiHandler {
   constructor(private readonly ctx: RomeAppContext) {}
@@ -24,6 +37,8 @@ class WelcomeApiHandler implements RomeAppApiHandler {
     }
 
     if (request.method === "POST" && route === "reset") {
+      const locale = requestLocale(request);
+      if (locale) await this.ctx.repositories.settings.set("guardianLanguage", locale);
       const progress = createProgressRepository(this.ctx.db);
       progress.reset();
       return Response.json({ ok: true });

--- a/rome_apps/welcome-to-rome/src/hooks/turn-middleware/copy.ts
+++ b/rome_apps/welcome-to-rome/src/hooks/turn-middleware/copy.ts
@@ -1,9 +1,9 @@
-// User-facing strings for the scripted conversation, kept apart from the
-// state-machine logic. Most interactive UI now lives in the app's
-// own inline components (src/web/*.tsx); what's left here is conversational
-// narration (text blocks) and the structured props for the completion card.
+// User-facing strings for the scripted conversation live in the app's locale
+// JSON. This adapter only interpolates runtime values and shapes component props.
 
 import type { AppIdea } from "../../db/repositories/progress.js";
+import { formatMessage, messagesFor, type WelcomeMessages } from "../../i18n/locales/index.js";
+import type { WelcomeLocale } from "../../locale.js";
 
 /** Props for the `completion-card` inline component. */
 export interface CompletionProps {
@@ -12,81 +12,55 @@ export interface CompletionProps {
   kickoffPrompt?: string;
 }
 
-export const copy = {
-  // --- Email handshake (the first onboarding step) ---
-  // Lead-in above the email-handshake card. The card itself shows the two
-  // addresses, so the text just sets up why.
-  emailIntro: (agentName: string) =>
-    [
-      `👋 Hi — I'm ${agentName}.`,
-      "",
-      "First things first: let's make sure we can reach each other by email. Here's my address and the one I have for you — give it a look, and I'll send you a quick hello.",
-    ].join("\n"),
-  // Lead-in above the email-receipt card, shown right after the hello is sent.
-  emailSentLead: "📬 Sent! It should land in a few seconds.",
-  // The hello email itself, sent by the script (no agent) via send_message.
-  // The body is Markdown — send_message renders it to HTML when no `html` is
-  // given, and a Markdown email theme will dress it up later.
-  helloEmailSubject: "Hello from Rome 👋",
-  helloEmailBody: (agentName: string) =>
-    [
-      "# Hello 👋",
-      "",
-      `I'm **${agentName}** — your new AI, here to help with whatever you need.`,
-      "",
-      "This is just a quick hello so we know email works between us. From here you can:",
-      "",
-      "- **Reply to this email** any time — I'll read it and get back to you.",
-      "- Forward me anything you'd like me to handle.",
-      "- Ask me to keep an eye on something and report back.",
-      "",
-      "Talk soon,",
-      "",
-      `**${agentName}**`,
-    ].join("\n"),
+export interface WelcomeCopy {
+  emailIntro(agentName: string): string;
+  emailSentLead: string;
+  helloEmailSubject: string;
+  helloEmailBody(agentName: string): string;
+  greet: string;
+  magicTrick: string;
+  chatgptNoMemory: string;
+  chatgptFailed: string;
+  questionsLead: string;
+  savingMemoryLead: string;
+  scoutsLead: string;
+  ideasHandoffLead: string;
+  ideasFailed: string;
+  unexpectedError: string;
+  takeaway(summary: string): string;
+  pickedIdea(idea: AppIdea): CompletionProps;
+  finishedNoPick: CompletionProps;
+  alreadyDone: CompletionProps;
+}
 
-  // Greeting, emitted as a text block above the intro-choice card (shown after
-  // the email handshake).
-  greet: [
-    "Now, let me get to know you a little.",
-    "",
-    "Two easy ways — pick whichever you like:",
-  ].join("\n"),
+function serverCopy(locale: WelcomeLocale): WelcomeMessages["server"] {
+  return messagesFor(locale).server;
+}
 
-  // --- Narration during the ChatGPT scrape (emitted as text while it runs) ---
-  magicTrick:
-    "✨ Watch the browser — I'll ask ChatGPT what it remembers about you and bring the highlights back. One moment…",
-  chatgptNoMemory:
-    "ChatGPT didn't have anything stored about you yet — no problem, let's just do the quick version.",
-  chatgptFailed: "I couldn't read that from ChatGPT just now — let's do the quick version instead.",
-
-  // --- Lead-ins ---
-  // Above the fixed getting-to-know-you questionnaire card.
-  questionsLead: "Great — a few quick questions (tap or type, whatever's easier):",
-  // Narrated (text block) right before the inline `welcome-memory` summon runs,
-  // on both the ChatGPT-import and the questionnaire branch.
-  savingMemoryLead: "Thanks — folding that into your memory now.",
-  scoutsLead:
-    "I can also set up a few scouting tasks for your briefing app, so Rome keeps an eye on useful things for you.",
-  ideasHandoffLead: "Got it. Brainstorming a few first apps for you…",
-  ideasFailed: "I couldn't tailor these to you, but here are a few solid starters.",
-
-  /** The memory takeaway, emitted as a normal text block (markdown) before the
-   *  idea picker — replaces the old bordered "What I took away" card. */
-  takeaway: (summary: string): string => `**What I took away**\n\n${summary}`,
-
-  // --- Completion card props ---
-  pickedIdea: (idea: AppIdea): CompletionProps => ({
-    heading: `Let's build "${idea.title}".`,
-    body: "Here's a prompt to kick it off — copy it into a normal chat with Rome when you're ready. You're all set!",
-    kickoffPrompt: idea.prompt,
-  }),
-  finishedNoPick: {
-    heading: "You're all set.",
-    body: "When you're ready to build something, just tell Rome what you have in mind. Welcome aboard.",
-  } satisfies CompletionProps,
-  alreadyDone: {
-    heading: "You've already finished the welcome.",
-    body: "You can start chatting with Rome normally — or run it again below.",
-  } satisfies CompletionProps,
-};
+export function copyFor(locale: WelcomeLocale): WelcomeCopy {
+  const copy = serverCopy(locale);
+  return {
+    emailIntro: (agentName) => formatMessage(copy.emailIntro, { agentName }),
+    emailSentLead: copy.emailSentLead,
+    helloEmailSubject: copy.helloEmailSubject,
+    helloEmailBody: (agentName) => formatMessage(copy.helloEmailBody, { agentName }),
+    greet: copy.greet,
+    magicTrick: copy.magicTrick,
+    chatgptNoMemory: copy.chatgptNoMemory,
+    chatgptFailed: copy.chatgptFailed,
+    questionsLead: copy.questionsLead,
+    savingMemoryLead: copy.savingMemoryLead,
+    scoutsLead: copy.scoutsLead,
+    ideasHandoffLead: copy.ideasHandoffLead,
+    ideasFailed: copy.ideasFailed,
+    unexpectedError: copy.unexpectedError,
+    takeaway: (summary) => formatMessage(copy.takeaway, { summary }),
+    pickedIdea: (idea) => ({
+      heading: formatMessage(copy.pickedIdea.heading, { title: idea.title }),
+      body: copy.pickedIdea.body,
+      kickoffPrompt: idea.prompt,
+    }),
+    finishedNoPick: copy.finishedNoPick,
+    alreadyDone: copy.alreadyDone,
+  };
+}

--- a/rome_apps/welcome-to-rome/src/hooks/turn-middleware/index.ts
+++ b/rome_apps/welcome-to-rome/src/hooks/turn-middleware/index.ts
@@ -10,6 +10,8 @@ import { runTurn, type TurnReply, type WelcomeEffects } from "./script.js";
 import { emitComponent, emitAskQuestion } from "./component.js";
 import { checkChatGptLogin, openChatGptTab, scrapeChatGpt } from "./chatgpt.js";
 import type { SummonResult } from "./script.js";
+import { copyFor } from "./copy.js";
+import { normalizeWelcomeLocale, type WelcomeLocale } from "../../locale.js";
 
 const AGENT_NAME = "welcome-to-rome";
 
@@ -83,7 +85,7 @@ class WelcomeTurnMiddleware implements TurnMiddlewareHook {
       });
       await this.emitReply(ctx, {
         kind: "text",
-        text: "Something went wrong with the welcome — you can start chatting with Rome normally.",
+        text: copyFor(await this.getLocale()).unexpectedError,
       });
     }
     // Deliberately do NOT call next(): the model is never invoked for this turn.
@@ -128,6 +130,7 @@ class WelcomeTurnMiddleware implements TurnMiddlewareHook {
           return "Rome";
         }
       },
+      getLocale: () => this.getLocale(),
       // Intermediate narration, typed out: a commentary block streams in word by
       // word (text_delta previews) then persists, so the UI feels alive while a
       // slow step (e.g. the ChatGPT scrape) runs. Awaited by callers to keep
@@ -145,10 +148,20 @@ class WelcomeTurnMiddleware implements TurnMiddlewareHook {
     };
   }
 
-  /** Send the onboarding hello via the host `send_message` action (channel:
-   *  email). No model involved — a deterministic script step. Any failure (no
-   *  appContext, action error, throw) resolves to `{ ok: false }` so the state
-   *  machine can move on instead of stranding onboarding. */
+  /** Read the server-side language selected by the guardian. */
+  private async getLocale(): Promise<WelcomeLocale> {
+    const appContext = this.deps.appContext;
+    if (!appContext) return "en";
+    try {
+      return normalizeWelcomeLocale(
+        await appContext.repositories.settings.get<unknown>("guardianLanguage"),
+      );
+    } catch {
+      return "en";
+    }
+  }
+
+  /** Send the deterministic onboarding hello through the email action. */
   private async sendEmail(to: string, subject: string, text: string): Promise<{ ok: boolean }> {
     const appContext = this.deps.appContext;
     if (!appContext) return { ok: false };

--- a/rome_apps/welcome-to-rome/src/hooks/turn-middleware/scout-suggestions.ts
+++ b/rome_apps/welcome-to-rome/src/hooks/turn-middleware/scout-suggestions.ts
@@ -1,3 +1,6 @@
+import { messagesFor } from "../../i18n/locales/index.js";
+import type { WelcomeLocale } from "../../locale.js";
+
 export interface ScoutSuggestion {
   title: string;
   prompt: string;
@@ -5,171 +8,23 @@ export interface ScoutSuggestion {
   reason: string;
 }
 
-interface ScoutTemplate {
-  id: string;
-  keywords: readonly string[];
-  title: string;
-  reason: string;
-  intervalMinutes: number;
-  prompt: string;
-}
-
-const TEMPLATES: readonly ScoutTemplate[] = [
-  {
-    id: "ai",
-    keywords: ["ai", "machine learning", "ml", "llm", "agent", "openai", "anthropic"],
-    title: "AI launches radar",
-    reason: "AI and agent updates",
-    intervalMinutes: 360,
-    prompt:
-      "Search public sources from the last 6 hours for important AI, LLM, and agent product launches or research updates. Prioritize OpenAI, Anthropic, Google DeepMind, Meta AI, major labs, arXiv, Hacker News, and credible engineering blogs. Return up to 5 items with links, one-line context, and why each matters.",
-  },
-  {
-    id: "engineering",
-    keywords: ["software", "engineering", "developer", "programming", "code", "devtools"],
-    title: "Developer tooling watch",
-    reason: "software engineering",
-    intervalMinutes: 720,
-    prompt:
-      "Look for notable developer tooling releases, framework updates, infrastructure incidents, and engineering writeups from the last 12 hours. Favor primary release notes and credible technical sources. Return up to 5 items with links, who should care, and a short practical takeaway.",
-  },
-  {
-    id: "data",
-    keywords: ["data", "analytics", "dashboard", "metrics", "bi"],
-    title: "Data stack watch",
-    reason: "data and analytics",
-    intervalMinutes: 720,
-    prompt:
-      "Scan public sources from the last 12 hours for meaningful data, analytics, warehouse, BI, and observability updates. Include product launches, breaking changes, strong technical posts, or notable benchmarks. Return a concise list with links and why each item is worth the guardian's attention.",
-  },
-  {
-    id: "research",
-    keywords: ["research", "science", "paper", "academic", "biology", "physics", "chemistry"],
-    title: "Research paper radar",
-    reason: "science and research",
-    intervalMinutes: 1440,
-    prompt:
-      "Find new or newly discussed research papers from the last day in the guardian's scientific and technical interest areas. Prioritize papers with practical implications, strong discussion, or major updates. Return up to 5 papers with title, link, field, one-sentence summary, and why it matters.",
-  },
-  {
-    id: "design",
-    keywords: ["design", "ux", "user experience", "product design", "interface"],
-    title: "Design signal scan",
-    reason: "design and UX",
-    intervalMinutes: 1440,
-    prompt:
-      "Search public design, product, and UX sources from the last day for strong case studies, interface patterns, design-system releases, and research writeups. Return up to 5 items with links, what changed, and one concrete idea the guardian could reuse.",
-  },
-  {
-    id: "product",
-    keywords: ["product", "strategy", "founder", "startup", "business", "entrepreneur"],
-    title: "Product launch watch",
-    reason: "product and business",
-    intervalMinutes: 720,
-    prompt:
-      "Look for notable product launches, startup moves, pricing changes, and strategy posts from the last 12 hours in the guardian's domains. Prioritize primary announcements and credible analysis. Return up to 5 items with links, what happened, and the strategic implication.",
-  },
-  {
-    id: "finance",
-    keywords: ["finance", "investing", "market", "stocks", "crypto", "personal finance"],
-    title: "Market-moving brief",
-    reason: "finance and investing",
-    intervalMinutes: 360,
-    prompt:
-      "Scan public financial news and market commentary from the last 6 hours for items likely to affect the guardian's interests. Include macro, earnings, policy, major company news, and crypto only when material. Return up to 5 items with source links, the move, and the practical takeaway.",
-  },
-  {
-    id: "marketing",
-    keywords: ["marketing", "growth", "content", "creator", "writing", "newsletter"],
-    title: "Audience trend scout",
-    reason: "marketing and content",
-    intervalMinutes: 1440,
-    prompt:
-      "Find strong examples, platform changes, and audience-growth tactics from the last day across marketing, content, newsletters, and creator ecosystems. Return up to 5 items with links, what is working, and how the guardian might adapt it.",
-  },
-  {
-    id: "education",
-    keywords: ["education", "learning", "teaching", "course", "student"],
-    title: "Learning resources scout",
-    reason: "education and learning",
-    intervalMinutes: 1440,
-    prompt:
-      "Search public sources from the last day for high-quality learning resources, courses, explainers, or education technology updates related to the guardian's interests. Return up to 5 items with links, who it is for, and why it is worth saving.",
-  },
-  {
-    id: "news",
-    keywords: ["news", "current events", "politics", "policy", "world"],
-    title: "Current events filter",
-    reason: "news and current events",
-    intervalMinutes: 360,
-    prompt:
-      "Scan credible public news sources from the last 6 hours for major current events relevant to the guardian's stated interests. Avoid noise and duplicates. Return up to 5 items with links, what changed, and why it matters.",
-  },
-  {
-    id: "health",
-    keywords: ["health", "fitness", "wellness", "nutrition", "medicine"],
-    title: "Health research watch",
-    reason: "health and fitness",
-    intervalMinutes: 1440,
-    prompt:
-      "Find credible health, fitness, wellness, or nutrition updates from the last day. Prefer primary research, public-health guidance, and expert sources over viral claims. Return up to 5 items with links, evidence quality, and the practical takeaway.",
-  },
-  {
-    id: "travel",
-    keywords: ["travel", "trip", "flights", "hotel", "cities"],
-    title: "Travel opportunity watch",
-    reason: "travel",
-    intervalMinutes: 1440,
-    prompt:
-      "Look for travel updates from the last day that could matter to the guardian, including destination news, fare trends, airline changes, visa updates, and practical guides. Return up to 5 items with links and why each is useful.",
-  },
-  {
-    id: "sports",
-    keywords: ["sports", "nba", "nfl", "soccer", "football", "baseball", "tennis"],
-    title: "Sports storyline scout",
-    reason: "sports",
-    intervalMinutes: 720,
-    prompt:
-      "Search public sports sources from the last 12 hours for notable games, roster moves, injuries, standings changes, and storylines in the guardian's sports interests. Return up to 5 items with links and why each one matters.",
-  },
-];
-
-const FALLBACKS: readonly ScoutSuggestion[] = [
-  {
-    title: "Personal interest radar",
-    reason: "your interests",
-    intervalMinutes: 720,
-    prompt:
-      "Search public sources from the last 12 hours for notable updates connected to the guardian's stated interests and current work. Prefer primary sources, credible analysis, and items with practical implications. Return up to 5 items with links, a one-line summary, and why each matters.",
-  },
-  {
-    title: "Useful links digest",
-    reason: "learning and discovery",
-    intervalMinutes: 1440,
-    prompt:
-      "Find high-signal articles, tools, papers, videos, or explainers from the last day that match the guardian's broad interests. Avoid generic news. Return up to 5 links with a short summary and why each is worth reading.",
-  },
-  {
-    title: "Briefing prep scout",
-    reason: "daily briefings",
-    intervalMinutes: 360,
-    prompt:
-      "Before the next briefing, look for timely public updates that could be useful to the guardian based on their role, interests, and recent onboarding context. Return a concise list of the best items with links and why they belong in the briefing.",
-  },
-];
-
-export function scoutSuggestionsFromBasis(basis: string, limit = 3): ScoutSuggestion[] {
+export function scoutSuggestionsFromBasis(
+  basis: string,
+  locale: WelcomeLocale = "en",
+  limit = 3,
+): ScoutSuggestion[] {
   const normalized = basis.toLowerCase();
-  const chosen = TEMPLATES.filter((template) =>
-    template.keywords.some((keyword) => normalized.includes(keyword)),
-  ).map(({ title, prompt, intervalMinutes, reason }) => ({
-    title,
-    prompt,
-    intervalMinutes,
-    reason,
-  }));
+  const { templates, fallbacks } = messagesFor(locale).scouts;
+  const chosen = templates
+    .filter((template) => template.keywords.some((keyword) => normalized.includes(keyword)))
+    .map(({ title, prompt, intervalMinutes, reason }) => ({
+      title,
+      prompt,
+      intervalMinutes,
+      reason,
+    }));
 
-  const suggestions = [...chosen, ...FALLBACKS].filter(
+  const suggestions = [...chosen, ...fallbacks].filter(
     (suggestion, index, all) => all.findIndex((item) => item.title === suggestion.title) === index,
   );
   return suggestions.slice(0, Math.max(0, limit));

--- a/rome_apps/welcome-to-rome/src/hooks/turn-middleware/script.test.ts
+++ b/rome_apps/welcome-to-rome/src/hooks/turn-middleware/script.test.ts
@@ -33,6 +33,7 @@ function makeEffects(node: WelcomeProgress["node"], overrides: Partial<WelcomePr
   const fx = {
     progress,
     getAgentName: vi.fn(async () => "Rome"),
+    getLocale: vi.fn(async () => "en" as const),
     say: vi.fn(async () => {}),
     summon: vi.fn(),
     chatgpt: {} as WelcomeEffects["chatgpt"],
@@ -54,6 +55,18 @@ describe("runTurn — email handshake gate", () => {
     expect(reply).toMatchObject({
       componentId: "email-handshake",
       lead: expect.stringContaining("I'm Nova."),
+    });
+  });
+
+  it("uses Chinese copy from the first welcome step", async () => {
+    const { fx } = makeEffects("greet");
+    vi.mocked(fx.getLocale).mockResolvedValue("zh-CN");
+
+    const reply = await runTurn("开始设置", fx);
+
+    expect(reply).toMatchObject({
+      componentId: "email-handshake",
+      lead: expect.stringContaining("👋 你好，我是 Rome。"),
     });
   });
 
@@ -117,6 +130,30 @@ describe("runTurn — getting-to-know-you questionnaire", () => {
     expect(getNode()).toBe("await_questions");
   });
 
+  it("uses Chinese questions when the guardian selected Chinese", async () => {
+    const { fx, getNode } = makeEffects("await_choice");
+    vi.mocked(fx.getLocale).mockResolvedValue("zh-CN");
+
+    const reply = await runTurn(resolution({ choice: "回答几个问题" }), fx);
+
+    expect(reply.kind).toBe("ask");
+    if (reply.kind === "ask") {
+      expect(reply.lead).toBe("很好，回答几个小问题吧。点击或输入都可以：");
+      expect(reply.questions[0]).toMatchObject({ question: "你的角色或所在领域是什么？" });
+    }
+    expect(getNode()).toBe("await_questions");
+  });
+
+  it("accepts the Chinese browser-skip action", async () => {
+    const { fx, getNode } = makeEffects("await_browser");
+    vi.mocked(fx.getLocale).mockResolvedValue("zh-CN");
+
+    const reply = await runTurn(resolution({ action: "暂时跳过" }), fx);
+
+    expect(reply).toMatchObject({ kind: "ask" });
+    expect(getNode()).toBe("await_questions");
+  });
+
   it("folds the answers into memory via an inline welcome-memory summon", async () => {
     const { fx, getNode } = makeEffects("await_questions");
     // Route the memory summon vs. the later ideas summon by agent name.
@@ -153,6 +190,27 @@ describe("runTurn — getting-to-know-you questionnaire", () => {
     expect(fx.summon).not.toHaveBeenCalled();
     expect(reply).toMatchObject({ kind: "ask" });
     expect(getNode()).toBe("await_questions");
+  });
+});
+
+describe("runTurn — locale fallback ideas", () => {
+  it("uses the Chinese fallback title without changing the English one", async () => {
+    const { fx } = makeEffects("await_idea");
+    vi.mocked(fx.getLocale).mockResolvedValue("zh-CN");
+
+    const reply = await runTurn(resolution({ ideaTitle: "培养习惯" }), fx);
+
+    expect(reply).toMatchObject({
+      componentId: "completion-card",
+      props: { heading: "我们来做「培养习惯」。" },
+    });
+
+    const { fx: englishFx } = makeEffects("await_idea");
+    const englishReply = await runTurn(resolution({ ideaTitle: "Habit garden" }), englishFx);
+    expect(englishReply).toMatchObject({
+      componentId: "completion-card",
+      props: { heading: 'Let\'s build "Habit garden".' },
+    });
   });
 });
 
@@ -198,5 +256,36 @@ describe("runTurn — briefing scout suggestions", () => {
     expect(fx.summon).toHaveBeenCalledOnce();
     expect(reply).toMatchObject({ componentId: "idea-picker" });
     expect(getNode()).toBe("await_idea");
+  });
+
+  it("localizes Chinese scout suggestions from Chinese answers", async () => {
+    const { fx } = makeEffects("await_questions");
+    vi.mocked(fx.getLocale).mockResolvedValue("zh-CN");
+    vi.mocked(fx.summon).mockResolvedValue({
+      ok: true,
+      output: { summary: "对人工智能和软件工程感兴趣。" },
+    });
+
+    const reply = await runTurn(
+      resolution({
+        answers: [{ questionId: "interests", value: "人工智能, 软件与工程" }],
+      }),
+      fx,
+    );
+
+    expect(reply).toMatchObject({
+      componentId: "scout-suggestions",
+      lead: "我还可以为你的 Briefing 添加几个观察任务，让 Rome 持续留意对你有用的信息。",
+      props: {
+        scouts: expect.arrayContaining([
+          expect.objectContaining({ title: "AI 发布雷达" }),
+          expect.objectContaining({ title: "开发者工具观察" }),
+        ]),
+      },
+    });
+    expect(fx.summon).toHaveBeenCalledWith(
+      "welcome-memory",
+      expect.stringContaining("Write every guardian-facing field in Simplified Chinese."),
+    );
   });
 });

--- a/rome_apps/welcome-to-rome/src/hooks/turn-middleware/script.ts
+++ b/rome_apps/welcome-to-rome/src/hooks/turn-middleware/script.ts
@@ -16,9 +16,11 @@
 // (index.ts) turns each reply into events; this file owns *what to show / ask,
 // and when*.
 
-import { copy, type CompletionProps } from "./copy.js";
+import { copyFor, type CompletionProps, type WelcomeCopy } from "./copy.js";
 import type { AppIdea, ProgressRepository } from "../../db/repositories/progress.js";
 import { encodeIdeas } from "../../db/repositories/progress.js";
+import { genericIdeas, introQuestionsFor } from "../../i18n/locales/index.js";
+import { guardianLanguageInstruction, type WelcomeLocale } from "../../locale.js";
 import { isDismissedInteraction, readResolutionJson } from "./resolution.js";
 import type { AskQuestion } from "./component.js";
 import { scoutSuggestionsFromBasis, type ScoutSuggestion } from "./scout-suggestions.js";
@@ -58,6 +60,8 @@ export interface WelcomeEffects {
   progress: ProgressRepository;
   /** Read the guardian-chosen name for the main agent, falling back to Rome. */
   getAgentName(): Promise<string>;
+  /** Read the guardian's selected Rome language. */
+  getLocale(): Promise<WelcomeLocale>;
   /** Emit an intermediate narration block (commentary), typed out word by word.
    *  Resolves once the whole block has streamed, so callers `await` it to keep
    *  ordering against later emits. */
@@ -78,25 +82,10 @@ export interface WelcomeEffects {
   };
 }
 
-// Generic starter ideas, used when the brainstorm specialist is unavailable or
-// hands back nothing usable — onboarding should still hand the guardian a first win.
-const GENERIC_IDEAS: AppIdea[] = [
-  {
-    title: "Mood diary",
-    prompt:
-      "Build me a diary app where I can record my mood, events, people, and notes each day. Give me a calendar view, searchable entries, and simple weekly mood trends so I can reflect on patterns over time.",
-  },
-  {
-    title: "Habit garden",
-    prompt:
-      "Build me a habit tracker where I can define a few recurring habits, check them off daily, and see streaks and weekly progress in a friendly dashboard.",
-  },
-  {
-    title: "Reading shelf",
-    prompt:
-      "Build me a reading-list app where I can paste links, add notes and tags, mark items as reading or finished, and browse everything later by topic or status.",
-  },
-];
+interface WelcomeLanguage {
+  locale: WelcomeLocale;
+  copy: WelcomeCopy;
+}
 
 function ideasFromSummon(output: unknown): AppIdea[] {
   const raw =
@@ -115,10 +104,11 @@ function ideasFromSummon(output: unknown): AppIdea[] {
 // The summon prompt fed to `welcome-memory`. Its system prompt already carries
 // the full fold-into-memory instructions, so this just frames + carries the
 // source text (a ChatGPT export, or the formatted questionnaire answers).
-function memoryPrompt(source: string): string {
+function memoryPrompt(source: string, locale: WelcomeLocale): string {
   return [
     "Here is what we just learned about the guardian. Fold the useful facts into",
     "their memory per your instructions, then call submit_output with { summary }.",
+    guardianLanguageInstruction(locale),
     "",
     source,
   ].join("\n");
@@ -137,11 +127,12 @@ function formatAnswers(answers: Record<string, string>): string {
   return lines.join("\n");
 }
 
-function ideasBrief(basis: string): string {
+function ideasBrief(basis: string, locale: WelcomeLocale): string {
   return [
     "Brainstorming your first apps to build.",
     "",
     "From what Rome learned about the guardian below, brainstorm a few concrete, personalized first apps, then hand back the idea tuples via submit_output.",
+    guardianLanguageInstruction(locale),
     "",
     basis,
   ].join("\n");
@@ -151,27 +142,30 @@ function ideasBrief(basis: string): string {
 /** The email handshake card (the first step): shows the agent's + guardian's
  *  addresses and an "agree & send" button. The card itself reads identity and
  *  provisions if needed (via core APIs); the script sends the hello on agree. */
-async function emailHandshakeReply(fx: WelcomeEffects): Promise<TurnReply> {
+async function emailHandshakeReply(
+  fx: WelcomeEffects,
+  language: WelcomeLanguage,
+): Promise<TurnReply> {
   return {
     kind: "component",
-    lead: copy.emailIntro(await fx.getAgentName()),
+    lead: language.copy.emailIntro(await fx.getAgentName()),
     componentId: "email-handshake",
     props: {},
   };
 }
 
 /** The "check your inbox" card shown after the hello is sent. */
-function receiptReply(guardianEmail: string): TurnReply {
+function receiptReply(guardianEmail: string, language: WelcomeLanguage): TurnReply {
   return {
     kind: "component",
-    lead: copy.emailSentLead,
+    lead: language.copy.emailSentLead,
     componentId: "email-receipt",
     props: { guardianEmail },
   };
 }
 
-function greetReply(): TurnReply {
-  return { kind: "component", lead: copy.greet, componentId: "intro-choice", props: {} };
+function greetReply(language: WelcomeLanguage): TurnReply {
+  return { kind: "component", lead: language.copy.greet, componentId: "intro-choice", props: {} };
 }
 
 /** The "open the browser, then continue" component (ChatGPT-import branch). */
@@ -179,84 +173,36 @@ function browserStep(notSignedIn = false): TurnReply {
   return { kind: "component", componentId: "browser-step", props: { notSignedIn } };
 }
 
-// The fixed getting-to-know-you questionnaire, shown as the host's built-in
-// ask_question card (one card, mostly tap-to-answer with a free-text box). The
-// set mirrors what the old `introductions` agent asked. Answers return next turn
-// as `{ answers: [{ questionId, value }] }`.
-const INTRO_QUESTIONS: AskQuestion[] = [
-  {
-    id: "role",
-    question: "What's your role or field?",
-    type: "single",
-    freeText: true,
-    options: [
-      "Engineering",
-      "Design",
-      "Product",
-      "Founder / business",
-      "Research",
-      "Operations",
-      "Marketing / content",
-    ],
+// Card submissions use stable English action codes; each locale also accepts
+// natural-language input in the guardian's language.
+const ACTION_PATTERNS_BY_LOCALE: Record<
+  WelcomeLocale,
+  { import: RegExp; answer: RegExp; skip: RegExp; none: RegExp; restart: RegExp }
+> = {
+  en: {
+    import: /import|chatgpt/,
+    answer: /answer|question/,
+    skip: /skip/,
+    none: /^(none|no|nope|skip|later|not now)\b/,
+    restart: /\b(start over|restart|revisit|do (it|this) again|run again)\b/,
   },
-  {
-    id: "interests",
-    question: "What are you into? Pick as many as apply.",
-    type: "multi",
-    freeText: true,
-    options: [
-      "Software & engineering",
-      "AI & machine learning",
-      "Data & analytics",
-      "Science & research",
-      "Design & UX",
-      "Product & strategy",
-      "Business & entrepreneurship",
-      "Finance & investing",
-      "Marketing & growth",
-      "Writing & content",
-      "Education & learning",
-      "Health & fitness",
-      "Productivity & organization",
-    ],
+  "zh-CN": {
+    import: /import|chatgpt|导入/,
+    answer: /answer|question|回答|问题|问答/,
+    skip: /skip|跳过|暂不|以后/,
+    none: /^(none|no|nope|skip|later|not now)\b|^(跳过|以后|暂不)/,
+    restart: /\b(start over|restart|revisit|do (it|this) again|run again)\b|重新开始|再来一次|重来/,
   },
-  {
-    id: "helpFirst",
-    question: "What would you love help with first?",
-    type: "single",
-    freeText: true,
-    options: [
-      "Email & messages",
-      "Research & summaries",
-      "Writing & content",
-      "Scheduling & reminders",
-      "Building little tools",
-    ],
-  },
-  {
-    id: "commStyle",
-    question: "How should Rome talk to you?",
-    type: "single",
-    freeText: true,
-    options: [
-      "Short & to the point",
-      "Detailed & thorough",
-      "Casual & friendly",
-      "Formal & professional",
-    ],
-  },
-  {
-    id: "anythingElse",
-    question: "Anything else I should know?",
-    type: "text",
-    optional: true,
-  },
-];
+};
 
 /** The fixed getting-to-know-you questionnaire (built-in ask_question card).
  *  Resolves next turn with `{ answers: [{ questionId, value }] }`. */
-function introQuestions(): TurnReply {
-  return { kind: "ask", lead: copy.questionsLead, questions: INTRO_QUESTIONS };
+function introQuestions(language: WelcomeLanguage): TurnReply {
+  return {
+    kind: "ask",
+    lead: language.copy.questionsLead,
+    questions: introQuestionsFor(language.locale),
+  };
 }
 
 /** The "pick your first app" buttons (the ideas themselves render above as a
@@ -266,10 +212,10 @@ function ideaPicker(ideas: AppIdea[]): TurnReply {
   return { kind: "component", componentId: "idea-picker", props: { ideas } };
 }
 
-function scoutSuggestions(scouts: ScoutSuggestion[]): TurnReply {
+function scoutSuggestions(scouts: ScoutSuggestion[], language: WelcomeLanguage): TurnReply {
   return {
     kind: "component",
-    lead: copy.scoutsLead,
+    lead: language.copy.scoutsLead,
     componentId: "scout-suggestions",
     props: { scouts },
   };
@@ -300,6 +246,8 @@ function field(userText: string, key: string): string | null {
  */
 export async function runTurn(userText: string, fx: WelcomeEffects): Promise<TurnReply> {
   const p = fx.progress.get();
+  const locale = await fx.getLocale();
+  const language: WelcomeLanguage = { locale, copy: copyFor(locale) };
   const now = () => new Date().toISOString();
 
   switch (p.node) {
@@ -308,7 +256,7 @@ export async function runTurn(userText: string, fx: WelcomeEffects): Promise<Tur
       // before getting-to-know-you). The kickoff message the user typed to open
       // the conversation is intentionally not consumed.
       fx.progress.patch({ node: "await_email" });
-      return emailHandshakeReply(fx);
+      return emailHandshakeReply(fx, language);
     }
 
     case "await_email": {
@@ -319,25 +267,29 @@ export async function runTurn(userText: string, fx: WelcomeEffects): Promise<Tur
       const res = readResolutionJson(userText);
       if (res?.skip === true || isDismissedInteraction(userText)) {
         fx.progress.patch({ node: "await_choice" });
-        return greetReply();
+        return greetReply(language);
       }
       // Only an explicit `{ agreed: true }` from the card sends mail. Anything
       // else — free text like "why do I need this?", or a malformed resolution —
       // must not fire an email; re-show the handshake and wait for a real choice.
       if (res?.agreed !== true) {
-        return emailHandshakeReply(fx);
+        return emailHandshakeReply(fx, language);
       }
       // Agreed: send the hello (script, no model). On failure, don't pretend a
       // mail is coming — just move on.
       const to = field(userText, "guardianEmail") ?? "guardian";
       const agentName = await fx.getAgentName();
-      const sent = await fx.email.send(to, copy.helloEmailSubject, copy.helloEmailBody(agentName));
+      const sent = await fx.email.send(
+        to,
+        language.copy.helloEmailSubject,
+        language.copy.helloEmailBody(agentName),
+      );
       if (!sent.ok) {
         fx.progress.patch({ node: "await_choice" });
-        return greetReply();
+        return greetReply(language);
       }
       fx.progress.patch({ node: "await_email_receipt" });
-      return receiptReply(to);
+      return receiptReply(to, language);
     }
 
     case "await_email_receipt": {
@@ -348,52 +300,57 @@ export async function runTurn(userText: string, fx: WelcomeEffects): Promise<Tur
       if (res?.resend === true) {
         const to = field(userText, "guardianEmail") ?? "guardian";
         const agentName = await fx.getAgentName();
-        await fx.email.send(to, copy.helloEmailSubject, copy.helloEmailBody(agentName));
-        return receiptReply(to);
+        await fx.email.send(
+          to,
+          language.copy.helloEmailSubject,
+          language.copy.helloEmailBody(agentName),
+        );
+        return receiptReply(to, language);
       }
       fx.progress.patch({ node: "await_choice" });
-      return greetReply();
+      return greetReply(language);
     }
 
     case "await_choice": {
       const choice = field(userText, "choice") ?? normalize(userText);
-      if (/import|chatgpt/.test(choice)) {
+      const patterns = ACTION_PATTERNS_BY_LOCALE[language.locale];
+      if (patterns.import.test(choice)) {
         // Pre-open ChatGPT in the server Chrome so it's already showing when the
         // guardian opens the Browser widget. Best-effort.
         await fx.chatgpt.openTab().catch(() => {});
         fx.progress.patch({ node: "await_browser" });
         return browserStep();
       }
-      if (/answer|question/.test(choice)) {
+      if (patterns.answer.test(choice)) {
         fx.progress.patch({ node: "await_questions" });
-        return introQuestions();
+        return introQuestions(language);
       }
-      return greetReply();
+      return greetReply(language);
     }
 
     case "await_browser": {
       const action = field(userText, "action") ?? normalize(userText);
-      if (/skip/.test(action)) {
+      if (ACTION_PATTERNS_BY_LOCALE[language.locale].skip.test(action)) {
         fx.progress.patch({ node: "await_questions" });
-        return introQuestions();
+        return introQuestions(language);
       }
       // "Continue": confirm sign-in, then scrape.
       const login = await fx.chatgpt.checkLogin();
       if (!login.loggedIn) {
         return browserStep(true);
       }
-      await fx.say(copy.magicTrick);
+      await fx.say(language.copy.magicTrick);
       const scrape = await fx.chatgpt.scrape();
       if (scrape.ok && scrape.reply) {
         // Fold the export into memory inline, then continue in this same turn.
         fx.progress.patch({ introRawInput: scrape.reply });
-        await foldMemory(fx, scrape.reply);
-        return continueAfterMemory(fx, now);
+        await foldMemory(fx, scrape.reply, language);
+        return continueAfterMemory(fx, now, language);
       }
       // No memory stored, or the scrape failed — fall back to the questionnaire.
-      await fx.say(scrape.noMemory ? copy.chatgptNoMemory : copy.chatgptFailed);
+      await fx.say(scrape.noMemory ? language.copy.chatgptNoMemory : language.copy.chatgptFailed);
       fx.progress.patch({ node: "await_questions" });
-      return introQuestions();
+      return introQuestions(language);
     }
 
     case "await_questions": {
@@ -403,41 +360,41 @@ export async function runTurn(userText: string, fx: WelcomeEffects): Promise<Tur
       // completed questionnaire: re-show the card and stay parked, so their
       // input isn't dropped and onboarding doesn't jump ahead.
       if (isDismissedInteraction(userText)) {
-        return continueAfterMemory(fx, now);
+        return continueAfterMemory(fx, now, language);
       }
       const answers = readAnswers(userText);
       if (!answers) {
-        return introQuestions();
+        return introQuestions(language);
       }
       // A real submission — fold the answers into memory inline (an all-blank
       // submit yields no source and just continues), then continue this turn.
       const source = formatAnswers(answers);
       if (source) {
         fx.progress.patch({ introRawInput: source });
-        await foldMemory(fx, source);
+        await foldMemory(fx, source, language);
       }
-      return continueAfterMemory(fx, now);
+      return continueAfterMemory(fx, now, language);
     }
 
     case "await_scouts": {
-      return brainstormAppIdeas(fx, now);
+      return brainstormAppIdeas(fx, now, language);
     }
 
     case "await_idea": {
-      const ideas = p.ideas.length > 0 ? p.ideas : GENERIC_IDEAS;
-      const idea = resolveChosenIdea(userText, ideas);
+      const ideas = p.ideas.length > 0 ? p.ideas : genericIdeas(language.locale);
+      const idea = resolveChosenIdea(userText, ideas, language.locale);
       fx.progress.patch({ node: "done", completedAt: now() });
-      return completionCard(idea ? copy.pickedIdea(idea) : copy.finishedNoPick);
+      return completionCard(idea ? language.copy.pickedIdea(idea) : language.copy.finishedNoPick);
     }
 
     case "done":
     default: {
       // The "run again" button (or a typed "start over") resets and re-greets.
-      if (readResolutionJson(userText)?.revisit === true || isRestart(userText)) {
+      if (readResolutionJson(userText)?.revisit === true || isRestart(userText, language.locale)) {
         fx.progress.patch({ node: "await_choice", ...FRESH_PROGRESS });
-        return greetReply();
+        return greetReply(language);
       }
-      return completionCard(copy.alreadyDone);
+      return completionCard(language.copy.alreadyDone);
     }
   }
 }
@@ -470,9 +427,13 @@ function summaryFromSummon(output: unknown): string | null {
  *  memory files itself; we keep its returned summary for the takeaway. Best
  *  effort — a failed summon just leaves `introSummary` unset and the brainstorm
  *  falls back to the raw input. */
-async function foldMemory(fx: WelcomeEffects, source: string): Promise<void> {
-  await fx.say(copy.savingMemoryLead);
-  const summoned = await fx.summon(MEMORY_AGENT, memoryPrompt(source));
+async function foldMemory(
+  fx: WelcomeEffects,
+  source: string,
+  language: WelcomeLanguage,
+): Promise<void> {
+  await fx.say(language.copy.savingMemoryLead);
+  const summoned = await fx.summon(MEMORY_AGENT, memoryPrompt(source, language.locale));
   const summary = summoned.ok ? summaryFromSummon(summoned.output) : null;
   if (summary) fx.progress.patch({ introSummary: summary });
 }
@@ -480,47 +441,59 @@ async function foldMemory(fx: WelcomeEffects, source: string): Promise<void> {
 /** Shared tail of both intro branches: surface the memory takeaway, then either
  *  offer briefing scouts or go straight to the first-app brainstorm. Runs inline
  *  within the triggering turn (the memory fold already happened via summon). */
-async function continueAfterMemory(fx: WelcomeEffects, now: () => string): Promise<TurnReply> {
+async function continueAfterMemory(
+  fx: WelcomeEffects,
+  now: () => string,
+  language: WelcomeLanguage,
+): Promise<TurnReply> {
   const current = fx.progress.get();
   // Surface what we learned as a normal assistant text block (markdown), not a
   // bordered card inside the picker.
   const takeaway = current.introSummary;
-  if (takeaway) await fx.say(copy.takeaway(takeaway));
+  if (takeaway) await fx.say(language.copy.takeaway(takeaway));
 
   const basis = takeaway ?? current.introRawInput ?? "";
-  const scouts = scoutSuggestionsFromBasis(basis);
+  const scouts = scoutSuggestionsFromBasis(basis, language.locale);
   if (scouts.length > 0) {
     fx.progress.patch({ node: "await_scouts" });
-    return scoutSuggestions(scouts);
+    return scoutSuggestions(scouts, language);
   }
-  return brainstormAppIdeas(fx, now);
+  return brainstormAppIdeas(fx, now, language);
 }
 
-async function brainstormAppIdeas(fx: WelcomeEffects, now: () => string): Promise<TurnReply> {
+async function brainstormAppIdeas(
+  fx: WelcomeEffects,
+  now: () => string,
+  language: WelcomeLanguage,
+): Promise<TurnReply> {
   const current = fx.progress.get();
-  await fx.say(copy.ideasHandoffLead);
+  await fx.say(language.copy.ideasHandoffLead);
 
   // The brainstorm is autonomous and its real "approval" is the idea picker
   // below (the guardian picks one), so summon the specialist INLINE rather
   // than handing off — no child session, no submit-result gate.
   const basis = current.introSummary ?? current.introRawInput ?? "";
-  const summoned = await fx.summon(IDEAS_AGENT, ideasBrief(basis));
+  const summoned = await fx.summon(IDEAS_AGENT, ideasBrief(basis, language.locale));
   let ideas = summoned.ok ? ideasFromSummon(summoned.output) : [];
   const usedFallback = ideas.length === 0;
-  if (usedFallback) ideas = GENERIC_IDEAS;
+  if (usedFallback) ideas = genericIdeas(language.locale);
 
   fx.progress.patch({
     node: "await_idea",
     appIdeas: encodeIdeas(ideas),
     appIdeasGeneratedAt: now(),
   });
-  if (usedFallback) await fx.say(copy.ideasFailed);
+  if (usedFallback) await fx.say(language.copy.ideasFailed);
   return ideaPicker(ideas);
 }
 
 /** Resolve which idea the guardian chose from the idea-picker's output (or, as a
  *  fallback, typed text). Returns undefined for the explore opt-out / no match. */
-function resolveChosenIdea(userText: string, ideas: AppIdea[]): AppIdea | undefined {
+function resolveChosenIdea(
+  userText: string,
+  ideas: AppIdea[],
+  locale: WelcomeLocale,
+): AppIdea | undefined {
   if (isDismissedInteraction(userText)) return undefined;
 
   const chosen = field(userText, "ideaTitle");
@@ -530,7 +503,7 @@ function resolveChosenIdea(userText: string, ideas: AppIdea[]): AppIdea | undefi
   }
 
   // Typed fallback: accept a number or a title mention.
-  if (isNone(userText)) return undefined;
+  if (isNone(userText, locale)) return undefined;
   const pick = parsePick(userText, ideas.length);
   if (pick !== null) return ideas[pick];
   const lower = normalize(userText);
@@ -541,13 +514,13 @@ function normalize(text: string): string {
   return text.trim().toLowerCase();
 }
 
-function isNone(text: string): boolean {
-  return /^(none|no|nope|skip|later|not now)\b/.test(normalize(text));
+function isNone(text: string, locale: WelcomeLocale): boolean {
+  return ACTION_PATTERNS_BY_LOCALE[locale].none.test(normalize(text));
 }
 
 /** A typed request to run onboarding again (fallback for the revisit button). */
-function isRestart(text: string): boolean {
-  return /\b(start over|restart|revisit|do (it|this) again|run again)\b/.test(normalize(text));
+function isRestart(text: string, locale: WelcomeLocale): boolean {
+  return ACTION_PATTERNS_BY_LOCALE[locale].restart.test(normalize(text));
 }
 
 /** Parse a 1-based idea choice into a 0-based index, or null. */

--- a/rome_apps/welcome-to-rome/src/i18n/locales/en.json
+++ b/rome_apps/welcome-to-rome/src/i18n/locales/en.json
@@ -1,0 +1,331 @@
+{
+  "server": {
+    "emailIntro": "👋 Hi — I'm {{agentName}}.\n\nFirst things first: let's make sure we can reach each other by email. Here's my address and the one I have for you — give it a look, and I'll send you a quick hello.",
+    "emailSentLead": "📬 Sent! It should land in a few seconds.",
+    "helloEmailSubject": "Hello from Rome 👋",
+    "helloEmailBody": "# Hello 👋\n\nI'm **{{agentName}}** — your new AI, here to help with whatever you need.\n\nThis is just a quick hello so we know email works between us. From here you can:\n\n- **Reply to this email** any time — I'll read it and get back to you.\n- Forward me anything you'd like me to handle.\n- Ask me to keep an eye on something and report back.\n\nTalk soon,\n\n**{{agentName}}**",
+    "greet": "Now, let me get to know you a little.\n\nTwo easy ways — pick whichever you like:",
+    "magicTrick": "✨ Watch the browser — I'll ask ChatGPT what it remembers about you and bring the highlights back. One moment…",
+    "chatgptNoMemory": "ChatGPT didn't have anything stored about you yet — no problem, let's just do the quick version.",
+    "chatgptFailed": "I couldn't read that from ChatGPT just now — let's do the quick version instead.",
+    "questionsLead": "Great — a few quick questions (tap or type, whatever's easier):",
+    "savingMemoryLead": "Thanks — folding that into your memory now.",
+    "scoutsLead": "I can also set up a few scouting tasks for your briefing app, so Rome keeps an eye on useful things for you.",
+    "ideasHandoffLead": "Got it. Brainstorming a few first apps for you…",
+    "ideasFailed": "I couldn't tailor these to you, but here are a few solid starters.",
+    "unexpectedError": "Something went wrong with the welcome — you can start chatting with Rome normally.",
+    "takeaway": "**What I took away**\n\n{{summary}}",
+    "pickedIdea": {
+      "heading": "Let's build \"{{title}}\".",
+      "body": "Here's a prompt to kick it off — copy it into a normal chat with Rome when you're ready. You're all set!"
+    },
+    "finishedNoPick": {
+      "heading": "You're all set.",
+      "body": "When you're ready to build something, just tell Rome what you have in mind. Welcome aboard."
+    },
+    "alreadyDone": {
+      "heading": "You've already finished the welcome.",
+      "body": "You can start chatting with Rome normally — or run it again below."
+    }
+  },
+  "web": {
+    "landing": {
+      "greeting": "Hi! So good to meet you. I'm {{agentName}} — I'll be helping you with pretty much everything from here on. Let me get you set up.",
+      "kickoff": "Let's get started 👋",
+      "start": "Start chat",
+      "opening": "Opening…",
+      "openError": "Couldn't open the chat just yet — give it another tap."
+    },
+    "emailHandshake": {
+      "confirmed": "Email confirmed",
+      "settingUp": "Setting up email…",
+      "unavailable": "Email isn't set up in this environment yet — we can sort that out later.",
+      "continue": "Continue",
+      "agentAddress": "My address",
+      "guardianAddress": "Yours",
+      "agree": "Looks right — say hello"
+    },
+    "emailReceipt": {
+      "inbox": "your inbox",
+      "connected": "Thanks — we're connected.",
+      "sentTo": "I just emailed",
+      "sentAfter": ". Take a look — did it arrive?",
+      "received": "Got it",
+      "missing": "Didn't get it?",
+      "spamHint": "Check your spam / junk folder — first emails often land there. Still nothing?",
+      "resend": "Resend",
+      "continue": "Continue anyway"
+    },
+    "introChoice": {
+      "importTitle": "Import from ChatGPT",
+      "importDescription": "Borrow what ChatGPT already remembers about you.",
+      "answerTitle": "Answer a few questions",
+      "answerDescription": "Tell me about yourself in a few quick taps."
+    },
+    "browserStep": {
+      "heading": "Let's borrow what ChatGPT knows about you ✨",
+      "openBefore": "Open the browser here: click",
+      "addBrowser": "➕ Add widget → Browser",
+      "openAfter": "(follow the arrow).",
+      "signIn": "Sign in to chatgpt.com in that browser.",
+      "returnWhenReady": "Come back and hit “I've signed in.”",
+      "openHeading": "Sign in to ChatGPT in the browser",
+      "openDescription": "Sign in to chatgpt.com on the right, then hit “I've signed in.”",
+      "notSignedIn": "I don't see ChatGPT signed in yet — sign in, then hit “I've signed in” again.",
+      "signedIn": "I've signed in",
+      "checking": "Checking…",
+      "skip": "Skip for now",
+      "skipSummary": "Skip — ask me questions"
+    },
+    "scouts": {
+      "skippedSummary": "Skipped briefing scouts",
+      "addedSummary": {
+        "one": "Added {{count}} briefing scout",
+        "other": "Added {{count}} briefing scouts"
+      },
+      "addedHeading": "Briefing scouts added",
+      "skippedHeading": "Briefing scouts skipped",
+      "addLater": "You can add scouts later from the Briefing app.",
+      "heading": "Add scouts to your briefing",
+      "description": "These run in the background and roll useful findings into your morning and evening briefs.",
+      "adding": "Adding",
+      "added": "Added",
+      "add": "Add",
+      "continue": "Continue",
+      "skip": "Skip for now",
+      "error": "Could not add this scout ({{status}}).",
+      "interval": {
+        "minutes": "{{minutes}} min",
+        "daily": "Daily",
+        "days": "Every {{days}} days",
+        "hours": "Every {{hours}}h"
+      }
+    },
+    "ideas": {
+      "heading": "Pick your first app to build",
+      "build": "Build this",
+      "explore": "I'll explore on my own",
+      "exploreSummary": "I'll explore on my own"
+    },
+    "completion": {
+      "fallbackHeading": "You're all set.",
+      "copied": "Copied",
+      "copyPrompt": "Copy prompt",
+      "explore": "Browse more Rome apps and see what you can build next.",
+      "opening": "Opening…",
+      "openShowcases": "Open Showcases",
+      "runAgain": "Run the welcome again"
+    }
+  },
+  "genericIdeas": [
+    {
+      "title": "Mood diary",
+      "prompt": "Build me a diary app where I can record my mood, events, people, and notes each day. Give me a calendar view, searchable entries, and simple weekly mood trends so I can reflect on patterns over time."
+    },
+    {
+      "title": "Habit garden",
+      "prompt": "Build me a habit tracker where I can define a few recurring habits, check them off daily, and see streaks and weekly progress in a friendly dashboard."
+    },
+    {
+      "title": "Reading shelf",
+      "prompt": "Build me a reading-list app where I can paste links, add notes and tags, mark items as reading or finished, and browse everything later by topic or status."
+    }
+  ],
+  "introQuestions": [
+    {
+      "id": "role",
+      "question": "What's your role or field?",
+      "type": "single",
+      "freeText": true,
+      "options": [
+        "Engineering",
+        "Design",
+        "Product",
+        "Founder / business",
+        "Research",
+        "Operations",
+        "Marketing / content"
+      ]
+    },
+    {
+      "id": "interests",
+      "question": "What are you into? Pick as many as apply.",
+      "type": "multi",
+      "freeText": true,
+      "options": [
+        "Software & engineering",
+        "AI & machine learning",
+        "Data & analytics",
+        "Science & research",
+        "Design & UX",
+        "Product & strategy",
+        "Business & entrepreneurship",
+        "Finance & investing",
+        "Marketing & growth",
+        "Writing & content",
+        "Education & learning",
+        "Health & fitness",
+        "Productivity & organization"
+      ]
+    },
+    {
+      "id": "helpFirst",
+      "question": "What would you love help with first?",
+      "type": "single",
+      "freeText": true,
+      "options": [
+        "Email & messages",
+        "Research & summaries",
+        "Writing & content",
+        "Scheduling & reminders",
+        "Building little tools"
+      ]
+    },
+    {
+      "id": "commStyle",
+      "question": "How should Rome talk to you?",
+      "type": "single",
+      "freeText": true,
+      "options": [
+        "Short & to the point",
+        "Detailed & thorough",
+        "Casual & friendly",
+        "Formal & professional"
+      ]
+    },
+    {
+      "id": "anythingElse",
+      "question": "Anything else I should know?",
+      "type": "text",
+      "optional": true
+    }
+  ],
+  "scouts": {
+    "templates": [
+      {
+        "id": "ai",
+        "keywords": ["ai", "machine learning", "ml", "llm", "agent", "openai", "anthropic"],
+        "title": "AI launches radar",
+        "reason": "AI and agent updates",
+        "intervalMinutes": 360,
+        "prompt": "Search public sources from the last 6 hours for important AI, LLM, and agent product launches or research updates. Prioritize OpenAI, Anthropic, Google DeepMind, Meta AI, major labs, arXiv, Hacker News, and credible engineering blogs. Return up to 5 items with links, one-line context, and why each matters."
+      },
+      {
+        "id": "engineering",
+        "keywords": ["software", "engineering", "developer", "programming", "code", "devtools"],
+        "title": "Developer tooling watch",
+        "reason": "software engineering",
+        "intervalMinutes": 720,
+        "prompt": "Look for notable developer tooling releases, framework updates, infrastructure incidents, and engineering writeups from the last 12 hours. Favor primary release notes and credible technical sources. Return up to 5 items with links, who should care, and a short practical takeaway."
+      },
+      {
+        "id": "data",
+        "keywords": ["data", "analytics", "dashboard", "metrics", "bi"],
+        "title": "Data stack watch",
+        "reason": "data and analytics",
+        "intervalMinutes": 720,
+        "prompt": "Scan public sources from the last 12 hours for meaningful data, analytics, warehouse, BI, and observability updates. Include product launches, breaking changes, strong technical posts, or notable benchmarks. Return a concise list with links and why each item is worth the guardian's attention."
+      },
+      {
+        "id": "research",
+        "keywords": ["research", "science", "paper", "academic", "biology", "physics", "chemistry"],
+        "title": "Research paper radar",
+        "reason": "science and research",
+        "intervalMinutes": 1440,
+        "prompt": "Find new or newly discussed research papers from the last day in the guardian's scientific and technical interest areas. Prioritize papers with practical implications, strong discussion, or major updates. Return up to 5 papers with title, link, field, one-sentence summary, and why it matters."
+      },
+      {
+        "id": "design",
+        "keywords": ["design", "ux", "user experience", "product design", "interface"],
+        "title": "Design signal scan",
+        "reason": "design and UX",
+        "intervalMinutes": 1440,
+        "prompt": "Search public design, product, and UX sources from the last day for strong case studies, interface patterns, design-system releases, and research writeups. Return up to 5 items with links, what changed, and one concrete idea the guardian could reuse."
+      },
+      {
+        "id": "product",
+        "keywords": ["product", "strategy", "founder", "startup", "business", "entrepreneur"],
+        "title": "Product launch watch",
+        "reason": "product and business",
+        "intervalMinutes": 720,
+        "prompt": "Look for notable product launches, startup moves, pricing changes, and strategy posts from the last 12 hours in the guardian's domains. Prioritize primary announcements and credible analysis. Return up to 5 items with links, what happened, and the strategic implication."
+      },
+      {
+        "id": "finance",
+        "keywords": ["finance", "investing", "market", "stocks", "crypto", "personal finance"],
+        "title": "Market-moving brief",
+        "reason": "finance and investing",
+        "intervalMinutes": 360,
+        "prompt": "Scan public financial news and market commentary from the last 6 hours for items likely to affect the guardian's interests. Include macro, earnings, policy, major company news, and crypto only when material. Return up to 5 items with source links, the move, and the practical takeaway."
+      },
+      {
+        "id": "marketing",
+        "keywords": ["marketing", "growth", "content", "creator", "writing", "newsletter"],
+        "title": "Audience trend scout",
+        "reason": "marketing and content",
+        "intervalMinutes": 1440,
+        "prompt": "Find strong examples, platform changes, and audience-growth tactics from the last day across marketing, content, newsletters, and creator ecosystems. Return up to 5 items with links, what is working, and how the guardian might adapt it."
+      },
+      {
+        "id": "education",
+        "keywords": ["education", "learning", "teaching", "course", "student"],
+        "title": "Learning resources scout",
+        "reason": "education and learning",
+        "intervalMinutes": 1440,
+        "prompt": "Search public sources from the last day for high-quality learning resources, courses, explainers, or education technology updates related to the guardian's interests. Return up to 5 items with links, who it is for, and why it is worth saving."
+      },
+      {
+        "id": "news",
+        "keywords": ["news", "current events", "politics", "policy", "world"],
+        "title": "Current events filter",
+        "reason": "news and current events",
+        "intervalMinutes": 360,
+        "prompt": "Scan credible public news sources from the last 6 hours for major current events relevant to the guardian's stated interests. Avoid noise and duplicates. Return up to 5 items with links, what changed, and why it matters."
+      },
+      {
+        "id": "health",
+        "keywords": ["health", "fitness", "wellness", "nutrition", "medicine"],
+        "title": "Health research watch",
+        "reason": "health and fitness",
+        "intervalMinutes": 1440,
+        "prompt": "Find credible health, fitness, wellness, or nutrition updates from the last day. Prefer primary research, public-health guidance, and expert sources over viral claims. Return up to 5 items with links, evidence quality, and the practical takeaway."
+      },
+      {
+        "id": "travel",
+        "keywords": ["travel", "trip", "flights", "hotel", "cities"],
+        "title": "Travel opportunity watch",
+        "reason": "travel",
+        "intervalMinutes": 1440,
+        "prompt": "Look for travel updates from the last day that could matter to the guardian, including destination news, fare trends, airline changes, visa updates, and practical guides. Return up to 5 items with links and why each is useful."
+      },
+      {
+        "id": "sports",
+        "keywords": ["sports", "nba", "nfl", "soccer", "football", "baseball", "tennis"],
+        "title": "Sports storyline scout",
+        "reason": "sports",
+        "intervalMinutes": 720,
+        "prompt": "Search public sports sources from the last 12 hours for notable games, roster moves, injuries, standings changes, and storylines in the guardian's sports interests. Return up to 5 items with links and why each one matters."
+      }
+    ],
+    "fallbacks": [
+      {
+        "title": "Personal interest radar",
+        "reason": "your interests",
+        "intervalMinutes": 720,
+        "prompt": "Search public sources from the last 12 hours for notable updates connected to the guardian's stated interests and current work. Prefer primary sources, credible analysis, and items with practical implications. Return up to 5 items with links, a one-line summary, and why each matters."
+      },
+      {
+        "title": "Useful links digest",
+        "reason": "learning and discovery",
+        "intervalMinutes": 1440,
+        "prompt": "Find high-signal articles, tools, papers, videos, or explainers from the last day that match the guardian's broad interests. Avoid generic news. Return up to 5 links with a short summary and why each is worth reading."
+      },
+      {
+        "title": "Briefing prep scout",
+        "reason": "daily briefings",
+        "intervalMinutes": 360,
+        "prompt": "Before the next briefing, look for timely public updates that could be useful to the guardian based on their role, interests, and recent onboarding context. Return a concise list of the best items with links and why they belong in the briefing."
+      }
+    ]
+  }
+}

--- a/rome_apps/welcome-to-rome/src/i18n/locales/index.ts
+++ b/rome_apps/welcome-to-rome/src/i18n/locales/index.ts
@@ -1,0 +1,39 @@
+import type { AppIdea } from "../../db/repositories/progress.js";
+import type { AskQuestion } from "../../hooks/turn-middleware/component.js";
+import { normalizeWelcomeLocale, type WelcomeLocale } from "../../locale.js";
+import en from "./en.json";
+import zhCN from "./zh-CN.json";
+
+// Both files must have the same shape. JSON keeps all guardian-facing copy in
+// one place per locale; this small module only selects it and handles templates.
+const MESSAGES_BY_LOCALE: Record<WelcomeLocale, typeof en> = {
+  en,
+  "zh-CN": zhCN,
+};
+
+export type WelcomeMessages = typeof en;
+
+export function messagesFor(locale: unknown): WelcomeMessages {
+  return MESSAGES_BY_LOCALE[normalizeWelcomeLocale(locale)];
+}
+
+export function formatMessage(template: string, values: Record<string, string | number>): string {
+  return Object.entries(values).reduce(
+    (message, [name, value]) => message.replaceAll(`{{${name}}}`, String(value)),
+    template,
+  );
+}
+
+// Generic starter ideas, used when the brainstorm specialist is unavailable or
+// hands back nothing usable — onboarding should still hand the guardian a first win.
+export function genericIdeas(locale: WelcomeLocale): AppIdea[] {
+  return messagesFor(locale).genericIdeas;
+}
+
+// The fixed getting-to-know-you questionnaire, shown as the host's built-in
+// ask_question card (one card, mostly tap-to-answer with a free-text box). The
+// set mirrors what the old `introductions` agent asked. Answers return next turn
+// as `{ answers: [{ questionId, value }] }`.
+export function introQuestionsFor(locale: WelcomeLocale): AskQuestion[] {
+  return messagesFor(locale).introQuestions as AskQuestion[];
+}

--- a/rome_apps/welcome-to-rome/src/i18n/locales/zh-CN.json
+++ b/rome_apps/welcome-to-rome/src/i18n/locales/zh-CN.json
@@ -1,0 +1,466 @@
+{
+  "server": {
+    "emailIntro": "👋 你好，我是 {{agentName}}。\n\n先确认一下我们的邮件是否互通。下面是我的邮箱和你的邮箱，确认后我会发一封简短的问候邮件。",
+    "emailSentLead": "📬 已发送，几秒后应该就会到达。",
+    "helloEmailSubject": "来自 Rome 的问候 👋",
+    "helloEmailBody": "# 你好 👋\n\n我是 **{{agentName}}**，你的 AI 助手。\n\n这是一封简短的问候邮件，用来确认我们之间的邮件正常送达。接下来你可以：\n\n- 随时**回复这封邮件**，我会阅读并回复。\n- 转发任何希望我处理的内容给我。\n- 让我持续留意某件事，并向你汇报。\n\n回头见，\n\n**{{agentName}}**",
+    "greet": "接下来，我想多了解你一些。\n\n有两种简单方式，选你喜欢的：",
+    "magicTrick": "✨ 看看浏览器：我会问 ChatGPT 它记得哪些关于你的信息，然后带回重点。稍等一下……",
+    "chatgptNoMemory": "ChatGPT 还没有保存关于你的信息——没关系，我们直接用简短问答来完成。",
+    "chatgptFailed": "刚才没能从 ChatGPT 读取到信息——我们改用简短问答来完成。",
+    "questionsLead": "很好，回答几个小问题吧。点击或输入都可以：",
+    "savingMemoryLead": "谢谢，我正在把这些信息整理进你的记忆。",
+    "scoutsLead": "我还可以为你的 Briefing 添加几个观察任务，让 Rome 持续留意对你有用的信息。",
+    "ideasHandoffLead": "了解。我正在为你想几个适合先做的小应用……",
+    "ideasFailed": "我暂时没能按你的情况定制，但这里有几个不错的起点。",
+    "unexpectedError": "欢迎流程出了点问题，不过你可以直接开始和 Rome 聊天。",
+    "takeaway": "**我记住了什么**\n\n{{summary}}",
+    "pickedIdea": {
+      "heading": "我们来做「{{title}}」。",
+      "body": "这里有一段启动提示词。准备好后，把它发到与 Rome 的普通聊天中即可。"
+    },
+    "finishedNoPick": {
+      "heading": "设置完成。",
+      "body": "想做点什么时，直接告诉 Rome 就好。欢迎加入。"
+    },
+    "alreadyDone": {
+      "heading": "你已经完成欢迎流程。",
+      "body": "现在可以直接和 Rome 聊天，也可以在下方重新运行欢迎流程。"
+    }
+  },
+  "web": {
+    "landing": {
+      "greeting": "你好，很高兴认识你。我是 {{agentName}}，之后会协助你处理各种事情。我们先完成设置。",
+      "kickoff": "开始设置 👋",
+      "start": "开始聊天",
+      "opening": "正在打开…",
+      "openError": "暂时无法打开聊天。请再试一次。"
+    },
+    "emailHandshake": {
+      "confirmed": "邮件已确认",
+      "settingUp": "正在设置邮件…",
+      "unavailable": "这个环境暂时还没有设置邮件，之后可以再处理。",
+      "continue": "继续",
+      "agentAddress": "我的邮箱",
+      "guardianAddress": "你的邮箱",
+      "agree": "确认并发送问候"
+    },
+    "emailReceipt": {
+      "inbox": "你的收件箱",
+      "connected": "谢谢，我们已经连上了。",
+      "sentTo": "我刚刚发了一封邮件到",
+      "sentAfter": "。请看看是否收到。",
+      "received": "收到了",
+      "missing": "没有收到？",
+      "spamHint": "先检查垃圾邮件或广告邮件。第一封邮件有时会被放进去。还是没有？",
+      "resend": "重新发送",
+      "continue": "仍然继续"
+    },
+    "introChoice": {
+      "importTitle": "从 ChatGPT 导入",
+      "importDescription": "使用 ChatGPT 已经记住的关于你的信息。",
+      "answerTitle": "回答几个问题",
+      "answerDescription": "用几次简单点击介绍你自己。"
+    },
+    "browserStep": {
+      "heading": "从 ChatGPT 借用它记得的关于你的信息 ✨",
+      "openBefore": "在这里打开浏览器：点击",
+      "addBrowser": "➕ 添加小组件 → 浏览器",
+      "openAfter": "（跟着箭头操作）。",
+      "signIn": "在该浏览器中登录 chatgpt.com。",
+      "returnWhenReady": "回来后点击「我已登录」。",
+      "openHeading": "在浏览器中登录 ChatGPT",
+      "openDescription": "在右侧的 chatgpt.com 登录，然后点击「我已登录」。",
+      "notSignedIn": "还没有检测到 ChatGPT 已登录——请完成登录后再点击「我已登录」。",
+      "signedIn": "我已登录",
+      "checking": "正在检查…",
+      "skip": "暂时跳过",
+      "skipSummary": "跳过，改为回答问题"
+    },
+    "scouts": {
+      "skippedSummary": "已跳过 Briefing 观察任务",
+      "addedSummary": {
+        "one": "已添加 {{count}} 个 Briefing 观察任务",
+        "other": "已添加 {{count}} 个 Briefing 观察任务"
+      },
+      "addedHeading": "Briefing 观察任务已添加",
+      "skippedHeading": "已跳过 Briefing 观察任务",
+      "addLater": "之后可以在 Briefing 应用中添加观察任务。",
+      "heading": "为你的 Briefing 添加观察任务",
+      "description": "它们会在后台运行，并把有用的发现整理到早晚简报中。",
+      "adding": "正在添加",
+      "added": "已添加",
+      "add": "添加",
+      "continue": "继续",
+      "skip": "暂时跳过",
+      "error": "无法添加此观察任务（{{status}}）。",
+      "interval": {
+        "minutes": "{{minutes}} 分钟",
+        "daily": "每天",
+        "days": "每 {{days}} 天",
+        "hours": "每 {{hours}} 小时"
+      }
+    },
+    "ideas": {
+      "heading": "选择第一个要做的应用",
+      "build": "开始构建",
+      "explore": "我想自己探索",
+      "exploreSummary": "我想自己探索"
+    },
+    "completion": {
+      "fallbackHeading": "设置完成。",
+      "copied": "已复制",
+      "copyPrompt": "复制提示词",
+      "explore": "浏览更多 Rome 应用，看看接下来可以做什么。",
+      "opening": "正在打开…",
+      "openShowcases": "打开 Showcases",
+      "runAgain": "重新开始欢迎流程"
+    }
+  },
+  "genericIdeas": [
+    {
+      "title": "心情日记",
+      "prompt": "帮我做一个日记应用，让我每天记录心情、发生的事、见过的人和笔记。提供日历视图、可搜索的条目，以及简单的每周心情趋势，方便我回顾长期规律。"
+    },
+    {
+      "title": "培养习惯",
+      "prompt": "帮我做一个习惯追踪应用，让我定义几个重复习惯、每天打卡，并在友好的仪表盘中查看连续天数和每周进度。"
+    },
+    {
+      "title": "阅读书架",
+      "prompt": "帮我做一个阅读清单应用，让我粘贴链接、添加笔记和标签、标记正在阅读或已完成的内容，并能按主题或状态在之后浏览。"
+    }
+  ],
+  "introQuestions": [
+    {
+      "id": "role",
+      "question": "你的角色或所在领域是什么？",
+      "type": "single",
+      "freeText": true,
+      "options": ["工程", "设计", "产品", "创业 / 商业", "研究", "运营", "市场 / 内容"]
+    },
+    {
+      "id": "interests",
+      "question": "你感兴趣哪些方向？可多选。",
+      "type": "multi",
+      "freeText": true,
+      "options": [
+        "软件与工程",
+        "AI 与机器学习",
+        "数据与分析",
+        "科学与研究",
+        "设计与用户体验",
+        "产品与策略",
+        "商业与创业",
+        "财务与投资",
+        "市场与增长",
+        "写作与内容",
+        "教育与学习",
+        "健康与健身",
+        "效率与组织"
+      ]
+    },
+    {
+      "id": "helpFirst",
+      "question": "最想先获得哪方面的帮助？",
+      "type": "single",
+      "freeText": true,
+      "options": ["邮件与消息", "调研与摘要", "写作与内容", "日程与提醒", "构建小工具"]
+    },
+    {
+      "id": "commStyle",
+      "question": "你希望 Rome 用什么方式和你交流？",
+      "type": "single",
+      "freeText": true,
+      "options": ["简短直接", "详细全面", "随意友好", "正式专业"]
+    },
+    {
+      "id": "anythingElse",
+      "question": "还有什么希望我知道的吗？",
+      "type": "text",
+      "optional": true
+    }
+  ],
+  "scouts": {
+    "templates": [
+      {
+        "id": "ai",
+        "keywords": [
+          "ai",
+          "machine learning",
+          "ml",
+          "llm",
+          "agent",
+          "openai",
+          "anthropic",
+          "人工智能",
+          "机器学习",
+          "大模型",
+          "智能体"
+        ],
+        "title": "AI 发布雷达",
+        "reason": "AI 与智能体动态",
+        "intervalMinutes": 360,
+        "prompt": "搜索过去 6 小时的重要 AI、LLM 与智能体产品发布或研究更新。优先关注 OpenAI、Anthropic、Google DeepMind、Meta AI、主要实验室、arXiv、Hacker News 和可信工程博客。最多返回 5 条，附链接、一句背景和重要性，并使用简体中文。"
+      },
+      {
+        "id": "engineering",
+        "keywords": [
+          "software",
+          "engineering",
+          "developer",
+          "programming",
+          "code",
+          "devtools",
+          "软件",
+          "工程",
+          "开发者",
+          "编程",
+          "代码",
+          "开发工具"
+        ],
+        "title": "开发者工具观察",
+        "reason": "软件工程",
+        "intervalMinutes": 720,
+        "prompt": "查找过去 12 小时值得关注的开发者工具发布、框架更新、基础设施事故和工程文章。优先官方发布说明和可信技术来源。最多返回 5 条，附链接、适用人群和简短实用结论，并使用简体中文。"
+      },
+      {
+        "id": "data",
+        "keywords": [
+          "data",
+          "analytics",
+          "dashboard",
+          "metrics",
+          "bi",
+          "数据",
+          "分析",
+          "仪表盘",
+          "指标",
+          "商业智能"
+        ],
+        "title": "数据栈观察",
+        "reason": "数据与分析",
+        "intervalMinutes": 720,
+        "prompt": "扫描过去 12 小时的重要数据、分析、数仓、BI 和可观测性更新，包括产品发布、破坏性变更、优质技术文章或重要基准。返回精简列表，附链接和每项值得关注的原因，并使用简体中文。"
+      },
+      {
+        "id": "research",
+        "keywords": [
+          "research",
+          "science",
+          "paper",
+          "academic",
+          "biology",
+          "physics",
+          "chemistry",
+          "研究",
+          "科学",
+          "论文",
+          "学术",
+          "生物",
+          "物理",
+          "化学"
+        ],
+        "title": "论文雷达",
+        "reason": "科学与研究",
+        "intervalMinutes": 1440,
+        "prompt": "寻找过去一天内与守护者科学和技术兴趣相关的新论文或近期热议论文。优先有实际影响、讨论充分或重大更新的内容。最多返回 5 篇，附标题、链接、领域、一句摘要和重要性，并使用简体中文。"
+      },
+      {
+        "id": "design",
+        "keywords": [
+          "design",
+          "ux",
+          "user experience",
+          "product design",
+          "interface",
+          "设计",
+          "用户体验",
+          "界面"
+        ],
+        "title": "设计信号扫描",
+        "reason": "设计与用户体验",
+        "intervalMinutes": 1440,
+        "prompt": "搜索过去一天的设计、产品和 UX 来源，寻找优秀案例、界面模式、设计系统发布和研究文章。最多返回 5 条，附链接、变化点和一个可复用的具体想法，并使用简体中文。"
+      },
+      {
+        "id": "product",
+        "keywords": [
+          "product",
+          "strategy",
+          "founder",
+          "startup",
+          "business",
+          "entrepreneur",
+          "产品",
+          "策略",
+          "创始人",
+          "创业",
+          "商业"
+        ],
+        "title": "产品发布观察",
+        "reason": "产品与商业",
+        "intervalMinutes": 720,
+        "prompt": "查找过去 12 小时守护者关注领域的产品发布、创业公司动作、定价变化和策略文章。优先官方公告和可信分析。最多返回 5 条，附链接、发生了什么及其策略含义，并使用简体中文。"
+      },
+      {
+        "id": "finance",
+        "keywords": [
+          "finance",
+          "investing",
+          "market",
+          "stocks",
+          "crypto",
+          "personal finance",
+          "金融",
+          "投资",
+          "市场",
+          "股票",
+          "加密货币",
+          "理财"
+        ],
+        "title": "市场动态简报",
+        "reason": "金融与投资",
+        "intervalMinutes": 360,
+        "prompt": "扫描过去 6 小时可能影响守护者关注方向的公开财经新闻和市场评论。包含宏观、财报、政策、重要公司新闻，只有在实质相关时才包含加密货币。最多返回 5 条，附来源链接、市场变化和实用结论，并使用简体中文。"
+      },
+      {
+        "id": "marketing",
+        "keywords": [
+          "marketing",
+          "growth",
+          "content",
+          "creator",
+          "writing",
+          "newsletter",
+          "营销",
+          "增长",
+          "内容",
+          "创作者",
+          "写作",
+          "通讯"
+        ],
+        "title": "受众趋势观察",
+        "reason": "营销与内容",
+        "intervalMinutes": 1440,
+        "prompt": "寻找过去一天营销、内容、通讯和创作者生态中的优秀案例、平台变化与受众增长方法。最多返回 5 条，附链接、有效做法和守护者可如何借鉴，并使用简体中文。"
+      },
+      {
+        "id": "education",
+        "keywords": [
+          "education",
+          "learning",
+          "teaching",
+          "course",
+          "student",
+          "教育",
+          "学习",
+          "教学",
+          "课程",
+          "学生"
+        ],
+        "title": "学习资源观察",
+        "reason": "教育与学习",
+        "intervalMinutes": 1440,
+        "prompt": "搜索过去一天与守护者兴趣相关的高质量学习资源、课程、讲解内容或教育技术更新。最多返回 5 条，附链接、适合对象和收藏理由，并使用简体中文。"
+      },
+      {
+        "id": "news",
+        "keywords": [
+          "news",
+          "current events",
+          "politics",
+          "policy",
+          "world",
+          "新闻",
+          "时事",
+          "政治",
+          "政策",
+          "世界"
+        ],
+        "title": "时事筛选",
+        "reason": "新闻与时事",
+        "intervalMinutes": 360,
+        "prompt": "扫描过去 6 小时可信公开新闻源，寻找与守护者所述兴趣相关的重要时事。避免噪音和重复。最多返回 5 条，附链接、变化和重要性，并使用简体中文。"
+      },
+      {
+        "id": "health",
+        "keywords": [
+          "health",
+          "fitness",
+          "wellness",
+          "nutrition",
+          "medicine",
+          "健康",
+          "健身",
+          "营养",
+          "医学"
+        ],
+        "title": "健康研究观察",
+        "reason": "健康与健身",
+        "intervalMinutes": 1440,
+        "prompt": "寻找过去一天可信的健康、健身、身心健康或营养更新。优先原始研究、公共卫生指引和专家来源，而非热门传言。最多返回 5 条，附链接、证据质量和实用结论，并使用简体中文。"
+      },
+      {
+        "id": "travel",
+        "keywords": [
+          "travel",
+          "trip",
+          "flights",
+          "hotel",
+          "cities",
+          "旅行",
+          "旅游",
+          "航班",
+          "酒店",
+          "城市"
+        ],
+        "title": "旅行机会观察",
+        "reason": "旅行",
+        "intervalMinutes": 1440,
+        "prompt": "查找过去一天可能对守护者有用的旅行更新，包括目的地新闻、票价趋势、航空公司变化、签证更新和实用指南。最多返回 5 条，附链接和每项的实用原因，并使用简体中文。"
+      },
+      {
+        "id": "sports",
+        "keywords": [
+          "sports",
+          "nba",
+          "nfl",
+          "soccer",
+          "football",
+          "baseball",
+          "tennis",
+          "体育",
+          "篮球",
+          "足球",
+          "网球",
+          "棒球"
+        ],
+        "title": "体育动态观察",
+        "reason": "体育",
+        "intervalMinutes": 720,
+        "prompt": "搜索过去 12 小时守护者关注运动中的重要比赛、阵容变化、伤病、排名变化和故事线。最多返回 5 条，附链接和每项重要性的说明，并使用简体中文。"
+      }
+    ],
+    "fallbacks": [
+      {
+        "title": "个人兴趣雷达",
+        "reason": "你的兴趣",
+        "intervalMinutes": 720,
+        "prompt": "搜索过去 12 小时与守护者所述兴趣和当前工作相关的重要公开更新。优先原始来源、可信分析和有实际意义的内容。最多返回 5 条，附链接、一句摘要和重要性，并使用简体中文。"
+      },
+      {
+        "title": "实用链接摘要",
+        "reason": "学习与探索",
+        "intervalMinutes": 1440,
+        "prompt": "寻找过去一天与守护者广泛兴趣相符的高信号文章、工具、论文、视频或讲解内容。避免泛泛新闻。最多返回 5 个链接，附简短摘要和阅读理由，并使用简体中文。"
+      },
+      {
+        "title": "简报准备观察",
+        "reason": "日常简报",
+        "intervalMinutes": 360,
+        "prompt": "在下一次简报前，根据守护者的角色、兴趣和最近欢迎流程中的背景，寻找有用且及时的公开更新。返回最好的精简列表，附链接及其应进入简报的原因，并使用简体中文。"
+      }
+    ]
+  }
+}

--- a/rome_apps/welcome-to-rome/src/locale.test.ts
+++ b/rome_apps/welcome-to-rome/src/locale.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  guardianLanguageInstruction,
+  normalizeWelcomeLocale,
+  welcomeLocaleFromCode,
+} from "./locale.js";
+import { getWelcomeCopy } from "./web/lib/copy.js";
+
+describe("normalizeWelcomeLocale", () => {
+  it("keeps Chinese and safely falls back to English", () => {
+    expect(normalizeWelcomeLocale("zh-CN")).toBe("zh-CN");
+    expect(normalizeWelcomeLocale("zh-TW")).toBe("en");
+    expect(normalizeWelcomeLocale(undefined)).toBe("en");
+  });
+
+  it("selects Chinese copy for the landing entry point", () => {
+    expect(getWelcomeCopy("zh-CN").landing.kickoff).toBe("开始设置 👋");
+    expect(getWelcomeCopy("zh-CN").landing.start).toBe("开始聊天");
+  });
+
+  it("maps each supported locale to its agent instruction", () => {
+    expect(guardianLanguageInstruction("en")).toBe("Write every guardian-facing field in English.");
+    expect(guardianLanguageInstruction("zh-CN")).toBe(
+      "Write every guardian-facing field in Simplified Chinese.",
+    );
+  });
+
+  it("recognizes only shipped locale codes", () => {
+    expect(welcomeLocaleFromCode("en")).toBe("en");
+    expect(welcomeLocaleFromCode("zh-CN")).toBe("zh-CN");
+    expect(welcomeLocaleFromCode("zh-TW")).toBeUndefined();
+  });
+});

--- a/rome_apps/welcome-to-rome/src/locale.ts
+++ b/rome_apps/welcome-to-rome/src/locale.ts
@@ -1,0 +1,20 @@
+export type WelcomeLocale = "en" | "zh-CN";
+
+const GUARDIAN_LANGUAGE_BY_CODE: Record<WelcomeLocale, string> = {
+  en: "English",
+  "zh-CN": "Simplified Chinese",
+};
+
+export function welcomeLocaleFromCode(locale: unknown): WelcomeLocale | undefined {
+  if (typeof locale !== "string") return undefined;
+  if (!Object.hasOwn(GUARDIAN_LANGUAGE_BY_CODE, locale)) return undefined;
+  return locale as WelcomeLocale;
+}
+
+export function normalizeWelcomeLocale(locale: unknown): WelcomeLocale {
+  return welcomeLocaleFromCode(locale) ?? "en";
+}
+
+export function guardianLanguageInstruction(locale: WelcomeLocale): string {
+  return `Write every guardian-facing field in ${GUARDIAN_LANGUAGE_BY_CODE[locale]}.`;
+}

--- a/rome_apps/welcome-to-rome/src/web/App.tsx
+++ b/rome_apps/welcome-to-rome/src/web/App.tsx
@@ -5,6 +5,7 @@ import { fetchAppApi, startChat, type RomeAppBootstrap } from "@rome-os/app-web-
 import { Button } from "@rome-os/ui/button";
 import { cn } from "@/lib/utils";
 import { fireBurst, fireWelcome } from "@/lib/confetti";
+import { getWelcomeCopy } from "@/lib/copy";
 
 // Side-effect imports: each module's top-level `defineComponent(...)` registers
 // an inline chat component into the SDK registry at bundle load, so the host can
@@ -25,16 +26,8 @@ const ROME_LOGO_VIDEO = new URL("./assets/rome-logo-2.mp4", import.meta.url).hre
 const FALLBACK_AGENT_NAME = "Rome";
 
 // The agent's opening line — written to read like a person saying hello, not a
-// product tagline. Typed out word by word below.
-function greeting(agentName: string): string {
-  return `Hi! So good to meet you. I'm ${agentName} — I'll be helping you with pretty much everything from here on. Let me get you set up.`;
-}
-
-// The kickoff message becomes the guardian's first chat turn. The turn-middleware
-// state machine ignores its text and greets (script.ts `greet` node), but it
-// still shows in the transcript — so it reads like something the guardian said.
-const KICKOFF = "Let's get started 👋";
-
+// product tagline. The active locale supplies it via `copy.landing.greeting`;
+// it is typed out word by word below.
 // Typewriter pacing — deliberately gentle (a greeting, not a loading bar); a
 // longer beat trails sentence-ending punctuation for a natural cadence. Mirrors
 // the in-chat typeOut feel (hooks/turn-middleware/index.ts).
@@ -91,13 +84,14 @@ function readAgentName(value: unknown): string {
   return typeof value === "string" && value.trim() ? value.trim() : FALLBACK_AGENT_NAME;
 }
 
-export default function App(_props: { bootstrap: RomeAppBootstrap }) {
+export default function App({ bootstrap }: { bootstrap: RomeAppBootstrap }) {
+  const copy = getWelcomeCopy(bootstrap.shell.locale);
   const [agentName, setAgentName] = useState<string | null>(null);
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
-  const { shown, done } = useTypewriter(agentName ? greeting(agentName) : "");
+  const { shown, done } = useTypewriter(agentName ? copy.landing.greeting(agentName) : "");
 
   useEffect(() => {
     let cancelled = false;
@@ -134,6 +128,10 @@ export default function App(_props: { bootstrap: RomeAppBootstrap }) {
     }
   }, []);
 
+  // The kickoff message becomes the guardian's first chat turn. The
+  // turn-middleware state machine ignores its text and greets (script.ts
+  // `greet` node), but it still shows in the transcript — so it reads like
+  // something the guardian said.
   async function handleStart() {
     if (starting) return;
     setStarting(true);
@@ -153,16 +151,21 @@ export default function App(_props: { bootstrap: RomeAppBootstrap }) {
     try {
       // Reset the welcome progress so every entry from this screen — a true
       // first run or a "run the welcome again" restart that landed back here —
-      // replays from a clean slate. No-op on first run (already fresh); a failure
-      // shouldn't block the chat, so it's best-effort.
-      await fetchAppApi("reset", { method: "POST" }).catch(() => {});
-
+      // replays from a clean slate. This full-mode page is outside
+      // RomeShellLayout, so include its bootstrap locale for the server-side
+      // middleware before opening the chat. A reset failure shouldn't block the
+      // chat, so this remains best-effort.
+      await fetchAppApi("reset", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ locale: bootstrap.shell.locale }),
+      }).catch(() => {});
       // startChat creates the session with the welcome-to-rome agent, posts the
       // kickoff turn, and soft-navigates to /chat/<id> — where the conversational
       // onboarding takes over.
-      await startChat({ message: KICKOFF, agentName: "welcome-to-rome" });
+      await startChat({ message: copy.landing.kickoff, agentName: "welcome-to-rome" });
     } catch {
-      setError("Couldn't open the chat just yet — give it another tap.");
+      setError(copy.landing.openError);
       setStarting(false);
     }
   }
@@ -217,7 +220,7 @@ export default function App(_props: { bootstrap: RomeAppBootstrap }) {
           disabled={starting || !done}
           className={cn("group", starting && "opacity-80")}
         >
-          {starting ? "Opening…" : "Start chat"}
+          {starting ? copy.landing.opening : copy.landing.start}
           <ArrowRight className="transition-transform group-hover:translate-x-0.5" />
         </Button>
         {error ? <span className="text-xs text-destructive">{error}</span> : null}

--- a/rome_apps/welcome-to-rome/src/web/browser-step.tsx
+++ b/rome_apps/welcome-to-rome/src/web/browser-step.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, Check, Loader2 } from "lucide-react";
 import { defineComponent, type AppComponentContext } from "@rome-os/app-web-sdk";
 import { Button } from "@rome-os/ui/button";
 import { CoachPointer, findWidgetCoachTarget } from "@/lib/coach";
+import { getWelcomeCopy } from "@/lib/copy";
 
 // The "open the browser, sign in to ChatGPT, then continue" step. Submits
 // `{ action: "continue" | "skip" }`. Two phases:
@@ -36,6 +37,7 @@ function Step({ label, children }: { label: string; children: React.ReactNode })
 }
 
 function BrowserStep({ ctx }: { ctx: AppComponentContext }) {
+  const copy = getWelcomeCopy(ctx.bootstrap.shell.locale);
   const notSignedIn = ctx.props.notSignedIn === true;
   const browserOpen = useBrowserOpen();
   const resolved = ctx.host.resolved;
@@ -59,12 +61,10 @@ function BrowserStep({ ctx }: { ctx: AppComponentContext }) {
     <div className="w-full max-w-md space-y-3">
       {!browserOpen ? (
         <div className="rounded-12 border border-border bg-card p-3">
-          <p className="mb-2 text-sm font-medium text-foreground">
-            Let's borrow what ChatGPT knows about you ✨
-          </p>
+          <p className="mb-2 text-sm font-medium text-foreground">{copy.browserStep.heading}</p>
           <ol className="space-y-1.5">
             <Step label="1">
-              Open the browser here: click{" "}
+              {copy.browserStep.openBefore}{" "}
               <strong
                 ref={anchorRef}
                 className={
@@ -73,21 +73,20 @@ function BrowserStep({ ctx }: { ctx: AppComponentContext }) {
                     : "inline-flex items-center rounded-8 border border-primary/35 bg-primary/5 px-1.5 py-0.5 text-foreground shadow-1 whitespace-nowrap"
                 }
               >
-                ➕ Add widget → Browser
+                {copy.browserStep.addBrowser}
               </strong>{" "}
-              (follow the arrow).
+              {copy.browserStep.openAfter}
             </Step>
-            <Step label="2">Sign in to chatgpt.com in that browser.</Step>
-            <Step label="3">Come back and hit “I've signed in.”</Step>
+            <Step label="2">{copy.browserStep.signIn}</Step>
+            <Step label="3">{copy.browserStep.returnWhenReady}</Step>
           </ol>
         </div>
       ) : (
         <div className="flex items-center justify-between gap-3 rounded-12 border border-border bg-card p-3">
           <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground">Sign in to ChatGPT in the browser</p>
+            <p className="text-sm font-medium text-foreground">{copy.browserStep.openHeading}</p>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Sign in to <strong className="text-foreground">chatgpt.com</strong> on the right, then
-              hit “I've signed in.”
+              {copy.browserStep.openDescription}
             </p>
           </div>
           <ArrowRight
@@ -99,7 +98,7 @@ function BrowserStep({ ctx }: { ctx: AppComponentContext }) {
 
       {notSignedIn ? (
         <p className="rounded-8 bg-warning-bg/60 px-2.5 py-1.5 text-xs text-warning-fg">
-          I don't see ChatGPT signed in yet — sign in, then hit “I've signed in” again.
+          {copy.browserStep.notSignedIn}
         </p>
       ) : null}
 
@@ -107,27 +106,27 @@ function BrowserStep({ ctx }: { ctx: AppComponentContext }) {
         <Button
           className="w-full"
           disabled={resolved}
-          onClick={() => ctx.host.submit({ action: "continue" }, "I've signed in")}
+          onClick={() => ctx.host.submit({ action: "continue" }, copy.browserStep.signedIn)}
         >
           {checking ? (
             <>
-              <Loader2 className="animate-spin" /> Checking…
+              <Loader2 className="animate-spin" /> {copy.browserStep.checking}
             </>
           ) : submitted ? (
             <>
-              <Check /> I've signed in
+              <Check /> {copy.browserStep.signedIn}
             </>
           ) : (
-            "I've signed in"
+            copy.browserStep.signedIn
           )}
         </Button>
         <Button
           className="w-full"
           variant="outline"
           disabled={resolved}
-          onClick={() => ctx.host.submit({ action: "skip" }, "Skip — ask me questions")}
+          onClick={() => ctx.host.submit({ action: "skip" }, copy.browserStep.skipSummary)}
         >
-          Skip for now
+          {copy.browserStep.skip}
         </Button>
       </div>
 

--- a/rome_apps/welcome-to-rome/src/web/completion-card.tsx
+++ b/rome_apps/welcome-to-rome/src/web/completion-card.tsx
@@ -7,6 +7,7 @@ import {
   navigateRome,
   type AppComponentContext,
 } from "@rome-os/app-web-sdk";
+import { getWelcomeCopy } from "@/lib/copy";
 
 // The full-mode welcome screen — the first screen of Rome (src/web/App.tsx),
 // shown standalone via the /full/apps route. "Run the welcome again" sends the
@@ -20,7 +21,9 @@ const SHOWCASES_APP_ID = "showcases";
 // (which clears the welcome progress on its next "Start chat"); the primary
 // action opens Showcases so the guardian has a natural next place to explore.
 function CompletionCard({ ctx }: { ctx: AppComponentContext }) {
-  const heading = typeof ctx.props.heading === "string" ? ctx.props.heading : "You're all set.";
+  const copy = getWelcomeCopy(ctx.bootstrap.shell.locale);
+  const heading =
+    typeof ctx.props.heading === "string" ? ctx.props.heading : copy.completion.fallbackHeading;
   const body = typeof ctx.props.body === "string" ? ctx.props.body : "";
   const kickoff = typeof ctx.props.kickoffPrompt === "string" ? ctx.props.kickoffPrompt : "";
   const [copied, setCopied] = useState(false);
@@ -44,7 +47,7 @@ function CompletionCard({ ctx }: { ctx: AppComponentContext }) {
     );
   };
 
-  const copy = async () => {
+  const copyKickoff = async () => {
     try {
       await navigator.clipboard.writeText(kickoff);
       setCopied(true);
@@ -64,25 +67,23 @@ function CompletionCard({ ctx }: { ctx: AppComponentContext }) {
           <p className="whitespace-pre-wrap text-xs text-foreground">{kickoff}</p>
           <button
             type="button"
-            onClick={copy}
+            onClick={copyKickoff}
             className="mt-2 inline-flex items-center gap-1.5 rounded-8 border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
           >
             {copied ? <Check className="size-3.5 text-primary" /> : <Copy className="size-3.5" />}
-            {copied ? "Copied" : "Copy prompt"}
+            {copied ? copy.completion.copied : copy.completion.copyPrompt}
           </button>
         </div>
       ) : null}
 
-      <p className="mt-3 text-xs text-muted-foreground">
-        Browse more Rome apps and see what you can build next.
-      </p>
+      <p className="mt-3 text-xs text-muted-foreground">{copy.completion.explore}</p>
       <button
         type="button"
         disabled={openingShowcases}
         onClick={openShowcases}
         className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-8 bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
       >
-        {openingShowcases ? "Opening…" : "Open Showcases"}
+        {openingShowcases ? copy.completion.opening : copy.completion.openShowcases}
         <ArrowRight className="size-4" />
       </button>
 
@@ -93,7 +94,7 @@ function CompletionCard({ ctx }: { ctx: AppComponentContext }) {
         className="mt-3 inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
       >
         <RotateCcw className="size-3.5" />
-        {restarting ? "Opening…" : "Run the welcome again"}
+        {restarting ? copy.completion.opening : copy.completion.runAgain}
       </button>
     </div>
   );

--- a/rome_apps/welcome-to-rome/src/web/email-handshake.tsx
+++ b/rome_apps/welcome-to-rome/src/web/email-handshake.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { ArrowRight, Check, Loader2, Mail } from "lucide-react";
 import { defineComponent, type AppComponentContext } from "@rome-os/app-web-sdk";
 import { Button } from "@rome-os/ui/button";
+import { getWelcomeCopy } from "@/lib/copy";
 
 // The first onboarding step: a mutual-email handshake. The card reads the two
 // addresses from the registry-native surfaces — the agent's provisioned address
@@ -93,6 +94,7 @@ function Address({ label, email }: { label: string; email: string }) {
 }
 
 function EmailHandshake({ ctx }: { ctx: AppComponentContext }) {
+  const copy = getWelcomeCopy(ctx.bootstrap.shell.locale);
   const resolved = ctx.host.resolved;
   const [phase, setPhase] = useState<Phase>(() =>
     resolved ? { kind: "ready", agentEmail: "", guardianEmail: "" } : { kind: "checking" },
@@ -125,7 +127,7 @@ function EmailHandshake({ ctx }: { ctx: AppComponentContext }) {
   if (resolved) {
     return (
       <div className="flex w-full max-w-md items-center gap-2 rounded-12 border border-primary/40 bg-primary/5 p-3 text-sm text-foreground">
-        <Check className="size-4 text-primary" /> Email confirmed
+        <Check className="size-4 text-primary" /> {copy.emailHandshake.confirmed}
       </div>
     );
   }
@@ -133,7 +135,7 @@ function EmailHandshake({ ctx }: { ctx: AppComponentContext }) {
   if (phase.kind === "checking") {
     return (
       <div className="flex w-full max-w-md items-center gap-2 rounded-12 border border-border bg-card p-3 text-sm text-muted-foreground">
-        <Loader2 className="size-4 animate-spin" /> Setting up email…
+        <Loader2 className="size-4 animate-spin" /> {copy.emailHandshake.settingUp}
       </div>
     );
   }
@@ -141,11 +143,12 @@ function EmailHandshake({ ctx }: { ctx: AppComponentContext }) {
   if (phase.kind === "unavailable") {
     return (
       <div className="w-full max-w-md space-y-3 rounded-12 border border-border bg-card p-3">
-        <p className="text-sm text-foreground">
-          Email isn't set up in this environment yet — we can sort that out later.
-        </p>
-        <Button className="w-full" onClick={() => ctx.host.submit({ skip: true }, "Skipped email")}>
-          Continue <ArrowRight />
+        <p className="text-sm text-foreground">{copy.emailHandshake.unavailable}</p>
+        <Button
+          className="w-full"
+          onClick={() => ctx.host.submit({ skip: true }, copy.emailHandshake.continue)}
+        >
+          {copy.emailHandshake.continue} <ArrowRight />
         </Button>
       </div>
     );
@@ -154,19 +157,19 @@ function EmailHandshake({ ctx }: { ctx: AppComponentContext }) {
   return (
     <div className="w-full max-w-md space-y-3 rounded-12 border border-border bg-card p-4">
       <div className="space-y-2">
-        <Address label="My address" email={phase.agentEmail} />
-        <Address label="Yours" email={phase.guardianEmail} />
+        <Address label={copy.emailHandshake.agentAddress} email={phase.agentEmail} />
+        <Address label={copy.emailHandshake.guardianAddress} email={phase.guardianEmail} />
       </div>
       <Button
         className="w-full"
         onClick={() =>
           ctx.host.submit(
             { agreed: true, guardianEmail: phase.guardianEmail },
-            "Looks right — say hello",
+            copy.emailHandshake.agree,
           )
         }
       >
-        Looks right — say hello <ArrowRight />
+        {copy.emailHandshake.agree} <ArrowRight />
       </Button>
     </div>
   );

--- a/rome_apps/welcome-to-rome/src/web/email-receipt.tsx
+++ b/rome_apps/welcome-to-rome/src/web/email-receipt.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { Check, MailCheck } from "lucide-react";
 import { defineComponent, type AppComponentContext } from "@rome-os/app-web-sdk";
 import { Button } from "@rome-os/ui/button";
+import { getWelcomeCopy } from "@/lib/copy";
 
 // Shown right after the hello email is sent. The guardian confirms receipt
 // (`{ received: true }`) — optional, either button moves on. "Didn't get it?"
@@ -10,15 +11,16 @@ import { Button } from "@rome-os/ui/button";
 // re-shows this card) and a plain continue (`{ received: false }`).
 
 function EmailReceipt({ ctx }: { ctx: AppComponentContext }) {
+  const copy = getWelcomeCopy(ctx.bootstrap.shell.locale);
   const resolved = ctx.host.resolved;
   const guardianEmail =
-    typeof ctx.props.guardianEmail === "string" ? ctx.props.guardianEmail : "your inbox";
+    typeof ctx.props.guardianEmail === "string" ? ctx.props.guardianEmail : copy.emailReceipt.inbox;
   const [showTrouble, setShowTrouble] = useState(false);
 
   if (resolved) {
     return (
       <div className="flex w-full max-w-md items-center gap-2 rounded-12 border border-primary/40 bg-primary/5 p-3 text-sm text-foreground">
-        <Check className="size-4 text-primary" /> Thanks — we're connected.
+        <Check className="size-4 text-primary" /> {copy.emailReceipt.connected}
       </div>
     );
   }
@@ -28,37 +30,39 @@ function EmailReceipt({ ctx }: { ctx: AppComponentContext }) {
       <div className="flex items-start gap-2.5">
         <MailCheck className="mt-0.5 size-4 shrink-0 text-primary" />
         <p className="text-sm text-foreground">
-          I just emailed <span className="font-medium">{guardianEmail}</span>. Take a look — did it
-          arrive?
+          {copy.emailReceipt.sentTo} <span className="font-medium">{guardianEmail}</span>
+          {copy.emailReceipt.sentAfter}
         </p>
       </div>
 
       <div className="grid grid-cols-2 gap-2">
-        <Button onClick={() => ctx.host.submit({ received: true }, "Got it")}>Got it</Button>
+        <Button onClick={() => ctx.host.submit({ received: true }, copy.emailReceipt.received)}>
+          {copy.emailReceipt.received}
+        </Button>
         <Button variant="outline" onClick={() => setShowTrouble((v) => !v)}>
-          Didn't get it?
+          {copy.emailReceipt.missing}
         </Button>
       </div>
 
       {showTrouble ? (
         <div className="space-y-2.5 rounded-12 border border-border bg-surface/60 p-3">
-          <p className="text-xs text-muted-foreground">
-            Check your spam / junk folder — first emails often land there. Still nothing?
-          </p>
+          <p className="text-xs text-muted-foreground">{copy.emailReceipt.spamHint}</p>
           <div className="grid grid-cols-2 gap-2">
             <Button
               size="sm"
               variant="outline"
-              onClick={() => ctx.host.submit({ resend: true, guardianEmail }, "Resend the email")}
+              onClick={() =>
+                ctx.host.submit({ resend: true, guardianEmail }, copy.emailReceipt.resend)
+              }
             >
-              Resend
+              {copy.emailReceipt.resend}
             </Button>
             <Button
               size="sm"
               variant="ghost"
-              onClick={() => ctx.host.submit({ received: false }, "Continue anyway")}
+              onClick={() => ctx.host.submit({ received: false }, copy.emailReceipt.continue)}
             >
-              Continue anyway
+              {copy.emailReceipt.continue}
             </Button>
           </div>
         </div>

--- a/rome_apps/welcome-to-rome/src/web/idea-picker.tsx
+++ b/rome_apps/welcome-to-rome/src/web/idea-picker.tsx
@@ -3,6 +3,7 @@ import { Compass } from "lucide-react";
 import { defineComponent, startChat, type AppComponentContext } from "@rome-os/app-web-sdk";
 import { Button } from "@rome-os/ui/button";
 import { Item, ItemActions, ItemContent, ItemDescription, ItemTitle } from "@/components/ui/item";
+import { getWelcomeCopy } from "@/lib/copy";
 
 // The "pick your first app" card. props: `{ ideas: [{title, prompt}] }`. Each
 // idea renders as a shadcn Item (title + description, with a "Build this" action
@@ -31,6 +32,7 @@ function readIdeas(value: unknown): Idea[] {
 }
 
 function IdeaPicker({ ctx }: { ctx: AppComponentContext }) {
+  const copy = getWelcomeCopy(ctx.bootstrap.shell.locale);
   const ideas = readIdeas(ctx.props.ideas);
   const resolved = ctx.host.resolved;
 
@@ -40,7 +42,7 @@ function IdeaPicker({ ctx }: { ctx: AppComponentContext }) {
 
   return (
     <div className="w-full max-w-md space-y-2">
-      <p className="text-sm font-medium text-foreground">Pick your first app to build</p>
+      <p className="text-sm font-medium text-foreground">{copy.ideas.heading}</p>
 
       {ideas.map((idea) => (
         <Item key={idea.title}>
@@ -50,7 +52,7 @@ function IdeaPicker({ ctx }: { ctx: AppComponentContext }) {
           </ItemContent>
           <ItemActions>
             <Button size="sm" disabled={resolved} onClick={() => build(idea)}>
-              Build this
+              {copy.ideas.build}
             </Button>
           </ItemActions>
         </Item>
@@ -61,9 +63,9 @@ function IdeaPicker({ ctx }: { ctx: AppComponentContext }) {
         size="sm"
         disabled={resolved}
         className="text-muted-foreground"
-        onClick={() => ctx.host.submit({ ideaTitle: EXPLORE }, "I'll explore on my own")}
+        onClick={() => ctx.host.submit({ ideaTitle: EXPLORE }, copy.ideas.exploreSummary)}
       >
-        <Compass /> I'll explore on my own
+        <Compass /> {copy.ideas.explore}
       </Button>
     </div>
   );

--- a/rome_apps/welcome-to-rome/src/web/intro-choice.tsx
+++ b/rome_apps/welcome-to-rome/src/web/intro-choice.tsx
@@ -2,27 +2,29 @@ import { createRoot } from "react-dom/client";
 import { MessagesSquare, Sparkles } from "lucide-react";
 import { defineComponent, type AppComponentContext } from "@rome-os/app-web-sdk";
 import { ChoiceCard, type Choice } from "@/lib/cards";
+import { getWelcomeCopy } from "@/lib/copy";
 
 // The opening "how should we do this?" card. Submits `{ choice: "import" | "answer" }`.
-const CHOICES: Choice[] = [
-  {
-    value: "import",
-    title: "Import from ChatGPT",
-    desc: "Borrow what ChatGPT already remembers about you.",
-    icon: <Sparkles className="size-4" />,
-  },
-  {
-    value: "answer",
-    title: "Answer a few questions",
-    desc: "Tell me about yourself in a few quick taps.",
-    icon: <MessagesSquare className="size-4" />,
-  },
-];
-
 function IntroChoice({ ctx }: { ctx: AppComponentContext }) {
+  const copy = getWelcomeCopy(ctx.bootstrap.shell.locale);
+  const choices: Choice[] = [
+    {
+      value: "import",
+      title: copy.introChoice.importTitle,
+      desc: copy.introChoice.importDescription,
+      icon: <Sparkles className="size-4" />,
+    },
+    {
+      value: "answer",
+      title: copy.introChoice.answerTitle,
+      desc: copy.introChoice.answerDescription,
+      icon: <MessagesSquare className="size-4" />,
+    },
+  ];
+
   return (
     <div className="w-full max-w-lg">
-      <ChoiceCard ctx={ctx} choices={CHOICES} outputKey="choice" columns={2} />
+      <ChoiceCard ctx={ctx} choices={choices} outputKey="choice" columns={2} />
     </div>
   );
 }

--- a/rome_apps/welcome-to-rome/src/web/lib/copy.ts
+++ b/rome_apps/welcome-to-rome/src/web/lib/copy.ts
@@ -1,0 +1,115 @@
+import { formatMessage, messagesFor, type WelcomeMessages } from "../../i18n/locales/index.js";
+
+interface WelcomeWebCopy {
+  landing: {
+    greeting(agentName: string): string;
+    kickoff: string;
+    start: string;
+    opening: string;
+    openError: string;
+  };
+  emailHandshake: {
+    confirmed: string;
+    settingUp: string;
+    unavailable: string;
+    continue: string;
+    agentAddress: string;
+    guardianAddress: string;
+    agree: string;
+  };
+  emailReceipt: {
+    inbox: string;
+    connected: string;
+    sentTo: string;
+    sentAfter: string;
+    received: string;
+    missing: string;
+    spamHint: string;
+    resend: string;
+    continue: string;
+  };
+  introChoice: {
+    importTitle: string;
+    importDescription: string;
+    answerTitle: string;
+    answerDescription: string;
+  };
+  browserStep: {
+    heading: string;
+    openBefore: string;
+    addBrowser: string;
+    openAfter: string;
+    signIn: string;
+    returnWhenReady: string;
+    openHeading: string;
+    openDescription: string;
+    notSignedIn: string;
+    signedIn: string;
+    checking: string;
+    skip: string;
+    skipSummary: string;
+  };
+  scouts: {
+    skippedSummary: string;
+    addedSummary(count: number): string;
+    addedHeading: string;
+    skippedHeading: string;
+    addLater: string;
+    heading: string;
+    description: string;
+    adding: string;
+    added: string;
+    add: string;
+    continue: string;
+    skip: string;
+    error(status: number): string;
+    interval(minutes: number): string;
+  };
+  ideas: {
+    heading: string;
+    build: string;
+    explore: string;
+    exploreSummary: string;
+  };
+  completion: {
+    fallbackHeading: string;
+    copied: string;
+    copyPrompt: string;
+    explore: string;
+    opening: string;
+    openShowcases: string;
+    runAgain: string;
+  };
+}
+
+function formatInterval(
+  interval: WelcomeMessages["web"]["scouts"]["interval"],
+  minutes: number,
+): string {
+  if (minutes < 60) return formatMessage(interval.minutes, { minutes });
+  if (minutes % 1440 === 0) {
+    return minutes === 1440
+      ? interval.daily
+      : formatMessage(interval.days, { days: minutes / 1440 });
+  }
+  if (minutes % 60 === 0) return formatMessage(interval.hours, { hours: minutes / 60 });
+  return formatMessage(interval.minutes, { minutes });
+}
+
+export function getWelcomeCopy(locale: string | undefined): WelcomeWebCopy {
+  const copy = messagesFor(locale).web;
+  return {
+    ...copy,
+    landing: {
+      ...copy.landing,
+      greeting: (agentName) => formatMessage(copy.landing.greeting, { agentName }),
+    },
+    scouts: {
+      ...copy.scouts,
+      addedSummary: (count) =>
+        formatMessage(copy.scouts.addedSummary[count === 1 ? "one" : "other"], { count }),
+      error: (status) => formatMessage(copy.scouts.error, { status }),
+      interval: (minutes) => formatInterval(copy.scouts.interval, minutes),
+    },
+  };
+}

--- a/rome_apps/welcome-to-rome/src/web/scout-suggestions.tsx
+++ b/rome_apps/welcome-to-rome/src/web/scout-suggestions.tsx
@@ -4,6 +4,7 @@ import { Check, Loader2, Plus, Radar, SkipForward, TriangleAlert } from "lucide-
 import { defineComponent, type AppComponentContext } from "@rome-os/app-web-sdk";
 import { Button } from "@rome-os/ui/button";
 import { cn } from "@/lib/utils";
+import { getWelcomeCopy } from "@/lib/copy";
 
 interface ScoutSuggestion {
   title: string;
@@ -42,14 +43,10 @@ function readScouts(value: unknown): ScoutSuggestion[] {
   });
 }
 
-function intervalLabel(minutes: number): string {
-  if (minutes < 60) return `${minutes} min`;
-  if (minutes % 1440 === 0) return minutes === 1440 ? "Daily" : `Every ${minutes / 1440} days`;
-  if (minutes % 60 === 0) return `Every ${minutes / 60}h`;
-  return `${minutes} min`;
-}
-
-async function addScout(scout: ScoutSuggestion): Promise<string | null> {
+async function addScout(
+  scout: ScoutSuggestion,
+  fallbackError: (status: number) => string,
+): Promise<string | null> {
   const res = await fetch("/api/apps/briefing/scouts", {
     method: "POST",
     credentials: "include",
@@ -63,10 +60,11 @@ async function addScout(scout: ScoutSuggestion): Promise<string | null> {
   });
   if (res.ok) return null;
   const body = (await res.json().catch(() => null)) as { error?: string } | null;
-  return body?.error ?? `Could not add this scout (${res.status}).`;
+  return body?.error ?? fallbackError(res.status);
 }
 
 function ScoutSuggestions({ ctx }: { ctx: AppComponentContext }) {
+  const copy = getWelcomeCopy(ctx.bootstrap.shell.locale);
   const scouts = readScouts(ctx.props.scouts);
   const resolved = ctx.host.resolved;
   const resolvedAdded = Array.isArray(ctx.result?.addedTitles)
@@ -100,7 +98,7 @@ function ScoutSuggestions({ ctx }: { ctx: AppComponentContext }) {
       return;
     }
     setStates((prev) => ({ ...prev, [scout.title]: { kind: "adding" } }));
-    const error = await addScout(scout);
+    const error = await addScout(scout, copy.scouts.error);
     setStates((prev) => ({
       ...prev,
       [scout.title]: error ? { kind: "error", message: error } : { kind: "added" },
@@ -111,9 +109,7 @@ function ScoutSuggestions({ ctx }: { ctx: AppComponentContext }) {
     const count = addedTitles.length;
     ctx.host.submit(
       { addedTitles },
-      count === 0
-        ? "Skipped briefing scouts"
-        : `Added ${count} briefing scout${count === 1 ? "" : "s"}`,
+      count === 0 ? copy.scouts.skippedSummary : copy.scouts.addedSummary(count),
     );
   };
 
@@ -121,7 +117,7 @@ function ScoutSuggestions({ ctx }: { ctx: AppComponentContext }) {
     return (
       <div className="w-full max-w-md rounded-12 border border-border bg-card p-4">
         <p className="text-sm font-medium text-foreground">
-          {resolvedAdded.length > 0 ? "Briefing scouts added" : "Briefing scouts skipped"}
+          {resolvedAdded.length > 0 ? copy.scouts.addedHeading : copy.scouts.skippedHeading}
         </p>
         {resolvedAdded.length > 0 ? (
           <ul className="mt-2 space-y-1.5 text-xs text-muted-foreground">
@@ -133,9 +129,7 @@ function ScoutSuggestions({ ctx }: { ctx: AppComponentContext }) {
             ))}
           </ul>
         ) : (
-          <p className="mt-1.5 text-xs text-muted-foreground">
-            You can add scouts later from the Briefing app.
-          </p>
+          <p className="mt-1.5 text-xs text-muted-foreground">{copy.scouts.addLater}</p>
         )}
       </div>
     );
@@ -146,11 +140,9 @@ function ScoutSuggestions({ ctx }: { ctx: AppComponentContext }) {
       <div>
         <p className="flex items-center gap-2 text-sm font-medium text-foreground">
           <Radar className="size-4 text-primary" aria-hidden />
-          Add scouts to your briefing
+          {copy.scouts.heading}
         </p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          These run in the background and roll useful findings into your morning and evening briefs.
-        </p>
+        <p className="mt-1 text-xs text-muted-foreground">{copy.scouts.description}</p>
       </div>
 
       <div className="space-y-2">
@@ -169,7 +161,7 @@ function ScoutSuggestions({ ctx }: { ctx: AppComponentContext }) {
                 <div className="min-w-0">
                   <p className="text-sm font-semibold text-foreground">{scout.title}</p>
                   <p className="mt-0.5 text-xs text-muted-foreground">
-                    {scout.reason} • {intervalLabel(scout.intervalMinutes)}
+                    {scout.reason} • {copy.scouts.interval(scout.intervalMinutes)}
                   </p>
                 </div>
                 <Button
@@ -185,7 +177,11 @@ function ScoutSuggestions({ ctx }: { ctx: AppComponentContext }) {
                   ) : (
                     <Plus className="size-3.5" aria-hidden />
                   )}
-                  {state.kind === "adding" ? "Adding" : isAdded ? "Added" : "Add"}
+                  {state.kind === "adding"
+                    ? copy.scouts.adding
+                    : isAdded
+                      ? copy.scouts.added
+                      : copy.scouts.add}
                 </Button>
               </div>
               <p className="mt-2 line-clamp-3 text-xs leading-relaxed text-muted-foreground">
@@ -212,12 +208,12 @@ function ScoutSuggestions({ ctx }: { ctx: AppComponentContext }) {
           {addedTitles.length > 0 ? (
             <>
               <Check className="size-3.5" aria-hidden />
-              Continue
+              {copy.scouts.continue}
             </>
           ) : (
             <>
               <SkipForward className="size-3.5" aria-hidden />
-              Skip for now
+              {copy.scouts.skip}
             </>
           )}
         </Button>


### PR DESCRIPTION
## What this PR does

The welcome flow only used English, even when Rome was set to Simplified Chinese. This PR localizes the landing screen, scripted onboarding, email handshake, inline cards, fallback ideas, scout suggestions, and the built-in question card for Rome's shipped languages.

The landing screen records the selected Rome language before it opens the app-backed welcome chat. The browser UI and server-side middleware then use the same locale.

## Design & Invariants

- `welcome-to-rome` keeps its shared client and server copy in `src/i18n/locales/{en,zh-CN}.json`.
- The welcome app accepts only Rome's shipped locale codes. Unknown codes fall back to English.
- Cards keep their stable action codes. The middleware also accepts Chinese natural-language input where a guardian types instead of using a card.
- The built-in question card uses the dashboard `chat` locale namespace.

## Test plan

- [x] Focused `vitest run --config vitest.config.ts` for the welcome locale, API, and state-machine tests
- [x] `pnpm --filter rome-web exec vitest run src/components/chat/blocks/QuestionCard.test.tsx`
- [x] `pnpm --filter @rome/app-welcome-to-rome typecheck`
- [x] `pnpm --filter @rome/app-welcome-to-rome build`
- [x] `pnpm exec biome check` for the changed welcome locale and adapter files
- [x] `git diff --check`
- [ ] Exercise English and Simplified Chinese welcome flows in a running Rome container

## Not in this PR

- Additional languages. Rome currently ships English and Simplified Chinese only.
- Localization of the separate Briefing app and its static app metadata.