### PR TITLE
build(devshell): add vultr-cli

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,10 @@
             # its own pinned binaries — see .github/workflows/ci.yml.
             pkgs.shellcheck
             pkgs.shfmt
+            # Vultr's API CLI, for ad-hoc host-side infrastructure work. It
+            # reads VULTR_API_KEY from the environment — keep the key out of
+            # the repo and out of the shell definition.
+            pkgs.vultr-cli
             # NOTE: `pnpm dev:all` needs no host-side mutagen — the rome-sync
             # sidecar (infra/rome-sync) bakes mutagen into its image and runs the
             # source-sync session inside the container.


### PR DESCRIPTION
## What this PR does

The devShell vendors the host-native tooling the repo needs, but it carries no client for the Vultr API. Anyone doing host-side Vultr work has to install one outside the shell, which is the one thing the shell exists to avoid.

Adds `pkgs.vultr-cli` next to the other host-native tools.

## Design & Invariants

The API key stays out of the flake. `vultr-cli` reads `VULTR_API_KEY` from the environment, and a value written into the shell definition would land in the world-readable nix store.

The version follows `flake.lock`, not the package list. The lock currently resolves `vultr-cli` to 3.9.2; `nix flake update nixpkgs` moves it to whatever unstable carries (3.11.0 today).

## Test plan

- [x] `nix build --no-link .#devShells.x86_64-linux.default` — the shell evaluates and builds.
- [x] `nix develop --command vultr-cli version` — prints `Vultr-CLI v3.9.2`. It also reports a missing `~/.vultr-cli.yaml`, which is non-fatal and expected without a config file.
- [ ] Darwin. The package is Go and builds for every system in `systems`, but I ran the checks on `x86_64-linux` only.

## Not in this PR

- No script or CI job calls `vultr-cli` yet — this makes the binary available, nothing more.
- No credential setup. `VULTR_API_KEY` comes from the host environment, and `setup.sh` does not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)