### PR TITLE
core: promote a LinkedIn participant to a Rome person

### DIFF
--- a/packages/core/src/api/routes/linkedin-threads.test.ts
+++ b/packages/core/src/api/routes/linkedin-threads.test.ts
@@ -134,3 +134,123 @@ describe("POST /linkedin/threads/:threadId/send", () => {
     });
   });
 });
+
+// Promotion is a guardian action, so it has an explicit endpoint — the poller
+// has no route into this. The UI that calls it is out of scope here.
+describe("LinkedIn participant routes", () => {
+  const ADA = "ACoAAAda0001";
+
+  function promoteDeps(over: Partial<Record<string, unknown>> = {}) {
+    return {
+      linkedInStoreRepo: {
+        listThreads: async () => [THREAD],
+        getMessages: async () => [],
+        getThreadParticipants: async () => [
+          {
+            participantId: ADA,
+            name: "Ada Lovelace",
+            headline: "Building the analytical engine",
+            type: "member",
+            isSelf: false,
+          },
+        ],
+        ...over,
+      },
+    } as unknown as ApiDeps;
+  }
+
+  function mountPromote(promote: ReturnType<typeof vi.fn>, deps = promoteDeps()): Hono {
+    return new Hono().route("/", linkedinThreadsRoutes(deps, { promoteParticipant: promote }));
+  }
+
+  it("lists a thread's stored participants", async () => {
+    const app = new Hono().route("/", linkedinThreadsRoutes(promoteDeps(), {}));
+    const res = await app.request(
+      `/linkedin/threads/${encodeURIComponent(THREAD.threadId)}/participants`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      {
+        participantId: ADA,
+        name: "Ada Lovelace",
+        headline: "Building the analytical engine",
+        type: "member",
+        isSelf: false,
+      },
+    ]);
+  });
+
+  it("promotes a participant and reports the person it created", async () => {
+    const promote = vi.fn(async () => ({ personId: "ada-lovelace", created: true }));
+    const res = await mountPromote(promote).request(
+      `/linkedin/participants/${encodeURIComponent(ADA)}/promote`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bondLevel: "inner-circle" }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ personId: "ada-lovelace", created: true });
+    expect(promote).toHaveBeenCalledWith(
+      ADA,
+      expect.objectContaining({ bondLevel: "inner-circle" }),
+    );
+  });
+
+  it("reports an already-promoted participant as created: false, not as an error", async () => {
+    const promote = vi.fn(async () => ({ personId: "ada-lovelace", created: false }));
+    const res = await mountPromote(promote).request(
+      `/linkedin/participants/${encodeURIComponent(ADA)}/promote`,
+      { method: "POST" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ personId: "ada-lovelace", created: false });
+  });
+
+  it("rejects a bond level the person graph does not define", async () => {
+    const promote = vi.fn();
+    const res = await mountPromote(promote).request(
+      `/linkedin/participants/${encodeURIComponent(ADA)}/promote`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bondLevel: "best-friend" }),
+      },
+    );
+
+    expect(res.status).toBe(400);
+    expect(promote).not.toHaveBeenCalled();
+  });
+
+  it("never lets the endpoint confer guardian", async () => {
+    const promote = vi.fn();
+    const res = await mountPromote(promote).request(
+      `/linkedin/participants/${encodeURIComponent(ADA)}/promote`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bondLevel: "guardian" }),
+      },
+    );
+
+    expect(res.status).toBe(400);
+    expect(promote).not.toHaveBeenCalled();
+  });
+
+  it("turns an unpromotable participant into a 404 rather than a 500", async () => {
+    const { LinkedInPromotionError } = await import("../../channels/linkedin-promote.js");
+    const promote = vi.fn(async () => {
+      throw new LinkedInPromotionError("unknown LinkedIn participant");
+    });
+    const res = await mountPromote(promote).request("/linkedin/participants/ACoAAGhost/promote", {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toContain("unknown LinkedIn participant");
+  });
+});

--- a/packages/core/src/api/routes/linkedin-threads.ts
+++ b/packages/core/src/api/routes/linkedin-threads.ts
@@ -5,6 +5,13 @@ import {
   type LinkedInSafeSendInput,
   type LinkedInSafeSendResult,
 } from "../../channels/linkedin-cli.js";
+import {
+  LinkedInPromotionError,
+  promoteLinkedInParticipant,
+  type LinkedInPromotionOptions,
+  type LinkedInPromotionResult,
+  type PromotableBondLevel,
+} from "../../channels/linkedin-promote.js";
 import type { ApiDeps } from "../deps.js";
 
 /**
@@ -13,14 +20,39 @@ import type { ApiDeps } from "../deps.js";
  * LinkedIn connection's poller (channels/linkedin.ts). Replies go through
  * opencli `linkedin safe-send`. It verifies the visible thread and recipient
  * before sending.
+ *
+ * Promotion of a mirrored participant into `persons` also lives here, as an
+ * explicit endpoint. The poller has no route into it: promotion is a guardian
+ * action, and an inbox full of strangers must not walk itself into the person
+ * graph. The UI that calls this is out of scope.
  */
 export interface LinkedInThreadsSeams {
   sendReply?: (input: LinkedInSafeSendInput) => Promise<LinkedInSafeSendResult>;
+  promoteParticipant?: (
+    participantId: string,
+    options: LinkedInPromotionOptions,
+  ) => Promise<LinkedInPromotionResult>;
 }
+
+/** The bond levels this endpoint accepts. `guardian` is deliberately absent —
+ *  it is conferred at the terminal, not by pointing at an inbox row. */
+const PROMOTABLE_BOND_LEVELS: readonly PromotableBondLevel[] = [
+  "inner-circle",
+  "acquaintance",
+  "other",
+];
 
 export function linkedinThreadsRoutes(deps: ApiDeps, seams: LinkedInThreadsSeams = {}): Hono {
   const app = new Hono();
   const sendReply = seams.sendReply ?? safeSendLinkedInReply;
+  const promoteParticipant: NonNullable<LinkedInThreadsSeams["promoteParticipant"]> =
+    seams.promoteParticipant ??
+    ((participantId, options) =>
+      promoteLinkedInParticipant(
+        participantId,
+        { participants: deps.linkedInStoreRepo, persons: deps.personMappingRepo },
+        options,
+      ));
 
   app.get("/linkedin/threads", async (c) => {
     const rows = await deps.linkedInStoreRepo.listThreads();
@@ -33,6 +65,51 @@ export function linkedinThreadsRoutes(deps: ApiDeps, seams: LinkedInThreadsSeams
     const before = parsePositiveInt(c.req.query("before"));
     const messages = await deps.linkedInStoreRepo.getMessages(threadId, { limit, before });
     return c.json(messages);
+  });
+
+  app.get("/linkedin/threads/:threadId/participants", async (c) => {
+    const participants = await deps.linkedInStoreRepo.getThreadParticipants(
+      c.req.param("threadId"),
+    );
+    return c.json(participants);
+  });
+
+  // Promote one mirrored identity into the person graph. Idempotent: an
+  // identity already mapped comes back as `created: false` rather than as an
+  // error, because "this participant is already a person" is the outcome the
+  // caller wanted, not a failure to achieve it.
+  app.post("/linkedin/participants/:participantId/promote", async (c) => {
+    const participantId = c.req.param("participantId");
+    const body = await c.req
+      .json<{ displayName?: unknown; bondLevel?: unknown }>()
+      .catch(() => ({}) as { displayName?: unknown; bondLevel?: unknown });
+
+    const options: LinkedInPromotionOptions = {};
+    if (typeof body.displayName === "string" && body.displayName.trim()) {
+      options.displayName = body.displayName.trim();
+    }
+    if (body.bondLevel !== undefined) {
+      if (!PROMOTABLE_BOND_LEVELS.includes(body.bondLevel as PromotableBondLevel)) {
+        return c.json(
+          { error: `bondLevel must be one of: ${PROMOTABLE_BOND_LEVELS.join(", ")}` },
+          400,
+        );
+      }
+      options.bondLevel = body.bondLevel as PromotableBondLevel;
+    }
+
+    try {
+      const result = await promoteParticipant(participantId, options);
+      return c.json(result);
+    } catch (err) {
+      // A participant that cannot be promoted is a statement about the request,
+      // not a server fault — the caller pointed at something that is not a
+      // promotable identity.
+      if (err instanceof LinkedInPromotionError) {
+        return c.json({ error: err.message }, 404);
+      }
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 500);
+    }
   });
 
   app.post("/linkedin/threads/:threadId/send", async (c) => {

--- a/packages/core/src/channels/linkedin-promote.test.ts
+++ b/packages/core/src/channels/linkedin-promote.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb, type TestDb } from "../test/helpers.js";
+import { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
+import { PersonMappingRepository } from "../db/repositories/person-mapping.js";
+import {
+  promoteLinkedInParticipant,
+  LinkedInPromotionError,
+  type LinkedInPromotionDeps,
+} from "./linkedin-promote.js";
+
+const ADA = "ACoAABuildingEngine";
+const SELF = "ACoAASelfViewer";
+
+describe("promoteLinkedInParticipant", () => {
+  let testDb: TestDb;
+  let linkedIn: LinkedInStoreRepository;
+  let personsRepo: PersonMappingRepository;
+  let deps: LinkedInPromotionDeps;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    linkedIn = new LinkedInStoreRepository(testDb.db);
+    personsRepo = new PersonMappingRepository(testDb.db);
+    deps = { participants: linkedIn, persons: personsRepo };
+
+    await linkedIn.upsertThreads([
+      {
+        threadId: "t1",
+        threadUrl: "https://www.linkedin.com/messaging/thread/t1/",
+        personName: "Ada Lovelace",
+        lastMessagePreview: "See you Sunday?",
+        lastMessageAt: new Date("2026-08-19T20:00:00Z"),
+        unread: true,
+        counterpartyType: "member",
+        category: "INBOX,PRIMARY_INBOX",
+      },
+    ]);
+    await linkedIn.upsertThreadParticipants("t1", [
+      {
+        participantId: ADA,
+        name: "Ada Lovelace",
+        headline: "Building the analytical engine",
+        type: "member",
+        isSelf: false,
+      },
+      { participantId: SELF, name: "Me", headline: null, type: "member", isSelf: true },
+    ]);
+  });
+
+  afterEach(() => {
+    testDb.close();
+  });
+
+  // Acceptance: promoting a participant creates a person and a `linkedin`
+  // channel mapping carrying the member id.
+  it("creates a person and a linkedin mapping carrying the member id", async () => {
+    const result = await promoteLinkedInParticipant(ADA, deps);
+
+    expect(result.created).toBe(true);
+
+    const person = await personsRepo.findById(result.personId);
+    expect(person).not.toBeNull();
+    expect(person!.displayName).toBe("Ada Lovelace");
+    expect(person!.channelMappings).toContainEqual({
+      channel: "linkedin",
+      channelUserId: ADA,
+    });
+  });
+
+  it("reuses the shared person create flow, so the person is reachable by id and by identity", async () => {
+    const { personId } = await promoteLinkedInParticipant(ADA, deps);
+
+    // Both reads are the ordinary person reads — promotion adds no second
+    // person store of its own.
+    const byId = await personsRepo.findById(personId);
+    const byIdentity = await personsRepo.findByChannelUser("linkedin", ADA);
+    expect(byIdentity?.id).toBe(byId!.id);
+    expect(byId!.profilePath).toBe(`memory/relationship/${personId}.md`);
+  });
+
+  // The headline has no column on `channel_mappings`; it stays on
+  // `linkedin_participants` and belongs in the memory profile.
+  it("does not smuggle the headline into the channel mapping", async () => {
+    await promoteLinkedInParticipant(ADA, deps);
+
+    const rows = (await testDb.db.all(
+      // biome-ignore lint/suspicious/noExplicitAny: raw row read for assertion
+      "SELECT display_name FROM channel_mappings WHERE channel = 'linkedin'" as any,
+    )) as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].display_name).toBe("Ada Lovelace");
+
+    // The headline is still readable where it lives.
+    const stored = await linkedIn.getParticipant(ADA);
+    expect(stored?.headline).toBe("Building the analytical engine");
+  });
+
+  // Acceptance: promoting a participant that is already mapped does not create
+  // a second person.
+  it("is idempotent — re-promoting returns the same person and creates no second one", async () => {
+    const first = await promoteLinkedInParticipant(ADA, deps);
+    const second = await promoteLinkedInParticipant(ADA, deps);
+
+    expect(second.personId).toBe(first.personId);
+    expect(second.created).toBe(false);
+
+    const persons = (await testDb.db.all(
+      // biome-ignore lint/suspicious/noExplicitAny: raw row read for assertion
+      "SELECT id FROM persons" as any,
+    )) as Array<Record<string, unknown>>;
+    expect(persons).toHaveLength(1);
+  });
+
+  it("returns the existing person when the identity was already claimed elsewhere", async () => {
+    // The identity is already mapped to a person created by another path.
+    await personsRepo.create({
+      displayName: "Ada L.",
+      bondLevel: "acquaintance",
+      channelMappings: [{ channel: "linkedin", channelUserId: ADA }],
+    });
+
+    const result = await promoteLinkedInParticipant(ADA, deps);
+    expect(result.created).toBe(false);
+
+    const persons = (await testDb.db.all(
+      // biome-ignore lint/suspicious/noExplicitAny: raw row read for assertion
+      "SELECT id FROM persons" as any,
+    )) as Array<Record<string, unknown>>;
+    expect(persons).toHaveLength(1);
+    // The pre-existing person keeps its own name — promotion claims nothing it
+    // did not create.
+    const person = await personsRepo.findById(result.personId);
+    expect(person!.displayName).toBe("Ada L.");
+  });
+
+  it("refuses an unknown participant rather than minting a nameless person", async () => {
+    await expect(promoteLinkedInParticipant("ACoAAGhost", deps)).rejects.toBeInstanceOf(
+      LinkedInPromotionError,
+    );
+
+    const persons = (await testDb.db.all(
+      // biome-ignore lint/suspicious/noExplicitAny: raw row read for assertion
+      "SELECT id FROM persons" as any,
+    )) as Array<Record<string, unknown>>;
+    expect(persons).toHaveLength(0);
+  });
+
+  it("refuses to promote the account owner", async () => {
+    await expect(promoteLinkedInParticipant(SELF, deps)).rejects.toBeInstanceOf(
+      LinkedInPromotionError,
+    );
+  });
+
+  it("accepts a caller-chosen bond level and display name", async () => {
+    const { personId } = await promoteLinkedInParticipant(ADA, deps, {
+      bondLevel: "inner-circle",
+      displayName: "Ada (work)",
+    });
+
+    const person = await personsRepo.findById(personId);
+    expect(person!.bondLevel).toBe("inner-circle");
+    expect(person!.displayName).toBe("Ada (work)");
+  });
+
+  it("defaults to the acquaintance bond level", async () => {
+    const { personId } = await promoteLinkedInParticipant(ADA, deps);
+    const person = await personsRepo.findById(personId);
+    expect(person!.bondLevel).toBe("acquaintance");
+  });
+
+  it("falls back to the member id when the participant has no stored name", async () => {
+    await linkedIn.upsertThreadParticipants("t1", [
+      { participantId: "ACoAANoName", name: null, headline: null, type: "member", isSelf: false },
+    ]);
+
+    const { personId } = await promoteLinkedInParticipant("ACoAANoName", deps);
+    const person = await personsRepo.findById(personId);
+    expect(person!.displayName).toBe("ACoAANoName");
+    expect(person!.channelMappings).toContainEqual({
+      channel: "linkedin",
+      channelUserId: "ACoAANoName",
+    });
+  });
+});

--- a/packages/core/src/channels/linkedin-promote.ts
+++ b/packages/core/src/channels/linkedin-promote.ts
@@ -1,0 +1,143 @@
+import type { LinkedInParticipantRow } from "./linkedin-sync.js";
+
+/**
+ * Promotion of a mirrored LinkedIn identity into the curated person graph.
+ *
+ * The mirror (`linkedin_participants`) and the person graph (`persons` +
+ * `channel_mappings`) answer different questions: the mirror records everyone
+ * a polled inbox happens to contain, while the person graph records who the
+ * guardian has decided to know. Promotion is the one-way door between them, and
+ * it only ever opens on a guardian action — never from the poller, which would
+ * otherwise drag a whole inbox of recruiters into the graph.
+ *
+ * The bridge itself needs no translation. `linkedin_participants.participant_id`
+ * holds the bare member id (`ACoAA…`), which is exactly what an inbound
+ * LinkedIn message normalizes its sender to, so writing that value as
+ * `channel_mappings.channel_user_id` is all it takes for the promoted person to
+ * resolve on their next message — the same trick the `wa_*` mirror plays with
+ * the JID.
+ */
+
+/** The channel name a promoted LinkedIn identity is mapped under. */
+export const LINKEDIN_CHANNEL = "linkedin";
+
+/** Bond levels promotion may confer. `guardian` is deliberately absent: it is
+ *  conferred by the terminal, not by pointing at an inbox row. */
+export type PromotableBondLevel = "inner-circle" | "acquaintance" | "other";
+
+const DEFAULT_BOND_LEVEL: PromotableBondLevel = "acquaintance";
+
+/** A participant that has never been mirrored, or must not become a person. */
+export class LinkedInPromotionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LinkedInPromotionError";
+  }
+}
+
+/** The slice of the LinkedIn store promotion reads. */
+export interface LinkedInParticipantReader {
+  getParticipant(participantId: string): Promise<LinkedInParticipantRow | null>;
+}
+
+/**
+ * The slice of {@link PersonMappingRepository} promotion writes through. Named
+ * as an interface rather than taking the repository itself so this stays a
+ * caller of the existing person create/link flow instead of a second one.
+ */
+export interface PersonGraphWriter {
+  findByChannelUser(
+    channel: string,
+    channelUserId: string,
+  ): Promise<{ id: string; displayName: string } | null>;
+  generatePersonId(displayName: string): Promise<string>;
+  createWithChannelMapping(
+    id: string,
+    data: {
+      displayName: string;
+      bondLevel: "guardian" | "inner-circle" | "acquaintance" | "other";
+      profilePath?: string;
+      approved?: boolean;
+    },
+    mapping: { channel: string; channelUserId: string; displayName?: string },
+  ): Promise<string>;
+}
+
+export interface LinkedInPromotionDeps {
+  participants: LinkedInParticipantReader;
+  persons: PersonGraphWriter;
+}
+
+export interface LinkedInPromotionOptions {
+  /** Overrides the mirrored name. Falls back to it, then to the member id. */
+  displayName?: string;
+  /** Defaults to `acquaintance` — promotion says "this is a person", not "this
+   *  person is close". Re-grading is the person graph's own business. */
+  bondLevel?: PromotableBondLevel;
+}
+
+export interface LinkedInPromotionResult {
+  personId: string;
+  /** False when the identity was already mapped, so nothing new was written. */
+  created: boolean;
+}
+
+/**
+ * Promote one mirrored LinkedIn participant into a Rome person.
+ *
+ * Idempotent by identity, not by call: the `(channel, channel_user_id)` unique
+ * constraint already makes a second mapping impossible, so the only real risk
+ * is a second *person* orphaning the first. Checking the mapping before minting
+ * anything closes that, and re-promoting simply reports the person already
+ * standing there.
+ *
+ * The headline is not written anywhere here. `channel_mappings` has no column
+ * for it, and it stays authoritative on `linkedin_participants`; a person's
+ * headline belongs in their memory profile, which is prose, not a mapping row.
+ */
+export async function promoteLinkedInParticipant(
+  participantId: string,
+  deps: LinkedInPromotionDeps,
+  options: LinkedInPromotionOptions = {},
+): Promise<LinkedInPromotionResult> {
+  const memberId = participantId.trim();
+  if (!memberId) {
+    throw new LinkedInPromotionError("a LinkedIn member id is required to promote a participant");
+  }
+
+  // Ask the person graph first. An identity already claimed has an answer that
+  // does not depend on the mirror still holding a row for it.
+  const existing = await deps.persons.findByChannelUser(LINKEDIN_CHANNEL, memberId);
+  if (existing) return { personId: existing.id, created: false };
+
+  const participant = await deps.participants.getParticipant(memberId);
+  if (!participant) {
+    throw new LinkedInPromotionError(`unknown LinkedIn participant: ${memberId}`);
+  }
+  if (participant.isSelf) {
+    throw new LinkedInPromotionError(
+      "refusing to promote the account owner: the guardian is not a contact of their own inbox",
+    );
+  }
+
+  // A person must be nameable. The member id is a poor name but an honest one,
+  // and it keeps a nameless mirror row from blocking a deliberate promotion.
+  const displayName = options.displayName?.trim() || participant.name?.trim() || memberId;
+  const bondLevel = options.bondLevel ?? DEFAULT_BOND_LEVEL;
+
+  const personId = await deps.persons.generatePersonId(displayName);
+  // The shared create/link flow, transactional: a person whose mapping failed
+  // to write would be unreachable, and an unreachable person is worse than none.
+  await deps.persons.createWithChannelMapping(
+    personId,
+    {
+      displayName,
+      bondLevel,
+      profilePath: `memory/relationship/${personId}.md`,
+      approved: true,
+    },
+    { channel: LINKEDIN_CHANNEL, channelUserId: memberId, displayName },
+  );
+
+  return { personId, created: true };
+}

--- a/packages/core/src/channels/linkedin.test.ts
+++ b/packages/core/src/channels/linkedin.test.ts
@@ -6,6 +6,9 @@ import {
   type LinkedInPollerOptions,
 } from "./linkedin.js";
 import { OpencliAuthError, type OpencliResult } from "./linkedin-cli.js";
+import { createTestDb } from "../test/helpers.js";
+import { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
+import { PersonMappingRepository } from "../db/repositories/person-mapping.js";
 import type {
   LinkedInMessageInput,
   LinkedInParticipantInput,
@@ -110,7 +113,7 @@ class ParticipantSink extends FakeSink {
 }
 
 function makePoller(
-  sink: FakeSink,
+  sink: LinkedInSyncSink,
   run: LinkedInPollerOptions["run"],
   overrides: Partial<LinkedInPollerOptions> = {},
 ) {
@@ -427,5 +430,81 @@ describe("LinkedInInboxPoller fault handling", () => {
     failing = false;
     await vi.waitFor(() => expect(poller.getRuntimeDegradation()).toBeNull());
     poller.stop();
+  });
+});
+
+// Acceptance: the poller never triggers promotion. A LinkedIn inbox holds many
+// identities that must not enter the curated person graph on their own — only a
+// guardian action may. This runs a real tick against the real store rather than
+// a fake, so the assertion is about what the tick actually wrote.
+describe("LinkedInInboxPoller and the person graph", () => {
+  function participantPollRun() {
+    return vi.fn(async (args: string[]) => {
+      if (args[1] === "inbox") return ok([inboxRow("t1", "2026-08-19T20:00:00.000Z")]);
+      if (args[1] === "thread-participants")
+        return ok([
+          participantRow("t1", "ACoAAAda0001"),
+          participantRow("t1", "ACoAALurk0002", { participant_index: 2, name: "Quiet One" }),
+        ]);
+      return ok([snapshotRow("t1", "m1")]);
+    });
+  }
+
+  it("mirrors participants without creating any person or channel mapping", async () => {
+    const testDb = createTestDb();
+    try {
+      const store = new LinkedInStoreRepository(testDb.db);
+      const persons = new PersonMappingRepository(testDb.db);
+
+      await makePoller(store, participantPollRun()).pollOnce();
+
+      // The tick did its own job.
+      const participants = await store.getThreadParticipants("t1");
+      expect(participants.map((p) => p.participantId)).toEqual(["ACoAAAda0001", "ACoAALurk0002"]);
+
+      // ...and nothing else. Neither mirrored identity became a person.
+      for (const id of ["ACoAAAda0001", "ACoAALurk0002"]) {
+        expect(await persons.findByChannelUser("linkedin", id)).toBeNull();
+      }
+      const personRows = (await testDb.db.all(
+        // biome-ignore lint/suspicious/noExplicitAny: raw row read for assertion
+        "SELECT id FROM persons" as any,
+      )) as unknown[];
+      expect(personRows).toHaveLength(0);
+      const mappingRows = (await testDb.db.all(
+        // biome-ignore lint/suspicious/noExplicitAny: raw row read for assertion
+        "SELECT id FROM channel_mappings" as any,
+      )) as unknown[];
+      expect(mappingRows).toHaveLength(0);
+    } finally {
+      testDb.close();
+    }
+  });
+
+  it("re-polling an already-promoted participant leaves the person untouched", async () => {
+    const testDb = createTestDb();
+    try {
+      const store = new LinkedInStoreRepository(testDb.db);
+      const persons = new PersonMappingRepository(testDb.db);
+      await persons.create({
+        displayName: "Ada Lovelace",
+        bondLevel: "inner-circle",
+        channelMappings: [{ channel: "linkedin", channelUserId: "ACoAAAda0001" }],
+      });
+
+      await makePoller(store, participantPollRun()).pollOnce();
+
+      const resolved = await persons.findByChannelUser("linkedin", "ACoAAAda0001");
+      // Still exactly one person, still the bond level the guardian chose: the
+      // poller neither re-promotes nor re-grades.
+      expect(resolved?.bondLevel).toBe("inner-circle");
+      const personRows = (await testDb.db.all(
+        // biome-ignore lint/suspicious/noExplicitAny: raw row read for assertion
+        "SELECT id FROM persons" as any,
+      )) as unknown[];
+      expect(personRows).toHaveLength(1);
+    } finally {
+      testDb.close();
+    }
   });
 });

--- a/packages/core/src/connections/integrations/linkedin.test.ts
+++ b/packages/core/src/connections/integrations/linkedin.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb, type TestDb } from "../../test/helpers.js";
+import { LinkedInStoreRepository } from "../../db/repositories/linkedin-store.js";
+import { PersonMappingRepository } from "../../db/repositories/person-mapping.js";
+import { promoteLinkedInParticipant } from "../../channels/linkedin-promote.js";
+import { toHistoryNormalizedMessage } from "./linkedin.js";
+import type { LinkedInHistoryMessage } from "../../channels/linkedin-sync.js";
+
+const ADA = "ACoAABuildingEngine";
+
+const historyRow = (over: Partial<LinkedInHistoryMessage> = {}): LinkedInHistoryMessage => ({
+  messageId: "m1",
+  threadId: "t1",
+  threadName: "Ada Lovelace",
+  sentAt: new Date("2026-08-19T20:00:00Z"),
+  senderName: "Ada Lovelace",
+  senderProfileUrl: `https://www.linkedin.com/in/${ADA}/`,
+  senderIsSelf: false,
+  text: "See you Sunday?",
+  subject: null,
+  ...over,
+});
+
+describe("toHistoryNormalizedMessage", () => {
+  // The bare member id is what `linkedin_participants.participant_id` and
+  // therefore `channel_mappings.channel_user_id` hold. An inbound message that
+  // carried the whole profile URL instead would never match a promoted person.
+  it("maps the sender to the bare member id, not the profile URL", () => {
+    const normalized = toHistoryNormalizedMessage(historyRow());
+    expect(normalized.channel).toBe("linkedin");
+    expect(normalized.channelUserId).toBe(ADA);
+  });
+
+  it("reads the member id out of any of LinkedIn's profile URL shapes", () => {
+    for (const url of [
+      `https://www.linkedin.com/in/${ADA}/`,
+      `https://www.linkedin.com/in/${ADA}`,
+      `https://linkedin.com/in/${ADA}/?originalSubdomain=uk`,
+    ]) {
+      expect(toHistoryNormalizedMessage(historyRow({ senderProfileUrl: url })).channelUserId).toBe(
+        ADA,
+      );
+    }
+  });
+
+  // A vanity handle is a public alias, not the member id the tables key on.
+  // Keeping the URL verbatim is honest; inventing a member id from it is not.
+  it("keeps the URL verbatim when it carries a vanity handle instead of a member id", () => {
+    const url = "https://www.linkedin.com/in/ada-lovelace/";
+    expect(toHistoryNormalizedMessage(historyRow({ senderProfileUrl: url })).channelUserId).toBe(
+      url,
+    );
+  });
+
+  it("still labels self and unknown senders when no profile URL was mirrored", () => {
+    expect(
+      toHistoryNormalizedMessage(historyRow({ senderProfileUrl: null, senderIsSelf: true }))
+        .channelUserId,
+    ).toBe("linkedin:self");
+    expect(
+      toHistoryNormalizedMessage(historyRow({ senderProfileUrl: null, senderIsSelf: false }))
+        .channelUserId,
+    ).toBe("linkedin:unknown");
+  });
+});
+
+describe("promoted participant resolution", () => {
+  let testDb: TestDb;
+  let linkedIn: LinkedInStoreRepository;
+  let personsRepo: PersonMappingRepository;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    linkedIn = new LinkedInStoreRepository(testDb.db);
+    personsRepo = new PersonMappingRepository(testDb.db);
+
+    await linkedIn.upsertThreads([
+      {
+        threadId: "t1",
+        threadUrl: "https://www.linkedin.com/messaging/thread/t1/",
+        personName: "Ada Lovelace",
+        lastMessagePreview: "See you Sunday?",
+        lastMessageAt: new Date("2026-08-19T20:00:00Z"),
+        unread: true,
+        counterpartyType: "member",
+        category: "INBOX,PRIMARY_INBOX",
+      },
+    ]);
+    await linkedIn.upsertThreadParticipants("t1", [
+      {
+        participantId: ADA,
+        name: "Ada Lovelace",
+        headline: "Building the analytical engine",
+        type: "member",
+        isSelf: false,
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    testDb.close();
+  });
+
+  // Acceptance: a message from a promoted participant resolves to that person.
+  it("resolves a message from a promoted participant to that person", async () => {
+    const { personId } = await promoteLinkedInParticipant(ADA, {
+      participants: linkedIn,
+      persons: personsRepo,
+    });
+
+    // The next inbound message, normalized exactly as the talker does it.
+    const normalized = toHistoryNormalizedMessage(historyRow());
+    const resolved = await personsRepo.findByChannelUser(
+      normalized.channel,
+      normalized.channelUserId,
+    );
+
+    expect(resolved?.id).toBe(personId);
+    expect(resolved?.displayName).toBe("Ada Lovelace");
+  });
+
+  it("does not resolve a participant that was never promoted", async () => {
+    const normalized = toHistoryNormalizedMessage(historyRow());
+    expect(
+      await personsRepo.findByChannelUser(normalized.channel, normalized.channelUserId),
+    ).toBeNull();
+  });
+});

--- a/packages/core/src/connections/integrations/linkedin.ts
+++ b/packages/core/src/connections/integrations/linkedin.ts
@@ -38,6 +38,7 @@ import {
 } from "../../channels/linkedin-cli.js";
 import { LinkedInInboxPoller } from "../../channels/linkedin.js";
 import type { LinkedInHistoryMessage, LinkedInSyncSink } from "../../channels/linkedin-sync.js";
+import { linkedInMemberIdFromProfileUrl } from "../../db/repositories/linkedin-store.js";
 import { CredentialRejected } from "../errors.js";
 import type { SetupFn } from "../setup/types.js";
 import type {
@@ -260,12 +261,31 @@ interface LinkedInTalker extends Talker {
   getRuntimeDegradation(): CapabilityDegradation | null;
 }
 
-function toHistoryNormalizedMessage(row: LinkedInHistoryMessage): NormalizedMessage {
+/**
+ * A mirrored message as the rest of Rome sees it.
+ *
+ * The sender is identified by the bare member id (`ACoAA…`) pulled out of the
+ * mirrored profile URL, because that is the value `linkedin_participants` and
+ * `channel_mappings.channel_user_id` agree on. Passing the whole URL through
+ * instead would put a promoted person permanently out of reach: their mapping
+ * says `ACoAA…` and every message would arrive claiming to be
+ * `https://www.linkedin.com/in/ACoAA…/`.
+ *
+ * A URL with no member id in it — a vanity handle like `/in/ada-lovelace` — is
+ * kept verbatim rather than guessed at. A handle is a public alias that can be
+ * reassigned, so treating one as an identity would eventually map a stranger
+ * onto someone else's person.
+ *
+ * Exported for the test that pins this correspondence; nothing else calls it.
+ */
+export function toHistoryNormalizedMessage(row: LinkedInHistoryMessage): NormalizedMessage {
   return {
     id: row.messageId,
     channel: "linkedin",
     channelUserId:
-      row.senderProfileUrl ?? (row.senderIsSelf ? "linkedin:self" : "linkedin:unknown"),
+      linkedInMemberIdFromProfileUrl(row.senderProfileUrl) ??
+      row.senderProfileUrl ??
+      (row.senderIsSelf ? "linkedin:self" : "linkedin:unknown"),
     displayName: row.senderName ?? "",
     threadId: row.threadId,
     ...(row.threadName ? { threadName: row.threadName } : {}),

--- a/packages/core/src/db/repositories/linkedin-store.test.ts
+++ b/packages/core/src/db/repositories/linkedin-store.test.ts
@@ -729,3 +729,53 @@ describe("linkedInMemberIdFromProfileUrl", () => {
     expect(linkedInMemberIdFromProfileUrl("")).toBeNull();
   });
 });
+
+describe("LinkedInStoreRepository.getParticipant", () => {
+  let testDb: TestDb;
+  let repo: LinkedInStoreRepository;
+
+  beforeEach(() => {
+    testDb = createTestDb();
+    repo = new LinkedInStoreRepository(testDb.db);
+  });
+
+  afterEach(() => {
+    testDb.close();
+  });
+
+  it("reads one stored identity by member id", async () => {
+    await repo.upsertThreadParticipants("t1", [
+      {
+        participantId: "ACoAAAda0001",
+        name: "Ada Lovelace",
+        headline: "Building the analytical engine",
+        type: "member",
+        isSelf: false,
+      },
+    ]);
+
+    expect(await repo.getParticipant("ACoAAAda0001")).toEqual({
+      participantId: "ACoAAAda0001",
+      name: "Ada Lovelace",
+      headline: "Building the analytical engine",
+      type: "member",
+      isSelf: false,
+    });
+  });
+
+  it("returns null for a member id it has never seen", async () => {
+    expect(await repo.getParticipant("ACoAAGhost")).toBeNull();
+  });
+
+  it("finds an identity independently of any thread it belongs to", async () => {
+    await repo.upsertThreadParticipants("t1", [
+      { participantId: "ACoAAAda0001", name: "Ada", headline: null, type: "member", isSelf: false },
+    ]);
+    // Ada leaves t1; the identity itself survives, so a promotion started from
+    // an older view still resolves.
+    await repo.upsertThreadParticipants("t1", []);
+
+    expect(await repo.getThreadParticipants("t1")).toEqual([]);
+    expect((await repo.getParticipant("ACoAAAda0001"))?.name).toBe("Ada");
+  });
+});

--- a/packages/core/src/db/repositories/linkedin-store.ts
+++ b/packages/core/src/db/repositories/linkedin-store.ts
@@ -528,6 +528,30 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
     }));
   }
 
+  /**
+   * One stored identity by member id, independent of thread membership.
+   *
+   * Deliberately not scoped to a thread: promotion names a person, not a
+   * conversation, and an identity outlives the membership rows that introduced
+   * it — someone who has since left every mirrored thread is still the same
+   * member, and a promotion started from an older view must still resolve.
+   */
+  async getParticipant(participantId: string): Promise<LinkedInParticipantRow | null> {
+    const rows = await this.db
+      .select()
+      .from(linkedinParticipants)
+      .where(eq(linkedinParticipants.participantId, participantId));
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      participantId: row.participantId,
+      name: row.name,
+      headline: row.headline,
+      type: row.type,
+      isSelf: row.isSelf,
+    };
+  }
+
   /** The reverse lookup: every thread a participant belongs to. */
   async getParticipantThreadIds(participantId: string): Promise<string[]> {
     const rows = await this.db


### PR DESCRIPTION
## Summary

Lets a stored LinkedIn participant become a Rome person, on guardian action only.

`promoteLinkedInParticipant` calls the existing person create/link flow rather than growing a second one — `generatePersonId` then `createWithChannelMapping` — so the `persons` row and its `linkedin` mapping land in one transaction and a person can never be left unreachable. The mapping carries the bare member id, which is what `linkedin_participants` already keys on.

It is idempotent by identity rather than by call: an identity already mapped comes back as `created: false`, because "already a person" is the outcome the caller wanted, not a failure. The unique constraint on `(channel, channel_user_id)` already stopped a second *mapping*; checking first is what stops a second *person* orphaning the first.

## The bridge was broken

The issue assumes a promoted participant resolves on its next message with no further wiring. It would not have. `toHistoryNormalizedMessage` identified a sender by their entire profile URL, so a promoted person was permanently unreachable — their mapping says `ACoAA…` while every message arrived claiming to be `https://www.linkedin.com/in/ACoAA…/`.

It now resolves the member id out of the URL, reusing the existing `linkedInMemberIdFromProfileUrl`. A vanity handle (`/in/ada-lovelace`) is kept verbatim rather than guessed at: a handle is a reassignable public alias, so treating one as an identity would eventually map a stranger onto someone else's person.

## Notes

- **The poller gains no dependency on the person graph.** Promotion has an explicit endpoint and nothing else calls it, so an inbox full of recruiters cannot walk itself into the curated graph.
- **The endpoint cannot confer `guardian`** — that belongs to the terminal, not to clicking a row in an inbox.
- **The headline is written nowhere new.** `channel_mappings` has no column for it, it stays authoritative on `linkedin_participants`, and a person's headline belongs in their memory profile, which is prose rather than a mapping row.
- No schema change and no migration: `getParticipant` reads tables #8 already added.
- Out of scope, as the issue says: the UI that triggers promotion, and any change to bond levels.

## Acceptance

- [x] promoting a participant creates a person and a `linkedin` channel mapping carrying the member id
- [x] a message from a promoted participant resolves to that person
- [x] promoting a participant that is already mapped does not create a second person
- [x] the poller never triggers promotion

## Test plan

Tests were written first, against the acceptance criteria.

- `channels/linkedin-promote.test.ts` — creates person + mapping; reachable by id and by identity; headline stays out of the mapping; idempotent re-promote; identity already claimed elsewhere; unknown participant and account owner refused; bond level and display-name handling.
- `connections/integrations/linkedin.test.ts` (new) — the member-id correspondence across LinkedIn's URL shapes, vanity handles kept verbatim, self/unknown fallbacks; then end-to-end, a promoted participant's next message resolving to that person and an unpromoted one resolving to nothing.
- `channels/linkedin.test.ts` — a real poll tick against the real store asserting participants were written and zero `persons` / `channel_mappings` rows were; and that re-polling an already-promoted participant leaves their person and bond level untouched.
- `db/repositories/linkedin-store.test.ts` — `getParticipant` by member id, null for unknown, and resolving an identity that has left every thread.
- `api/routes/linkedin-threads.test.ts` — participant listing, promote success, already-promoted as `created: false`, invalid and `guardian` bond levels rejected, unpromotable participant as 404.

Verified locally: `packages/core` typecheck clean, `biome check src` clean, and the full unit suite green (3884 passing). The only suites that do not load here are `terminal-server` and `auth-me`, which need `node-pty`'s native module — it has no prebuild for this sandbox and its gyp toolchain is absent. Unrelated to this change.

Closes rome-os/rome#9