### PR TITLE
fix(web): make Stop an icon button at every width

### DIFF
--- a/packages/web/src/components/chat/ChatComposer.tsx
+++ b/packages/web/src/components/chat/ChatComposer.tsx
@@ -1034,16 +1034,11 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
                 variant="outline"
                 size="icon-md"
                 onClick={onStop}
-                // Square on mobile, icon + label above `sm`. The width override
-                // is important because `icon-lg` sets width via `size-*`: they
-                // are different utilities at equal specificity, so without it
-                // the winner is whichever Tailwind happens to emit last.
-                className="touch-target gap-2 sm:w-auto! sm:px-3"
+                className="touch-target"
                 title={t("composer.stopGenerating")}
                 aria-label={t("composer.stopGenerating")}
               >
-                <span aria-hidden="true" className="inline-block h-2.5 w-2.5 bg-foreground" />
-                <span className="hidden sm:inline">{t("composer.stop")}</span>
+                <span aria-hidden="true" className="inline-block size-2.5 bg-foreground" />
               </Button>
             )}
             <Button

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -206,7 +206,6 @@
     "send": "Send",
     "sendTitle": "Send",
     "queueTurnTitle": "Queue a new turn",
-    "stop": "Stop",
     "stopGenerating": "Stop generating"
   },
   "questionCard": {

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -206,7 +206,6 @@
     "send": "发送",
     "sendTitle": "发送",
     "queueTurnTitle": "排队新一轮对话",
-    "stop": "停止",
     "stopGenerating": "停止生成"
   },
   "questionCard": {


### PR DESCRIPTION
## What this PR does

Stop was the only control in the composer whose shape changed with the viewport: a 36px square below `sm`, icon plus the word "Stop" above it. Send is the more frequent action and is icon-only at every width, so two buttons sitting in the same cluster followed different rules. Holding that split cost two responsive overrides and a `hidden sm:inline` span.

Stop now renders as an `icon-md` square at every width, which is exactly what Send already renders.

## Design & Invariants

Both buttons in the cluster resolve their geometry from one place. `icon-md` is `size-[var(--control-h-md)]` in [`packages/ui/src/button.tsx`](packages/ui/src/button.tsx), and neither button overrides width or padding. A regression is any override that makes Stop and Send disagree at some breakpoint.

The accessible name still comes from `composer.stopGenerating` on both `title` and `aria-label`. The glyph carries `aria-hidden`, so dropping the visible label costs nothing to a screen reader.

`composer.stop` had one consumer, so it is removed from `en` and `zh-CN` rather than left to orphan.

The alternative was to make Send match Stop instead — icon plus label above `sm` for both. Send is the higher-frequency action and reads fine as a glyph, so widening it to carry a word buys nothing. This direction is the trade-off worth naming: Stop is an interrupt, usually hit under time pressure, and a word is easier to acquire correctly than a glyph. Worth watching for mis-clicks on Send, which sits immediately to Stop's right. The cheapest mitigation, if that shows up, is a wider gap in the cluster rather than the label coming back.

## Test plan

- [x] `pnpm typecheck` — clean across the workspace.
- [x] `pnpm test:unit` — 528 tests across 36 files pass.
- [x] Both locale files re-parsed as JSON after the key removal.
- [ ] Stop exercised in the browser during a streaming turn at mobile and desktop widths.

## Not in this PR

- The gap between Stop and Send is unchanged. Adjusting it is only worth doing with mis-click evidence.