### PR TITLE
feat(core): serve a union of persons and unplaced senders

### DIFF
--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -32,6 +32,7 @@ import { feedbackRoutes } from "./routes/feedback.js";
 import { systemUpgradeRoutes } from "./routes/system-upgrade.js";
 import { personsRoutes } from "./routes/persons.js";
 import { linkedinThreadsRoutes } from "./routes/linkedin-threads.js";
+import { identitiesRoutes } from "./routes/identities.js";
 import { whatsappContactsRoutes } from "./routes/whatsapp-contacts.js";
 import { sentinelLogRoutes } from "./routes/sentinel-log.js";
 import { webhookInvocationsRoutes } from "./routes/webhook-invocations.js";
@@ -146,6 +147,7 @@ export function buildApp(
   api.route("/", routinesRoutes(deps));
   api.route("/", eventCatalogRoutes(deps));
   api.route("/", personsRoutes(deps));
+  api.route("/", identitiesRoutes(deps));
   api.route("/", whatsappContactsRoutes(deps));
   api.route("/", linkedinThreadsRoutes(deps));
   api.route("/", sentinelLogRoutes(deps));

--- a/packages/core/src/api/routes/identities.test.ts
+++ b/packages/core/src/api/routes/identities.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import type { IdentityPage, IdentityRow } from "@rome/api-types/identities";
+import { identitiesRoutes } from "./identities.js";
+import { createTestDb, buildTestDeps, type TestDb, type TestDeps } from "../../test/helpers.js";
+import { seedBaseline, type BaselineIds } from "../../test/seeds.js";
+import { persons, sentinelLog } from "../../db/schema.js";
+import { STRANGER_PERSON_ID } from "../../constants.js";
+
+// GET /identities is the People page's one read: a union of curated persons and
+// the senders the sentinel log saw but nobody placed, all in the shared
+// IdentityRow shape. These tests pin the union's behavior — what shows up, under
+// which typed id and level, and that reading never writes.
+
+describe("Identities API", () => {
+  let testDb: TestDb;
+  let deps: TestDeps;
+  let app: Hono;
+  let baseline: BaselineIds;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    baseline = await seedBaseline(testDb.db);
+    deps = await buildTestDeps(testDb.db);
+    app = new Hono().route("/", identitiesRoutes(deps));
+  });
+
+  afterEach(() => testDb.close());
+
+  async function fetchPage(query = ""): Promise<IdentityPage> {
+    const res = await app.request(`/identities${query}`);
+    expect(res.status).toBe(200);
+    return (await res.json()) as IdentityPage;
+  }
+
+  async function fetchRows(): Promise<IdentityRow[]> {
+    return (await fetchPage()).identities;
+  }
+
+  it("returns curated persons as person-form rows with their level and channels", async () => {
+    const rows = await fetchRows();
+    const alice = rows.find((r) => r.id === `person:${baseline.persons.innerCircleId}`);
+    expect(alice).toBeDefined();
+    expect(alice!.level).toBe("inner-circle");
+    expect(alice!.channels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ channel: "telegram", channelUserId: "tg-alice" }),
+      ]),
+    );
+
+    const guardian = rows.find((r) => r.id === `person:${baseline.persons.guardianId}`);
+    expect(guardian?.level).toBe("guardian");
+  });
+
+  it("returns unmapped sentinel senders as unknown channel-form rows", async () => {
+    const rows = await fetchRows();
+    const unknown = rows.find((r) => r.id === "channel:telegram:tg-stranger-999");
+    expect(unknown).toBeDefined();
+    expect(unknown!.level).toBe("unknown");
+    // A mapped sender is a person, never also a channel row.
+    expect(rows.find((r) => r.id === "channel:telegram:tg-alice")).toBeUndefined();
+  });
+
+  it("renders each stranger mapping as its own channel-form row, never the sentinel person", async () => {
+    await deps.personMappingRepo.addChannelMapping(
+      STRANGER_PERSON_ID,
+      "telegram",
+      "tg-spammer",
+      "Spammer",
+    );
+    const rows = await fetchRows();
+    const stranger = rows.find((r) => r.id === "channel:telegram:tg-spammer");
+    expect(stranger).toBeDefined();
+    expect(stranger!.level).toBe("stranger");
+    expect(rows.find((r) => r.id === `person:${STRANGER_PERSON_ID}`)).toBeUndefined();
+  });
+
+  it('buckets a bond level outside today\'s enum under "other"', async () => {
+    await testDb.db
+      .update(persons)
+      .set({ bondLevel: "colleague" as never })
+      .where(eq(persons.id, baseline.persons.otherId));
+    const rows = await fetchRows();
+    const row = rows.find((r) => r.id === `person:${baseline.persons.otherId}`);
+    expect(row?.level).toBe("other");
+  });
+
+  it("carries each identity's newest dynamic, naming the surface it came from", async () => {
+    const rows = await fetchRows();
+    const unknown = rows.find((r) => r.id === "channel:telegram:tg-stranger-999")!;
+    expect(unknown.latest?.source).toBe("telegram");
+    expect(unknown.latest?.preview).toBe("who are you");
+    expect(unknown.messageCount).toBe(1);
+    // Nothing has ever been said to Bob, so his row carries no dynamic at all.
+    expect(
+      rows.find((r) => r.id === `person:${baseline.persons.acquaintanceId}`)!.latest,
+    ).toBeNull();
+  });
+
+  it("takes the newest word across a person's channels, and counts them all", async () => {
+    // Alice's sentinel history is on telegram; a second mapping with newer
+    // history has to win, whichever channel it sits on.
+    await deps.personMappingRepo.addChannelMapping(
+      baseline.persons.innerCircleId,
+      "webchat",
+      "web-alice",
+      "Alice Inner",
+    );
+    const webId = await deps.sentinelLogRepo.create({
+      messageId: "msg-web-1",
+      channel: "webchat",
+      channelUserId: "web-alice",
+      displayName: "Alice Inner",
+      text: "from the web",
+      action: "ignored",
+    });
+    // Stamped a minute past the baseline rather than left to the clock: the
+    // baseline's rows are written in the same second this one would be, and the
+    // order settles a tie on the channel name, which is not what this test is
+    // about.
+    const seeded = (await fetchRows()).find(
+      (r) => r.id === `person:${baseline.persons.innerCircleId}`,
+    )!.latest!.timestamp;
+    await testDb.db
+      .update(sentinelLog)
+      .set({ createdAt: new Date((seeded + 60) * 1000) })
+      .where(eq(sentinelLog.id, webId));
+
+    const alice = (await fetchRows()).find(
+      (r) => r.id === `person:${baseline.persons.innerCircleId}`,
+    )!;
+    expect(alice.latest?.source).toBe("webchat");
+    expect(alice.latest?.preview).toBe("from the web");
+    // Two telegram exchanges and one on webchat: the count is over the person,
+    // not over whichever channel answered most recently.
+    expect(alice.messageCount).toBe(3);
+  });
+
+  it("rejects a cursor that names no position rather than answering the first page", async () => {
+    const res = await app.request("/identities?cursor=not-a-cursor");
+    expect(res.status).toBe(400);
+  });
+
+  it("answers a search over names and channel identifiers", async () => {
+    const byName = await fetchPage("?q=bob");
+    expect(byName.identities.map((r) => r.id)).toEqual([
+      `person:${baseline.persons.acquaintanceId}`,
+    ]);
+
+    const byChannelId = await fetchPage("?q=tg-stranger-999");
+    expect(byChannelId.identities.map((r) => r.id)).toEqual(["channel:telegram:tg-stranger-999"]);
+  });
+
+  it("answers for one identity by id, whatever page it would land on", async () => {
+    const page = await fetchPage(`?id=${encodeURIComponent("channel:telegram:tg-stranger-999")}`);
+    expect(page.identities.map((r) => r.id)).toEqual(["channel:telegram:tg-stranger-999"]);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("pages by activity, and the cursor resumes without repeating a row", async () => {
+    const first = await fetchPage("?limit=2");
+    expect(first.identities).toHaveLength(2);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await fetchPage(`?limit=2&cursor=${encodeURIComponent(first.nextCursor!)}`);
+    // A cursor the route ignored would answer an empty page here, and every
+    // "no repeats" assertion below would hold vacuously.
+    expect(second.identities.length).toBeGreaterThan(0);
+    const firstIds = first.identities.map((r) => r.id);
+    expect(second.identities.some((r) => firstIds.includes(r.id))).toBe(false);
+
+    const all = await fetchRows();
+    expect([...firstIds, ...second.identities.map((r) => r.id)]).toEqual(
+      all.slice(0, firstIds.length + second.identities.length).map((r) => r.id),
+    );
+  });
+
+  it("counts every level over the whole union, not the page it returned", async () => {
+    const full = await fetchPage();
+    // One row per page, so a count taken over the page would report at most one
+    // of anything — the failure the Unknown chip's signal depends on avoiding.
+    const firstOfMany = await fetchPage("?limit=1");
+    expect(firstOfMany.identities).toHaveLength(1);
+    expect(firstOfMany.counts).toEqual(full.counts);
+    expect(firstOfMany.totals).toEqual(full.totals);
+    expect(full.counts.unknown).toBe(
+      full.identities.filter((row) => row.level === "unknown" && row.latest !== null).length,
+    );
+  });
+
+  it("leaves the guardian out of the chip counts, but not the totals", async () => {
+    const page = await fetchPage();
+    expect(page.counts.guardian).toBe(0);
+    // The directory's headings count the rows they show, guardian included —
+    // a heading over one visible row that reads 0 is the number being wrong.
+    expect(page.totals.guardian).toBe(
+      page.identities.filter((row) => row.level === "guardian").length,
+    );
+  });
+
+  it("filters by level before paging, so a level's view is the whole union", async () => {
+    const page = await fetchPage("?level=unknown");
+    expect(page.identities.every((row) => row.level === "unknown")).toBe(true);
+    // The other chips keep their numbers while one chip's view is on screen.
+    const all = await fetchPage();
+    expect(page.counts).toEqual(all.counts);
+  });
+
+  it('excludes both unplaced ends of the ladder from the "all" view', async () => {
+    await deps.personMappingRepo.addChannelMapping(
+      STRANGER_PERSON_ID,
+      "telegram",
+      "tg-spammer",
+      "Spammer",
+    );
+    const page = await fetchPage("?level=all");
+    expect(page.identities.some((row) => row.level === "unknown")).toBe(false);
+    expect(page.identities.some((row) => row.level === "stranger")).toBe(false);
+  });
+
+  it("rejects a level that names no view rather than answering as all", async () => {
+    expect((await app.request("/identities?level=nonsense")).status).toBe(400);
+  });
+
+  it("never materializes a person row — reads are a union", async () => {
+    const before = await testDb.db.select({ id: persons.id }).from(persons);
+    await fetchRows();
+    const after = await testDb.db.select({ id: persons.id }).from(persons);
+    expect(after.length).toBe(before.length);
+  });
+
+  it("sorts identities with a dynamic newest first, and the rest last", async () => {
+    const rows = await fetchRows();
+    const at = (id: string) => rows.findIndex((r) => r.id === id);
+    // Alice's sentinel history is the newest thing in the baseline, and Bob has
+    // none at all.
+    expect(at(`person:${baseline.persons.innerCircleId}`)).toBeLessThan(
+      at(`person:${baseline.persons.acquaintanceId}`),
+    );
+    const firstSilent = rows.findIndex((row) => row.latest === null);
+    expect(firstSilent).toBeGreaterThan(0);
+    expect(rows.slice(firstSilent).every((row) => row.latest === null)).toBe(true);
+  });
+});

--- a/packages/core/src/api/routes/identities.ts
+++ b/packages/core/src/api/routes/identities.ts
@@ -1,0 +1,212 @@
+import { Hono } from "hono";
+import { sql } from "drizzle-orm";
+import {
+  channelIdentityId,
+  compareCodePoints,
+  compareIdentityRows,
+  identityMatchesQuery,
+  normalizeBondLevel,
+  parseIdentityCursor,
+  parseIdentityFilterLevel,
+  personIdentityId,
+  sliceIdentityPage,
+  type IdentityDynamic,
+  type IdentityRow,
+} from "@rome/api-types/identities";
+import { STRANGER_PERSON_ID } from "../../constants.js";
+import type { ApiDeps } from "../deps.js";
+
+// The People page's one read: a union of curated persons and the senders the
+// sentinel log saw but nobody placed, every row in the shared `IdentityRow`
+// shape and carrying its newest dynamic. A read — no person row is
+// materialized here, ever; writes stay on the `/persons/*` mutation routes.
+
+interface SentinelActivity {
+  channel: string;
+  channelUserId: string;
+  displayName: string | null;
+  lastMessage: string | null;
+  lastMessageAt: number | null;
+  messageCount: number;
+}
+
+interface ChannelActivity {
+  latest: IdentityDynamic | null;
+  messageCount: number;
+}
+
+const activityKey = (channel: string, channelUserId: string) => `${channel}\n${channelUserId}`;
+
+/** The newer of two dynamics, or whichever one exists. */
+function newer(a: IdentityDynamic | null, b: IdentityDynamic | null): IdentityDynamic | null {
+  if (!a) return b;
+  if (!b) return a;
+  return b.timestamp > a.timestamp ? b : a;
+}
+
+export function identitiesRoutes(deps: ApiDeps): Hono {
+  const app = new Hono();
+
+  app.get("/identities", async (c) => {
+    const query = c.req.query("q") ?? "";
+    const includeNeverMessaged = c.req.query("includeNeverMessaged") === "true";
+    const wanted = c.req.query("id");
+    const limit = parsePositiveInt(c.req.query("limit"));
+    const cursor = c.req.query("cursor") ?? null;
+    const rawLevel = c.req.query("level");
+    const level = parseIdentityFilterLevel(rawLevel);
+    if (rawLevel != null && rawLevel !== "" && level === null) {
+      return c.json({ error: `level must name a bond level or "all"` }, 400);
+    }
+
+    const parsedCursor = parseIdentityCursor(cursor);
+    if (cursor != null && cursor !== "" && parsedCursor === null) {
+      return c.json({ error: "cursor is not an identity cursor" }, 400);
+    }
+
+    const matching = (await buildIdentityUnion(deps)).filter((row) =>
+      identityMatchesQuery(row, query),
+    );
+    matching.sort(compareIdentityRows);
+
+    // Everything below the query is the page's business, not the union's: the
+    // level, the cursor, and `?id=` all scope which rows come back while the
+    // counts stay whole-union.
+    return c.json(
+      sliceIdentityPage(matching, {
+        cursor: parsedCursor,
+        limit,
+        level,
+        id: wanted ?? null,
+        includeNeverMessaged: includeNeverMessaged || query.trim() !== "",
+      }),
+    );
+  });
+
+  return app;
+}
+
+/** The full union, unordered and unfiltered. */
+async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
+  // Bare display_name/text ride SQLite's guarantee that with a lone MAX()
+  // aggregate the other selected columns come from the row that supplied the
+  // max — i.e. the newest message names the sender.
+  const sentinelRows = (await deps.db.all(sql`
+    SELECT
+      channel,
+      channel_user_id AS channelUserId,
+      display_name AS displayName,
+      text AS lastMessage,
+      MAX(created_at) AS lastMessageAt,
+      COUNT(*) AS messageCount
+    FROM sentinel_log
+    GROUP BY channel, channel_user_id
+  `)) as Array<Record<string, unknown>>;
+
+  const sentinel = new Map<string, SentinelActivity>();
+  const senders: SentinelActivity[] = [];
+  for (const row of sentinelRows) {
+    const activity: SentinelActivity = {
+      channel: String(row.channel),
+      channelUserId: String(row.channelUserId),
+      displayName: (row.displayName as string | null) ?? null,
+      lastMessage: (row.lastMessage as string | null) ?? null,
+      lastMessageAt: row.lastMessageAt == null ? null : Number(row.lastMessageAt),
+      messageCount: Number(row.messageCount ?? 0),
+    };
+    senders.push(activity);
+    sentinel.set(activityKey(activity.channel, activity.channelUserId), activity);
+  }
+
+  const activityFor = (channel: string, channelUserId: string): ChannelActivity => {
+    const entry = sentinel.get(activityKey(channel, channelUserId));
+    return {
+      latest:
+        entry?.lastMessageAt == null
+          ? null
+          : { source: channel, timestamp: entry.lastMessageAt, preview: entry.lastMessage },
+      messageCount: entry?.messageCount ?? 0,
+    };
+  };
+
+  /** Best name on record for an identity with no person row: what the sender
+   *  called themselves, then the raw channel user id. */
+  const displayNameFor = (channel: string, channelUserId: string): string =>
+    sentinel.get(activityKey(channel, channelUserId))?.displayName ?? channelUserId;
+
+  // One statement, so an identity moving between two people mid-read cannot
+  // land under both of them.
+  const persons = (await deps.personMappingRepo.findAllWithMappings()).sort((a, b) =>
+    compareCodePoints(a.id, b.id),
+  );
+  const rows: IdentityRow[] = [];
+  const mapped = new Set<string>();
+
+  for (const person of persons) {
+    for (const mapping of person.channelMappings) {
+      mapped.add(activityKey(mapping.channel, mapping.channelUserId));
+    }
+
+    if (person.id === STRANGER_PERSON_ID) {
+      // The sentinel is a person row, but each dismissed identity is its own
+      // row on the ladder — a channel-form id, so recovering one is the same
+      // move that places an unknown sender.
+      for (const mapping of person.channelMappings) {
+        rows.push({
+          id: channelIdentityId(mapping.channel, mapping.channelUserId),
+          displayName: displayNameFor(mapping.channel, mapping.channelUserId),
+          level: "stranger",
+          channels: [{ channel: mapping.channel, channelUserId: mapping.channelUserId }],
+          ...activityFor(mapping.channel, mapping.channelUserId),
+          neverMessaged: false,
+        });
+      }
+      continue;
+    }
+
+    const activity = person.channelMappings
+      .map((mapping) => activityFor(mapping.channel, mapping.channelUserId))
+      .reduce<ChannelActivity>(
+        (best, next) => ({
+          latest: newer(best.latest, next.latest),
+          messageCount: best.messageCount + next.messageCount,
+        }),
+        { latest: null, messageCount: 0 },
+      );
+
+    rows.push({
+      id: personIdentityId(person.id),
+      displayName: person.displayName,
+      level: person.bondLevel === "guardian" ? "guardian" : normalizeBondLevel(person.bondLevel),
+      channels: person.channelMappings.map((mapping) => ({
+        channel: mapping.channel,
+        channelUserId: mapping.channelUserId,
+      })),
+      ...activity,
+      neverMessaged: false,
+    });
+  }
+
+  // Unknown = seen but never placed.
+  for (const sender of senders) {
+    const key = activityKey(sender.channel, sender.channelUserId);
+    if (mapped.has(key)) continue;
+    mapped.add(key);
+    rows.push({
+      id: channelIdentityId(sender.channel, sender.channelUserId),
+      displayName: displayNameFor(sender.channel, sender.channelUserId),
+      level: "unknown",
+      channels: [{ channel: sender.channel, channelUserId: sender.channelUserId }],
+      ...activityFor(sender.channel, sender.channelUserId),
+      neverMessaged: false,
+    });
+  }
+
+  return rows;
+}
+
+function parsePositiveInt(raw: string | undefined): number | undefined {
+  if (raw == null) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined;
+}

--- a/packages/core/src/db/repositories/person-mapping.test.ts
+++ b/packages/core/src/db/repositories/person-mapping.test.ts
@@ -18,6 +18,34 @@ describe("PersonMappingRepository", () => {
     testDb.close();
   });
 
+  it("findAllWithMappings() reads every person and their identities at once", async () => {
+    // One statement, so an identity moving between two people mid-read cannot
+    // land under both of them — which is the identity union's whole premise.
+    const alice = await repo.create({
+      displayName: "Alice",
+      bondLevel: "inner-circle",
+      channelMappings: [
+        { channel: "telegram", channelUserId: "tg-alice" },
+        { channel: "whatsapp", channelUserId: "wa-alice" },
+      ],
+    });
+    const bob = await repo.create({ displayName: "Bob", bondLevel: "acquaintance" });
+
+    const rows = await repo.findAllWithMappings();
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    expect(byId.size).toBe(rows.length);
+    expect(byId.get(alice)!.displayName).toBe("Alice");
+    expect(
+      byId
+        .get(alice)!
+        .channelMappings.map((m) => `${m.channel}:${m.channelUserId}`)
+        .sort(),
+    ).toEqual(["telegram:tg-alice", "whatsapp:wa-alice"]);
+    // A person holding no identity is still a person, and the left join has to
+    // answer them with an empty list rather than dropping them.
+    expect(byId.get(bob)!.channelMappings).toEqual([]);
+  });
+
   it("createPerson() inserts person record", async () => {
     const id = await repo.create({
       displayName: "Alice",

--- a/packages/core/src/db/repositories/person-mapping.ts
+++ b/packages/core/src/db/repositories/person-mapping.ts
@@ -183,6 +183,42 @@ export class PersonMappingRepository {
   }
 
   /**
+   * Every person with their channel mappings, read as one statement.
+   *
+   * One snapshot, unlike {@link findAll}: a mapping moving between two people
+   * mid-read would otherwise land under both of them (or neither), because
+   * each person's mappings arrive in their own autocommit query. The identity
+   * union's whole premise is that an identity has one owner, so it reads this.
+   */
+  async findAllWithMappings() {
+    const rows = await this.db
+      .select({ person: persons, mapping: channelMappings })
+      .from(persons)
+      .leftJoin(channelMappings, eq(channelMappings.personId, persons.id));
+
+    const byPerson = new Map<
+      string,
+      typeof persons.$inferSelect & {
+        channelMappings: { channel: string; channelUserId: string }[];
+      }
+    >();
+    for (const row of rows) {
+      let person = byPerson.get(row.person.id);
+      if (!person) {
+        person = { ...row.person, channelMappings: [] };
+        byPerson.set(row.person.id, person);
+      }
+      if (row.mapping) {
+        person.channelMappings.push({
+          channel: row.mapping.channel,
+          channelUserId: row.mapping.channelUserId,
+        });
+      }
+    }
+    return [...byPerson.values()];
+  }
+
+  /**
    * Create a person and claim their channel identities, both or neither.
    *
    * An identity filed under the stranger sentinel is a dismissal rather than a


### PR DESCRIPTION
First of five rebuilding [amantru/rome-internal#2399](https://github.com/amantru/rome-internal/pull/2399) here, extended to the second mirror this repo has. Merge in order — each PR broadens the union or the timeline the one before it introduced. Replaces #44, which carried the whole change in one diff.

## What this PR does

The People page's sections come from separate endpoints, none of which can answer where a person stands relative to another. A curated person and a sender still waiting in the sentinel log are two shapes, and the page has to order them together and page through the result.

`GET /api/identities` answers that union in the shared `IdentityRow` shape from `@rome/api-types/identities`, ordered by activity and paged, filtered by `q`, `level`, or answered for a single `id`.

## Design & Invariants

**Reads never write.** No person row is materialized by the endpoint. Pinned by a test that asserts the person count is unchanged across a read — the union is derived, and a read that quietly created rows would make the address book grow by being looked at.

**Counts and the level filter are the server's answers.** Both computed over everything the query matched and before paging. A client that filtered its loaded rows would show a level's view as whatever of it happened to land on page one, and count only that.

**The cursor names a position, not a row.** Between two requests a row is moved to another level, merged away, or dismissed — every one an ordinary write on this page — and a cursor that has to find that row again answers the next page empty.

**One ownership snapshot.** `findAllWithMappings` reads persons and their mappings in one statement, so an identity moving between two people mid-read cannot land under both. `findAll` issues a query per person, and each arrives in its own autocommit.

**A dismissed identity is a row, the sentinel person is not.** The stranger sentinel is a person row, but each identity mapped onto it renders as its own channel-form id, so recovering one is the same move that places an unknown sender.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run` in `packages/core` — 448 pass across the touched areas. New coverage: persons and unplaced senders in one ordered page, a stranger mapping as its own row, a bond level outside the enum bucketed under "other", counts equal across a one-row page and the full union, `level` filtering before paging, a search over names and channel identifiers, a by-id fetch, the cursor resuming without repeating a row, the newest word winning across a person's channels, and the person count unchanged across a read
- [x] `biome check` clean on every touched path

## Not in this PR

- The WhatsApp address book, the LinkedIn participant mirror, and the merged timeline — the four PRs stacked on this one.
- Nothing in the dashboard reads this endpoint. The page rebuild is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
