### PR TITLE
fix(apps): stop reading design-system constants off the host

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -39,6 +39,12 @@ Two cases need a prefix instead. The first is a natural name that would itself b
 
 Aliases are layer-1 pointers at other layer-1 tokens, such as `--card: var(--surface)`. `var()` resolves lazily at the element, so an alias declared once tracks every theme × mode swap without re-declaration.
 
+**Only theme values cross the Shadow DOM boundary into an app.** Custom properties inherit, and inheritance cannot be narrowed. Every name the dashboard declares on `:root` reaches every app, whether or not the app was meant to see it. The promise is only the theme layer: the palette and the resolved semantic values `buildThemeCss` emits.
+
+Everything else an app paints with holds the same value under every theme and mode, so the app carries it in its own bundle. Importing `@rome-os/app-web-sdk/styles`, or the kit sheet directly, is what puts it there. An app with no kit sheet declares the few constants it needs itself.
+
+An app that reads a fixed value it never compiled renders correctly against the one host that declares it and breaks anywhere else. `packages/web/src/styles/app-token-contract.test.ts` fails on any `var()` an app cannot resolve from its own CSS, from a sheet it imports, or from the theme contract. A `var(--x, fallback)` is exempt, having stated its own default.
+
 **Never ship a host-owned value in layer 2.** A literal theme color or shadow there forks the host's single source of truth. It also freezes that value into every consumer's compiled CSS. Fixed values belong in the kit's layer-1 block. The fixed typography-role scale belongs in a non-inline `@theme` block where Tailwind emits overridable variables.
 
 **Control-geometry tokens (`--control-*`, `--field-*`, `--badge-*`) are layer 1 with no layer-2 entry, deliberately.** They get no `@theme` registration and no generated utility. Components read them in bracket form, such as `h-[var(--control-h-md)]`. That keeps the shared token greppable at every call site and classifies correctly under `tailwind-merge`. Values live in the kit's `:root, :host` block.

--- a/packages/web/src/styles/app-token-contract.test.ts
+++ b/packages/web/src/styles/app-token-contract.test.ts
@@ -1,0 +1,138 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { extname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { getThemeDefinitions } from "@/lib/theme";
+
+/**
+ * The host→app custom-property contract. Rule and rationale:
+ * docs/design-system.md, "Only theme values cross the Shadow DOM boundary".
+ *
+ * Resolution here is by name, not by value. An app may pin a constant to its
+ * own value, which the app template invites, and divergence from the kit is the
+ * app's call. Sourcing a name from the host by accident is not.
+ */
+
+const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
+
+/** Directories holding a workspace of app packages, each `<pkg>/src/web`. */
+const APP_ROOTS = ["rome_apps", "example_apps", "packages/app-template"];
+
+/** Stylesheets that carry the design-system canon into an app's own bundle.
+ *  Importing either puts the kit's `:host` constants (and Tailwind's theme
+ *  keys, which v4 emits on `:root, :host`) inside the app's shadow root, so the
+ *  app resolves them without reaching past the boundary. */
+const CANON_IMPORTS = ["@rome-os/app-web-sdk/styles", "@rome-os/ui/styles.css"];
+
+/** Families Tailwind generates into the importing bundle rather than the kit
+ *  source: its own default theme keys and the `--tw-*` internals utilities set
+ *  on the elements they apply to. Only consulted for an app that imports the
+ *  canon, which is what pulls Tailwind in. */
+const TAILWIND_FAMILIES = [/^--tw-/, /^--spacing(-|$)/, /^--default-/, /^--breakpoint-/];
+
+function stripComments(css: string): string {
+  return css.replaceAll(/\/\*[\s\S]*?\*\//g, "");
+}
+
+function declaredNames(css: string): Set<string> {
+  return new Set(
+    [...stripComments(css).matchAll(/(?:^|[;{}\s])(--[a-zA-Z0-9_-]+)\s*:/g)].map((m) => m[1]),
+  );
+}
+
+/** Names the sheet reads with no fallback. A `var(--x, …)` is exempt: the app
+ *  has stated what the property means when nothing supplies it, so it is not
+ *  relying on the host to. That also covers a property the app sets from JS as
+ *  an inline style, which no stylesheet declares. */
+function referencedNames(css: string): Set<string> {
+  return new Set(
+    [...stripComments(css).matchAll(/var\(\s*(--[a-zA-Z0-9_-]+)\s*([,)])/g)]
+      .filter((m) => m[2] === ")")
+      .map((m) => m[1]),
+  );
+}
+
+function cssFiles(directory: string): string[] {
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) return cssFiles(path);
+    return extname(path) === ".css" ? [path] : [];
+  });
+}
+
+/** Every name `buildThemeCss` emits, across every registered theme: the palette
+ *  primitives plus both mapping halves. Derived from the definitions rather than
+ *  listed here, so adding a theme token widens the contract automatically and
+ *  removing one narrows it — which is the point, since a dropped token is
+ *  exactly the change that would silently break an app. */
+function themeContract(): Set<string> {
+  const names = new Set<string>();
+  for (const theme of getThemeDefinitions()) {
+    for (const tokens of [theme.palette, theme.light, theme.dark]) {
+      for (const name of Object.keys(tokens)) names.add(`--${name}`);
+    }
+  }
+  return names;
+}
+
+function kitNames(): Set<string> {
+  return declaredNames(readFileSync(resolve(repoRoot, "packages/ui/src/styles.css"), "utf8"));
+}
+
+interface AppSources {
+  name: string;
+  files: { path: string; css: string }[];
+}
+
+function appSources(): AppSources[] {
+  return APP_ROOTS.flatMap((root) => {
+    const rootPath = resolve(repoRoot, root);
+    if (!existsSync(rootPath)) return [];
+    return readdirSync(rootPath, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => ({
+        name: `${root}/${entry.name}`,
+        files: cssFiles(resolve(rootPath, entry.name, "src/web")).map((path) => ({
+          path,
+          css: readFileSync(path, "utf8"),
+        })),
+      }))
+      .filter((app) => app.files.length > 0);
+  });
+}
+
+describe("app token contract", () => {
+  const apps = appSources();
+
+  it("finds the app stylesheets it is meant to police", () => {
+    // A rename of `src/web` or of an app root would otherwise turn this whole
+    // file into a green no-op.
+    expect(apps.map((app) => app.name)).toContain("rome_apps/coding");
+    expect(apps.length).toBeGreaterThan(5);
+  });
+
+  it("reads no custom property the host has not promised", () => {
+    const contract = themeContract();
+    const kit = kitNames();
+
+    const violations = apps.flatMap((app) => {
+      const importsCanon = app.files.some((file) =>
+        CANON_IMPORTS.some((specifier) => file.css.includes(specifier)),
+      );
+      const declared = new Set(app.files.flatMap((file) => [...declaredNames(file.css)]));
+      return app.files.flatMap((file) =>
+        [...referencedNames(file.css)]
+          .filter((name) => !declared.has(name) && !contract.has(name))
+          .filter(
+            (name) =>
+              !importsCanon ||
+              (!kit.has(name) && !TAILWIND_FAMILIES.some((family) => family.test(name))),
+          )
+          .map((name) => `${relative(repoRoot, file.path)}: ${name}`),
+      );
+    });
+
+    expect(violations.sort()).toEqual([]);
+  });
+});

--- a/rome_apps/coding/src/web/styles.css
+++ b/rome_apps/coding/src/web/styles.css
@@ -25,6 +25,15 @@
   --acc: var(--brand);
   --acc-ink: var(--brand-fg);
 
+  /* Corner radii, held here rather than read from the host. This app ships no
+     kit stylesheet, so an undeclared `var(--rome-radius-12)` resolves only by
+     inheriting the dashboard's `:root`, which renders correctly against that one
+     host and nowhere else. Geometry does not vary with theme or mode, so a local
+     copy costs nothing. Contract: docs/design-system.md. */
+  --rome-radius-12: 12px;
+  --rome-radius-16: 16px;
+  --rome-radius-full: 9999px;
+
   box-sizing: border-box;
   min-height: 100%;
   padding: clamp(1rem, 2vw, 1.75rem);

--- a/rome_apps/workflow-studio/src/web/styles.css
+++ b/rome_apps/workflow-studio/src/web/styles.css
@@ -11,6 +11,13 @@
     sans-serif;
   font-size: 14px;
   color: var(--foreground);
+
+  /* The control radius, held here rather than read from the host. This app
+     ships no kit stylesheet, so an undeclared `var(--control-r-md)` resolves
+     only by inheriting the dashboard's `:root`, which renders correctly against
+     that one host and nowhere else. Geometry does not vary with theme or mode,
+     so a local copy costs nothing. Contract: docs/design-system.md. */
+  --control-r-md: 10px;
 }
 
 .ws-root {


### PR DESCRIPTION
## What this PR does

An app bundle mounts in a Shadow DOM, and CSS custom properties inherit through that boundary. Inheritance cannot be narrowed, so every name the dashboard declares on `:root` reaches every app whether or not the app was meant to see it. Two apps were living off that.

`rome_apps/coding` reads `var(--rome-radius-12 / -16 / -full)` at seven sites and `rome_apps/workflow-studio` reads `var(--control-r-md)` at three. Both are hand-written CSS that imports no kit stylesheet, so neither name existed anywhere in their own bundles. They render correctly because the one host they are ever mounted in happens to declare them. Every other app imports `@rome-os/app-web-sdk/styles` and was already self-sufficient.

Both apps now declare the constants they use, at the kit's values. A new test holds every app to the boundary.

## Design & Invariants

Only the theme layer is host-owned: the palette and the resolved semantic values `buildThemeCss` emits, which apps inherit so they track the live theme and mode. Everything else an app paints with holds the same value under every theme and mode, and the kit declares it on `:host` as well as `:root` so an app that imports the canon resolves it from its own bundle. `docs/design-system.md` carries the rule.

`packages/web/src/styles/app-token-contract.test.ts` fails on any `var()` an app cannot resolve from its own CSS, from a sheet it imports, or from the theme contract. The contract is derived from `getThemeDefinitions()` rather than listed in the test, so dropping a theme token narrows it automatically — that is the change that would otherwise break an app silently. A `var(--x, fallback)` is exempt: the app has stated what the property means when nothing supplies it, which also covers a property set from JSX as an inline style. The test lives in `packages/web` because that package owns both sides, emitting the contract in `themes.ts` and mounting the shadow root in `rome-app-host.tsx`.

Resolution is by name, not by value. An app may pin a constant to its own value, which the app template invites.

The alternative for the two apps was to import `@rome-os/app-web-sdk/styles` like everyone else. It carries Tailwind preflight, which would restyle markup neither app was authored against. Declaring four constants changes no pixel: the values match the kit, so an explicit declaration replaces an identical inherited one.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 5642 tests, all packages
- [x] The guard is red on both original bugs: removed each fix, watched the test name the file and the token, restored
- [x] The guard is red on a host-only leak — appended `var(--rome-mobile-header-height)` to an app that imports the canon, confirmed the failure, reverted
- [ ] Browser check skipped. The four declarations hold the kit's exact values (`10px`, `12px`, `16px`, `9999px`), so there is no rendering delta to exercise.

## Not in this PR

- The dashboard's own `:root` names that no app should see, `--rome-safe-area-*` and `--rome-mobile-*` in `packages/web/src/globals.css`. Moving them onto the dashboard's layout root takes them out of the inherited chain. The test already catches an app that reads one.
- A snapshot of the `:root` custom-property names the host declares, which would make widening the surface a reviewed act rather than a silent one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)