### PR TITLE
fix(desktop): give the menu bar one of each

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -11,6 +11,7 @@ import {
 import { registerIpcHandlers } from "./ipc";
 import { isQuitting, setupLifecycle } from "./lifecycle";
 import { setupUpdater, updateManager } from "./updater";
+import { RESTART_BUTTON, updateDialogFor } from "./update-dialog";
 import { setupTray } from "./tray";
 import { setupApplicationMenu } from "./menu";
 import { shouldReturnToDashboard } from "./startup-surface";
@@ -96,7 +97,16 @@ async function bootstrap() {
         }
       },
       () => createSettingsWindow(),
-      () => updateManager.checkForUpdates("manual"),
+      // The check only broadcasts a status, which nothing renders unless the
+      // settings window happens to be open — so from a menu the common
+      // "already up to date" answer arrived as silence.
+      async () => {
+        const status = await updateManager.checkForUpdates("manual");
+        const { response } = await updateManager.showStatusDialog(updateDialogFor(status));
+        if (status.state === "downloaded" && response === RESTART_BUTTON) {
+          await updateManager.installUpdate();
+        }
+      },
     );
     setupTray({
       getMainWindow: () => mainWindow,

--- a/packages/desktop/src/main/lifecycle.ts
+++ b/packages/desktop/src/main/lifecycle.ts
@@ -110,9 +110,9 @@ export function setupLifecycle(options: SetupLifecycleOptions): void {
 }
 
 /**
- * Called from UI surfaces (Cmd+Q/app-menu Quit, tray "Stop agent and quit",
- * ⌘⇧Q accelerator) to start the full shutdown path. Idempotent — the
- * before-quit handler runs the actual shutdown.
+ * Called from UI surfaces (⌘Q / app-menu Quit, tray "Stop agent and quit") to
+ * start the full shutdown path. Idempotent — the before-quit handler runs the
+ * actual shutdown.
  */
 export function requestStopAndQuit(): void {
   quitting = true;

--- a/packages/desktop/src/main/menu.ts
+++ b/packages/desktop/src/main/menu.ts
@@ -1,5 +1,7 @@
-import { app, Menu, BrowserWindow } from "electron";
+import { app, Menu, BrowserWindow, shell } from "electron";
 import { requestStopAndQuit } from "./lifecycle";
+
+const DOCS_URL = "https://romeos.cc/docs/rome";
 
 export function setupApplicationMenu(
   showDashboard: () => void,
@@ -8,77 +10,80 @@ export function setupApplicationMenu(
 ): void {
   const isMac = process.platform === "darwin";
 
-  // Tray-resident model: red dot / ⌘W only hide windows. Cmd+Q and the
-  // explicit "Stop agent and quit" surfaces go through the real shutdown
-  // path. Closing the focused window invokes its `close` handler, which
-  // window.ts intercepts to hide unless lifecycle.isQuitting() is true.
-  const hideFocusedWindow = (): void => {
-    const focused = BrowserWindow.getFocusedWindow();
-    if (focused && !focused.isDestroyed()) {
-      focused.close();
-    }
-  };
-
-  const stopAndQuitItem: Electron.MenuItemConstructorOptions = {
-    label: "Stop agent and quit",
-    accelerator: "Shift+CmdOrCtrl+Q",
-    click: () => requestStopAndQuit(),
-  };
-
-  const hideWindowItem: Electron.MenuItemConstructorOptions = {
-    label: isMac ? "Close Window" : "Close",
-    accelerator: "CmdOrCtrl+W",
-    click: hideFocusedWindow,
-  };
-
+  // Tray-resident model: ⌘Q is the only quit, and it stops the agent on its
+  // way out. `role: "close"` closes the focused window, which window.ts
+  // intercepts and turns into a hide unless lifecycle.isQuitting() is true.
   const quitItem: Electron.MenuItemConstructorOptions = {
     label: "Quit Rome",
     accelerator: "CmdOrCtrl+Q",
     click: () => requestStopAndQuit(),
   };
 
+  const settingsItem: Electron.MenuItemConstructorOptions = {
+    label: "Settings…",
+    accelerator: "CmdOrCtrl+,",
+    click: () => openSettings(),
+  };
+
+  const checkForUpdatesItem: Electron.MenuItemConstructorOptions = {
+    label: "Check for Updates…",
+    click: () => {
+      void checkForUpdates();
+    },
+  };
+
   const template: Electron.MenuItemConstructorOptions[] = [
-    // App menu (macOS only)
+    // App menu (macOS only). Everything about the application itself: its
+    // version, its updates, and its own preferences — which is the desktop
+    // shell's settings window, not the dashboard's Settings page. The sidebar
+    // owns that one, and it is user-customisable, so no menu mirrors it.
     ...(isMac
       ? [
           {
             label: app.name,
             submenu: [
               { role: "about" as const },
+              checkForUpdatesItem,
               { type: "separator" as const },
-              {
-                label: "Settings…",
-                accelerator: "CmdOrCtrl+,",
-                click: () => openSettings(),
-              },
+              settingsItem,
+              { type: "separator" as const },
+              { role: "services" as const },
               { type: "separator" as const },
               { role: "hide" as const },
               { role: "hideOthers" as const },
               { role: "unhide" as const },
               { type: "separator" as const },
               quitItem,
-              stopAndQuitItem,
             ],
           } as Electron.MenuItemConstructorOptions,
         ]
       : []),
 
-    // File menu
+    // File menu. On macOS this is Electron's own `fileMenu` role spelled out:
+    // one Close. Not the role itself, because its non-mac branch is
+    // `role: "quit"`, which calls app.quit() directly and would skip stopping
+    // the runtime.
+    //
+    // Windows and Linux have no app menu, so what lives there on a Mac hangs
+    // here — unchanged from before this commit, since nothing builds for them.
     {
       label: "File",
       submenu: [
-        {
-          label: "Settings…",
-          accelerator: isMac ? undefined : "CmdOrCtrl+,",
-          click: () => openSettings(),
-        },
-        { type: "separator" },
-        hideWindowItem,
-        ...(isMac ? [] : [stopAndQuitItem]),
+        { role: "close" },
+        ...(isMac
+          ? []
+          : [
+              { type: "separator" as const },
+              settingsItem,
+              {
+                label: "Stop agent and quit",
+                accelerator: "Shift+CmdOrCtrl+Q",
+                click: () => requestStopAndQuit(),
+              } as Electron.MenuItemConstructorOptions,
+            ]),
       ],
     },
 
-    // Edit menu (standard copy/paste support)
     {
       label: "Edit",
       submenu: [
@@ -88,59 +93,52 @@ export function setupApplicationMenu(
         { role: "cut" },
         { role: "copy" },
         { role: "paste" },
+        { role: "pasteAndMatchStyle" },
+        { role: "delete" },
         { role: "selectAll" },
       ],
     },
 
-    // View menu
+    // View menu. The dashboard entry is here rather than under Window because
+    // it navigates content — and because it is the only way back when a
+    // provider's OAuth page has taken over this frameless window.
     {
       label: "View",
       submenu: [
+        {
+          label: "Show Rome Dashboard",
+          accelerator: "CmdOrCtrl+Shift+D",
+          click: () => showDashboard(),
+        },
+        { type: "separator" },
         { role: "reload" },
         { role: "forceReload" },
-        { role: "toggleDevTools" },
         { type: "separator" },
         { role: "resetZoom" },
         { role: "zoomIn" },
         { role: "zoomOut" },
         { type: "separator" },
         { role: "togglefullscreen" },
-      ],
-    },
-
-    // Window menu
-    {
-      label: "Window",
-      submenu: [
-        { role: "minimize" },
-        { role: "zoom" },
         { type: "separator" },
-        // Carries an accelerator because this is the only way back when a
-        // provider's OAuth page has taken over the window: there is no back
-        // affordance to reach for, and a menu nobody thinks to open is not one.
-        {
-          label: "Web Dashboard",
-          accelerator: "CmdOrCtrl+Shift+D",
-          click: () => showDashboard(),
-        },
-        {
-          label: "Settings",
-          click: () => openSettings(),
-        },
-        ...(isMac ? [{ type: "separator" as const }, { role: "front" as const }] : []),
+        { role: "toggleDevTools" },
       ],
     },
 
-    // Help menu
+    // The role is what makes AppKit list the open windows; a hand-rolled
+    // Window menu gets minimize and zoom but never the list.
+    { role: "windowMenu" },
+
     {
-      label: "Help",
+      role: "help",
       submenu: [
         {
-          label: "Update Rome",
+          label: "Rome Help",
           click: () => {
-            void checkForUpdates();
+            void shell.openExternal(DOCS_URL);
           },
         },
+        // Updates move to the app menu on a Mac; without one they stay here.
+        ...(isMac ? [] : [checkForUpdatesItem]),
       ],
     },
   ];

--- a/packages/desktop/src/main/tray.ts
+++ b/packages/desktop/src/main/tray.ts
@@ -126,10 +126,11 @@ export function setupTray(options: SetupTrayOptions): Tray {
       },
       { type: "separator" },
       {
-        // Accelerator is informational only — tray menus don't register
-        // global shortcuts. The real ⌘⇧Q binding lives in the app menu.
+        // No accelerator: tray menus cannot register shortcuts of their own,
+        // so one printed here only advertises a key. ⌘⇧Q used to be that key
+        // and no longer exists — the app menu's ⌘Q is the one quit, and it
+        // stops the agent on its way out.
         label: stopping ? "Stopping agent…" : "Stop agent and quit",
-        accelerator: "Shift+CmdOrCtrl+Q",
         enabled: !stopping,
         click: () => {
           if (tray) {

--- a/packages/desktop/src/main/update-dialog.test.ts
+++ b/packages/desktop/src/main/update-dialog.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { RESTART_BUTTON, updateDialogFor } from "./update-dialog";
+import type { UpdateState, UpdateStatus } from "./updater";
+
+function status(over: Partial<UpdateStatus> = {}): UpdateStatus {
+  return {
+    state: "not-available",
+    autoUpdateEnabled: true,
+    currentVersion: "1.0.107",
+    updateVersion: null,
+    lastCheckedAt: null,
+    message: "Rome is up to date.",
+    error: null,
+    progress: null,
+    ...over,
+  };
+}
+
+// The whole point of the menu item: before this, a manual check that found
+// nothing produced no dialog at all, so the item looked broken.
+describe("updateDialogFor", () => {
+  it("carries the manager's own sentence rather than composing a second one", () => {
+    expect(updateDialogFor(status()).message).toBe("Rome is up to date.");
+    expect(
+      updateDialogFor(status({ state: "downloading", message: "Downloading Rome 1.0.108…" }))
+        .message,
+    ).toBe("Downloading Rome 1.0.108…");
+  });
+
+  it("puts the cause of a failure in the detail, where the message is vague", () => {
+    const options = updateDialogFor(
+      status({
+        state: "error",
+        message: "Could not check for updates.",
+        error: "net::ERR_INTERNET_DISCONNECTED",
+      }),
+    );
+    expect(options.type).toBe("warning");
+    expect(options.detail).toBe("net::ERR_INTERNET_DISCONNECTED");
+  });
+
+  it("omits the detail when a failure carries no cause", () => {
+    // `detail: null` would render the string "null" under the message.
+    expect(updateDialogFor(status({ state: "error", error: null })).detail).toBeUndefined();
+  });
+
+  it("says something in every state a check can resolve into", () => {
+    const states: UpdateState[] = [
+      "idle",
+      "checking",
+      "available",
+      "not-available",
+      "downloading",
+      "downloaded",
+      "error",
+    ];
+    for (const state of states) {
+      const options = updateDialogFor(status({ state, message: `state: ${state}` }));
+      expect(options.message).toBe(`state: ${state}`);
+      expect(options.buttons?.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// A check in this state returns early without doing anything, so a lone OK
+// would answer "ready to install" with no way to install.
+describe("updateDialogFor · downloaded", () => {
+  const options = updateDialogFor(
+    status({ state: "downloaded", message: "Rome 1.0.108 is ready to install." }),
+  );
+
+  it("offers the restart the automatic prompt offers", () => {
+    expect(options.buttons).toEqual(["Restart Now", "Later"]);
+    expect(options.defaultId).toBe(RESTART_BUTTON);
+  });
+
+  it("lets Escape mean Later", () => {
+    expect(options.cancelId).toBe(1);
+    expect(options.cancelId).not.toBe(RESTART_BUTTON);
+  });
+});

--- a/packages/desktop/src/main/update-dialog.ts
+++ b/packages/desktop/src/main/update-dialog.ts
@@ -1,0 +1,44 @@
+import type { MessageBoxOptions } from "electron";
+import type { UpdateStatus } from "./updater";
+
+/** The button that installs, when the dialog offers one. */
+export const RESTART_BUTTON = 0;
+
+/**
+ * What the "Check for Updates…" menu item says when the check comes back.
+ *
+ * The manager already writes a sentence for every state it can reach, so this
+ * carries it rather than composing a second one that could disagree. Two states
+ * need more than the sentence:
+ *
+ * `error` — the message is deliberately vague and the cause sits in `error`,
+ * which becomes the detail.
+ *
+ * `downloaded` — a check in this state returns early without doing anything,
+ * so a lone OK would answer "ready to install" with no way to install. The
+ * automatic prompt offers Restart Now; asking on purpose should not offer less.
+ *
+ * `available` is not a state this ever sees — `update-available` starts the
+ * download in the same tick, so a resolved check reads `downloading`.
+ */
+export function updateDialogFor(status: UpdateStatus): MessageBoxOptions {
+  if (status.state === "error") {
+    return {
+      type: "warning",
+      message: status.message,
+      detail: status.error ?? undefined,
+      buttons: ["OK"],
+    };
+  }
+  if (status.state === "downloaded") {
+    return {
+      type: "info",
+      message: status.message,
+      detail: "Restart Rome now to finish installing, or install it the next time you quit.",
+      buttons: ["Restart Now", "Later"],
+      defaultId: RESTART_BUTTON,
+      cancelId: 1,
+    };
+  }
+  return { type: "info", message: status.message, buttons: ["OK"] };
+}

--- a/packages/desktop/src/main/updater.ts
+++ b/packages/desktop/src/main/updater.ts
@@ -192,6 +192,14 @@ class UpdateManager {
   }
 
   async installUpdate(): Promise<UpdateStatus> {
+    // The state check alone does not make this idempotent: the first call
+    // leaves the state at "downloaded", so a second would reach
+    // quitAndInstall again. There are two ways in now — the automatic prompt
+    // and the menu's — and both can be on screen for one download.
+    if (this.installRequested) {
+      return this.getStatus();
+    }
+
     if (this.status.state !== "downloaded") {
       return this.setStatus({
         state: this.status.state,
@@ -310,17 +318,30 @@ class UpdateManager {
     });
   }
 
+  /**
+   * Visible, or nothing. A sheet is attached to a window, and this app hides
+   * its windows rather than closing them — so "a window exists" is a poor
+   * proxy for "the user can see the sheet". Falling through to a windowless
+   * dialog is the honest answer when everything is in the tray.
+   */
   private getDialogWindow(): BrowserWindow | undefined {
     const focused = BrowserWindow.getFocusedWindow();
-    if (focused && !focused.isDestroyed()) {
+    if (focused && !focused.isDestroyed() && focused.isVisible()) {
       return focused;
     }
-    return BrowserWindow.getAllWindows().find((window) => !window.isDestroyed());
+    return BrowserWindow.getAllWindows().find(
+      (window) => !window.isDestroyed() && window.isVisible(),
+    );
   }
 
   private showDialog(options: MessageBoxOptions): Promise<Electron.MessageBoxReturnValue> {
     const window = this.getDialogWindow();
     return window ? dialog.showMessageBox(window, options) : dialog.showMessageBox(options);
+  }
+
+  /** The menu's "Check for Updates…" reporting what a manual check found. */
+  showStatusDialog(options: MessageBoxOptions): Promise<Electron.MessageBoxReturnValue> {
+    return this.showDialog(options);
   }
 
   private refreshAutoUpdateSetting(): boolean {


### PR DESCRIPTION
## What this PR does

Three menu items opened the same settings window. Two quit items ran the same function on two accelerators. And the one item that reached for the updater was wired to a call that only broadcasts a status, so a manual check for updates did nothing a user could see.

| | Before |
| --- | --- |
| `Settings…` | app menu, `File` and `Window` all called `openSettings` |
| Quit | `Quit Rome` and `Stop agent and quit` are both `requestStopAndQuit` |
| `Help → Update Rome` | awaited a status nothing renders — silence when up to date |

The first is tidying. The other two are defects, and moving a silent item into the app menu would have made the second one louder.

## Design & Invariants

**Placement follows the platform, not this app's history.** Updates and preferences are the application's own, so they sit in the app menu. The dashboard is content, so it moves to `View` — and it keeps `⇧⌘D`, because when a provider's OAuth page takes over this frameless window that item is the only way back. `Window` becomes the role: a hand-rolled Window menu gets minimize and zoom and never the open-window list, which only AppKit's real windows menu populates.

**No runtime menu, and nothing moved to the tray either.** Docker Desktop, OrbStack, Podman and UTM all keep runtime lifecycle in the menu-bar extra; Rancher Desktop has no such menu at all. The one candidate worth having, Restart, turned out to call `ensureReady()`, which no-ops on a healthy container.

**Nothing mirrors the dashboard.** Its Settings page stays the sidebar's, and that sidebar is user-customisable, so a fixed menu would drift from it per user.

**`role: "close"` replaces `hideWindowItem`.** Electron's definition is the same label, the same accelerator and the same `close()`, which `window.ts` already turns into a hide; deleting ours also drops a `getFocusedWindow()`-returns-null branch. `role: "fileMenu"` would collapse the menu further, but its non-mac branch is `role: "quit"` — `app.quit()` directly, skipping the runtime stop.

**The dialog carries the manager's own sentence** rather than composing a second one that could disagree. Two states need more: `error` puts its cause in `detail`, and `downloaded` gets **Restart Now** — a check in that state returns early without doing anything, so a lone OK would have said "ready to install" and offered no way to install it.

**`installUpdate` becomes idempotent.** Its state check was not enough — the first call leaves the state at `downloaded`, so a second reached `quitAndInstall` again. Nothing exercised that before: `promptToInstall` guards with `!installRequested` and was the only way in. Now one download can put two prompts on screen, so the rule moves to the method both pass through. Refusing the second call is safe because the flag is set after the app is already committed to quitting.

**`getDialogWindow` now requires a visible window.** It checked only for destruction, and this app hides windows rather than closing them, so a sheet could attach to something nobody could see. `promptToInstall` reaches that path today.

**Non-macOS is untouched.** `electron-builder.yml` builds macOS only, so those branches are dead; they keep the contents and the `⇧⌘Q` they had. The one exception is the tray's accelerator *label*, dropped unconditionally — tray menus register nothing, so it is decoration, and a platform branch for one line of it is not worth having.

## Test plan

- [x] `pnpm --filter rome-desktop test` — 89 tests, 9 files (83 before).
- [x] `pnpm --filter rome-desktop typecheck` — clean.
- [x] `npx biome check` on all seven changed files — clean.
- [x] `updateDialogFor` covered in six directions: the manager's sentence carried through, `error` detail present, `error` with no cause omitting `detail` (`null` would render as "null"), every state answering with something, and both halves of the `downloaded` buttons.
- [x] **Menu template built and dumped through a temporary probe** — one `Settings…`, one `Quit Rome`, no `⇧⌘Q` anywhere, and only three explicit accelerators (`⌘,`, `⌘Q`, `⇧⌘D`), asserted distinct. The probe was deleted rather than committed.
- [x] `role: "windowMenu"` carries no `Close` on macOS — read from Electron 36.9.5's bundled role table, so `File → Close Window` remains the only `⌘W`.
- [x] Clicked through on-device — needs a desktop release.
- [x] Every check above was re-run in this repository, not carried over. The probe was rebuilt here and the two `downloaded` cases were confirmed load-bearing by deleting that branch: 2 failed, 87 passed. Electron resolves to 36.9.5 here too, so the role-table reading holds.

## Not in this PR

- **Suppressing the manual dialog while a download runs.** A check that finds an update resolves as `downloading`, so the menu answers "Downloading Rome 1.0.108…" and the automatic prompt follows when it lands. Two dialogs, but sequential and each informative; only a download fast enough to finish before the first is dismissed stacks them. The alternative — staying silent for `available`/`downloading` and letting the automatic prompt speak — reinstates the silence this PR exists to remove, in the one case where the user most wants an answer. The install path they both reach is idempotent, which is the part with a consequence.
- **A `.catch` on the menu's async handler.** `checkForUpdates` already absorbs network failures; what remains is a native dialog rejecting, which costs a log line and nothing a user sees.
- **The install sentence, written twice.** Identical in `promptToInstall` and the `downloaded` branch. Sharing it couples the two modules for one stable string.
- **Runtime actions in the tray.** Rome's tray is the thinnest in this family, and `View setup logs` is a grey link two clicks into Settings. Deferred as scope, not dismissed.
- **The agent image updater.** `rome-image:apply` is registered but never exposed in preload, `SettingsPage` never references `romeImage`, and the pinned tag's digest does not move — machinery that runs a timer and can reach nothing. Agents update with the app, so this is dead weight rather than a broken feature.
- **`openRuntimeFolder`.** Exposed through preload, called by nothing.
- **"agent" versus "Rome".** The tray and quit strings say one, every status string says the other.



---

Ported from `amantru/rome-internal#2449` (`950dff06`), which the public snapshot predates. The diff is byte-identical.
