### PR TITLE
fix(web): keep an in-app setup link inside the Mac app

### DIFF
--- a/packages/web/src/components/markdown.tsx
+++ b/packages/web/src/components/markdown.tsx
@@ -10,6 +10,7 @@ import {
   type MarkdownTheme,
 } from "@rome-os/ui/markdown";
 import { useTheme } from "../hooks/use-theme";
+import { isInternalHref, toInternalPath } from "../lib/internal-href";
 import type { ResolvedTheme, ThemeName } from "../lib/theme";
 
 export { MARKDOWN_LINK_CLASS };
@@ -92,31 +93,6 @@ export function getBuiltinMermaidTheme(
 ): MarkdownTheme | undefined {
   if (theme !== "ember" && theme !== "ash" && theme !== "slate") return undefined;
   return BUILTIN_MERMAID_THEMES[theme][resolved];
-}
-
-function isInternalHref(href: string | undefined): href is string {
-  if (!href) return false;
-  if (href.startsWith("/") && !href.startsWith("//")) return true;
-  if (href.startsWith("#") || href.startsWith("?")) return true;
-  if (typeof window !== "undefined") {
-    try {
-      const url = new URL(href, window.location.href);
-      return url.origin === window.location.origin;
-    } catch {
-      return false;
-    }
-  }
-  return false;
-}
-
-function toInternalPath(href: string): string {
-  if (href.startsWith("/") || href.startsWith("#") || href.startsWith("?")) return href;
-  try {
-    const url = new URL(href, window.location.href);
-    return `${url.pathname}${url.search}${url.hash}`;
-  } catch {
-    return href;
-  }
 }
 
 // Web-dashboard Markdown uses the shared renderer, but keeps in-app hrefs on

--- a/packages/web/src/components/setup/setup-renderer.test.tsx
+++ b/packages/web/src/components/setup/setup-renderer.test.tsx
@@ -6,6 +6,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 import { SetupRenderer, type SetupRenderProps } from "@/components/setup/setup-renderer";
 import type { SetupState } from "@/lib/setup-api";
 
@@ -17,7 +18,15 @@ beforeAll(() => {
   Element.prototype.scrollIntoView = () => {};
 });
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  delete window.rome;
+});
+
+/** What `isElectronShell` reads: the desktop preload's bridge, absent in a browser. */
+function asDesktopApp() {
+  window.rome = {};
+}
 
 function renderState(state: SetupState, over: Partial<SetupRenderProps> = {}) {
   const props: SetupRenderProps = {
@@ -30,7 +39,13 @@ function renderState(state: SetupState, over: Partial<SetupRenderProps> = {}) {
     onRetry: vi.fn(),
     ...over,
   };
-  render(<SetupRenderer {...props} />);
+  // Both call sites live inside the dashboard's router, and an in-app setup
+  // link renders as a <Link>, which needs one.
+  render(
+    <MemoryRouter>
+      <SetupRenderer {...props} />
+    </MemoryRouter>,
+  );
   return props;
 }
 
@@ -165,5 +180,43 @@ describe("SetupRenderer custom registry", () => {
     );
     expect(screen.getByText("custom-discord-presenting")).toBeTruthy();
     expect(screen.queryByText("std")).toBeNull();
+  });
+});
+
+describe("setup view links", () => {
+  const view = {
+    title: "Sign in to LinkedIn in Rome's browser",
+    links: [
+      { label: "Open Rome's browser", url: "/desktop" },
+      { label: "Open @BotFather", url: "https://t.me/BotFather" },
+    ],
+  };
+
+  // Safari holds no Rome session, so a link home arrives at a sign-in wall.
+  it("routes an in-app link inside the Mac app instead of opening a tab", () => {
+    asDesktopApp();
+    renderState({ status: "presenting", view });
+
+    const link = screen.getByRole("link", { name: "Open Rome's browser" });
+    expect(link.getAttribute("target")).toBeNull();
+    expect(link.getAttribute("href")).toBe("/desktop");
+  });
+
+  it("still hands a remote link to the browser inside the Mac app", () => {
+    asDesktopApp();
+    renderState({ status: "presenting", view });
+
+    const link = screen.getByRole("link", { name: "Open @BotFather" });
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("href")).toBe("https://t.me/BotFather");
+  });
+
+  // A browser has tabs, and the panel stays readable in the one behind.
+  it("leaves both kinds opening a new tab in a browser", () => {
+    renderState({ status: "presenting", view });
+
+    for (const name of ["Open Rome's browser", "Open @BotFather"]) {
+      expect(screen.getByRole("link", { name }).getAttribute("target")).toBe("_blank");
+    }
   });
 });

--- a/packages/web/src/components/setup/setup-renderer.tsx
+++ b/packages/web/src/components/setup/setup-renderer.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useId, useState, type ComponentType, type ReactElement } from "react";
+import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
@@ -18,6 +19,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { isElectronShell } from "@/lib/electron-shell";
+import { isInternalHref, toInternalPath } from "@/lib/internal-href";
 import type { SetupState, SetupView, SetupViewLink, SetupViewStep } from "@/lib/setup-api";
 
 /** Everything a renderer (standard or custom) needs. */
@@ -238,21 +241,37 @@ function StepList({ steps }: { steps?: SetupViewStep[] }): ReactElement | null {
   );
 }
 
-/** Labeled external links — shared by presented views and prompt-form preambles. */
+const SETUP_LINK_CLASS = "text-info-fg underline underline-offset-2";
+
+/**
+ * Labeled links — shared by presented views and prompt-form preambles.
+ *
+ * Payloads mix destinations: Telegram sends the guardian to t.me, LinkedIn to
+ * `/desktop`, this dashboard's own view of the browser Rome signs in through.
+ * A new tab is right for the first and right for the second in a browser, where
+ * the panel stays readable in the tab behind it.
+ *
+ * The Mac app has no tabs, and its shell hands every new-window request to
+ * Safari, which holds no Rome session — so there a link home arrives at a
+ * sign-in wall. Only that shell switches to in-app routing; a browser keeps the
+ * new tab it already opens.
+ */
 function LinkList({ links }: { links?: SetupViewLink[] }): ReactElement | null {
   if (!links || links.length === 0) return null;
+  const keepInApp = isElectronShell();
   return (
     <ul className="space-y-1 text-aux">
       {links.map((link) => (
         <li key={link.url}>
-          <a
-            href={link.url}
-            target="_blank"
-            rel="noreferrer"
-            className="text-info-fg underline underline-offset-2"
-          >
-            {link.label}
-          </a>
+          {keepInApp && isInternalHref(link.url) ? (
+            <Link to={toInternalPath(link.url)} className={SETUP_LINK_CLASS}>
+              {link.label}
+            </Link>
+          ) : (
+            <a href={link.url} target="_blank" rel="noreferrer" className={SETUP_LINK_CLASS}>
+              {link.label}
+            </a>
+          )}
         </li>
       ))}
     </ul>

--- a/packages/web/src/lib/internal-href.ts
+++ b/packages/web/src/lib/internal-href.ts
@@ -1,0 +1,32 @@
+/**
+ * Whether an href addresses this dashboard rather than somewhere else.
+ *
+ * Server-authored payloads mix the two freely — a setup view can point at
+ * `https://t.me/BotFather` and at `/desktop` in the same list — so the renderer
+ * has to tell them apart before deciding how to open one.
+ */
+export function isInternalHref(href: string | undefined): href is string {
+  if (!href) return false;
+  if (href.startsWith("/") && !href.startsWith("//")) return true;
+  if (href.startsWith("#") || href.startsWith("?")) return true;
+  if (typeof window !== "undefined") {
+    try {
+      const url = new URL(href, window.location.href);
+      return url.origin === window.location.origin;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/** The router path for an href `isInternalHref` accepted. */
+export function toInternalPath(href: string): string {
+  if (href.startsWith("/") || href.startsWith("#") || href.startsWith("?")) return href;
+  try {
+    const url = new URL(href, window.location.href);
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return href;
+  }
+}


### PR DESCRIPTION
## What this PR does

LinkedIn does not use OAuth. Rome reads the inbox through a browser it runs itself, so the setup signs in there: it opens a LinkedIn login tab in that browser and hands the guardian a link to `/desktop`, this dashboard's view of it.

`LinkList` renders every setup link as `target="_blank"`. The Electron shell hands every new-window request to the system browser, which holds no Rome session — so the one link that points **home** is the one that leaves, and it arrives at Rome's own `/login` wall.

The destination already works in the Mac app; the sidebar's Browser entry is the same route. Only the way in was broken.

## Design & Invariants

**Routing is the shell's choice, not the payload's.** A browser keeps the new tab for both kinds of link — that is what a tab is for, and the panel's three steps stay readable behind the sign-in. The Mac app has no tabs, so an in-app destination routes in place, arriving the way clicking the sidebar does rather than reloading the window.

**Leaving the panel costs nothing.** `use-setup` calls `cancelSetup` only from the Cancel button, never on unmount; the coroutine polls `whoami` server-side on its own deadline; and returning to Connections reattaches to the live session through the placeholder's cid. The guardian sees progress again, not a restarted flow.

**`isElectronShell` over the `is-electron` class.** It reads the preload bridge, which `contextBridge` installs before any page script, so it cannot be sampled before the shell is known. Same helper, same reason, as `SettingsTabPage` and `AppGrid`.

**`isInternalHref` / `toInternalPath` move to `lib/`.** `markdown.tsx` has told these apart correctly all along, and they are DOM-only string work with no business behind a React renderer. Not a bundle argument — `markdown.tsx` is eager through chat either way.

**Rejected: fixing it in the shell.** `setWindowOpenHandler` could keep loopback URLs in the window, and would need no browser gate at all since it only exists under Electron. But the main process can only re-open a URL, so the click would reload the whole dashboard instead of routing — worse than the sidebar it is meant to match.

## Test plan

- [x] `pnpm --filter rome-web test` — 144 files, 1089 tests, all passing.
- [x] `pnpm --filter rome-web typecheck` — clean.
- [x] `npx biome check` on all four changed files — clean.
- [x] **The desktop case fails against the old renderer**, verified by restoring the unconditional anchor: 1 failed, 13 passed. The other two new cases stay green there, because they assert behaviour that must not change.
- [x] Three cases: in-app link under the shell routes without a new tab; a remote link under the shell still opens one; a browser opens one for both.
- [x] `markdown.test.tsx` still green, including its own "routes internal links through react-router and opens external ones in a new tab".
- [x] `renderState` now wraps in `MemoryRouter`, matching where `SetupRenderer` actually mounts.
- [x] Clicked through on-device — needs the change in a runtime image first.
- [x] Every check above was re-run in this repository, not carried over: dependencies installed from the committed lockfile, and the suite is one test larger here than it was in the source repo.

## Not in this PR

- **The step-3 copy.** "Leave the tab open" reads as a browser tab but means a tab in Rome's own browser, which the Mac app shows too. Correct as written; noting it because it looks wrong at a glance.
- **A progress readout while on `/desktop`.** A browser keeps the panel in the tab behind; the Mac app cannot. Returning to Connections is the way to check, and it reattaches.
- **Anything for the other integrations.** Telegram, Discord, Feishu and WeChat all emit remote URLs today, so `linkedin.ts` is the only payload this reaches. Feishu's custom renderer delegates to `StandardSetupRenderer`, so it would be covered if that changed.


---

Ported from `amantru/rome-internal#2447` (`4a323240`), which the public snapshot predates. The diff is byte-identical; the checks below were re-run here rather than carried over.
