### PR TITLE
fix(web): put the chat composer on one control step

### DIFF
--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -1636,7 +1636,7 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
                     ref={composerRef}
                     // The box look lives on the composer now so the chip row can sit
                     // outside it; this mount adds the floating blur/translucency.
-                    boxClassName="rounded-16 border border-border bg-surface/95 p-3 shadow-10 backdrop-blur-md supports-[backdrop-filter]:bg-surface/80"
+                    boxClassName="rounded-16 border border-border bg-surface/95 p-4 shadow-10 backdrop-blur-md supports-[backdrop-filter]:bg-surface/80"
                     onSend={handleComposerSend}
                     isStreaming={displayedStreaming}
                     onStop={() => void stopMessage()}

--- a/packages/web/src/components/chat/ChatComponent.tsx
+++ b/packages/web/src/components/chat/ChatComponent.tsx
@@ -369,7 +369,7 @@ export function ChatComponent({
           <ChatComposer
             ref={draftComposerRef}
             // Box look lives on the composer so the chip row sits outside it.
-            boxClassName="rounded-16 border border-border bg-surface/95 p-3 shadow-10 backdrop-blur-md supports-[backdrop-filter]:bg-surface/80"
+            boxClassName="rounded-16 border border-border bg-surface/95 p-4 shadow-10 backdrop-blur-md supports-[backdrop-filter]:bg-surface/80"
             onSend={handleDraftSend}
             showProjectSelector
             showModelSelector

--- a/packages/web/src/components/chat/ChatComposer.tsx
+++ b/packages/web/src/components/chat/ChatComposer.tsx
@@ -153,7 +153,7 @@ export interface ChatComposerProps {
 // The empty input is one line box tall, expressed as `1lh` so it resolves
 // against whatever `text-body` currently is rather than restating the role's
 // px here. The textarea carries no vertical padding, so that leaves the box's
-// own `p-3` as the only inset above the text and the empty composer reads
+// own `p-4` as the only inset above the text and the empty composer reads
 // symmetric top to bottom. `min-height` outranks the height the resize below
 // writes, which is why the floor lives in CSS and the resize only caps.
 //
@@ -845,7 +845,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
           clears the box's rounded-16 corner zone, so no tray corner shows in the
           gap; only the top chip row (rounded-t-16) peeks. Scrolls horizontally
           on overflow. */}
-      <div className="relative z-0 -mb-8 flex items-center gap-2 overflow-x-auto rounded-t-16 border border-border bg-surface-muted/65 px-3 pb-10 pt-2 backdrop-blur-md [scrollbar-width:none] [&::-webkit-scrollbar]:hidden supports-[backdrop-filter]:bg-surface-muted/45 empty:hidden">
+      <div className="relative z-0 -mb-8 flex items-center gap-2 overflow-x-auto rounded-t-16 border border-border bg-surface-muted/65 px-4 pb-10 pt-2 backdrop-blur-md [scrollbar-width:none] [&::-webkit-scrollbar]:hidden supports-[backdrop-filter]:bg-surface-muted/45 empty:hidden">
         {effectiveMention && (
           // Its × cancels the live handoff while collaborating, otherwise clears
           // a removable draft mention.
@@ -926,7 +926,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
                         : t("composer.placeholderDefault")
                     }
                     rows={1}
-                    className="block w-full resize-none border-0 bg-transparent px-2 text-body text-foreground placeholder:text-subtle-foreground focus:outline-none focus:ring-0"
+                    className="block w-full resize-none border-0 bg-transparent text-body text-foreground placeholder:text-subtle-foreground focus:outline-none focus:ring-0"
                     style={{
                       minHeight: TEXTAREA_MIN_HEIGHT,
                       maxHeight: `${TEXTAREA_MAX_HEIGHT}px`,
@@ -1008,7 +1008,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
             disabled={isComposerBusy}
             label={t("composer.uploadFiles")}
             icon={<Paperclip aria-hidden />}
-            className="text-muted-foreground hover:text-foreground"
+            className="touch-target text-muted-foreground hover:text-foreground"
           />
           {showModelSelector && modelSelectorEnabled && (
             <ModelSelectorMenu
@@ -1032,13 +1032,13 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
               <Button
                 type="button"
                 variant="outline"
-                size="icon-lg"
+                size="icon-md"
                 onClick={onStop}
                 // Square on mobile, icon + label above `sm`. The width override
                 // is important because `icon-lg` sets width via `size-*`: they
                 // are different utilities at equal specificity, so without it
                 // the winner is whichever Tailwind happens to emit last.
-                className="gap-2 rounded-full sm:w-auto! sm:px-3"
+                className="touch-target gap-2 sm:w-auto! sm:px-3"
                 title={t("composer.stopGenerating")}
                 aria-label={t("composer.stopGenerating")}
               >
@@ -1052,14 +1052,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
                   ? "secondary"
                   : "default"
               }
-              size="icon-lg"
+              size="icon-md"
               onClick={() => void runSend()}
               disabled={
                 isComposerBusy || (!inputText.trim() && pendingUploads.length === 0 && !draftSkill)
               }
               title={isStreaming ? t("composer.queueTurnTitle") : t("composer.sendTitle")}
               aria-label={isStreaming ? t("composer.queueTurnTitle") : t("composer.sendTitle")}
-              className="rounded-full"
+              className="touch-target"
             >
               <ArrowUp aria-hidden />
             </Button>

--- a/packages/web/src/components/chat/composer/ComposerChip.tsx
+++ b/packages/web/src/components/chat/composer/ComposerChip.tsx
@@ -48,7 +48,12 @@ export const ComposerChip = forwardRef<HTMLSpanElement, ComposerChipProps>(funct
           type="button"
           onClick={onRemove}
           aria-label={removeLabel}
-          className="-mr-1 ml-1 shrink-0 rounded-full p-1 opacity-60 transition hover:bg-foreground/10 hover:opacity-100"
+          // The visible box stays 20px so the chip's own height does not move.
+          // The pointer target reaches past it through `after:-inset-*`, which
+          // is how a Selection control clears the floor without growing its
+          // row (docs/ui/component-roles.md, and `Switch` in the kit). Raising
+          // the chip to a control step instead is the negative example there.
+          className="relative -mr-1 ml-1 shrink-0 rounded-full p-1 opacity-60 transition after:absolute after:-inset-1.5 hover:bg-foreground/10 hover:opacity-100"
         >
           <X className="size-3" strokeWidth={2.5} />
         </button>

--- a/packages/web/src/components/chat/composer/ImpersonationMenu.tsx
+++ b/packages/web/src/components/chat/composer/ImpersonationMenu.tsx
@@ -48,10 +48,10 @@ export function ImpersonationMenu({
             </>
           }
           className={cn(
-            "relative",
+            "relative touch-target",
             selectedPerson
               ? "bg-info-bg text-info-fg hover:bg-info-bg"
-              : "bg-surface text-muted-foreground hover:bg-surface-muted hover:text-foreground",
+              : "text-muted-foreground hover:bg-surface-muted hover:text-foreground",
           )}
         />
       </DropdownMenuTrigger>

--- a/packages/web/src/components/chat/composer/ModelSelectorMenu.tsx
+++ b/packages/web/src/components/chat/composer/ModelSelectorMenu.tsx
@@ -36,11 +36,12 @@ export function ModelSelectorMenu({
           disabled={disabled}
           label={t("modelSelector.label")}
           icon={<Zap aria-hidden />}
-          className={
+          className={cn(
+            "touch-target",
             customSelected
               ? "bg-info-bg text-info-fg hover:bg-info-bg"
-              : "bg-surface text-muted-foreground hover:bg-surface-muted hover:text-foreground"
-          }
+              : "text-muted-foreground hover:bg-surface-muted hover:text-foreground",
+          )}
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent side="top" align="start" className="w-56 rounded-12 p-2">

--- a/packages/web/src/components/chat/composer/PendingUploadsList.tsx
+++ b/packages/web/src/components/chat/composer/PendingUploadsList.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import type { PendingUpload } from "@/lib/chat-types";
+import { ComposerChip } from "./ComposerChip";
 
 export interface PendingUploadsListProps {
   uploads: PendingUpload[];
@@ -7,37 +8,26 @@ export interface PendingUploadsListProps {
   disabled: boolean;
 }
 
+/**
+ * Pending attachments, rendered in the same chip language as the pre-send tray.
+ * They share a surface, so a second pill geometry here read as two systems —
+ * `ComposerChip` owns height, radius, padding and text size for both.
+ */
 export function PendingUploadsList({ uploads, onRemove, disabled }: PendingUploadsListProps) {
   const { t } = useTranslation("chat");
   if (uploads.length === 0) return null;
   return (
     <div className="mb-3 flex flex-wrap gap-2">
       {uploads.map((upload, index) => (
-        <div
+        <ComposerChip
           key={upload.id}
-          className="flex max-w-full items-center gap-2 rounded-full border border-border bg-surface-muted px-3 py-1 text-badge text-foreground"
+          prefix={t("composer.filePill", { index: index + 1 })}
+          title={upload.file.name}
+          onRemove={disabled ? undefined : () => onRemove(upload.id)}
+          removeLabel={t("composer.removeFile", { name: upload.file.name })}
         >
-          <span className="shrink-0 text-muted-foreground">
-            {t("composer.filePill", { index: index + 1 })}
-          </span>
-          <span className="max-w-[14rem] truncate">{upload.file.name}</span>
-          <button
-            type="button"
-            className="rounded-full p-1 text-subtle-foreground hover:bg-border hover:text-foreground disabled:opacity-50"
-            onClick={() => onRemove(upload.id)}
-            disabled={disabled}
-            aria-label={t("composer.removeFile", { name: upload.file.name })}
-          >
-            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
+          {upload.file.name}
+        </ComposerChip>
       ))}
     </div>
   );

--- a/packages/web/src/components/chat/composer/ReasoningEffortMenu.tsx
+++ b/packages/web/src/components/chat/composer/ReasoningEffortMenu.tsx
@@ -38,7 +38,7 @@ export function ReasoningEffortMenu({
           type="button"
           variant="ghost"
           disabled={disabled}
-          className="text-muted-foreground"
+          className="touch-target text-muted-foreground"
           aria-label={t("reasoningEffort.label")}
           title={t("reasoningEffort.label")}
         >

--- a/packages/web/src/components/project-selector.tsx
+++ b/packages/web/src/components/project-selector.tsx
@@ -13,6 +13,7 @@ import { IconButton } from "@/components/ui/icon-button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { EmptyState, EmptyStateIcon, EmptyStateTitle } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@rome-os/ui/spinner";
@@ -128,17 +129,16 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
         }}
       >
         <PopoverTrigger asChild>
-          <button
+          <Button
             type="button"
-            className={`group relative inline-flex h-10 max-w-[200px] items-center gap-2 rounded-full px-3 text-ui transition focus:outline-none focus:ring-2 focus:ring-ring ${
+            variant="ghost"
+            size="md"
+            className={cn(
+              "group relative max-w-[200px] touch-target",
               isDefault
-                ? `bg-surface-muted/60 text-muted-foreground hover:bg-surface-muted ${
-                    menuOpen ? "bg-surface-muted" : ""
-                  }`
-                : `bg-surface-muted text-foreground hover:bg-surface-hover ${
-                    menuOpen ? "bg-surface-hover" : ""
-                  }`
-            }`}
+                ? "bg-surface-muted/60 text-muted-foreground hover:bg-surface-muted"
+                : "bg-surface-muted text-foreground hover:bg-surface-hover",
+            )}
             title={isDefault ? t("project.buttonLabel") : draftProjectLabel}
             aria-label={t("project.buttonLabel")}
           >
@@ -149,7 +149,7 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
             />
             <span className="truncate">{isDefault ? defaultProjectName : draftProjectLabel}</span>
             <ChevronDown className="size-3 shrink-0 opacity-50" aria-hidden />
-          </button>
+          </Button>
         </PopoverTrigger>
 
         <PopoverContent

--- a/packages/web/src/focus-model-backlog.test.ts
+++ b/packages/web/src/focus-model-backlog.test.ts
@@ -42,7 +42,7 @@ function remainingSites(): string[] {
 }
 
 /** Lower this when you convert one. Never raise it. */
-const REMAINING = 62;
+const REMAINING = 60;
 
 describe("the ring-based focus backlog", () => {
   it("never grows, and shrinks only with the pin", () => {


### PR DESCRIPTION
## What this PR does

The chat composer toolbar accreted three control heights, two radius languages and two left edges. The project trigger was a hand-rolled `<button>` at 40px with a full radius — neither is a step on `--control-h-*` or `--control-r-*`. Send and Stop sat at 44px with a full radius of their own. The textarea carried a private `px-2`, which put the text column 8px to the right of the chip tray directly above it.

Nothing caught the drift. `control-size-vocabulary.spec.ts` sweeps `/dev/gallery` for members carrying `data-slot` and `data-size`, so a raw `<button>` on a product screen is invisible to it.

Two smaller divergences rode along. `PendingUploadsList` hand-rolled a second pill geometry next to `ComposerChip`, whose own comment claims one pill language for the surface, and both render on the composer at once. The chip remove control was a 20px pointer target, under the 24px floor in [`box-size-primitives.md`](docs/ui/primitive-token/box-size-primitives.md).

## Design & Invariants

Every control in the toolbar names the 36px `md` step and takes the height, radius and horizontal padding that step supplies. That is the Control role's promise in [`component-roles.md`](docs/ui/component-roles.md): two members at the same size name are the same height with no adjustment at the call site. No literal height, radius or control padding is left at these call sites, so the row cannot go ragged again without someone reintroducing one.

The box inset is 16px and the row gap is 8px. Both are plain `--rome-space-*` steps, per [`spacing-primitives.md`](docs/ui/primitive-token/spacing-primitives.md): a call site never writes an arbitrary spacing value.

The chip keeps its own scale. Inline content answers to the text around it, not to the controls beside it, and interactivity does not promote the role — so the remove control keeps its 20px box and reaches a real pointer target through `after:-inset-*`, the way a Selection control clears the floor without growing its row. `Switch` in the kit is the reference. Raising the chip to `--control-h-sm` instead is the negative example the role doc names twice.

An alternative was to keep Send and Stop at the 44px `icon-lg` step, which the role allows for a square icon control, and read the size difference as emphasis. One step for the whole row won because `lg` is a hit area rather than a prominence step. The cost is that Send no longer clears the 44px touch floor unaided, so it now pairs with `.touch-target` like every other control in the row.

### Latent trap

The pre-send chip tray is a sibling of the composer box with its own horizontal inset. Nothing ties the two together — they agreed only because both were 12px. A future change to the box inset has to move both or the chip row stops lining up with the text.

## Test plan

- [x] `pnpm typecheck` — passes repo-wide.
- [x] `pnpm --filter rome-web test` — 1089/1089.
- [x] `biome check` on the changed files — clean. The one warning in the tree is pre-existing, in `HandoffCard.tsx`, which this PR does not touch.
- [x] Measured on the real `/chat` under `pnpm start:web:mock`: one control height (36px), one radius (10px), one alignment edge (17px = 1px border + 16px inset).
- [x] Confirmed the invariant in `composer-line-box.spec.ts` still holds by hand — top inset 17px equals bottom inset 17px.
- [ ] `pnpm test:e2e` not run: the local dev server was bound to a single interface for remote preview, and Playwright's config targets `localhost:3200`.

## Not in this PR

- No test pins the toolbar to one step, so the drift this PR fixes can recur. `control-size-vocabulary.spec.ts` cannot catch it, because it only measures kit members on `/dev/gallery`. A spec anchored on the existing `[data-chat-composer-toolbar]` hook would close it.
- `Button`'s `shape="pill"` variant stays undocumented. Full-round is not a `--control-r-*` step, so a pill is off-role by the letter of the Control contract, and `pill` appears nowhere in `component-roles.md` — not even under Known divergences. That is a kit-level call rather than a composer one.
- Nothing ties the chip tray's inset to the box's. See the trap above.
- `focus-model-backlog.test.ts` moves from 62 to 60 rather than converting more sites. Replacing the project trigger removed two hand-rolled `focus:ring-*` sites, and the ratchet's own comment asks for the pin to be lowered when that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
