### PR TITLE
feat(core): fold the WhatsApp address book into the identity union

### DIFF
--- a/packages/core/src/api/deps.ts
+++ b/packages/core/src/api/deps.ts
@@ -4,6 +4,7 @@ import type { DrizzleDb } from "../db/index.js";
 import type { PersonMappingRepository } from "../db/repositories/person-mapping.js";
 import type { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
 import type { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
+import type { WhatsAppAccounts } from "../channels/whatsapp-accounts.js";
 import type { WebChatRepository } from "../db/repositories/webchat.js";
 import type { WebhookInvocationsRepository } from "../db/repositories/webhook-invocations.js";
 import type { ApprovalsRepository } from "../db/repositories/approvals.js";
@@ -71,6 +72,9 @@ export interface ApiDeps {
   personMappingRepo: PersonMappingRepository;
   /** Durable mirror of the WhatsApp address book + message history (People tab). */
   whatsAppStoreRepo: WhatsAppStoreRepository;
+  /** WhatsApp's account plane over that mirror — who it can reach, folded onto
+   *  one account per person, and what was last said to each. */
+  whatsAppAccounts: WhatsAppAccounts;
   /** Durable mirror of the LinkedIn inbox + message history (People tab). */
   linkedInStoreRepo: LinkedInStoreRepository;
   webchatRepo: WebChatRepository;

--- a/packages/core/src/api/routes/identities.test.ts
+++ b/packages/core/src/api/routes/identities.test.ts
@@ -289,6 +289,26 @@ describe("Identities API", () => {
     expect(person.latest?.preview).toBe("from the lid address");
   });
 
+  it("is one row for an account the address book still holds as two cards", async () => {
+    // The store groups on the number a row carries, so a row that has not
+    // learned its number yet is a second card. The channel's account plane is
+    // what says they are one account, and the union takes that answer whole
+    // rather than re-deriving it from jids it should not be reading.
+    await deps.whatsAppStoreRepo.upsertContacts([
+      { jid: "15550009999@s.whatsapp.net", name: "Split Contact" },
+      { jid: "99900099999@lid", phoneNumber: "15550009999" },
+    ]);
+
+    const rows = await fetchRows();
+    const split = rows.filter((r) => r.displayName === "Split Contact");
+    expect(split).toHaveLength(1);
+    expect(split[0].id).toBe("channel:whatsapp:15550009999@s.whatsapp.net");
+    expect(split[0].channels.map((ch) => ch.channelUserId)).toEqual([
+      "15550009999@s.whatsapp.net",
+      "99900099999@lid",
+    ]);
+  });
+
   it("answers a search over names and channel identifiers, silent contacts included", async () => {
     const byName = await fetchPage("?q=silent");
     expect(byName.identities.map((r) => r.id)).toEqual([`channel:whatsapp:${SILENT_JID}`]);

--- a/packages/core/src/api/routes/identities.test.ts
+++ b/packages/core/src/api/routes/identities.test.ts
@@ -8,22 +8,70 @@ import { seedBaseline, type BaselineIds } from "../../test/seeds.js";
 import { persons, sentinelLog } from "../../db/schema.js";
 import { STRANGER_PERSON_ID } from "../../constants.js";
 
-// GET /identities is the People page's one read: a union of curated persons and
-// the senders the sentinel log saw but nobody placed, all in the shared
-// IdentityRow shape. These tests pin the union's behavior — what shows up, under
-// which typed id and level, and that reading never writes.
+// GET /identities is the People page's one read: a union of curated persons,
+// unmapped sentinel-log senders, and unlinked WhatsApp contacts, all in the
+// shared IdentityRow shape. These tests pin the union's behavior — what shows
+// up, under which typed id and level, and that reading never writes.
+
+const SILENT_JID = "15550001111@s.whatsapp.net";
+const TALKING_JID = "15550002222@s.whatsapp.net";
+const LINKED_JID = "15550003333@s.whatsapp.net";
+const GROUP_JID = "120363000000000001@g.us";
 
 describe("Identities API", () => {
   let testDb: TestDb;
   let deps: TestDeps;
   let app: Hono;
   let baseline: BaselineIds;
+  let waOnlyPersonId: string;
 
   beforeEach(async () => {
     testDb = createTestDb();
     baseline = await seedBaseline(testDb.db);
     deps = await buildTestDeps(testDb.db);
     app = new Hono().route("/", identitiesRoutes(deps));
+
+    // The WhatsApp mirror: a silent address-book contact, a talking unlinked
+    // contact, a contact linked to a curated person, and a group chat.
+    await deps.whatsAppStoreRepo.upsertContacts([
+      { jid: SILENT_JID, phoneNumber: "15550001111", name: "Silent Sam" },
+      { jid: TALKING_JID, phoneNumber: "15550002222", notify: "Talky Tina" },
+      { jid: LINKED_JID, phoneNumber: "15550003333", name: "Alice WA" },
+    ]);
+    await deps.whatsAppStoreRepo.upsertChats([
+      { jid: GROUP_JID, name: "Sunday hikes", isGroup: true },
+    ]);
+    await deps.whatsAppStoreRepo.upsertMessages([
+      {
+        id: "wa-1",
+        chatJid: TALKING_JID,
+        senderJid: TALKING_JID,
+        fromMe: false,
+        timestamp: new Date("2026-08-17T10:00:00Z"),
+        type: "text",
+        text: "hello from tina",
+        hasMedia: false,
+      },
+      {
+        id: "wa-2",
+        chatJid: LINKED_JID,
+        senderJid: LINKED_JID,
+        fromMe: false,
+        timestamp: new Date("2026-08-17T11:00:00Z"),
+        type: "text",
+        text: "hello from alice's wa",
+        hasMedia: false,
+      },
+    ]);
+    // A curated person known only through WhatsApp, so the mirror is the only
+    // history their row can carry. Baseline's Alice is deliberately not reused
+    // here: she also has sentinel history, which is its own test below.
+    waOnlyPersonId = await deps.personMappingRepo.create({
+      displayName: "WhatsApp Only",
+      bondLevel: "acquaintance",
+      approved: true,
+      channelMappings: [{ channel: "whatsapp", channelUserId: LINKED_JID }],
+    });
   });
 
   afterEach(() => testDb.close());
@@ -34,8 +82,10 @@ describe("Identities API", () => {
     return (await res.json()) as IdentityPage;
   }
 
+  /** The rows of the first page, with silent contacts included — what most of
+   *  these tests assert over. */
   async function fetchRows(): Promise<IdentityRow[]> {
-    return (await fetchPage()).identities;
+    return (await fetchPage("?includeNeverMessaged=true")).identities;
   }
 
   it("returns curated persons as person-form rows with their level and channels", async () => {
@@ -53,13 +103,59 @@ describe("Identities API", () => {
     expect(guardian?.level).toBe("guardian");
   });
 
+  it("projects WhatsApp history onto the person a contact is linked to", async () => {
+    const rows = await fetchRows();
+    const person = rows.find((r) => r.id === `person:${waOnlyPersonId}`)!;
+    expect(person.latest?.preview).toBe("hello from alice's wa");
+    expect(person.latest?.source).toBe("whatsapp");
+    expect(person.messageCount).toBeGreaterThan(0);
+    // The linked contact never shows up a second time as an unknown row.
+    expect(rows.find((r) => r.id === `channel:whatsapp:${LINKED_JID}`)).toBeUndefined();
+  });
+
+  it("takes the newest word when a person has history on two surfaces", async () => {
+    // Baseline stamps Alice's sentinel entry at seed time; her WhatsApp mirror
+    // row is older, so the sentinel is what her row reports.
+    await deps.personMappingRepo.addChannelMapping(
+      baseline.persons.innerCircleId,
+      "whatsapp",
+      TALKING_JID,
+      "Alice WA",
+    );
+    const rows = await fetchRows();
+    const alice = rows.find((r) => r.id === `person:${baseline.persons.innerCircleId}`)!;
+    expect(alice.latest?.preview).not.toBe("hello from tina");
+    expect(alice.latest?.source).toBe("telegram");
+  });
+
   it("returns unmapped sentinel senders as unknown channel-form rows", async () => {
     const rows = await fetchRows();
     const unknown = rows.find((r) => r.id === "channel:telegram:tg-stranger-999");
     expect(unknown).toBeDefined();
     expect(unknown!.level).toBe("unknown");
+    expect(unknown!.neverMessaged).toBe(false);
     // A mapped sender is a person, never also a channel row.
     expect(rows.find((r) => r.id === "channel:telegram:tg-alice")).toBeUndefined();
+  });
+
+  it("returns unlinked WhatsApp contacts as unknown rows, flagging the silent ones", async () => {
+    const rows = await fetchRows();
+    const silent = rows.find((r) => r.id === `channel:whatsapp:${SILENT_JID}`);
+    expect(silent).toBeDefined();
+    expect(silent!.level).toBe("unknown");
+    expect(silent!.displayName).toBe("Silent Sam");
+    expect(silent!.neverMessaged).toBe(true);
+
+    const talking = rows.find((r) => r.id === `channel:whatsapp:${TALKING_JID}`);
+    expect(talking).toBeDefined();
+    expect(talking!.displayName).toBe("Talky Tina");
+    expect(talking!.neverMessaged).toBe(false);
+    expect(talking!.latest?.preview).toBe("hello from tina");
+  });
+
+  it("excludes group chats — a group cannot hold a bond", async () => {
+    const rows = await fetchRows();
+    expect(rows.find((r) => r.id.includes(GROUP_JID))).toBeUndefined();
   });
 
   it("renders each stranger mapping as its own channel-form row, never the sentinel person", async () => {
@@ -88,14 +184,30 @@ describe("Identities API", () => {
 
   it("carries each identity's newest dynamic, naming the surface it came from", async () => {
     const rows = await fetchRows();
-    const unknown = rows.find((r) => r.id === "channel:telegram:tg-stranger-999")!;
-    expect(unknown.latest?.source).toBe("telegram");
-    expect(unknown.latest?.preview).toBe("who are you");
-    expect(unknown.messageCount).toBe(1);
-    // Nothing has ever been said to Bob, so his row carries no dynamic at all.
-    expect(
-      rows.find((r) => r.id === `person:${baseline.persons.acquaintanceId}`)!.latest,
-    ).toBeNull();
+    const tina = rows.find((r) => r.id === `channel:whatsapp:${TALKING_JID}`)!;
+    expect(tina.latest).toEqual({
+      source: "whatsapp",
+      timestamp: Math.floor(new Date("2026-08-17T10:00:00Z").getTime() / 1000),
+      preview: "hello from tina",
+    });
+    expect(rows.find((r) => r.id === `channel:whatsapp:${SILENT_JID}`)!.latest).toBeNull();
+  });
+
+  it("leaves never-messaged contacts out of the default page", async () => {
+    const page = await fetchPage();
+    expect(page.identities.find((r) => r.id === `channel:whatsapp:${SILENT_JID}`)).toBeUndefined();
+  });
+
+  it("still counts the silent contacts the default page hides", async () => {
+    // The toggle governs the rows, never the numbers: the offer to show them is
+    // the only place this count is read, and it is made from the view that
+    // hides them.
+    const hidden = await fetchPage();
+    const shown = await fetchPage("?includeNeverMessaged=true");
+    expect(hidden.neverMessagedTotal).toBe(shown.neverMessagedTotal);
+    expect(hidden.neverMessagedTotal).toBeGreaterThan(0);
+    expect(hidden.totals).toEqual(shown.totals);
+    expect(hidden.counts).toEqual(shown.counts);
   });
 
   it("takes the newest word across a person's channels, and counts them all", async () => {
@@ -142,28 +254,63 @@ describe("Identities API", () => {
     expect(res.status).toBe(400);
   });
 
-  it("answers a search over names and channel identifiers", async () => {
-    const byName = await fetchPage("?q=bob");
-    expect(byName.identities.map((r) => r.id)).toEqual([
-      `person:${baseline.persons.acquaintanceId}`,
+  it("is one row for a WhatsApp contact its owner and its history address differently", async () => {
+    // The address book consolidates a phone jid and a `@lid` jid into one
+    // contact. A person mapped to one of them and a sentinel row under the
+    // other is one identity, not a curated person plus an unknown sender.
+    const phoneJid = "15550007777@s.whatsapp.net";
+    const lidJid = "88817260077@lid";
+    await deps.whatsAppStoreRepo.upsertContacts([
+      { jid: phoneJid, phoneNumber: "15550007777", name: "One Contact" },
+      { jid: lidJid, phoneNumber: "15550007777", name: "One Contact" },
     ]);
+    await deps.sentinelLogRepo.create({
+      messageId: "msg-lid-1",
+      channel: "whatsapp",
+      channelUserId: lidJid,
+      displayName: "One Contact",
+      text: "from the lid address",
+      action: "ignored",
+    });
+    const personId = await deps.personMappingRepo.create({
+      displayName: "One Contact",
+      bondLevel: "acquaintance",
+      approved: true,
+      channelMappings: [{ channel: "whatsapp", channelUserId: phoneJid }],
+    });
 
-    const byChannelId = await fetchPage("?q=tg-stranger-999");
-    expect(byChannelId.identities.map((r) => r.id)).toEqual(["channel:telegram:tg-stranger-999"]);
+    const rows = await fetchRows();
+    expect(rows.filter((r) => r.channels.some((ch) => ch.channelUserId === lidJid))).toHaveLength(
+      1,
+    );
+    expect(rows.find((r) => r.id === `channel:whatsapp:${lidJid}`)).toBeUndefined();
+    const person = rows.find((r) => r.id === `person:${personId}`)!;
+    expect(person.channels.map((ch) => ch.channelUserId).sort()).toEqual([lidJid, phoneJid].sort());
+    expect(person.latest?.preview).toBe("from the lid address");
+  });
+
+  it("answers a search over names and channel identifiers, silent contacts included", async () => {
+    const byName = await fetchPage("?q=silent");
+    expect(byName.identities.map((r) => r.id)).toEqual([`channel:whatsapp:${SILENT_JID}`]);
+
+    const byNumber = await fetchPage("?q=15550001111");
+    expect(byNumber.identities.map((r) => r.id)).toEqual([`channel:whatsapp:${SILENT_JID}`]);
   });
 
   it("answers for one identity by id, whatever page it would land on", async () => {
-    const page = await fetchPage(`?id=${encodeURIComponent("channel:telegram:tg-stranger-999")}`);
-    expect(page.identities.map((r) => r.id)).toEqual(["channel:telegram:tg-stranger-999"]);
+    const page = await fetchPage(`?id=${encodeURIComponent(`channel:whatsapp:${SILENT_JID}`)}`);
+    expect(page.identities.map((r) => r.id)).toEqual([`channel:whatsapp:${SILENT_JID}`]);
     expect(page.nextCursor).toBeNull();
   });
 
   it("pages by activity, and the cursor resumes without repeating a row", async () => {
-    const first = await fetchPage("?limit=2");
+    const first = await fetchPage("?includeNeverMessaged=true&limit=2");
     expect(first.identities).toHaveLength(2);
     expect(first.nextCursor).not.toBeNull();
 
-    const second = await fetchPage(`?limit=2&cursor=${encodeURIComponent(first.nextCursor!)}`);
+    const second = await fetchPage(
+      `?includeNeverMessaged=true&limit=2&cursor=${encodeURIComponent(first.nextCursor!)}`,
+    );
     // A cursor the route ignored would answer an empty page here, and every
     // "no repeats" assertion below would hold vacuously.
     expect(second.identities.length).toBeGreaterThan(0);
@@ -177,33 +324,39 @@ describe("Identities API", () => {
   });
 
   it("counts every level over the whole union, not the page it returned", async () => {
-    const full = await fetchPage();
+    const full = await fetchPage("?includeNeverMessaged=true");
     // One row per page, so a count taken over the page would report at most one
     // of anything — the failure the Unknown chip's signal depends on avoiding.
-    const firstOfMany = await fetchPage("?limit=1");
+    const firstOfMany = await fetchPage("?includeNeverMessaged=true&limit=1");
     expect(firstOfMany.identities).toHaveLength(1);
     expect(firstOfMany.counts).toEqual(full.counts);
     expect(firstOfMany.totals).toEqual(full.totals);
+    expect(firstOfMany.neverMessagedTotal).toEqual(full.neverMessagedTotal);
     expect(full.counts.unknown).toBe(
       full.identities.filter((row) => row.level === "unknown" && row.latest !== null).length,
     );
   });
 
-  it("leaves the guardian out of the chip counts, but not the totals", async () => {
-    const page = await fetchPage();
+  it("leaves the guardian and silent contacts out of the chip counts, but not the totals", async () => {
+    const page = await fetchPage("?includeNeverMessaged=true");
     expect(page.counts.guardian).toBe(0);
     // The directory's headings count the rows they show, guardian included —
     // a heading over one visible row that reads 0 is the number being wrong.
     expect(page.totals.guardian).toBe(
       page.identities.filter((row) => row.level === "guardian").length,
     );
+    expect(page.totals.unknown).toBeGreaterThan(page.counts.unknown);
+    expect(page.neverMessagedTotal).toBeGreaterThan(0);
+    // A contact that has never said anything is not waiting on a decision.
+    const silent = page.identities.filter((row) => row.neverMessaged);
+    expect(silent.length).toBe(page.neverMessagedTotal);
   });
 
   it("filters by level before paging, so a level's view is the whole union", async () => {
-    const page = await fetchPage("?level=unknown");
+    const page = await fetchPage("?level=unknown&includeNeverMessaged=true");
     expect(page.identities.every((row) => row.level === "unknown")).toBe(true);
     // The other chips keep their numbers while one chip's view is on screen.
-    const all = await fetchPage();
+    const all = await fetchPage("?includeNeverMessaged=true");
     expect(page.counts).toEqual(all.counts);
   });
 
@@ -214,7 +367,7 @@ describe("Identities API", () => {
       "tg-spammer",
       "Spammer",
     );
-    const page = await fetchPage("?level=all");
+    const page = await fetchPage("?level=all&includeNeverMessaged=true");
     expect(page.identities.some((row) => row.level === "unknown")).toBe(false);
     expect(page.identities.some((row) => row.level === "stranger")).toBe(false);
   });
@@ -230,16 +383,17 @@ describe("Identities API", () => {
     expect(after.length).toBe(before.length);
   });
 
-  it("sorts identities with a dynamic newest first, and the rest last", async () => {
+  it("sorts talked-to identities newest first and silent ones last", async () => {
     const rows = await fetchRows();
     const at = (id: string) => rows.findIndex((r) => r.id === id);
-    // Alice's sentinel history is the newest thing in the baseline, and Bob has
-    // none at all.
-    expect(at(`person:${baseline.persons.innerCircleId}`)).toBeLessThan(
-      at(`person:${baseline.persons.acquaintanceId}`),
-    );
-    const firstSilent = rows.findIndex((row) => row.latest === null);
-    expect(firstSilent).toBeGreaterThan(0);
-    expect(rows.slice(firstSilent).every((row) => row.latest === null)).toBe(true);
+    // The WhatsApp-only person's message (11:00) is newer than Tina's (10:00);
+    // Silent Sam said nothing and sorts after everyone with history.
+    expect(at(`person:${waOnlyPersonId}`)).toBeLessThan(at(`channel:whatsapp:${TALKING_JID}`));
+    const silentIndex = at(`channel:whatsapp:${SILENT_JID}`);
+    for (const row of rows) {
+      if (row.latest != null) {
+        expect(at(row.id)).toBeLessThan(silentIndex);
+      }
+    }
   });
 });

--- a/packages/core/src/api/routes/identities.ts
+++ b/packages/core/src/api/routes/identities.ts
@@ -10,16 +10,19 @@ import {
   parseIdentityFilterLevel,
   personIdentityId,
   sliceIdentityPage,
+  whatsAppDisplayName,
+  type IdentityChannel,
   type IdentityDynamic,
   type IdentityRow,
 } from "@rome/api-types/identities";
 import { STRANGER_PERSON_ID } from "../../constants.js";
 import type { ApiDeps } from "../deps.js";
 
-// The People page's one read: a union of curated persons and the senders the
-// sentinel log saw but nobody placed, every row in the shared `IdentityRow`
-// shape and carrying its newest dynamic. A read — no person row is
-// materialized here, ever; writes stay on the `/persons/*` mutation routes.
+// The People page's one read: a union of curated persons, unmapped senders from
+// the sentinel log, and the WhatsApp contacts nobody has placed yet, every row
+// in the shared `IdentityRow` shape and carrying its newest dynamic. A read —
+// no person row is materialized here, ever; writes stay on the `/persons/*`
+// mutation routes.
 
 interface SentinelActivity {
   channel: string;
@@ -27,6 +30,28 @@ interface SentinelActivity {
   displayName: string | null;
   lastMessage: string | null;
   lastMessageAt: number | null;
+  messageCount: number;
+}
+
+/**
+ * One identity a channel mirror already holds, in the one shape the union
+ * reads mirrors through.
+ *
+ * WhatsApp's address book answers in its own columns. Projecting it onto this
+ * makes every rule below channel-agnostic: adding a second mirror is a branch
+ * in {@link readMirror}, not another special case in the union.
+ */
+interface MirrorIdentity {
+  channel: string;
+  /** The identifier a mapping or a placement should name — the form the
+   *  channel's own `channel_mappings` rows are keyed by. */
+  channelUserId: string;
+  /** Every identifier this identity answers to, `channelUserId` included. */
+  aliases: string[];
+  displayName: string;
+  /** The person this identity was already promoted into, or null. */
+  linkedPersonId: string | null;
+  latest: IdentityDynamic | null;
   messageCount: number;
 }
 
@@ -70,8 +95,14 @@ export function identitiesRoutes(deps: ApiDeps): Hono {
     matching.sort(compareIdentityRows);
 
     // Everything below the query is the page's business, not the union's: the
-    // level, the cursor, and `?id=` all scope which rows come back while the
-    // counts stay whole-union.
+    // level, the silent contacts, the cursor, and `?id=` all scope which rows
+    // come back while the counts stay whole-union. Pruning the silent ones here
+    // instead would answer `neverMessagedTotal: 0` in the very view whose
+    // toggle that number is for.
+    //
+    // A search does reach them: the toggle holds the address book out of the
+    // browsing views, not out of a lookup for a name or number the guardian
+    // typed.
     return c.json(
       sliceIdentityPage(matching, {
         cursor: parsedCursor,
@@ -86,8 +117,65 @@ export function identitiesRoutes(deps: ApiDeps): Hono {
   return app;
 }
 
+/**
+ * Every identity the channel mirrors already hold, projected onto one shape.
+ *
+ * Read whole, not through the address-book endpoint's bound: this answer is
+ * paged, and an identity past a cutoff is one the guardian cannot find, that no
+ * count includes, and whose alias group the cutoff may have split.
+ */
+async function readMirror(deps: ApiDeps): Promise<MirrorIdentity[]> {
+  const contacts = await deps.whatsAppStoreRepo.listContacts({ limit: null });
+
+  const identities: MirrorIdentity[] = [];
+  for (const contact of contacts) {
+    // Group chats are conversations, not identities — they cannot hold a bond.
+    if (contact.isGroup) continue;
+    identities.push({
+      channel: "whatsapp",
+      channelUserId: contact.jid,
+      aliases: contact.aliases.length > 0 ? contact.aliases : [contact.jid],
+      displayName: whatsAppDisplayName(contact) ?? contact.jid,
+      linkedPersonId: contact.linkedPersonId,
+      latest:
+        contact.lastMessageAt == null
+          ? null
+          : {
+              source: "whatsapp",
+              timestamp: contact.lastMessageAt,
+              preview: contact.lastMessagePreview,
+            },
+      messageCount: contact.messageCount,
+    });
+  }
+  return identities;
+}
+
 /** The full union, unordered and unfiltered. */
 async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
+  const mirror = await readMirror(deps);
+  const mirrorByAlias = new Map<string, MirrorIdentity>();
+  for (const identity of mirror) {
+    for (const alias of identity.aliases) {
+      mirrorByAlias.set(activityKey(identity.channel, alias), identity);
+    }
+  }
+
+  // One mirrored identity is one identity however many identifiers address it,
+  // so every one of them answers to the representative form. Without this the
+  // same person is both a curated person (mapped to one form) and an unknown
+  // sender (a sentinel row under another) — two rows the page cannot merge and
+  // the guardian cannot tell apart.
+  //
+  // WhatsApp consolidates a phone jid and a `@lid` jid in the store, so the
+  // fold is a lookup against what it consolidated.
+  const canonicalId = (channel: string, channelUserId: string): string =>
+    mirrorByAlias.get(activityKey(channel, channelUserId))?.channelUserId ?? channelUserId;
+  const identityKey = (channel: string, channelUserId: string) =>
+    activityKey(channel, canonicalId(channel, channelUserId));
+  const mirrorFor = (channel: string, channelUserId: string) =>
+    mirrorByAlias.get(identityKey(channel, channelUserId));
+
   // Bare display_name/text ride SQLite's guarantee that with a lone MAX()
   // aggregate the other selected columns come from the row that supplied the
   // max — i.e. the newest message names the sender.
@@ -103,7 +191,7 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
     GROUP BY channel, channel_user_id
   `)) as Array<Record<string, unknown>>;
 
-  const sentinel = new Map<string, SentinelActivity>();
+  const sentinel = new Map<string, SentinelActivity[]>();
   const senders: SentinelActivity[] = [];
   for (const row of sentinelRows) {
     const activity: SentinelActivity = {
@@ -115,24 +203,82 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
       messageCount: Number(row.messageCount ?? 0),
     };
     senders.push(activity);
-    sentinel.set(activityKey(activity.channel, activity.channelUserId), activity);
+    const key = identityKey(activity.channel, activity.channelUserId);
+    const group = sentinel.get(key);
+    if (group) group.push(activity);
+    else sentinel.set(key, [activity]);
   }
 
+  // The newest word wins across both histories: a channel mirror holds the full
+  // thread, the sentinel log holds what every channel saw. Both are read across
+  // every alias of the identity, so which identifier a mapping happens to name
+  // never decides what the row shows.
   const activityFor = (channel: string, channelUserId: string): ChannelActivity => {
-    const entry = sentinel.get(activityKey(channel, channelUserId));
+    const key = identityKey(channel, channelUserId);
+    const mirrored = mirrorByAlias.get(key);
+    const sentinelEntries = sentinel.get(key) ?? [];
+    const sentinelDynamic = sentinelEntries.reduce<IdentityDynamic | null>(
+      (best, entry) =>
+        newer(
+          best,
+          entry.lastMessageAt == null
+            ? null
+            : { source: channel, timestamp: entry.lastMessageAt, preview: entry.lastMessage },
+        ),
+      null,
+    );
+    const sentinelCount = sentinelEntries.reduce((sum, entry) => sum + entry.messageCount, 0);
     return {
-      latest:
-        entry?.lastMessageAt == null
-          ? null
-          : { source: channel, timestamp: entry.lastMessageAt, preview: entry.lastMessage },
-      messageCount: entry?.messageCount ?? 0,
+      latest: newer(sentinelDynamic, mirrored?.latest ?? null),
+      // The mirror's count when there is one: a mirrored message and the
+      // sentinel row that saw it are one message, and adding them would count
+      // every exchange twice.
+      messageCount: mirrored != null ? mirrored.messageCount : sentinelCount,
     };
   };
 
-  /** Best name on record for an identity with no person row: what the sender
-   *  called themselves, then the raw channel user id. */
-  const displayNameFor = (channel: string, channelUserId: string): string =>
-    sentinel.get(activityKey(channel, channelUserId))?.displayName ?? channelUserId;
+  /**
+   * Every identifier a row's channels answer to.
+   *
+   * A mirrored identity is one identity under several identifiers, and a
+   * mapping names only one of them. The contract asks for all of them because
+   * a search reads this list: an omitted alias is a contact the guardian
+   * cannot reach by the phone number they know. The mapping's own form leads,
+   * so a client mutating the row addresses the mapping that exists.
+   */
+  const channelsOf = (channels: IdentityChannel[]): IdentityChannel[] => {
+    const seen = new Set<string>();
+    const out: IdentityChannel[] = [];
+    const add = (channel: string, channelUserId: string) => {
+      const key = activityKey(channel, channelUserId);
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push({ channel, channelUserId });
+    };
+    for (const channel of channels) {
+      add(channel.channel, channel.channelUserId);
+      for (const alias of mirrorFor(channel.channel, channel.channelUserId)?.aliases ?? []) {
+        add(channel.channel, alias);
+      }
+    }
+    return out;
+  };
+
+  /** Best name on record for an identity with no person row: the mirror's name,
+   *  then what the sender called themselves, then the raw identifier. */
+  const displayNameFor = (channel: string, channelUserId: string): string => {
+    const key = identityKey(channel, channelUserId);
+    const fromSentinel = (sentinel.get(key) ?? []).reduce<SentinelActivity | null>(
+      (best, entry) =>
+        best == null || (entry.lastMessageAt ?? 0) > (best.lastMessageAt ?? 0) ? entry : best,
+      null,
+    );
+    return (
+      mirrorByAlias.get(key)?.displayName ??
+      fromSentinel?.displayName ??
+      canonicalId(channel, channelUserId)
+    );
+  };
 
   // One statement, so an identity moving between two people mid-read cannot
   // land under both of them.
@@ -142,21 +288,42 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
   const rows: IdentityRow[] = [];
   const mapped = new Set<string>();
 
+  // Which person owns each identity, decided once before any row is built. The
+  // unique index already holds one mapping per identifier, but two people can
+  // map two aliases of one identity, and that identity is one row: the lowest
+  // person id takes it, so the union never shows or counts it twice, and shows
+  // the same one on every read.
+  const ownerOf = new Map<string, string>();
   for (const person of persons) {
     for (const mapping of person.channelMappings) {
-      mapped.add(activityKey(mapping.channel, mapping.channelUserId));
+      const key = identityKey(mapping.channel, mapping.channelUserId);
+      if (!ownerOf.has(key)) ownerOf.set(key, person.id);
+    }
+  }
+
+  for (const person of persons) {
+    const owned = person.channelMappings.filter(
+      (mapping) => ownerOf.get(identityKey(mapping.channel, mapping.channelUserId)) === person.id,
+    );
+    for (const mapping of person.channelMappings) {
+      mapped.add(identityKey(mapping.channel, mapping.channelUserId));
     }
 
     if (person.id === STRANGER_PERSON_ID) {
       // The sentinel is a person row, but each dismissed identity is its own
       // row on the ladder — a channel-form id, so recovering one is the same
       // move that places an unknown sender.
-      for (const mapping of person.channelMappings) {
+      for (const mapping of owned) {
         rows.push({
-          id: channelIdentityId(mapping.channel, mapping.channelUserId),
+          id: channelIdentityId(
+            mapping.channel,
+            canonicalId(mapping.channel, mapping.channelUserId),
+          ),
           displayName: displayNameFor(mapping.channel, mapping.channelUserId),
           level: "stranger",
-          channels: [{ channel: mapping.channel, channelUserId: mapping.channelUserId }],
+          channels: channelsOf([
+            { channel: mapping.channel, channelUserId: mapping.channelUserId },
+          ]),
           ...activityFor(mapping.channel, mapping.channelUserId),
           neverMessaged: false,
         });
@@ -164,7 +331,9 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
       continue;
     }
 
-    const activity = person.channelMappings
+    // Only the identities this person owns contribute: an alias another person
+    // already took is that person's history, not a second copy of it here.
+    const activity = owned
       .map((mapping) => activityFor(mapping.channel, mapping.channelUserId))
       .reduce<ChannelActivity>(
         (best, next) => ({
@@ -178,27 +347,46 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
       id: personIdentityId(person.id),
       displayName: person.displayName,
       level: person.bondLevel === "guardian" ? "guardian" : normalizeBondLevel(person.bondLevel),
-      channels: person.channelMappings.map((mapping) => ({
-        channel: mapping.channel,
-        channelUserId: mapping.channelUserId,
-      })),
+      channels: channelsOf(person.channelMappings),
       ...activity,
       neverMessaged: false,
     });
   }
 
-  // Unknown = seen but never placed.
+  // Unknown = seen (or synced) but never placed. Senders first…
   for (const sender of senders) {
-    const key = activityKey(sender.channel, sender.channelUserId);
+    const key = identityKey(sender.channel, sender.channelUserId);
     if (mapped.has(key)) continue;
     mapped.add(key);
     rows.push({
-      id: channelIdentityId(sender.channel, sender.channelUserId),
+      id: channelIdentityId(sender.channel, canonicalId(sender.channel, sender.channelUserId)),
       displayName: displayNameFor(sender.channel, sender.channelUserId),
       level: "unknown",
-      channels: [{ channel: sender.channel, channelUserId: sender.channelUserId }],
+      channels: channelsOf([{ channel: sender.channel, channelUserId: sender.channelUserId }]),
       ...activityFor(sender.channel, sender.channelUserId),
       neverMessaged: false,
+    });
+  }
+
+  // …then mirrored identities the sentinel never saw. `neverMessaged` marks the
+  // silent ones so the page can keep a 9,000-contact address book out of the
+  // stream while search still reaches it.
+  for (const identity of mirror) {
+    if (identity.linkedPersonId != null) continue;
+    const key = identityKey(identity.channel, identity.channelUserId);
+    if (mapped.has(key)) continue;
+    mapped.add(key);
+    const activity = activityFor(identity.channel, identity.channelUserId);
+    rows.push({
+      id: channelIdentityId(identity.channel, identity.channelUserId),
+      displayName: identity.displayName,
+      level: "unknown",
+      channels: identity.aliases.map((alias) => ({
+        channel: identity.channel,
+        channelUserId: alias,
+      })),
+      ...activity,
+      neverMessaged: activity.latest == null,
     });
   }
 

--- a/packages/core/src/api/routes/identities.ts
+++ b/packages/core/src/api/routes/identities.ts
@@ -10,12 +10,13 @@ import {
   parseIdentityFilterLevel,
   personIdentityId,
   sliceIdentityPage,
-  whatsAppDisplayName,
   type IdentityChannel,
   type IdentityDynamic,
   type IdentityRow,
 } from "@rome/api-types/identities";
 import { STRANGER_PERSON_ID } from "../../constants.js";
+import type { TalkAccountActivity } from "../../channels/account-activity.js";
+import type { TalkAccounts } from "../../channels/accounts.js";
 import type { ApiDeps } from "../deps.js";
 
 // The People page's one read: a union of curated persons, unmapped senders from
@@ -34,23 +35,23 @@ interface SentinelActivity {
 }
 
 /**
- * One identity a channel mirror already holds, in the one shape the union
- * reads mirrors through.
+ * One identity a channel's account plane already holds, in the shape the union
+ * reads every mirror through.
  *
- * WhatsApp's address book answers in its own columns. Projecting it onto this
- * makes every rule below channel-agnostic: adding a second mirror is a branch
- * in {@link readMirror}, not another special case in the union.
+ * The projection is `Account` plus its activity, and nothing channel-specific
+ * survives it: which addressings a channel hands out, which of them is
+ * canonical, and what counts as an account at all are the channel's answers,
+ * given once behind {@link TalkAccounts}. So every rule below is
+ * channel-agnostic, and adding a mirror is an entry in {@link mirrorPlanes}
+ * rather than another special case in the union.
  */
 interface MirrorIdentity {
   channel: string;
-  /** The identifier a mapping or a placement should name — the form the
-   *  channel's own `channel_mappings` rows are keyed by. */
+  /** The account's own address — what a mapping or a placement should name. */
   channelUserId: string;
-  /** Every identifier this identity answers to, `channelUserId` included. */
+  /** Every address the account answers to, `channelUserId` included. */
   aliases: string[];
   displayName: string;
-  /** The person this identity was already promoted into, or null. */
-  linkedPersonId: string | null;
   latest: IdentityDynamic | null;
   messageCount: number;
 }
@@ -117,43 +118,71 @@ export function identitiesRoutes(deps: ApiDeps): Hono {
   return app;
 }
 
+/** A channel whose account plane the union reads. One entry per mirror. */
+interface MirrorPlane {
+  channel: string;
+  accounts: TalkAccounts & TalkAccountActivity;
+}
+
+function mirrorPlanes(deps: ApiDeps): MirrorPlane[] {
+  return [{ channel: "whatsapp", accounts: deps.whatsAppAccounts }];
+}
+
+/**
+ * One page big enough to hold any listing — what `TalkAccounts.listAccounts`
+ * says to ask for when a caller needs every account exactly once. Its order is
+ * stable but the listing under it is not, so walking cursors across a live
+ * mirror would skip or repeat an account as an inbound message reordered it.
+ */
+const WHOLE_LISTING = Number.MAX_SAFE_INTEGER;
+
 /**
  * Every identity the channel mirrors already hold, projected onto one shape.
  *
- * Read whole, not through the address-book endpoint's bound: this answer is
- * paged, and an identity past a cutoff is one the guardian cannot find, that no
- * count includes, and whose alias group the cutoff may have split.
+ * Read whole rather than paged: this answer is paged here, and an identity past
+ * a channel's own cutoff is one the guardian cannot find and no count includes.
  */
-async function readMirror(deps: ApiDeps): Promise<MirrorIdentity[]> {
-  const contacts = await deps.whatsAppStoreRepo.listContacts({ limit: null });
-
+async function readMirrors(deps: ApiDeps): Promise<MirrorIdentity[]> {
   const identities: MirrorIdentity[] = [];
-  for (const contact of contacts) {
-    // Group chats are conversations, not identities — they cannot hold a bond.
-    if (contact.isGroup) continue;
-    identities.push({
-      channel: "whatsapp",
-      channelUserId: contact.jid,
-      aliases: contact.aliases.length > 0 ? contact.aliases : [contact.jid],
-      displayName: whatsAppDisplayName(contact) ?? contact.jid,
-      linkedPersonId: contact.linkedPersonId,
-      latest:
-        contact.lastMessageAt == null
-          ? null
-          : {
-              source: "whatsapp",
-              timestamp: contact.lastMessageAt,
-              preview: contact.lastMessagePreview,
-            },
-      messageCount: contact.messageCount,
-    });
+  for (const { channel, accounts } of mirrorPlanes(deps)) {
+    const [listing, activity, addresses] = await Promise.all([
+      accounts.listAccounts({ limit: WHOLE_LISTING }),
+      accounts.listActivity(),
+      accounts.listAddresses(),
+    ]);
+
+    // The addressing set of each account, which is the address map read the
+    // other way round. A row carries all of them because a search reads them:
+    // an omitted address is a contact the guardian cannot reach by the phone
+    // number they know.
+    const aliasesOf = new Map<string, string[]>();
+    for (const [address, accountId] of addresses) {
+      const group = aliasesOf.get(accountId);
+      if (group) group.push(address);
+      else aliasesOf.set(accountId, [address]);
+    }
+
+    for (const account of listing.accounts) {
+      const seen = activity.get(account.id);
+      identities.push({
+        channel,
+        channelUserId: account.id,
+        aliases: (aliasesOf.get(account.id) ?? [account.id]).sort(compareCodePoints),
+        displayName: account.label,
+        latest:
+          seen == null
+            ? null
+            : { source: channel, timestamp: seen.lastMessageAt, preview: seen.lastMessagePreview },
+        messageCount: seen?.messageCount ?? 0,
+      });
+    }
   }
   return identities;
 }
 
 /** The full union, unordered and unfiltered. */
 async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
-  const mirror = await readMirror(deps);
+  const mirror = await readMirrors(deps);
   const mirrorByAlias = new Map<string, MirrorIdentity>();
   for (const identity of mirror) {
     for (const alias of identity.aliases) {
@@ -161,14 +190,14 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
     }
   }
 
-  // One mirrored identity is one identity however many identifiers address it,
-  // so every one of them answers to the representative form. Without this the
-  // same person is both a curated person (mapped to one form) and an unknown
-  // sender (a sentinel row under another) — two rows the page cannot merge and
-  // the guardian cannot tell apart.
+  // One mirrored identity is one identity however many addresses reach it, so
+  // every one of them answers to the account's own. Without this the same
+  // person is both a curated person (mapped to one form) and an unknown sender
+  // (a sentinel row under another) — two rows the page cannot merge and the
+  // guardian cannot tell apart.
   //
-  // WhatsApp consolidates a phone jid and a `@lid` jid in the store, so the
-  // fold is a lookup against what it consolidated.
+  // Which addresses fold onto which account is the channel's answer, not a
+  // rule the union derives: it is the address map read as given.
   const canonicalId = (channel: string, channelUserId: string): string =>
     mirrorByAlias.get(activityKey(channel, channelUserId))?.channelUserId ?? channelUserId;
   const identityKey = (channel: string, channelUserId: string) =>
@@ -372,7 +401,9 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
   // silent ones so the page can keep a 9,000-contact address book out of the
   // stream while search still reaches it.
   for (const identity of mirror) {
-    if (identity.linkedPersonId != null) continue;
+    // A promoted contact is already a person row above, and it was reached
+    // through the same fold, so `mapped` is what holds it back — no second
+    // read of who owns what.
     const key = identityKey(identity.channel, identity.channelUserId);
     if (mapped.has(key)) continue;
     mapped.add(key);

--- a/packages/core/src/channels/account-activity.ts
+++ b/packages/core/src/channels/account-activity.ts
@@ -1,0 +1,38 @@
+import type { AccountId } from "./accounts.js";
+
+/**
+ * What happened on a channel's accounts.
+ *
+ * `TalkAccounts` (accounts.ts) answers *who* a channel can reach, and says that
+ * a last message, a count and a preview are a separate read keyed by
+ * {@link AccountId}. This is that read. Keeping it apart is what lets a channel
+ * hold an address book it has no history for, and what stops the identity of an
+ * account from depending on how much has been said to it.
+ */
+
+export interface AccountActivity {
+  /** Unix seconds of the newest message, sent or received. */
+  lastMessageAt: number;
+  /** One line of that message; null when it carried no text (an image, a call). */
+  lastMessagePreview: string | null;
+  /**
+   * Every record the channel holds for the account — not every line a timeline
+   * would render. A reaction counts, and so does a message Rome sent.
+   */
+  messageCount: number;
+}
+
+export interface TalkAccountActivity {
+  /**
+   * Activity for every account that has any, keyed by {@link AccountId}.
+   *
+   * An account the channel has never exchanged anything with is absent rather
+   * than present and zeroed, so "silent" is one condition to test instead of
+   * two that can disagree.
+   *
+   * Read whole, not paged: this is joined against a listing the caller pages
+   * itself, and an account whose activity fell past a cutoff would read as
+   * silent rather than as what it is.
+   */
+  listActivity(): Promise<Map<AccountId, AccountActivity>>;
+}

--- a/packages/core/src/channels/accounts.ts
+++ b/packages/core/src/channels/accounts.ts
@@ -60,4 +60,19 @@ export interface TalkAccounts {
   /** The account an identifier belongs to, or null. Accepts any identifier the
    *  channel can receive on — and an {@link AccountId}, which round-trips. */
   resolve(identifier: string): Promise<Account | null>;
+
+  /**
+   * Every address the channel stores, mapped to the account that owns it — I4
+   * read whole instead of one identifier at a time.
+   *
+   * For a caller folding a stored table of identifiers onto accounts: a channel
+   * that mirrors its address book locally answers `resolve` from a full read,
+   * so resolving a table row by row costs one full read per row. The same map
+   * inverted is the addressing set of an account, which a caller needs whenever
+   * it must show or match every form an account can be reached at.
+   *
+   * The addresses are the ones the channel holds. A lone identifier that misses
+   * here may still be a form the channel accepts — `resolve` is what takes it.
+   */
+  listAddresses(): Promise<Map<string, AccountId>>;
 }

--- a/packages/core/src/channels/linkedin-accounts.test.ts
+++ b/packages/core/src/channels/linkedin-accounts.test.ts
@@ -71,6 +71,13 @@ describe("LinkedInAccounts", () => {
     expect(await accounts.resolve("ACoAASelf0003")).toBeNull();
   });
 
+  it("lists the member ids it holds, the guardian's own excluded", async () => {
+    expect([...(await accounts.listAddresses()).entries()]).toEqual([
+      ["ACoAAAda0001", "ACoAAAda0001"],
+      ["ACoAAGrace002", "ACoAAGrace002"],
+    ]);
+  });
+
   it("returns null for an unknown identifier", async () => {
     expect(await accounts.resolve("ACoAANobody999")).toBeNull();
     expect(await accounts.resolve("https://www.linkedin.com/in/ada-lovelace/")).toBeNull();

--- a/packages/core/src/channels/linkedin-accounts.ts
+++ b/packages/core/src/channels/linkedin-accounts.ts
@@ -37,6 +37,15 @@ export class LinkedInAccounts implements TalkAccounts {
     return accounts.find((account) => account.id === memberId) ?? null;
   }
 
+  async listAddresses(): Promise<Map<string, AccountId>> {
+    // A member is stored under its member id and nothing else; the profile URL
+    // that also names it is derived on sight, not held, so `resolve` is what
+    // takes one.
+    const addresses = new Map<string, AccountId>();
+    for (const account of await this.load()) addresses.set(account.id, account.id);
+    return addresses;
+  }
+
   private async load(): Promise<Account[]> {
     const rows = await this.store.listParticipants({ limit: null });
     return rows.filter((row) => !row.isSelf).map(toAccount);

--- a/packages/core/src/channels/whatsapp-accounts.test.ts
+++ b/packages/core/src/channels/whatsapp-accounts.test.ts
@@ -79,6 +79,81 @@ describe("WhatsAppAccounts", () => {
     expect((await accounts.resolve("99900099999@lid"))!.id).toBe("15550009999@s.whatsapp.net");
   });
 
+  it("maps every stored address, and the derived id, onto the one account", async () => {
+    await repo.upsertContacts([
+      { jid: "15550009999@s.whatsapp.net", name: "Split Contact" },
+      { jid: "99900099999@lid", phoneNumber: "15550009999" },
+    ]);
+
+    const addresses = await accounts.listAddresses();
+    expect([...addresses.entries()].sort()).toEqual([
+      ["15550009999@s.whatsapp.net", "15550009999@s.whatsapp.net"],
+      ["99900099999@lid", "15550009999@s.whatsapp.net"],
+    ]);
+  });
+
+  it("sums activity across both addressings of one account", async () => {
+    await repo.upsertContacts([
+      { jid: PHONE, phoneNumber: "15550007777", name: "One Contact" },
+      { jid: LID, phoneNumber: "15550007777" },
+    ]);
+    await repo.upsertMessages([
+      message("a", PHONE, "2026-08-20T10:00:00Z", "on phone"),
+      message("b", LID, "2026-08-21T10:00:00Z", "on lid"),
+    ]);
+
+    const activity = await accounts.listActivity();
+    expect(activity.size).toBe(1);
+    const seen = activity.get((await accounts.resolve(PHONE))!.id)!;
+    expect(seen.lastMessagePreview).toBe("on lid");
+    expect(seen.lastMessageAt).toBe(Date.parse("2026-08-21T10:00:00Z") / 1000);
+    expect(seen.messageCount).toBe(2);
+  });
+
+  it("leaves an account nothing was ever said to out of the activity read", async () => {
+    // Absent, not present and zeroed: a caller testing "silent" has one
+    // condition to read rather than two that can disagree.
+    await repo.upsertContacts([
+      { jid: PHONE, phoneNumber: "15550007777", name: "One Contact" },
+      { jid: "15550008888@s.whatsapp.net", phoneNumber: "15550008888", name: "Never Spoke" },
+    ]);
+    await repo.upsertMessages([message("a", PHONE, "2026-08-20T10:00:00Z", "hi")]);
+
+    const activity = await accounts.listActivity();
+    expect([...activity.keys()]).toEqual([PHONE]);
+  });
+
+  it("labels an unnamed account with its number as a person writes one", async () => {
+    await repo.upsertContacts([{ jid: PHONE, phoneNumber: "15550007777" }]);
+
+    const page = await accounts.listAccounts({ limit: 50 });
+    expect(page.accounts[0].label).toBe("+1 (555) 000-7777");
+  });
+
+  it("answers a listing, its addresses and its activity from one read", async () => {
+    // The three are joined by the caller, so they must describe the same
+    // mirror — and a page of the People union should not cost three scans.
+    await repo.upsertContacts([{ jid: PHONE, phoneNumber: "15550007777", name: "One Contact" }]);
+    let reads = 0;
+    const listContacts = repo.listContacts.bind(repo);
+    repo.listContacts = async (opts) => {
+      reads += 1;
+      return listContacts(opts);
+    };
+
+    await Promise.all([
+      accounts.listAccounts({ limit: 50 }),
+      accounts.listActivity(),
+      accounts.listAddresses(),
+    ]);
+    expect(reads).toBe(1);
+
+    // The sharing lasts exactly as long as the read: a later caller sees a
+    // contact the first three could not have.
+    await repo.upsertContacts([{ jid: LID, phoneNumber: "15550008888", name: "Later" }]);
+    expect((await accounts.listAccounts({ limit: 50 })).accounts).toHaveLength(2);
+  });
+
   it("resolves a device-suffixed JID and a bare phone number", async () => {
     await repo.upsertContacts([{ jid: PHONE, phoneNumber: "15550007777", name: "One Contact" }]);
 

--- a/packages/core/src/channels/whatsapp-accounts.ts
+++ b/packages/core/src/channels/whatsapp-accounts.ts
@@ -1,4 +1,6 @@
+import { formatWhatsAppPhone } from "@rome/api-types/identities";
 import type { Account, AccountId, TalkAccounts } from "./accounts.js";
+import type { AccountActivity, TalkAccountActivity } from "./account-activity.js";
 import { pageAccounts } from "./account-paging.js";
 import type {
   WhatsAppContactRow,
@@ -64,8 +66,11 @@ function firstNonEmpty(...values: Array<string | null>): string | null {
  *   then a phone-number row for the same person is a second `Account` (I1).
  *   Nothing links the two but the name, and names are not identity.
  */
-export class WhatsAppAccounts implements TalkAccounts {
+export class WhatsAppAccounts implements TalkAccounts, TalkAccountActivity {
   constructor(private readonly store: WhatsAppStoreRepository) {}
+
+  /** The read a concurrent set of calls shares. See {@link load}. */
+  private reading: Promise<Snapshot> | null = null;
 
   async listAccounts(input: {
     query?: string;
@@ -86,20 +91,73 @@ export class WhatsAppAccounts implements TalkAccounts {
     return null;
   }
 
+  async listAddresses(): Promise<Map<string, AccountId>> {
+    const { grouped } = await this.load();
+    const addresses = new Map<string, AccountId>();
+    for (const [id, group] of grouped) {
+      // The id first: it is derived from the account's digits, so it is an
+      // address the account answers to whether or not a row spells it out.
+      addresses.set(id, id);
+      for (const row of group) {
+        for (const alias of row.aliases) addresses.set(alias, id);
+      }
+    }
+    return addresses;
+  }
+
+  async listActivity(): Promise<Map<AccountId, AccountActivity>> {
+    const { grouped } = await this.load();
+    const activity = new Map<AccountId, AccountActivity>();
+    for (const [id, group] of grouped) {
+      // A conversation usually sits on one addressing, but history split across
+      // both is two rows here, so the newest wins and the counts add.
+      const newest = group.reduce(
+        (best, row) => ((row.lastMessageAt ?? -1) > (best.lastMessageAt ?? -1) ? row : best),
+        group[0],
+      );
+      const messageCount = group.reduce((n, row) => n + row.messageCount, 0);
+      if (newest.lastMessageAt == null) continue;
+      activity.set(id, {
+        lastMessageAt: newest.lastMessageAt,
+        lastMessagePreview: newest.lastMessagePreview,
+        messageCount,
+      });
+    }
+    return activity;
+  }
+
   /**
-   * Every account, plus the index every identifier resolves through. The store
-   * already folds a person's two addressings onto one card, but it folds on the
-   * phone number a row carries, so a row that has not learned its number yet
-   * stays separate. Re-keying on the canonical id here collapses those too —
-   * one `Account` per account, whatever the mirror's row shape (I1).
+   * The whole mirror, folded. Every call reads the address book and rebuilds
+   * the index, so walking pages costs one full read per page and `resolve`
+   * costs one per identifier. That is bounded by address-book size and holds no
+   * stale rows. A caller that resolves per message wants a real cache, and the
+   * cache belongs here, where a sync can invalidate it rather than the caller
+   * guessing at when it went stale.
    *
-   * Every call reads the whole address book and rebuilds the index, so walking
-   * pages costs one full read per page and `resolve` costs one per identifier.
-   * That is bounded by address-book size and holds no stale rows. A caller that
-   * resolves per message wants a cache, and the cache belongs behind this port,
-   * where it can be invalidated on a sync rather than guessed at by the caller.
+   * Reads already in flight are shared. That is not that cache: the window
+   * closes the moment the read settles, so nothing outlives a sync. It is what
+   * makes the several reads a single caller needs at once — a listing, its
+   * addresses, its activity — one read of one mirror, so the three answers
+   * cannot describe address books a sync moved between.
    */
-  private async load(): Promise<{ accounts: Account[]; byKey: Map<string, Account> }> {
+  private load(): Promise<Snapshot> {
+    if (this.reading) return this.reading;
+    const reading = this.read();
+    this.reading = reading;
+    const done = () => {
+      if (this.reading === reading) this.reading = null;
+    };
+    reading.then(done, done);
+    return reading;
+  }
+
+  /**
+   * The store already folds a person's two addressings onto one card, but it
+   * folds on the phone number a row carries, so a row that has not learned its
+   * number yet stays separate. Re-keying on the canonical id here collapses
+   * those too — one `Account` per account, whatever the mirror's row shape (I1).
+   */
+  private async read(): Promise<Snapshot> {
     const rows = (await this.store.listContacts({ limit: null })).filter(
       (row) => !row.isGroup && !isGroupJid(row.jid),
     );
@@ -119,8 +177,16 @@ export class WhatsAppAccounts implements TalkAccounts {
       accounts.push(account);
       for (const key of accountKeys(id, group)) byKey.set(key, account);
     }
-    return { accounts, byKey };
+    return { accounts, byKey, grouped };
   }
+}
+
+/** One fold of the mirror: the accounts, the index they resolve through, and
+ *  the rows behind each, which the activity read sums over. */
+interface Snapshot {
+  accounts: Account[];
+  byKey: Map<string, Account>;
+  grouped: Map<AccountId, WhatsAppContactRow[]>;
 }
 
 /**
@@ -155,7 +221,9 @@ function toAccount(id: AccountId, group: WhatsAppContactRow[]): Account {
     pick((row) => row.notify) ??
     pick((row) => row.verifiedName) ??
     pick((row) => row.chatName) ??
-    pick((row) => row.phoneNumber) ??
+    // No name on record anywhere: the number, written the way a person writes
+    // one. The raw JID is a last resort, not a label.
+    formatWhatsAppPhone(pick((row) => row.phoneNumber) ?? id) ??
     id;
 
   return { id, label, identifiers };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ import { SessionsRepository } from "./db/repositories/sessions.js";
 import { PersonMappingRepository } from "./db/repositories/person-mapping.js";
 import { LinkedInStoreRepository } from "./db/repositories/linkedin-store.js";
 import { WhatsAppStoreRepository } from "./db/repositories/whatsapp-store.js";
+import { WhatsAppAccounts } from "./channels/whatsapp-accounts.js";
 import { SentinelLogRepository } from "./db/repositories/sentinel-log.js";
 import { ApprovalsRepository } from "./db/repositories/approvals.js";
 import { SettingsRepository } from "./db/repositories/settings.js";
@@ -224,6 +225,7 @@ async function main() {
   const sessionsRepo = new SessionsRepository(db);
   const personMappingRepo = new PersonMappingRepository(db);
   const whatsAppStoreRepo = new WhatsAppStoreRepository(db);
+  const whatsAppAccounts = new WhatsAppAccounts(whatsAppStoreRepo);
   const linkedInStoreRepo = new LinkedInStoreRepository(db);
   const sentinelLogRepo = new SentinelLogRepository(db);
   const approvalsRepo = new ApprovalsRepository(db);
@@ -1144,6 +1146,7 @@ async function main() {
       actionLoader,
       personMappingRepo,
       whatsAppStoreRepo,
+      whatsAppAccounts,
       linkedInStoreRepo,
       webchatRepo,
       webhookInvocationsRepo,

--- a/packages/core/src/test/helpers.ts
+++ b/packages/core/src/test/helpers.ts
@@ -51,6 +51,7 @@ import { SessionsRepository } from "../db/repositories/sessions.js";
 import { PersonMappingRepository } from "../db/repositories/person-mapping.js";
 import { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
 import { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
+import { WhatsAppAccounts } from "../channels/whatsapp-accounts.js";
 import { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
 import { ApprovalsRepository } from "../db/repositories/approvals.js";
 import { SettingsRepository } from "../db/repositories/settings.js";
@@ -371,6 +372,7 @@ export async function buildTestDeps(
   const sessionsRepo = new SessionsRepository(db);
   const personMappingRepo = new PersonMappingRepository(db);
   const whatsAppStoreRepo = new WhatsAppStoreRepository(db);
+  const whatsAppAccounts = new WhatsAppAccounts(whatsAppStoreRepo);
   const linkedInStoreRepo = new LinkedInStoreRepository(db);
   const sentinelLogRepo = new SentinelLogRepository(db);
   const approvalsRepo = new ApprovalsRepository(db);
@@ -529,6 +531,7 @@ export async function buildTestDeps(
     sessionsRepo,
     personMappingRepo,
     whatsAppStoreRepo,
+    whatsAppAccounts,
     linkedInStoreRepo,
     sentinelLogRepo,
     approvalsRepo,


### PR DESCRIPTION
Rebased onto `main` — #46 is merged, and #56 landed the channel account contract this now builds on.

## What this PR does

An identity Rome has met through WhatsApp but nobody has placed is missing from the union. It is neither a curated person nor a sender the sentinel log saw, so the People page cannot offer it for placement or count it as waiting.

The union reads the address book as a third source, through `TalkAccounts` — the account plane #56 defined and nothing consumed yet. This is its first consumer.

## Design & Invariants

**The channel answers who, the union answers where they sit.** Which addressings WhatsApp hands out, which of them is canonical, which fold together, and what counts as an account at all are the channel's answers, given once behind `TalkAccounts`. Every rule in the union is channel-agnostic above it, so adding the LinkedIn mirror is an entry in `mirrorPlanes` rather than another special case. The alternative — the shape this PR started as — had the route deriving all of that from `listContacts` columns, which meant knowing how to read a jid at each of the four places ownership, activity, aliasing, and display names are decided.

**`listAddresses` is I4 read whole.** Folding a stored table of identifiers onto accounts — every channel mapping, every sender the sentinel log saw — one `resolve` at a time costs one full address-book read per row, because a channel that mirrors its address book locally answers `resolve` from a full read. The same map inverted is an account's addressing set, which a row carries because a search reads it: an omitted address is a contact the guardian cannot reach by the phone number they know.

**Activity is a separate read, keyed by `AccountId`.** `accounts.ts` already says so; `TalkAccountActivity` is that read. Keeping it out of the account plane is what lets a channel hold an address book it has no history for, and stops an account's identity from depending on how much has been said to it. An account nothing was ever said to is absent rather than present and zeroed, so "silent" is one condition to test instead of two that can disagree.

**One read of one mirror.** `WhatsAppAccounts` shares a read already in flight. That is not the cache the contract anticipates — the window closes the moment the read settles, so nothing outlives a sync — but it makes the listing, its addresses and its activity one read, so the three answers the union joins cannot describe address books a sync moved between.

**Two people mapped to two addresses of one account is a conflict the index cannot catch.** The unique index is on `(channel, channel_user_id)`, and two addresses are two identifiers. The lowest person id takes the identity, so the union never shows or counts it twice and answers the same way on every read.

**The address book is never mirrored into persons.** Contacts stay a browsable list and become a person row only on a guardian's move. `/api/whatsapp/contacts` keeps serving its existing consumers untouched.

**The union reads the whole listing.** `listAccounts` orders stably over a listing that does not hold still, so walking cursors across a live mirror skips or repeats an account as an inbound message reorders it. The union asks for one page big enough to hold the listing, which is what the contract says to do. A contact past a cutoff is one the guardian cannot find and no count includes.

**A silent contact is hidden, never uncounted.** `neverMessaged` marks a contact that has never said or been sent anything, so the page can hold a 9,000-contact address book out of the browsing views. `neverMessagedTotal` is read from the very view that hides them, so the toggle cannot be what prunes them, and a search still reaches them — the toggle governs browsing, not a lookup for a name or number the guardian typed.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 528 pass, none skipped
- [x] `biome check` clean on every touched path

New coverage: an account the address book still holds as two cards arriving as one union row, WhatsApp history projected onto the person a contact is linked to, a linked contact never appearing twice, the newest word taken across two surfaces, silent contacts flagged and held out of the default page but still counted, group chats excluded, a search reaching a silent contact by name and by number, `listAddresses` mapping every stored address and the derived id onto one account, activity summed across both addressings, a silent account absent from the activity read, an unnamed account labelled with its formatted number, and the three reads served from one scan with the sharing window closing when it settles.

## Not in this PR

- The LinkedIn participant mirror and the merged timeline — the PRs stacked on this one. `LinkedInAccounts` already implements the contract, so folding it in is a line in `mirrorPlanes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
