### PR TITLE
fix(core): read deleteSessionsByProjectPathPrefix's id list inside its transaction

### DIFF
--- a/packages/core/src/db/repositories/webchat.test.ts
+++ b/packages/core/src/db/repositories/webchat.test.ts
@@ -861,6 +861,64 @@ describe("WebChatRepository", () => {
     });
   });
 
+  describe("deleteSessionsByProjectPathPrefix id read", () => {
+    it("reads the session ids inside the same transaction as the deletes", async () => {
+      await repo.createSession("sess-tx", "Tx", undefined, "alpha", null, "alpha");
+      const { db, statements } = trackStatements(testDb.db);
+      const trackedRepo = new WebChatRepository(db);
+
+      await expect(trackedRepo.deleteSessionsByProjectPathPrefix("alpha")).resolves.toBe(1);
+
+      // A `select` on the connection itself means the id list was read in its
+      // own autocommit statement before the transaction opened.
+      expect(statements).toEqual(["transaction"]);
+    });
+
+    it("deletes a session created for the project after the id read", async () => {
+      await repo.createSession("sess-alpha", "Alpha", undefined, "alpha", null, "alpha");
+      await repo.createSession("sess-other", "Other", undefined, "other", null, "other");
+
+      // Stand in for the concurrent create that lands in the window between the
+      // id read and the deletes. Reading the ids first leaves this session
+      // pointing at a project that no longer exists.
+      const original = testDb.db.transaction.bind(testDb.db);
+      const spy = vi
+        .spyOn(testDb.db, "transaction")
+        .mockImplementation((cb: Parameters<typeof original>[0]) => {
+          const now = new Date();
+          testDb.db
+            .insert(romeSessions)
+            .values({
+              id: "sess-alpha-raced",
+              name: "Alpha Raced",
+              projectName: "alpha",
+              projectPath: "alpha",
+              type: "webchat",
+              createdAt: now,
+              activityAt: now,
+            })
+            .run();
+          return original(cb);
+        });
+
+      await expect(repo.deleteSessionsByProjectPathPrefix("alpha")).resolves.toBe(2);
+      spy.mockRestore();
+
+      await expect(repo.listSessionRefsByProjectPathPrefix("alpha")).resolves.toEqual([]);
+      await expect(repo.getSession("sess-alpha")).resolves.toBeNull();
+      await expect(repo.getSession("sess-alpha-raced")).resolves.toBeNull();
+      await expect(repo.getSession("sess-other")).resolves.toMatchObject({ id: "sess-other" });
+    });
+
+    it("returns 0 and deletes nothing when no session matches the prefix", async () => {
+      await repo.createSession("sess-other", "Other", undefined, "other", null, "other");
+
+      await expect(repo.deleteSessionsByProjectPathPrefix("alpha")).resolves.toBe(0);
+
+      await expect(repo.getSession("sess-other")).resolves.toMatchObject({ id: "sess-other" });
+    });
+  });
+
   it("pages project sessions by latest chat activity", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2029-01-01T00:00:00.000Z"));

--- a/packages/core/src/db/repositories/webchat.ts
+++ b/packages/core/src/db/repositories/webchat.ts
@@ -676,13 +676,24 @@ export class WebChatRepository {
   }
 
   async deleteSessionsByProjectPathPrefix(projectPath: string): Promise<number> {
-    const sessions = await this.listSessionRefsByProjectPathPrefix(projectPath);
-    const sessionIds = sessions.map((session) => session.id);
-    if (sessionIds.length === 0) return 0;
+    // The id read belongs in the same transaction as the deletes it drives.
+    // Reading first and awaiting leaves a window where a session created for
+    // the project lands after the list is taken: it isn't in the id list, so
+    // it survives the delete and is left pointing at a project that no longer
+    // exists. `.all()` is the synchronous terminal the better-sqlite3
+    // transaction scope requires (the same shape the deletes' `.run()` uses).
+    return this.db.transaction((tx) => {
+      const sessionIds = tx
+        .select({ id: romeSessions.id })
+        .from(romeSessions)
+        .where(projectPathPrefixCondition(projectPath))
+        .orderBy(asc(romeSessions.createdAt), asc(romeSessions.id))
+        .all()
+        .map((row) => row.id);
+      if (sessionIds.length === 0) return 0;
 
-    // Same persistence contract as deleteSession(), but batched for project
-    // deletion and all session kinds (top-level chats plus handoff children).
-    await this.db.transaction((tx) => {
+      // Same persistence contract as deleteSession(), but batched for project
+      // deletion and all session kinds (top-level chats plus handoff children).
       for (const chunk of chunkArray(sessionIds, SESSION_DELETE_CHUNK_SIZE)) {
         tx.delete(romeAgentTraceBlocks).where(inArray(romeAgentTraceBlocks.sessionId, chunk)).run();
         tx.delete(romeAgentMessages).where(inArray(romeAgentMessages.sessionId, chunk)).run();
@@ -693,9 +704,9 @@ export class WebChatRepository {
         tx.delete(sharedChats).where(inArray(sharedChats.sessionId, chunk)).run();
         tx.delete(romeSessions).where(inArray(romeSessions.id, chunk)).run();
       }
-    });
 
-    return sessionIds.length;
+      return sessionIds.length;
+    });
   }
 
   async listProjects(): Promise<StoredWebchatProject[]> {


### PR DESCRIPTION
## Summary

`WebChatRepository.deleteSessionsByProjectPathPrefix` awaited `listSessionRefsByProjectPathPrefix` and only then opened the transaction that deletes those ids. A session created for the project during that await is absent from the id list, so it survives the project delete and is left pointing at a project that no longer exists.

The read now runs inside the same transaction as the deletes, as a `tx.select(...).all()` — the synchronous terminal the better-sqlite3 transaction scope requires, matching the deletes' `.run()` — with the count returned from inside the transaction callback.

Unchanged: the chunked deletes and `SESSION_DELETE_CHUNK_SIZE`, the early return of `0` on an empty list, the returned count, and `listSessionRefsByProjectPathPrefix` itself (the projects route still calls it on its own). `deleteSession` is untouched — it takes an id from the caller and runs no list step.

## Acceptance

- [x] The session id read runs inside the same transaction as the deletes.
- [x] The method returns the number of deleted sessions.
- [x] A test inserts a session for the project during the window between the id read and the deletes, and asserts no session under that project path prefix survives.

## Test plan

Tests were written first and confirmed failing against the old implementation (`expected [ 'select', 'transaction' ] to deeply equal [ 'transaction' ]` and `expected 1 to be 2`), then pass with the fix.

- [x] `reads the session ids inside the same transaction as the deletes` — reuses the existing `trackStatements` proxy; a `select` on the connection itself would mean the ids were read in their own autocommit statement before the transaction opened.
- [x] `deletes a session created for the project after the id read` — inserts a session for the project in the window between the id read and the deletes, then asserts nothing under that prefix survives and unrelated projects are untouched.
- [x] `returns 0 and deletes nothing when no session matches the prefix` — covers the early return now living inside the transaction.
- [x] `pnpm --filter @rome/core exec vitest run src/db` — 232 passed (16 files), including the pre-existing prefix-delete, legacy-ambiguity and LIKE-wildcard cases.
- [x] `pnpm --filter @rome/core exec vitest run src/api/routes/projects-files.test.ts` — 50 passed (the only production caller).
- [x] `tsc --noEmit` on `@rome/core` and `biome check` on both changed files.

Closes rome-os/rome#18

🤖 Generated with [Claude Code](https://claude.com/claude-code)