### PR TITLE
fix: handle mention-only messages

### DIFF
--- a/packages/core/src/channels/feishu.test.ts
+++ b/packages/core/src/channels/feishu.test.ts
@@ -262,6 +262,19 @@ describe("FeishuAdapter", () => {
     expect(captured[0].threadType).toBe("group");
   });
 
+  it("delivers an @-only group message as a greeting", async () => {
+    await channel.emit({
+      chatType: "group",
+      content: "",
+      rawContentType: "text",
+      mentions: [],
+      mentionedBot: true,
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].text).toBe("hello");
+  });
+
   it("ignores group messages that do not mention the bot by default", async () => {
     await channel.emit({ chatType: "group", mentionedBot: false });
     expect(captured).toHaveLength(0);

--- a/packages/core/src/channels/feishu.ts
+++ b/packages/core/src/channels/feishu.ts
@@ -225,7 +225,8 @@ export class FeishuAdapter implements ProviderAdapter {
 
     // MVP: text-bearing messages only. Media-only messages arrive with empty
     // content and are dropped until attachment support lands.
-    const text = resolveMentions(m.content ?? "", m.mentions);
+    const resolvedText = resolveMentions(m.content ?? "", m.mentions);
+    const text = resolvedText || (m.rawContentType === "text" && m.mentionedBot ? "hello" : "");
     if (!text) return;
     const threadType = m.chatType === "p2p" ? "private" : "group";
     if (threadType === "group") {


### PR DESCRIPTION
## What this PR does

Rome prompted me to mention it in a Lark group to bind that group. I mentioned the bot without adding any text, but Rome did not respond.

The Lark SDK normalizes an @-only text message to an empty content string. The Feishu adapter treated that event like an unsupported media-only message and dropped it. An @-only text message now enters the normal inbound path as `hello`.

Just an idea, close this at any time if there is a better solution, as I'm not expert of agent development
