### PR TITLE
feat(core): promote a LinkedIn participant to a Rome person

### DIFF
--- a/packages/core/src/api/routes/linkedin-threads.test.ts
+++ b/packages/core/src/api/routes/linkedin-threads.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import { OpencliAuthError } from "../../channels/linkedin-cli.js";
 import { linkedinThreadsRoutes } from "./linkedin-threads.js";
-import type { LinkedInThreadRow } from "../../db/repositories/linkedin-store.js";
+import type {
+  LinkedInParticipantContactRow,
+  LinkedInThreadRow,
+} from "../../db/repositories/linkedin-store.js";
 import type { ApiDeps } from "../deps.js";
 
 type SendReplySpy = ReturnType<typeof vi.fn>;
@@ -22,10 +25,22 @@ const THREAD: LinkedInThreadRow = {
   messageCount: 2,
 };
 
-function buildDeps(threads = [THREAD]): ApiDeps {
+const ADA: LinkedInParticipantContactRow = {
+  participantId: "ACoAAAda0001",
+  name: "Ada Lovelace",
+  headline: "Engineer",
+  type: "member",
+  isSelf: false,
+  threadCount: 2,
+  linkedPersonId: null,
+  linkedPersonName: null,
+};
+
+function buildDeps(threads = [THREAD], participants = [ADA]): ApiDeps {
   return {
     linkedInStoreRepo: {
       listThreads: async () => threads,
+      listParticipants: async () => participants,
       getMessages: async () => [],
     },
   } as unknown as ApiDeps;
@@ -52,6 +67,34 @@ function successfulSender(): SendReplySpy {
     messageChars: 15,
   }));
 }
+
+describe("GET /linkedin/participants", () => {
+  // Promotion goes through `/api/persons/create` + `/api/persons/link`; this
+  // route exists so a caller can tell which identities have already been there.
+  it("serves each mirrored identity with its promotion state", async () => {
+    const res = await mount(successfulSender()).request("/linkedin/participants");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([ADA]);
+  });
+
+  it("carries the person a promoted identity resolves to", async () => {
+    const promoted = {
+      ...ADA,
+      linkedPersonId: "ada-lovelace",
+      linkedPersonName: "Ada Lovelace",
+    };
+    const res = await mount(successfulSender(), buildDeps([THREAD], [promoted])).request(
+      "/linkedin/participants",
+    );
+
+    const rows = (await res.json()) as LinkedInParticipantContactRow[];
+    expect(rows[0].linkedPersonId).toBe("ada-lovelace");
+    // The headline stays on the mirror row — `channel_mappings` has no column
+    // for it, and it belongs in the person's memory profile.
+    expect(rows[0].headline).toBe("Engineer");
+  });
+});
 
 describe("GET /linkedin/threads", () => {
   // The count is now derived from stored membership rather than copied off the

--- a/packages/core/src/api/routes/linkedin-threads.ts
+++ b/packages/core/src/api/routes/linkedin-threads.ts
@@ -13,6 +13,13 @@ import type { ApiDeps } from "../deps.js";
  * LinkedIn connection's poller (channels/linkedin.ts). Replies go through
  * opencli `linkedin safe-send`. It verifies the visible thread and recipient
  * before sending.
+ *
+ * Promoting a mirrored participant to a curated `persons` entry reuses the
+ * existing `/api/persons/create` + `/api/persons/link` routes — a participant's
+ * bare member id is the `channelUserId` those endpoints expect for LinkedIn,
+ * and it is what an inbound LinkedIn message resolves through. Nothing here
+ * promotes: the mirror is read-only towards the person graph, and the guardian
+ * decides which of an inbox's many identities earns a person.
  */
 export interface LinkedInThreadsSeams {
   sendReply?: (input: LinkedInSafeSendInput) => Promise<LinkedInSafeSendResult>;
@@ -24,6 +31,14 @@ export function linkedinThreadsRoutes(deps: ApiDeps, seams: LinkedInThreadsSeams
 
   app.get("/linkedin/threads", async (c) => {
     const rows = await deps.linkedInStoreRepo.listThreads();
+    return c.json(rows);
+  });
+
+  // Every mirrored identity, each row carrying the person it was promoted into
+  // (or null). A caller needs that to tell "promote" from "already promoted"
+  // without guessing — the same annotation `/api/whatsapp/contacts` carries.
+  app.get("/linkedin/participants", async (c) => {
+    const rows = await deps.linkedInStoreRepo.listParticipants();
     return c.json(rows);
   });
 

--- a/packages/core/src/channels/linkedin-sync.ts
+++ b/packages/core/src/channels/linkedin-sync.ts
@@ -39,6 +39,19 @@ export interface LinkedInMessageInput {
   reactionCount?: number | null;
 }
 
+// The obfuscated member id inside a mirrored profile URL —
+// `https://www.linkedin.com/in/ACoAA…/`. A vanity handle (`/in/ada-lovelace`)
+// deliberately does not match: it is a public alias, not the member id these
+// tables key on, and storing one would break the correspondence with
+// `channel_mappings.channel_user_id`.
+const MEMBER_ID_IN_PROFILE_URL = /\/in\/(ACoAA[A-Za-z0-9_-]+)/;
+
+/** The bare LinkedIn member id inside a stored profile URL, or null. */
+export function linkedInMemberIdFromProfileUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  return MEMBER_ID_IN_PROFILE_URL.exec(url)?.[1] ?? null;
+}
+
 /** One identity in a thread's participant list, per the thread snapshot. */
 export interface LinkedInParticipantInput {
   /**

--- a/packages/core/src/channels/linkedin.test.ts
+++ b/packages/core/src/channels/linkedin.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { sql } from "drizzle-orm";
 import {
   LinkedInInboxPoller,
   pollDelayMs,
@@ -6,6 +7,8 @@ import {
   type LinkedInPollerOptions,
 } from "./linkedin.js";
 import { OpencliAuthError, type OpencliResult } from "./linkedin-cli.js";
+import { createTestDb } from "../test/helpers.js";
+import { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
 import type {
   LinkedInMessageInput,
   LinkedInParticipantInput,
@@ -110,7 +113,7 @@ class ParticipantSink extends FakeSink {
 }
 
 function makePoller(
-  sink: FakeSink,
+  sink: LinkedInSyncSink,
   run: LinkedInPollerOptions["run"],
   overrides: Partial<LinkedInPollerOptions> = {},
 ) {
@@ -427,5 +430,43 @@ describe("LinkedInInboxPoller fault handling", () => {
     failing = false;
     await vi.waitFor(() => expect(poller.getRuntimeDegradation()).toBeNull());
     poller.stop();
+  });
+});
+
+/**
+ * Promotion is a guardian action, never a consequence of syncing. A LinkedIn
+ * inbox holds many identities — recruiters, newsletters, strangers — that must
+ * not walk into the curated person graph on their own.
+ *
+ * The sink contract is the guarantee: it exposes no way to write `persons`. This
+ * runs the poller against the real store to show that holds end to end, not just
+ * against a fake that could not have promoted anyone anyway.
+ */
+describe("LinkedInInboxPoller and the person graph", () => {
+  it("mirrors a thread's participants without promoting any of them", async () => {
+    const testDb = createTestDb();
+    try {
+      const store = new LinkedInStoreRepository(testDb.db);
+      const run = vi.fn(async (args: string[]) => {
+        if (args[1] === "inbox") return ok([inboxRow("t1", "2026-08-19T20:00:00.000Z")]);
+        if (args[1] === "thread-participants") return ok([participantRow("t1", "ACoAAAda0001")]);
+        return ok([snapshotRow("t1", "m1")]);
+      });
+
+      await makePoller(store, run).pollOnce();
+
+      // The mirror did its job...
+      expect((await store.getThreadParticipants("t1")).map((p) => p.participantId)).toEqual([
+        "ACoAAAda0001",
+      ]);
+      // ...and left the person graph alone.
+      expect(await store.listParticipants()).toEqual([
+        expect.objectContaining({ participantId: "ACoAAAda0001", linkedPersonId: null }),
+      ]);
+      expect(testDb.db.all(sql`SELECT id FROM persons`)).toEqual([]);
+      expect(testDb.db.all(sql`SELECT id FROM channel_mappings`)).toEqual([]);
+    } finally {
+      testDb.close();
+    }
   });
 });

--- a/packages/core/src/connections/integrations/linkedin.test.ts
+++ b/packages/core/src/connections/integrations/linkedin.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { createTestDb, type TestDb } from "../../test/helpers.js";
+import { PersonMappingRepository } from "../../db/repositories/person-mapping.js";
+import { createLinkedInDescriptor } from "./linkedin.js";
+import type {
+  LinkedInHistoryMessage,
+  LinkedInSyncSink,
+  LinkedInThreadCursor,
+} from "../../channels/linkedin-sync.js";
+import type { Credential, RuntimeKit } from "../types.js";
+import type { InboundMessage } from "@rome-os/app-runtime";
+
+/** A sink that only answers history reads — the rest of the mirror is idle here. */
+function historySink(rows: LinkedInHistoryMessage[]): LinkedInSyncSink {
+  return {
+    async upsertThreads() {},
+    async upsertMessages() {},
+    async getThreadCursors(): Promise<Map<string, LinkedInThreadCursor>> {
+      return new Map();
+    },
+    async markThreadSynced() {},
+    async fetchHistory() {
+      return rows;
+    },
+  };
+}
+
+function historyMessage(overrides: Partial<LinkedInHistoryMessage> = {}): LinkedInHistoryMessage {
+  return {
+    messageId: "m1",
+    threadId: "2-abc==",
+    threadName: "Ada Lovelace",
+    sentAt: new Date("2026-08-19T20:00:00Z"),
+    senderName: "Ada Lovelace",
+    senderProfileUrl: "https://www.linkedin.com/in/ACoAAAda0001/",
+    senderIsSelf: false,
+    text: "hello",
+    subject: null,
+    ...overrides,
+  };
+}
+
+async function readHistory(rows: LinkedInHistoryMessage[]): Promise<InboundMessage[]> {
+  const descriptor = createLinkedInDescriptor({
+    syncSink: historySink(rows),
+    minIntervalMs: 15 * 60_000,
+    maxIntervalMs: 30 * 60_000,
+  });
+  const talker = descriptor.capabilities.talker!.build(
+    {} as Record<string, Credential>,
+    {} as RuntimeKit,
+  );
+  const history = talker.feature("history");
+  if (!history) throw new Error("the LinkedIn talker did not expose a history feature");
+  return await history.query({});
+}
+
+/**
+ * The promotion bridge: a mirrored participant that a guardian turned into a
+ * person is recognised on their next message with nothing else wired up. That
+ * only holds if both sides name the identity the same way — the bare member id.
+ */
+describe("LinkedIn message identity", () => {
+  let testDb: TestDb;
+  let people: PersonMappingRepository;
+
+  beforeEach(() => {
+    testDb = createTestDb();
+    people = new PersonMappingRepository(testDb.db);
+  });
+
+  afterEach(() => {
+    testDb.close();
+  });
+
+  it("maps a message to the member id `linkedin_participants` is keyed by", async () => {
+    const [message] = await readHistory([historyMessage()]);
+    expect(message.senderId).toBe("ACoAAAda0001");
+  });
+
+  it("resolves a promoted participant to their person", async () => {
+    await people.createWithChannelMapping(
+      "ada-lovelace",
+      { displayName: "Ada Lovelace", bondLevel: "acquaintance", approved: true },
+      { channel: "linkedin", channelUserId: "ACoAAAda0001", displayName: "Ada Lovelace" },
+    );
+
+    const [message] = await readHistory([historyMessage()]);
+    const person = await people.findByChannelUser("linkedin", message.senderId);
+
+    expect(person?.id).toBe("ada-lovelace");
+  });
+
+  it("does not resolve a participant nobody promoted", async () => {
+    const [message] = await readHistory([historyMessage()]);
+    expect(await people.findByChannelUser("linkedin", message.senderId)).toBeNull();
+  });
+
+  // The guardian's own mapping is conferred at connect time from their public
+  // profile URL, which carries a vanity handle and no member id. Falling back to
+  // the URL keeps that mapping resolving instead of stranding it.
+  it("falls back to the profile URL when it carries no member id", async () => {
+    const [message] = await readHistory([
+      historyMessage({ senderProfileUrl: "https://www.linkedin.com/in/ada-lovelace/" }),
+    ]);
+    expect(message.senderId).toBe("https://www.linkedin.com/in/ada-lovelace/");
+  });
+
+  it("falls back to a sentinel when the sender has no profile URL at all", async () => {
+    const [them] = await readHistory([historyMessage({ senderProfileUrl: null })]);
+    expect(them.senderId).toBe("linkedin:unknown");
+
+    const [me] = await readHistory([
+      historyMessage({ senderProfileUrl: null, senderIsSelf: true }),
+    ]);
+    expect(me.senderId).toBe("linkedin:self");
+  });
+});

--- a/packages/core/src/connections/integrations/linkedin.ts
+++ b/packages/core/src/connections/integrations/linkedin.ts
@@ -37,6 +37,7 @@ import {
   type RunOpencli,
 } from "../../channels/linkedin-cli.js";
 import { LinkedInInboxPoller } from "../../channels/linkedin.js";
+import { linkedInMemberIdFromProfileUrl } from "../../channels/linkedin-sync.js";
 import type { LinkedInHistoryMessage, LinkedInSyncSink } from "../../channels/linkedin-sync.js";
 import { CredentialRejected } from "../errors.js";
 import type { SetupFn } from "../setup/types.js";
@@ -260,12 +261,31 @@ interface LinkedInTalker extends Talker {
   getRuntimeDegradation(): CapabilityDegradation | null;
 }
 
+/**
+ * The `channel_mappings.channel_user_id` a LinkedIn message resolves through.
+ *
+ * The bare member id is the identity the mirror keys on — `linkedin_participants`
+ * is primary-keyed by it and promotion writes it into the mapping — so a promoted
+ * participant is recognised on their next message with nothing else wired up.
+ *
+ * The stored profile URL stays the fallback rather than being replaced by one:
+ * a URL carrying no member id is a vanity handle (`/in/ada-lovelace`), which is
+ * the form the guardian's own mapping is conferred in at connect time. Narrowing
+ * to the member id alone would strand it.
+ */
+function linkedInChannelUserId(row: LinkedInHistoryMessage): string {
+  return (
+    linkedInMemberIdFromProfileUrl(row.senderProfileUrl) ??
+    row.senderProfileUrl ??
+    (row.senderIsSelf ? "linkedin:self" : "linkedin:unknown")
+  );
+}
+
 function toHistoryNormalizedMessage(row: LinkedInHistoryMessage): NormalizedMessage {
   return {
     id: row.messageId,
     channel: "linkedin",
-    channelUserId:
-      row.senderProfileUrl ?? (row.senderIsSelf ? "linkedin:self" : "linkedin:unknown"),
+    channelUserId: linkedInChannelUserId(row),
     displayName: row.senderName ?? "",
     threadId: row.threadId,
     ...(row.threadName ? { threadName: row.threadName } : {}),

--- a/packages/core/src/db/repositories/linkedin-store.test.ts
+++ b/packages/core/src/db/repositories/linkedin-store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { sql } from "drizzle-orm";
 import { createTestDb, type TestDb } from "../../test/helpers.js";
 import { LinkedInStoreRepository, linkedInMemberIdFromProfileUrl } from "./linkedin-store.js";
+import { PersonMappingRepository } from "./person-mapping.js";
 
 describe("LinkedInStoreRepository", () => {
   let testDb: TestDb;
@@ -576,6 +577,103 @@ describe("LinkedInStoreRepository", () => {
           sql`SELECT name FROM pragma_table_info('linkedin_threads')`,
         ) as Array<{ name: string }>;
         expect(columns.map((c) => c.name)).not.toContain("participant_count");
+      });
+    });
+
+    // A mirrored participant becomes a Rome person through the existing person
+    // create/link flow — there is no second write path here. The bare member id
+    // is the channel identity on both sides, so promotion needs no translation
+    // step and nothing in this repository ever writes `persons`.
+    describe("promotion to a person", () => {
+      let people: PersonMappingRepository;
+
+      const personCount = () =>
+        Number(
+          (testDb.db.all(sql`SELECT COUNT(*) AS n FROM persons`) as Array<{ n: number }>)[0].n,
+        );
+
+      beforeEach(async () => {
+        people = new PersonMappingRepository(testDb.db);
+        await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
+        await repo.upsertThreadParticipants("t1", [ada, self]);
+      });
+
+      it("lists a mirrored identity as unpromoted until a person claims it", async () => {
+        const rows = await repo.listParticipants();
+
+        expect(rows.map((r) => r.participantId)).toEqual([ada.participantId, self.participantId]);
+        expect(rows.map((r) => r.linkedPersonId)).toEqual([null, null]);
+        expect(rows[0].threadCount).toBe(1);
+      });
+
+      it("promoting writes a person and a linkedin mapping carrying the member id", async () => {
+        await people.createWithChannelMapping(
+          "ada-lovelace",
+          { displayName: "Ada Lovelace", bondLevel: "acquaintance", approved: true },
+          { channel: "linkedin", channelUserId: ada.participantId, displayName: ada.name },
+        );
+
+        const mapping = (
+          testDb.db.all(
+            sql`SELECT channel, channel_user_id AS channelUserId, person_id AS personId
+                FROM channel_mappings`,
+          ) as Array<Record<string, string>>
+        )[0];
+        expect(mapping).toEqual({
+          channel: "linkedin",
+          channelUserId: ada.participantId,
+          personId: "ada-lovelace",
+        });
+
+        const rows = await repo.listParticipants();
+        const promoted = rows.find((r) => r.participantId === ada.participantId);
+        expect(promoted?.linkedPersonId).toBe("ada-lovelace");
+        expect(promoted?.linkedPersonName).toBe("Ada Lovelace");
+        // The headline stays on the mirror row: `channel_mappings` has nowhere
+        // to put it, and it belongs in the person's memory profile.
+        expect(promoted?.headline).toBe("Engineer");
+        // Promoting one identity says nothing about the rest of the inbox.
+        expect(rows.find((r) => r.participantId === self.participantId)?.linkedPersonId).toBeNull();
+      });
+
+      it("refuses to promote a participant a person already holds", async () => {
+        await people.createWithChannelMapping(
+          "ada-lovelace",
+          { displayName: "Ada Lovelace", bondLevel: "acquaintance", approved: true },
+          { channel: "linkedin", channelUserId: ada.participantId },
+        );
+
+        await expect(
+          people.createWithChannelMapping(
+            "ada-lovelace-2",
+            { displayName: "Ada Lovelace", bondLevel: "acquaintance", approved: true },
+            { channel: "linkedin", channelUserId: ada.participantId },
+          ),
+        ).rejects.toThrow(/already belongs to person/);
+
+        expect(personCount()).toBe(1);
+        expect((await repo.listParticipants())[0].linkedPersonId).toBe("ada-lovelace");
+      });
+
+      it("linking an already-promoted participant re-points the one mapping", async () => {
+        await people.createWithChannelMapping(
+          "ada-lovelace",
+          { displayName: "Ada Lovelace", bondLevel: "acquaintance", approved: true },
+          { channel: "linkedin", channelUserId: ada.participantId, displayName: "Ada Lovelace" },
+        );
+        await people.createWithId("ada-byron", {
+          displayName: "Ada Byron",
+          bondLevel: "inner-circle",
+        });
+
+        await people.addChannelMapping("ada-byron", "linkedin", ada.participantId);
+
+        expect(personCount()).toBe(2);
+        const rows = await repo.listParticipants();
+        expect(rows.find((r) => r.participantId === ada.participantId)).toMatchObject({
+          linkedPersonId: "ada-byron",
+          linkedPersonName: "Ada Byron",
+        });
       });
     });
 

--- a/packages/core/src/db/repositories/linkedin-store.ts
+++ b/packages/core/src/db/repositories/linkedin-store.ts
@@ -6,6 +6,7 @@ import {
   linkedinThreads,
 } from "../schema.js";
 import type { DrizzleDb } from "../index.js";
+import { linkedInMemberIdFromProfileUrl } from "../../channels/linkedin-sync.js";
 import type {
   LinkedInHistoryMessage,
   LinkedInMessageInput,
@@ -16,9 +17,15 @@ import type {
   LinkedInThreadInput,
 } from "../../channels/linkedin-sync.js";
 
+// The member-id form lives with the poller/store contract, not here: it is the
+// identity both sides of the mirror agree on. Re-exported so callers reading
+// participant rows reach it from the same module those rows come from.
+export { linkedInMemberIdFromProfileUrl };
+
 const UPSERT_CHUNK = 200;
 const HISTORY_READ_LIMIT = 1000;
 const THREADS_READ_LIMIT = 10000;
+const PARTICIPANTS_READ_LIMIT = 10000;
 
 /** One thread row for the People tab's LinkedIn section. */
 export interface LinkedInThreadRow {
@@ -60,6 +67,27 @@ export interface LinkedInMessageRow {
   reactionCount: number | null;
 }
 
+/**
+ * One mirrored LinkedIn identity, annotated with whether it has been promoted
+ * to a curated `persons` entry. `isSelf` rides along rather than being filtered
+ * out here: which identities a caller offers for promotion is its own policy,
+ * and the guardian's own row is still a real member of the threads it appears
+ * in.
+ */
+export interface LinkedInParticipantContactRow {
+  /** Bare LinkedIn member id — the `channelUserId` promotion writes. */
+  participantId: string;
+  name: string | null;
+  headline: string | null;
+  type: string | null;
+  isSelf: boolean;
+  /** How many mirrored threads this identity belongs to. */
+  threadCount: number;
+  /** The person this identity was promoted into, or null when unpromoted. */
+  linkedPersonId: string | null;
+  linkedPersonName: string | null;
+}
+
 /** One thread's membership paired with the age of the read that produced it. */
 export interface LinkedInThreadParticipantSet {
   participants: LinkedInParticipantRow[];
@@ -73,19 +101,6 @@ export interface LinkedInParticipantBackfillResult {
   threads: number;
   /** Distinct identities the seed proved. */
   participants: number;
-}
-
-// The obfuscated member id inside a mirrored profile URL —
-// `https://www.linkedin.com/in/ACoAA…/`. A vanity handle (`/in/ada-lovelace`)
-// deliberately does not match: it is a public alias, not the member id these
-// tables key on, and storing one would break the correspondence with
-// `channel_mappings.channel_user_id`.
-const MEMBER_ID_IN_PROFILE_URL = /\/in\/(ACoAA[A-Za-z0-9_-]+)/;
-
-/** The bare LinkedIn member id inside a stored profile URL, or null. */
-export function linkedInMemberIdFromProfileUrl(url: string | null | undefined): string | null {
-  if (!url) return null;
-  return MEMBER_ID_IN_PROFILE_URL.exec(url)?.[1] ?? null;
 }
 
 function chunked<T>(items: T[], size: number): T[][] {
@@ -502,6 +517,48 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
       threads: new Set([...memberships.values()].map((m) => m.threadId)).size,
       participants: identities.size,
     };
+  }
+
+  /**
+   * Every stored LinkedIn identity, each row saying whether it has already been
+   * promoted to a person. The join is on the member id itself — no translation
+   * step — because `linkedin_participants.participant_id` and a `linkedin`
+   * `channel_mappings.channel_user_id` are the same identifier by construction.
+   *
+   * Promotion is a guardian action against these rows, not something this
+   * repository performs: a LinkedIn inbox holds many identities that should
+   * never enter the curated person graph, so nothing here writes `persons`.
+   */
+  async listParticipants(): Promise<LinkedInParticipantContactRow[]> {
+    const rows = (await this.db.all(sql`
+      SELECT
+        p.participant_id AS participantId,
+        p.name AS name,
+        p.headline AS headline,
+        p.type AS type,
+        p.is_self AS isSelf,
+        (SELECT COUNT(*) FROM linkedin_thread_participants tp
+           WHERE tp.participant_id = p.participant_id) AS threadCount,
+        cm.person_id AS linkedPersonId,
+        person.display_name AS linkedPersonName
+      FROM linkedin_participants p
+      LEFT JOIN channel_mappings cm
+        ON cm.channel = 'linkedin' AND cm.channel_user_id = p.participant_id
+      LEFT JOIN persons person ON person.id = cm.person_id
+      ORDER BY lower(coalesce(p.name, p.participant_id)) ASC, p.participant_id ASC
+      LIMIT ${PARTICIPANTS_READ_LIMIT}
+    `)) as Array<Record<string, unknown>>;
+
+    return rows.map((r) => ({
+      participantId: String(r.participantId),
+      name: (r.name as string | null) ?? null,
+      headline: (r.headline as string | null) ?? null,
+      type: (r.type as string | null) ?? null,
+      isSelf: Boolean(r.isSelf),
+      threadCount: Number(r.threadCount ?? 0),
+      linkedPersonId: (r.linkedPersonId as string | null) ?? null,
+      linkedPersonName: (r.linkedPersonName as string | null) ?? null,
+    }));
   }
 
   /** One thread's participants with their person-level facts, by member id. */


### PR DESCRIPTION
## What this PR does

A mirrored LinkedIn participant had no way into the curated person graph. `linkedin_participants` held the identity and `persons` held the people, and nothing joined them, so an inbox the poller had mirrored for weeks still met every sender as a stranger.

Promotion reuses `/api/persons/create` and `/api/persons/link`. Both routes are already channel-agnostic, and a participant's bare member id is the `channelUserId` they expect for LinkedIn, so promotion needs no second write path and no translation step. `listParticipants` joins the mirror against `channel_mappings` on that member id and reports the person each identity resolves to, or null. `GET /api/linkedin/participants` serves it, the same annotation `/api/whatsapp/contacts` carries.

## Design & Invariants

**The bridge the issue assumes did not hold.** `linkedin_participants` keys on the bare member id (`ACoAA…`), but an inbound LinkedIn message carried the full profile URL as its `channelUserId`. A person promoted on the member id would have sat there while every message from them resolved to nobody, and the acceptance criterion would have passed by inspection and failed in production.

`linkedInChannelUserId` closes it: a message maps to the member id inside its sender's profile URL. The invariant is that one identifier names a LinkedIn identity on both sides of the mirror — the participant table, the channel mapping, and the inbound message all say `ACoAA…`.

The stored URL stays the fallback rather than being replaced by one. A URL carrying no member id is a vanity handle (`/in/ada-lovelace/`), and that is the form the guardian's own mapping is conferred in at connect time. Narrowing to the member id alone would strand it. The alternative — rewriting the guardian conferral to use a member id — needs an identifier the connect-time identity probe does not report, and it would break a mapping that already works.

**Promotion stays a guardian action.** A LinkedIn inbox holds recruiters, newsletters and strangers who must not walk into the person graph on their own. Nothing in the mirror writes `persons`, and the `LinkedInSyncSink` contract the poller holds exposes no way to. A regression here is any sync path that reaches the person tables.

A headline stays on `linkedin_participants` and belongs in the person's memory profile. `channel_mappings` has no column for it and gains none.

`linkedInMemberIdFromProfileUrl` moves to `channels/linkedin-sync.ts`, the poller/store contract, so the channel adapter reaches it without importing the database layer. `linkedin-store.ts` re-exports it, so its importers are untouched.

## Test plan

- [x] `pnpm typecheck` — clean across all 29 projects
- [x] `pnpm test:unit` — 539 files pass, including 82 across the four LinkedIn suites
- [x] `biome check` on the changed files — clean
- [x] Promoting a participant writes a person and a `linkedin` mapping carrying the member id, and the row reports it (`linkedin-store.test.ts`)
- [x] A message from a promoted participant resolves to that person (`connections/integrations/linkedin.test.ts`)
- [x] A vanity-handle sender still resolves through the profile URL, so the guardian mapping holds (`connections/integrations/linkedin.test.ts`)
- [x] Promoting a participant a person already holds rejects and leaves one person standing. The link path re-points the single mapping rather than duplicating (`linkedin-store.test.ts`)
- [x] A full `pollOnce()` against the real store stores membership and leaves `persons` and `channel_mappings` empty (`channels/linkedin.test.ts`)
- [ ] `pnpm dev:all` — not run. This sandbox has no access to the Docker socket. The change is backend-only and adds no runtime wiring beyond a pure function.

## Not in this PR

- The People tab UI that triggers promotion — out of scope per the issue. `GET /api/linkedin/participants` is what it will read.
- Any change to bond levels — out of scope per the issue.
- Routing LinkedIn messages into the agent pipeline. The talker's `deliver` stays unused, so `linkedInChannelUserId` reaches person resolution through the history feature today.

Closes rome-os/rome#9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
