### PR TITLE
feat(web): run a chat row action from a letter key

### DIFF
--- a/packages/web/src/shell/RecentChats.test.tsx
+++ b/packages/web/src/shell/RecentChats.test.tsx
@@ -692,3 +692,132 @@ describe("RecentChats", () => {
     );
   });
 });
+
+describe("RecentChats row menu shortcuts", () => {
+  const activeSession = () => ({
+    id: "active-1",
+    name: "Active chat",
+    createdAt: "2026-07-09T10:00:00.000Z",
+    activityAt: "2026-07-09T10:00:00.000Z",
+    lastSeenActivityAt: null,
+    unread: false,
+    projectName: "alpha",
+    projectPath: "alpha",
+  });
+
+  const archivedSession = () => ({
+    ...activeSession(),
+    id: "archived-1",
+    name: "Archived chat",
+    archivedAt: "2026-07-08T12:00:00.000Z",
+  });
+
+  async function openRowMenu() {
+    const user = userEvent.setup();
+    renderRecentChats();
+    await screen.findByRole("link");
+    await user.click(screen.getByRole("button", { name: "Chat actions" }));
+    return user;
+  }
+
+  it("archives the row on A", async () => {
+    const spy = mockSessions([activeSession()]);
+    const user = await openRowMenu();
+
+    await user.keyboard("a");
+
+    await waitFor(() =>
+      expect(
+        spy.mock.calls.some(
+          ([url, init]) =>
+            /\/api\/chat\/sessions\/active-1\/archive$/.test(String(url)) &&
+            init?.method === "PATCH" &&
+            String(init?.body).includes('"archived":true'),
+        ),
+      ).toBe(true),
+    );
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+  });
+
+  it("unarchives an archived row on A", async () => {
+    localStorage.setItem("rome-recent-chats-status-filter", "all");
+    const spy = mockSessions([archivedSession()]);
+    const user = await openRowMenu();
+
+    await user.keyboard("a");
+
+    await waitFor(() =>
+      expect(
+        spy.mock.calls.some(
+          ([url, init]) =>
+            /\/api\/chat\/sessions\/archived-1\/archive$/.test(String(url)) &&
+            init?.method === "PATCH" &&
+            String(init?.body).includes('"archived":false'),
+        ),
+      ).toBe(true),
+    );
+  });
+
+  it("pins the row on P", async () => {
+    const spy = mockSessions([activeSession()]);
+    const user = await openRowMenu();
+
+    await user.keyboard("p");
+
+    await waitFor(() =>
+      expect(
+        spy.mock.calls.some(
+          ([url, init]) =>
+            /\/api\/chat\/sessions\/active-1\/pin$/.test(String(url)) &&
+            init?.method === "PATCH" &&
+            String(init?.body).includes('"pinned":true'),
+        ),
+      ).toBe(true),
+    );
+  });
+
+  it("opens the rename input on R", async () => {
+    mockSessions([activeSession()]);
+    const user = await openRowMenu();
+
+    await user.keyboard("r");
+
+    const input = await screen.findByRole("textbox", { name: "Chat name" });
+    expect((input as HTMLInputElement).value).toBe("Active chat");
+  });
+
+  it("leaves the letter to the browser when a modifier is held", async () => {
+    const spy = mockSessions([activeSession()]);
+    const user = await openRowMenu();
+
+    await user.keyboard("{Control>}a{/Control}");
+
+    expect(
+      spy.mock.calls.some(([url]) => /\/api\/chat\/sessions\/active-1\/archive$/.test(String(url))),
+    ).toBe(false);
+    expect(screen.getByRole("menu")).toBeTruthy();
+  });
+
+  it("keeps the hint out of the item's accessible name", async () => {
+    mockSessions([activeSession()]);
+    await openRowMenu();
+
+    const archive = screen.getByRole("menuitem", { name: "Archive" });
+    expect(archive.getAttribute("aria-keyshortcuts")).toBe("A");
+    expect(archive.textContent).toContain("A");
+  });
+
+  it("binds no letter to Delete", async () => {
+    const spy = mockSessions([activeSession()]);
+    const user = await openRowMenu();
+
+    expect(screen.getByRole("menuitem", { name: "Delete" }).hasAttribute("aria-keyshortcuts")).toBe(
+      false,
+    );
+
+    await user.keyboard("d");
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(spy.mock.calls.some(([, init]) => init?.method === "DELETE")).toBe(false);
+  });
+});

--- a/packages/web/src/shell/RecentChats.tsx
+++ b/packages/web/src/shell/RecentChats.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { IconButton } from "@/components/ui/icon-button";
@@ -168,6 +169,7 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState("");
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const activeSessionId = activeSessionFromPath(location.pathname);
   const searchShortcut = chatSearchShortcutForPlatform();
@@ -440,6 +442,16 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
     const isActive = activeSessionId === session.id;
     const unread = session.unread && !isActive;
     const isEditing = editingId === session.id;
+    const togglePin = () => void setPinned(session.id, !session.pinnedAt);
+    const beginRename = () => startRename(session);
+    const toggleArchive = session.archived
+      ? () => void handleUnarchive(session.id)
+      : () => void setArchived(session.id, true);
+    const shortcuts: Record<string, () => void> = {
+      p: togglePin,
+      r: beginRename,
+      a: toggleArchive,
+    };
     return (
       <div
         key={session.id}
@@ -496,7 +508,10 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
               aria-label={t("recentChats.unread")}
             />
           ) : null}
-          <DropdownMenu>
+          <DropdownMenu
+            open={openMenuId === session.id}
+            onOpenChange={(open) => setOpenMenuId(open ? session.id : null)}
+          >
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
@@ -507,37 +522,54 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
                 <Ellipsis className="h-3 w-3" aria-hidden />
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent side="bottom" align="end">
-              <DropdownMenuItem
-                className="text-ui"
-                onSelect={() => void setPinned(session.id, !session.pinnedAt)}
-              >
+            <DropdownMenuContent
+              side="bottom"
+              align="end"
+              onKeyDown={(event) => {
+                // Radix composes this ahead of its own typeahead and drops that
+                // handler once the event is defaulted. Without the preventDefault
+                // a bare letter only moves focus to the item it spells.
+                if (event.ctrlKey || event.altKey || event.metaKey) return;
+                const run = shortcuts[event.key.toLowerCase()];
+                if (!run) return;
+                event.preventDefault();
+                run();
+                setOpenMenuId(null);
+              }}
+            >
+              <DropdownMenuItem className="text-ui" aria-keyshortcuts="P" onSelect={togglePin}>
                 {session.pinnedAt ? (
                   <PinOff className="h-3.5 w-3.5 shrink-0" aria-hidden />
                 ) : (
                   <Pin className="h-3.5 w-3.5 shrink-0" aria-hidden />
                 )}
                 {session.pinnedAt ? t("recentChats.unpinChat") : t("recentChats.pinChat")}
+                <DropdownMenuShortcut aria-hidden>P</DropdownMenuShortcut>
               </DropdownMenuItem>
-              <DropdownMenuItem className="text-ui" onSelect={() => startRename(session)}>
+              <DropdownMenuItem className="text-ui" aria-keyshortcuts="R" onSelect={beginRename}>
                 <Pencil className="h-3.5 w-3.5 shrink-0" aria-hidden />
                 {t("recentChats.rename")}
+                <DropdownMenuShortcut aria-hidden>R</DropdownMenuShortcut>
               </DropdownMenuItem>
               {session.archived ? (
                 <DropdownMenuItem
                   className="text-ui"
-                  onSelect={() => void handleUnarchive(session.id)}
+                  aria-keyshortcuts="A"
+                  onSelect={toggleArchive}
                 >
                   <ArchiveRestore className="h-3.5 w-3.5 shrink-0" aria-hidden />
                   {t("recentChats.unarchive")}
+                  <DropdownMenuShortcut aria-hidden>A</DropdownMenuShortcut>
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuItem
                   className="text-ui"
-                  onSelect={() => void setArchived(session.id, true)}
+                  aria-keyshortcuts="A"
+                  onSelect={toggleArchive}
                 >
                   <Archive className="h-3.5 w-3.5 shrink-0" aria-hidden />
                   {t("recentChats.archive")}
+                  <DropdownMenuShortcut aria-hidden>A</DropdownMenuShortcut>
                 </DropdownMenuItem>
               )}
               <DropdownMenuItem


### PR DESCRIPTION
## What this PR does

The chat row menu carries four actions and reaches all of them only through the pointer or the arrow keys. A guardian who opens the menu from the keyboard walks the list to archive one chat.

Pin, rename, and archive each answer to a letter while the menu is open — `P`, `R`, `A`. The menu shows the letter beside the action, through the kit's `DropdownMenuShortcut`.

## Design & Invariants

Radix owns typeahead inside a menu. A bare letter moves focus to the item whose label starts with it, so `A` on its own lands on "Archive" without running it. The handler sits on `DropdownMenuContent`, which Radix composes ahead of its own typeahead, and calls `preventDefault` so the typeahead handler drops the event. A letter that no action claims still reaches typeahead.

Three invariants hold:

- The letter and the menu item run the same function. `togglePin`, `beginRename`, and `toggleArchive` are defined once per row, and both `onSelect` and the letter map read them. An action that binds a letter without sharing the function is a regression.
- The hint carries `aria-hidden` and the item carries `aria-keyshortcuts`. The accessible name of an item stays the label alone. A hint that joins the accessible name is a regression, and the existing role queries in `RecentChats.test.tsx` catch it.
- A Ctrl, Alt, or Meta chord falls through untouched.

The letter path skips `onSelect`, which is what closes the menu, so the menu becomes controlled through one `openMenuId` on `RecentChats`. `renderSession` is a plain function rather than a component and holds no state of its own. Only one row menu opens at a time, so one id covers every row.

Delete takes no letter. A destructive action one keystroke away, in a menu that opens on hover, is a bad trade.

The alternative design was a chord such as `⌘⇧A`, which bypasses typeahead for free. A chord reads as a global shortcut that works with the menu closed, and this feature is scoped to the open menu.

## Test plan

- [x] `pnpm typecheck` — clean across every workspace
- [x] `pnpm test:unit` — core 3882, web 1098, ui 528, all passing
- [x] Seven tests added to `RecentChats.test.tsx`, covering each letter, the archived row, the modifier fall-through, the accessible name, and the unbound Delete
- [x] Neutered the handler and confirmed the four behavioral tests fail, so they are not vacuous
- [x] `biome check` on both changed files
- [x] `pnpm --filter rome-web build`
- [ ] Browser pass. The Docker daemon is unreachable here, so `pnpm dev:all` does not start, and no Playwright browsers are cached. Focus restoration after `startRename` defers through `setTimeout` and deserves a click-through.

## Not in this PR

- The project group menu and the sidebar header menu take no letters, so the sidebar is inconsistent until someone decides they should match.
- Delete takes no letter, for the reason above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
