### PR TITLE
feat(core): fold LinkedIn participants into the identity union

### DIFF
--- a/packages/api-types/src/identities.ts
+++ b/packages/api-types/src/identities.ts
@@ -1,6 +1,7 @@
 // The People page's unified identity contract: one row shape for every
 // identity Rome has met — curated persons, unmapped senders still sitting in
-// the sentinel log, and WhatsApp address-book contacts nobody has placed yet.
+// the sentinel log, and the mirrored address books nobody has placed yet
+// (WhatsApp contacts, LinkedIn participants).
 //
 // The pieces live here rather than in core because three implementations have
 // to agree on them at once: the `/api/identities` route that computes the
@@ -155,7 +156,8 @@ export interface IdentityRow {
    * Every channel identity this row stands for, aliases included.
    *
    * One person can reach a channel under more than one identifier — a WhatsApp
-   * contact is one row under both its phone jid and its `@lid` jid — and the
+   * contact is one row under both its phone jid and its `@lid` jid, a LinkedIn
+   * member under both a bare member id and a profile URL naming it — and the
    * union consolidates them. All of them belong here, not just whichever the
    * store picked as representative: {@link identityMatchesQuery} searches this
    * list, so an omitted alias is a contact the guardian cannot find by the
@@ -179,13 +181,17 @@ export interface IdentityRow {
    * timeline does not carry it, and an exchange Rome replied to counts the
    * reply. So this is not the length of {@link TimelinePage}, and a client that
    * treats it as one will disagree with the timeline it paged.
+   *
+   * A group conversation contributes to neither: a timeline entry names no
+   * sender, so nothing said in a room of ten people is attributable to one of
+   * them, and the union leaves group threads out of every identity's history.
    */
   messageCount: number;
   /**
-   * A WhatsApp address-book contact that has never said (or been sent)
-   * anything. Only ever true on level "unknown"; the page hides these behind
-   * a toggle so a 9,000-contact address book doesn't bury the four senders
-   * actually waiting.
+   * A mirrored address-book identity — a WhatsApp contact, a LinkedIn
+   * participant — that has never said (or been sent) anything. Only ever true
+   * on level "unknown"; the page hides these behind a toggle so a
+   * 9,000-contact address book doesn't bury the four senders actually waiting.
    */
   neverMessaged: boolean;
 }

--- a/packages/core/src/api/deps.ts
+++ b/packages/core/src/api/deps.ts
@@ -4,6 +4,7 @@ import type { DrizzleDb } from "../db/index.js";
 import type { PersonMappingRepository } from "../db/repositories/person-mapping.js";
 import type { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
 import type { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
+import type { LinkedInAccounts } from "../channels/linkedin-accounts.js";
 import type { WhatsAppAccounts } from "../channels/whatsapp-accounts.js";
 import type { WebChatRepository } from "../db/repositories/webchat.js";
 import type { WebhookInvocationsRepository } from "../db/repositories/webhook-invocations.js";
@@ -77,6 +78,8 @@ export interface ApiDeps {
   whatsAppAccounts: WhatsAppAccounts;
   /** Durable mirror of the LinkedIn inbox + message history (People tab). */
   linkedInStoreRepo: LinkedInStoreRepository;
+  /** The account plane over that mirror. */
+  linkedInAccounts: LinkedInAccounts;
   webchatRepo: WebChatRepository;
   webhookInvocationsRepo: WebhookInvocationsRepository;
   approvalsRepo: ApprovalsRepository;

--- a/packages/core/src/api/routes/identities.test.ts
+++ b/packages/core/src/api/routes/identities.test.ts
@@ -9,9 +9,10 @@ import { persons, sentinelLog } from "../../db/schema.js";
 import { STRANGER_PERSON_ID } from "../../constants.js";
 
 // GET /identities is the People page's one read: a union of curated persons,
-// unmapped sentinel-log senders, and unlinked WhatsApp contacts, all in the
-// shared IdentityRow shape. These tests pin the union's behavior — what shows
-// up, under which typed id and level, and that reading never writes.
+// unmapped sentinel-log senders, and the mirrored address books nobody has
+// placed yet — WhatsApp contacts and LinkedIn participants — all in the shared
+// IdentityRow shape. These tests pin the union's behavior: what shows up, under
+// which typed id and level, and that reading never writes.
 
 const SILENT_JID = "15550001111@s.whatsapp.net";
 const TALKING_JID = "15550002222@s.whatsapp.net";
@@ -415,5 +416,184 @@ describe("Identities API", () => {
         expect(at(row.id)).toBeLessThan(silentIndex);
       }
     }
+  });
+
+  // LinkedIn is the union's second mirror, and it folds identities on its own
+  // terms: a member id is the identity, a profile URL naming one is the same
+  // identity, and only a direct thread's messages are attributable to one
+  // person. These pin that it lands in the same row shape as WhatsApp.
+  describe("LinkedIn identities", () => {
+    const ADA = "ACoAAAda0001";
+    const GRACE = "ACoAAGrace002";
+    const SELF = "ACoAASelf0003";
+    const LINUS = "ACoAALinus004";
+    const ADA_URL = `https://www.linkedin.com/in/${ADA}/`;
+
+    const participant = (participantId: string, name: string, isSelf = false) => ({
+      participantId,
+      name,
+      headline: null,
+      type: "member",
+      isSelf,
+    });
+
+    const liMessage = (
+      threadId: string,
+      messageId: string,
+      at: string,
+      text: string | null,
+      overrides: { senderIsSelf?: boolean } = {},
+    ) => ({
+      messageId,
+      threadId,
+      sentAt: new Date(at),
+      senderIsSelf: overrides.senderIsSelf ?? false,
+      text,
+      subject: null,
+    });
+
+    const ada = participant(ADA, "Ada Lovelace");
+    const grace = participant(GRACE, "Grace Hopper");
+    const linus = participant(LINUS, "Linus Linked");
+    const me = participant(SELF, "Me Myself", true);
+
+    const seconds = (at: string) => Math.floor(Date.parse(at) / 1000);
+
+    beforeEach(async () => {
+      const thread = (threadId: string) => ({
+        threadId,
+        threadUrl: `https://www.linkedin.com/messaging/thread/${threadId}/`,
+        unread: false,
+      });
+      await deps.linkedInStoreRepo.upsertThreads([
+        thread("li-ada"),
+        thread("li-group"),
+        thread("li-linus"),
+      ]);
+      await deps.linkedInStoreRepo.upsertThreadParticipants("li-ada", [ada, me]);
+      await deps.linkedInStoreRepo.upsertThreadParticipants("li-group", [ada, grace, me]);
+      await deps.linkedInStoreRepo.upsertThreadParticipants("li-linus", [linus, me]);
+      await deps.linkedInStoreRepo.upsertMessages([
+        liMessage("li-ada", "m-1", "2026-08-17T09:00:00Z", "hello from ada"),
+        liMessage("li-ada", "m-2", "2026-08-17T09:30:00Z", "thanks", { senderIsSelf: true }),
+        liMessage("li-group", "m-1", "2026-08-18T09:00:00Z", "a blast to everyone"),
+        liMessage("li-linus", "m-1", "2026-08-17T12:30:00Z", "hi from linus"),
+      ]);
+    });
+
+    it("returns an unplaced participant as an unknown row under their member id", async () => {
+      const row = (await fetchRows()).find((r) => r.id === `channel:linkedin:${ADA}`);
+      expect(row).toBeDefined();
+      expect(row?.level).toBe("unknown");
+      expect(row?.displayName).toBe("Ada Lovelace");
+      expect(row?.neverMessaged).toBe(false);
+      // Both directions of the direct thread, newest word first.
+      expect(row?.latest).toEqual({
+        source: "linkedin",
+        timestamp: seconds("2026-08-17T09:30:00Z"),
+        preview: "thanks",
+      });
+      expect(row?.messageCount).toBe(2);
+    });
+
+    it("counts a group thread as nobody's news — a group cannot hold a bond", async () => {
+      const rows = await fetchRows();
+      // Grace posts only in the group, so she is a mirrored identity with
+      // nothing attributable to her: silent, and held behind the toggle.
+      const graceRow = rows.find((r) => r.id === `channel:linkedin:${GRACE}`);
+      expect(graceRow?.latest).toBeNull();
+      expect(graceRow?.neverMessaged).toBe(true);
+      const hidden = await fetchPage();
+      expect(hidden.identities.some((r) => r.id === `channel:linkedin:${GRACE}`)).toBe(false);
+      // And the group's newer message is not Ada's either.
+      const adaRow = rows.find((r) => r.id === `channel:linkedin:${ADA}`);
+      expect(adaRow?.latest?.timestamp).toBeLessThan(seconds("2026-08-18T09:00:00Z"));
+    });
+
+    it("never offers the account owner as an identity to place", async () => {
+      const rows = await fetchRows();
+      expect(rows.some((r) => r.channels.some((ch) => ch.channelUserId === SELF))).toBe(false);
+    });
+
+    it("projects LinkedIn history onto the person a participant was promoted into", async () => {
+      const personId = await deps.personMappingRepo.create({
+        displayName: "Linus Linked",
+        bondLevel: "acquaintance",
+        approved: true,
+        channelMappings: [{ channel: "linkedin", channelUserId: LINUS }],
+      });
+
+      const rows = await fetchRows();
+      const person = rows.find((r) => r.id === `person:${personId}`);
+      expect(person?.latest?.preview).toBe("hi from linus");
+      expect(person?.latest?.source).toBe("linkedin");
+      expect(person?.messageCount).toBe(1);
+      // The promoted participant never shows up a second time as an unknown row.
+      expect(rows.find((r) => r.id === `channel:linkedin:${LINUS}`)).toBeUndefined();
+    });
+
+    it("is one row for a participant whose mapping names their profile URL", async () => {
+      // A guardian can write the profile link they have, and the mirror stores
+      // no row for that form — LinkedIn derives the member id from it instead.
+      // The union asks the channel rather than comparing the two as strings,
+      // which would show one person as two rows and split their history.
+      const personId = await deps.personMappingRepo.create({
+        displayName: "Ada Lovelace",
+        bondLevel: "acquaintance",
+        approved: true,
+        channelMappings: [{ channel: "linkedin", channelUserId: ADA_URL }],
+      });
+
+      const rows = await fetchRows();
+      expect(rows.filter((r) => r.channels.some((ch) => ch.channelUserId === ADA))).toHaveLength(1);
+      expect(rows.find((r) => r.id === `channel:linkedin:${ADA}`)).toBeUndefined();
+      const person = rows.find((r) => r.id === `person:${personId}`);
+      expect(person?.latest?.preview).toBe("thanks");
+      // The mapping's own form leads, so a client mutating the row addresses
+      // the mapping that exists rather than the one it wishes existed.
+      expect(person?.channels.map((ch) => ch.channelUserId)).toEqual([ADA_URL, ADA]);
+    });
+
+    it("folds a sentinel sender onto the participant whose URL it named", async () => {
+      await deps.sentinelLogRepo.create({
+        messageId: "msg-li-1",
+        channel: "linkedin",
+        channelUserId: ADA_URL,
+        displayName: "Ada Lovelace",
+        text: "from the url form",
+        action: "ignored",
+      });
+
+      const rows = await fetchRows();
+      const matching = rows.filter((r) =>
+        r.channels.some((ch) => ch.channel === "linkedin" && ch.channelUserId === ADA),
+      );
+      expect(matching).toHaveLength(1);
+      // The row is offered under the member id, which is the identifier a
+      // placement writes.
+      expect(matching[0].id).toBe(`channel:linkedin:${ADA}`);
+      expect(matching[0].latest?.preview).toBe("from the url form");
+    });
+
+    it("leaves a vanity URL as its own row — it names no mirrored participant", async () => {
+      // The guardian's own LinkedIn mapping is conferred at connect time as a
+      // vanity handle carrying no member id. The channel answers null for it,
+      // and null is the right answer: nothing in the mirror is keyed by one.
+      await deps.sentinelLogRepo.create({
+        messageId: "msg-li-2",
+        channel: "linkedin",
+        channelUserId: "https://www.linkedin.com/in/ada-lovelace/",
+        displayName: "Ada Lovelace",
+        text: "under a vanity handle",
+        action: "ignored",
+      });
+
+      const rows = await fetchRows();
+      expect(
+        rows.find((r) => r.id === "channel:linkedin:https://www.linkedin.com/in/ada-lovelace/"),
+      ).toBeDefined();
+      // And it did not swallow the real Ada, who is still her own unknown row.
+      expect(rows.find((r) => r.id === `channel:linkedin:${ADA}`)?.messageCount).toBe(2);
+    });
   });
 });

--- a/packages/core/src/api/routes/identities.ts
+++ b/packages/core/src/api/routes/identities.ts
@@ -20,10 +20,10 @@ import type { TalkAccounts } from "../../channels/accounts.js";
 import type { ApiDeps } from "../deps.js";
 
 // The People page's one read: a union of curated persons, unmapped senders from
-// the sentinel log, and the WhatsApp contacts nobody has placed yet, every row
-// in the shared `IdentityRow` shape and carrying its newest dynamic. A read —
-// no person row is materialized here, ever; writes stay on the `/persons/*`
-// mutation routes.
+// the sentinel log, and the mirrored accounts nobody has placed yet — WhatsApp
+// contacts, LinkedIn participants — every row in the shared `IdentityRow` shape
+// and carrying its newest dynamic. A read — no person row is materialized here,
+// ever; writes stay on the `/persons/*` mutation routes.
 
 interface SentinelActivity {
   channel: string;
@@ -125,7 +125,10 @@ interface MirrorPlane {
 }
 
 function mirrorPlanes(deps: ApiDeps): MirrorPlane[] {
-  return [{ channel: "whatsapp", accounts: deps.whatsAppAccounts }];
+  return [
+    { channel: "whatsapp", accounts: deps.whatsAppAccounts },
+    { channel: "linkedin", accounts: deps.linkedInAccounts },
+  ];
 }
 
 /**
@@ -136,14 +139,27 @@ function mirrorPlanes(deps: ApiDeps): MirrorPlane[] {
  */
 const WHOLE_LISTING = Number.MAX_SAFE_INTEGER;
 
+/** Every identifier the union already holds on a channel, from the person
+ *  mappings and the sentinel log. Keyed by channel. */
+type StoredIdentifiers = Map<string, Set<string>>;
+
+/** The mirrors, and the index that says which identity an address belongs to. */
+interface MirrorRead {
+  identities: MirrorIdentity[];
+  byAddress: Map<string, MirrorIdentity>;
+}
+
 /**
- * Every identity the channel mirrors already hold, projected onto one shape.
+ * Every identity the channel mirrors already hold, projected onto one shape,
+ * with each of them indexed under every address it answers to.
  *
  * Read whole rather than paged: this answer is paged here, and an identity past
  * a channel's own cutoff is one the guardian cannot find and no count includes.
  */
-async function readMirrors(deps: ApiDeps): Promise<MirrorIdentity[]> {
+async function readMirrors(deps: ApiDeps, stored: StoredIdentifiers): Promise<MirrorRead> {
   const identities: MirrorIdentity[] = [];
+  const byAddress = new Map<string, MirrorIdentity>();
+
   for (const { channel, accounts } of mirrorPlanes(deps)) {
     const [listing, activity, addresses] = await Promise.all([
       accounts.listAccounts({ limit: WHOLE_LISTING }),
@@ -162,9 +178,10 @@ async function readMirrors(deps: ApiDeps): Promise<MirrorIdentity[]> {
       else aliasesOf.set(accountId, [address]);
     }
 
+    const byId = new Map<string, MirrorIdentity>();
     for (const account of listing.accounts) {
       const seen = activity.get(account.id);
-      identities.push({
+      const identity: MirrorIdentity = {
         channel,
         channelUserId: account.id,
         aliases: (aliasesOf.get(account.id) ?? [account.id]).sort(compareCodePoints),
@@ -174,37 +191,39 @@ async function readMirrors(deps: ApiDeps): Promise<MirrorIdentity[]> {
             ? null
             : { source: channel, timestamp: seen.lastMessageAt, preview: seen.lastMessagePreview },
         messageCount: seen?.messageCount ?? 0,
-      });
+      };
+      identities.push(identity);
+      byId.set(account.id, identity);
+      for (const alias of identity.aliases) byAddress.set(activityKey(channel, alias), identity);
+    }
+
+    // An identifier the union holds that the channel's address map did not
+    // cover. A channel can still accept one — LinkedIn derives a member id from
+    // a profile URL naming it and stores no row for the URL, so a guardian who
+    // pasted a profile link into a mapping wrote a form only `resolve` takes.
+    // Left unresolved, that mapping is a second row for someone the page
+    // already shows, and half their history hangs off it.
+    //
+    // Asked in one batch, because a plane that folds the whole mirror per call
+    // shares the read already in flight, so the misses cost one read rather
+    // than one each. The addresses stay as the channel gave them: this is the
+    // fold, not a new alias to publish on the row.
+    const missing = [...(stored.get(channel) ?? [])].filter(
+      (identifier) => !addresses.has(identifier),
+    );
+    const found = await Promise.all(
+      missing.map(async (identifier) => [identifier, await accounts.resolve(identifier)] as const),
+    );
+    for (const [identifier, account] of found) {
+      const identity = account && byId.get(account.id);
+      if (identity) byAddress.set(activityKey(channel, identifier), identity);
     }
   }
-  return identities;
+  return { identities, byAddress };
 }
 
 /** The full union, unordered and unfiltered. */
 async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
-  const mirror = await readMirrors(deps);
-  const mirrorByAlias = new Map<string, MirrorIdentity>();
-  for (const identity of mirror) {
-    for (const alias of identity.aliases) {
-      mirrorByAlias.set(activityKey(identity.channel, alias), identity);
-    }
-  }
-
-  // One mirrored identity is one identity however many addresses reach it, so
-  // every one of them answers to the account's own. Without this the same
-  // person is both a curated person (mapped to one form) and an unknown sender
-  // (a sentinel row under another) — two rows the page cannot merge and the
-  // guardian cannot tell apart.
-  //
-  // Which addresses fold onto which account is the channel's answer, not a
-  // rule the union derives: it is the address map read as given.
-  const canonicalId = (channel: string, channelUserId: string): string =>
-    mirrorByAlias.get(activityKey(channel, channelUserId))?.channelUserId ?? channelUserId;
-  const identityKey = (channel: string, channelUserId: string) =>
-    activityKey(channel, canonicalId(channel, channelUserId));
-  const mirrorFor = (channel: string, channelUserId: string) =>
-    mirrorByAlias.get(identityKey(channel, channelUserId));
-
   // Bare display_name/text ride SQLite's guarantee that with a lone MAX()
   // aggregate the other selected columns come from the row that supplied the
   // max — i.e. the newest message names the sender.
@@ -220,18 +239,53 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
     GROUP BY channel, channel_user_id
   `)) as Array<Record<string, unknown>>;
 
+  const senders: SentinelActivity[] = sentinelRows.map((row) => ({
+    channel: String(row.channel),
+    channelUserId: String(row.channelUserId),
+    displayName: (row.displayName as string | null) ?? null,
+    lastMessage: (row.lastMessage as string | null) ?? null,
+    lastMessageAt: row.lastMessageAt == null ? null : Number(row.lastMessageAt),
+    messageCount: Number(row.messageCount ?? 0),
+  }));
+
+  // One statement, so an identity moving between two people mid-read cannot
+  // land under both of them.
+  const persons = (await deps.personMappingRepo.findAllWithMappings()).sort((a, b) =>
+    compareCodePoints(a.id, b.id),
+  );
+
+  // Every identifier the union is about to fold, gathered before the mirrors
+  // are read so a channel can be asked about the ones its address map misses.
+  const stored: StoredIdentifiers = new Map();
+  const remember = (channel: string, channelUserId: string) => {
+    const group = stored.get(channel);
+    if (group) group.add(channelUserId);
+    else stored.set(channel, new Set([channelUserId]));
+  };
+  for (const sender of senders) remember(sender.channel, sender.channelUserId);
+  for (const person of persons) {
+    for (const mapping of person.channelMappings) remember(mapping.channel, mapping.channelUserId);
+  }
+
+  const { identities: mirror, byAddress: mirrorByAddress } = await readMirrors(deps, stored);
+
+  // One mirrored identity is one identity however many addresses reach it, so
+  // every one of them answers to the account's own. Without this the same
+  // person is both a curated person (mapped to one form) and an unknown sender
+  // (a sentinel row under another) — two rows the page cannot merge and the
+  // guardian cannot tell apart.
+  //
+  // Which addresses fold onto which account is the channel's answer, not a
+  // rule the union derives: it is the address map read as given.
+  const canonicalId = (channel: string, channelUserId: string): string =>
+    mirrorByAddress.get(activityKey(channel, channelUserId))?.channelUserId ?? channelUserId;
+  const identityKey = (channel: string, channelUserId: string) =>
+    activityKey(channel, canonicalId(channel, channelUserId));
+  const mirrorFor = (channel: string, channelUserId: string) =>
+    mirrorByAddress.get(identityKey(channel, channelUserId));
+
   const sentinel = new Map<string, SentinelActivity[]>();
-  const senders: SentinelActivity[] = [];
-  for (const row of sentinelRows) {
-    const activity: SentinelActivity = {
-      channel: String(row.channel),
-      channelUserId: String(row.channelUserId),
-      displayName: (row.displayName as string | null) ?? null,
-      lastMessage: (row.lastMessage as string | null) ?? null,
-      lastMessageAt: row.lastMessageAt == null ? null : Number(row.lastMessageAt),
-      messageCount: Number(row.messageCount ?? 0),
-    };
-    senders.push(activity);
+  for (const activity of senders) {
     const key = identityKey(activity.channel, activity.channelUserId);
     const group = sentinel.get(key);
     if (group) group.push(activity);
@@ -244,7 +298,7 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
   // never decides what the row shows.
   const activityFor = (channel: string, channelUserId: string): ChannelActivity => {
     const key = identityKey(channel, channelUserId);
-    const mirrored = mirrorByAlias.get(key);
+    const mirrored = mirrorByAddress.get(key);
     const sentinelEntries = sentinel.get(key) ?? [];
     const sentinelDynamic = sentinelEntries.reduce<IdentityDynamic | null>(
       (best, entry) =>
@@ -303,17 +357,12 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
       null,
     );
     return (
-      mirrorByAlias.get(key)?.displayName ??
+      mirrorByAddress.get(key)?.displayName ??
       fromSentinel?.displayName ??
       canonicalId(channel, channelUserId)
     );
   };
 
-  // One statement, so an identity moving between two people mid-read cannot
-  // land under both of them.
-  const persons = (await deps.personMappingRepo.findAllWithMappings()).sort((a, b) =>
-    compareCodePoints(a.id, b.id),
-  );
   const rows: IdentityRow[] = [];
   const mapped = new Set<string>();
 

--- a/packages/core/src/api/routes/linkedin-threads.test.ts
+++ b/packages/core/src/api/routes/linkedin-threads.test.ts
@@ -34,6 +34,9 @@ const ADA: LinkedInParticipantContactRow = {
   threadCount: 2,
   linkedPersonId: null,
   linkedPersonName: null,
+  lastMessageAt: 1_776_000_000,
+  lastMessagePreview: "See you Thursday",
+  messageCount: 2,
 };
 
 function buildDeps(threads = [THREAD], participants = [ADA]): ApiDeps {

--- a/packages/core/src/channels/account-snapshot.test.ts
+++ b/packages/core/src/channels/account-snapshot.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { sharedRead } from "./account-snapshot.js";
+
+describe("sharedRead", () => {
+  /** A read that only settles when the test says so. */
+  function gated() {
+    let calls = 0;
+    let release: (value: number) => void = () => {};
+    const read = sharedRead(() => {
+      calls += 1;
+      return new Promise<number>((resolve) => {
+        release = resolve;
+      });
+    });
+    return { read, release: (value: number) => release(value), calls: () => calls };
+  }
+
+  it("serves callers that overlap from one read", async () => {
+    const { read, release, calls } = gated();
+
+    const both = Promise.all([read(), read()]);
+    release(7);
+
+    expect(await both).toEqual([7, 7]);
+    expect(calls()).toBe(1);
+  });
+
+  it("reads again once the shared one has settled — this is not a cache", async () => {
+    const { read, release, calls } = gated();
+
+    const first = read();
+    release(1);
+    expect(await first).toBe(1);
+
+    const second = read();
+    release(2);
+    expect(await second).toBe(2);
+    expect(calls()).toBe(2);
+  });
+
+  it("does not hold a failed read for the next caller", async () => {
+    let calls = 0;
+    const read = sharedRead(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("mirror unavailable");
+      return "ok";
+    });
+
+    await expect(read()).rejects.toThrow("mirror unavailable");
+    await expect(read()).resolves.toBe("ok");
+  });
+});

--- a/packages/core/src/channels/account-snapshot.ts
+++ b/packages/core/src/channels/account-snapshot.ts
@@ -1,0 +1,28 @@
+/**
+ * The read-sharing half of a mirrored account plane, for a channel that folds
+ * its whole address book on every call.
+ *
+ * A `TalkAccounts` consumer usually needs several answers about the same
+ * mirror at once — a listing, its addresses, its activity — and each is its own
+ * method. Wrapping the fold here makes those one read of one mirror, so the
+ * answers cannot describe address books a sync moved between, and a caller that
+ * asks for all three pays for one.
+ *
+ * This is not a cache. The shared window closes the moment the read settles, so
+ * nothing outlives a sync and no invalidation is owed. A channel that wants to
+ * stop re-reading per call wants a real cache, and that belongs in the channel,
+ * where a sync can invalidate it.
+ */
+export function sharedRead<T>(read: () => Promise<T>): () => Promise<T> {
+  let inFlight: Promise<T> | null = null;
+  return () => {
+    if (inFlight) return inFlight;
+    const started = read();
+    inFlight = started;
+    const settled = () => {
+      if (inFlight === started) inFlight = null;
+    };
+    started.then(settled, settled);
+    return started;
+  };
+}

--- a/packages/core/src/channels/linkedin-accounts.test.ts
+++ b/packages/core/src/channels/linkedin-accounts.test.ts
@@ -96,4 +96,68 @@ describe("LinkedInAccounts", () => {
     const byLabel = await accounts.listAccounts({ limit: 50, query: "hopper" });
     expect(byLabel.accounts.map((a) => a.id)).toEqual(["ACoAAGrace002"]);
   });
+
+  describe("activity", () => {
+    beforeEach(async () => {
+      // `t1` from the outer setup already holds Ada, Grace and the guardian, so
+      // it is a group by membership. Ada gets a 1:1 alongside it.
+      await repo.upsertThreads([
+        {
+          threadId: "t-direct",
+          threadUrl: "https://www.linkedin.com/messaging/thread/t-direct/",
+          personName: "Ada Lovelace",
+          unread: false,
+        },
+      ]);
+      await repo.upsertThreadParticipants("t-direct", [ada, self]);
+      await repo.upsertMessages([
+        {
+          messageId: "m-1",
+          threadId: "t-direct",
+          sentAt: new Date("2026-08-19T10:00:00Z"),
+          senderName: "Ada Lovelace",
+          senderProfileUrl: "https://www.linkedin.com/in/ACoAAAda0001/",
+          senderHeadline: null,
+          senderType: "member",
+          senderIsSelf: false,
+          text: "See you Thursday",
+          subject: null,
+          reactionCount: null,
+        },
+        {
+          messageId: "m-2",
+          threadId: "t1",
+          sentAt: new Date("2026-08-20T10:00:00Z"),
+          senderName: "Grace Hopper",
+          senderProfileUrl: "https://www.linkedin.com/in/ACoAAGrace002/",
+          senderHeadline: null,
+          senderType: "member",
+          senderIsSelf: false,
+          text: "hello everyone",
+          subject: null,
+          reactionCount: null,
+        },
+      ]);
+    });
+
+    it("reports what a member's direct threads carried", async () => {
+      const activity = await accounts.listActivity();
+
+      expect(activity.get("ACoAAAda0001" as never)).toEqual({
+        lastMessageAt: Math.floor(Date.parse("2026-08-19T10:00:00Z") / 1000),
+        lastMessagePreview: "See you Thursday",
+        messageCount: 1,
+      });
+    });
+
+    it("leaves a member Rome only shares a group with absent, not zeroed", async () => {
+      // The contract's "silent" is one condition to test, and a group message is
+      // nobody's: a `TimelineEntry` names no sender.
+      const activity = await accounts.listActivity();
+
+      expect(activity.has("ACoAAGrace002" as never)).toBe(false);
+      // Still an account, though — silence is not absence from the address book.
+      expect((await accounts.resolve("ACoAAGrace002"))!.label).toBe("Grace Hopper");
+    });
+  });
 });

--- a/packages/core/src/channels/linkedin-accounts.ts
+++ b/packages/core/src/channels/linkedin-accounts.ts
@@ -1,5 +1,7 @@
 import type { Account, AccountId, TalkAccounts } from "./accounts.js";
+import type { AccountActivity, TalkAccountActivity } from "./account-activity.js";
 import { pageAccounts } from "./account-paging.js";
+import { sharedRead } from "./account-snapshot.js";
 import { linkedInMemberIdFromProfileUrl } from "./linkedin-sync.js";
 import type {
   LinkedInParticipantContactRow,
@@ -19,7 +21,7 @@ import type {
  * The guardian's own `isSelf` row is not an account: it names the viewer, not
  * someone the channel reaches.
  */
-export class LinkedInAccounts implements TalkAccounts {
+export class LinkedInAccounts implements TalkAccounts, TalkAccountActivity {
   constructor(private readonly store: LinkedInStoreRepository) {}
 
   async listAccounts(input: {
@@ -27,29 +29,68 @@ export class LinkedInAccounts implements TalkAccounts {
     cursor?: string;
     limit: number;
   }): Promise<{ accounts: Account[]; nextCursor?: string }> {
-    return pageAccounts(await this.load(), input);
+    const { accounts } = await this.load();
+    return pageAccounts(accounts, input);
   }
 
   async resolve(identifier: string): Promise<Account | null> {
     const memberId = memberIdFrom(identifier);
     if (!memberId) return null;
-    const accounts = await this.load();
-    return accounts.find((account) => account.id === memberId) ?? null;
+    const { byId } = await this.load();
+    return byId.get(memberId) ?? null;
   }
 
   async listAddresses(): Promise<Map<string, AccountId>> {
     // A member is stored under its member id and nothing else; the profile URL
     // that also names it is derived on sight, not held, so `resolve` is what
     // takes one.
+    const { accounts } = await this.load();
     const addresses = new Map<string, AccountId>();
-    for (const account of await this.load()) addresses.set(account.id, account.id);
+    for (const account of accounts) addresses.set(account.id, account.id);
     return addresses;
   }
 
-  private async load(): Promise<Account[]> {
-    const rows = await this.store.listParticipants({ limit: null });
-    return rows.filter((row) => !row.isSelf).map(toAccount);
+  /**
+   * What the mirror holds on each member's *direct* threads, and nothing from
+   * the group ones — see `DIRECT_THREADS` in the store for why a room of ten
+   * people is nobody's history. A member Rome only shares group threads with is
+   * absent here rather than zeroed, which is the contract's own "silent".
+   */
+  async listActivity(): Promise<Map<AccountId, AccountActivity>> {
+    const { rows } = await this.load();
+    const activity = new Map<AccountId, AccountActivity>();
+    for (const row of rows) {
+      if (row.lastMessageAt == null) continue;
+      activity.set(row.participantId as AccountId, {
+        lastMessageAt: row.lastMessageAt,
+        lastMessagePreview: row.lastMessagePreview,
+        messageCount: row.messageCount,
+      });
+    }
+    return activity;
   }
+
+  /**
+   * The whole mirror, read unbounded because every answer above is drawn from
+   * it and a truncated read would report a member as absent rather than as
+   * missed. Concurrent calls share one read; see {@link sharedRead} for what
+   * that is and is not.
+   */
+  private readonly load = sharedRead(() => this.read());
+
+  private async read(): Promise<Snapshot> {
+    const rows = (await this.store.listParticipants({ limit: null })).filter((row) => !row.isSelf);
+    const accounts = rows.map(toAccount);
+    return { rows, accounts, byId: new Map(accounts.map((a) => [String(a.id), a])) };
+  }
+}
+
+/** One fold of the mirror: the participant rows, the accounts they project
+ *  onto, and the index `resolve` answers from. */
+interface Snapshot {
+  rows: LinkedInParticipantContactRow[];
+  accounts: Account[];
+  byId: Map<string, Account>;
 }
 
 /**

--- a/packages/core/src/channels/whatsapp-accounts.ts
+++ b/packages/core/src/channels/whatsapp-accounts.ts
@@ -2,6 +2,7 @@ import { formatWhatsAppPhone } from "@rome/api-types/identities";
 import type { Account, AccountId, TalkAccounts } from "./accounts.js";
 import type { AccountActivity, TalkAccountActivity } from "./account-activity.js";
 import { pageAccounts } from "./account-paging.js";
+import { sharedRead } from "./account-snapshot.js";
 import type {
   WhatsAppContactRow,
   WhatsAppStoreRepository,
@@ -69,9 +70,6 @@ function firstNonEmpty(...values: Array<string | null>): string | null {
 export class WhatsAppAccounts implements TalkAccounts, TalkAccountActivity {
   constructor(private readonly store: WhatsAppStoreRepository) {}
 
-  /** The read a concurrent set of calls shares. See {@link load}. */
-  private reading: Promise<Snapshot> | null = null;
-
   async listAccounts(input: {
     query?: string;
     cursor?: string;
@@ -132,24 +130,10 @@ export class WhatsAppAccounts implements TalkAccounts, TalkAccountActivity {
    * costs one per identifier. That is bounded by address-book size and holds no
    * stale rows. A caller that resolves per message wants a real cache, and the
    * cache belongs here, where a sync can invalidate it rather than the caller
-   * guessing at when it went stale.
-   *
-   * Reads already in flight are shared. That is not that cache: the window
-   * closes the moment the read settles, so nothing outlives a sync. It is what
-   * makes the several reads a single caller needs at once — a listing, its
-   * addresses, its activity — one read of one mirror, so the three answers
-   * cannot describe address books a sync moved between.
+   * guessing at when it went stale. Concurrent calls share one read; see
+   * {@link sharedRead} for what that is and is not.
    */
-  private load(): Promise<Snapshot> {
-    if (this.reading) return this.reading;
-    const reading = this.read();
-    this.reading = reading;
-    const done = () => {
-      if (this.reading === reading) this.reading = null;
-    };
-    reading.then(done, done);
-    return reading;
-  }
+  private readonly load = sharedRead(() => this.read());
 
   /**
    * The store already folds a person's two addressings onto one card, but it

--- a/packages/core/src/db/repositories/linkedin-store.test.ts
+++ b/packages/core/src/db/repositories/linkedin-store.test.ts
@@ -814,6 +814,130 @@ describe("LinkedInStoreRepository", () => {
       });
     });
   });
+
+  // The identity union reads a participant as a person-shaped row: who they
+  // are, what was last said, and how much of it there is. "What was said" is
+  // the direct threads only — a timeline entry names no sender, so a group
+  // thread's messages cannot be attributed to one of its members.
+  describe("participant activity", () => {
+    const ada = {
+      participantId: "ACoAAAda0001",
+      name: "Ada Lovelace",
+      headline: "Engineer",
+      type: "member",
+      isSelf: false,
+    };
+    const grace = {
+      participantId: "ACoAAGrace002",
+      name: "Grace Hopper",
+      headline: null,
+      type: "member",
+      isSelf: false,
+    };
+    const self = {
+      participantId: "ACoAASelf0003",
+      name: "Me Myself",
+      headline: null,
+      type: "member",
+      isSelf: true,
+    };
+
+    const message = (
+      threadId: string,
+      messageId: string,
+      at: string,
+      text: string | null,
+      overrides: { senderIsSelf?: boolean; subject?: string | null } = {},
+    ) => ({
+      messageId,
+      threadId,
+      sentAt: new Date(at),
+      senderName: "Ada Lovelace",
+      senderProfileUrl: `https://www.linkedin.com/in/${ada.participantId}/`,
+      senderHeadline: null,
+      senderType: "member",
+      senderIsSelf: overrides.senderIsSelf ?? false,
+      text,
+      subject: overrides.subject ?? null,
+      reactionCount: null,
+    });
+
+    const seconds = (at: string) => Math.floor(Date.parse(at) / 1000);
+
+    const participantRow = async (participantId: string) => {
+      const rows = await repo.listParticipants();
+      const row = rows.find((r) => r.participantId === participantId);
+      if (!row) throw new Error(`no participant row for ${participantId}`);
+      return row;
+    };
+
+    beforeEach(async () => {
+      await repo.upsertThreads([
+        thread("t-direct", new Date("2026-08-19T20:00:00Z")),
+        thread("t-group", new Date("2026-08-20T20:00:00Z")),
+      ]);
+      await repo.upsertThreadParticipants("t-direct", [ada, self]);
+      await repo.upsertThreadParticipants("t-group", [ada, grace, self]);
+      await repo.upsertMessages([
+        message("t-direct", "m-1", "2026-08-19T10:00:00Z", "hello from the 1:1"),
+        message("t-direct", "m-2", "2026-08-19T11:00:00Z", "on my way", { senderIsSelf: true }),
+        message("t-group", "m-3", "2026-08-20T10:00:00Z", "hello everyone"),
+      ]);
+    });
+
+    it("reports a direct thread's newest message, both directions counted", async () => {
+      const row = await participantRow(ada.participantId);
+      expect(row.lastMessageAt).toBe(seconds("2026-08-19T11:00:00Z"));
+      expect(row.lastMessagePreview).toBe("on my way");
+      expect(row.messageCount).toBe(2);
+    });
+
+    it("leaves a group thread out of a member's activity", async () => {
+      // Grace is only ever on the group thread, so nothing is attributable to
+      // her — the newer group message is not her news, and never Ada's either.
+      expect(await participantRow(grace.participantId)).toMatchObject({
+        lastMessageAt: null,
+        lastMessagePreview: null,
+        messageCount: 0,
+      });
+      const row = await participantRow(ada.participantId);
+      expect(row.lastMessageAt).toBeLessThan(seconds("2026-08-20T10:00:00Z"));
+    });
+
+    it("counts a thread LinkedIn calls a group as one, whatever its membership says", async () => {
+      // The flag gets a veto over the membership: a two-row participant set on
+      // a thread the snapshot flagged as a group is a set that was read before
+      // the rest of the members were.
+      await repo.upsertThreads([thread("t-flagged", new Date("2026-08-21T20:00:00Z"))]);
+      await repo.markThreadSynced("t-flagged", { isGroup: true });
+      await repo.upsertThreadParticipants("t-flagged", [grace, self]);
+      await repo.upsertMessages([
+        message("t-flagged", "m-4", "2026-08-21T10:00:00Z", "in a group"),
+      ]);
+
+      expect((await participantRow(grace.participantId)).messageCount).toBe(0);
+    });
+
+    it("treats a thread with no snapshot as direct when only one member is on it", async () => {
+      // `is_group` stays null until a thread snapshot reports one, and a thread
+      // seeded from stored messages has membership but no snapshot. Reading the
+      // flag alone would make every such thread nobody's history.
+      const flag = testDb.db.all(
+        sql`SELECT is_group AS isGroup FROM linkedin_threads WHERE thread_id = 't-direct'`,
+      ) as Array<Record<string, unknown>>;
+      expect(flag[0].isGroup).toBeNull();
+      expect((await participantRow(ada.participantId)).messageCount).toBe(2);
+    });
+
+    it("falls back to the InMail subject when a message carries no text", async () => {
+      await repo.upsertMessages([
+        message("t-direct", "m-5", "2026-08-19T12:00:00Z", null, { subject: "Role at Analytical" }),
+      ]);
+      expect((await participantRow(ada.participantId)).lastMessagePreview).toBe(
+        "Role at Analytical",
+      );
+    });
+  });
 });
 
 describe("linkedInMemberIdFromProfileUrl", () => {

--- a/packages/core/src/db/repositories/linkedin-store.ts
+++ b/packages/core/src/db/repositories/linkedin-store.ts
@@ -86,6 +86,15 @@ export interface LinkedInParticipantContactRow {
   /** The person this identity was promoted into, or null when unpromoted. */
   linkedPersonId: string | null;
   linkedPersonName: string | null;
+  /**
+   * Unix seconds of the newest message on this identity's direct threads, or
+   * null when the mirror holds none. See {@link DIRECT_THREADS} for why a group
+   * thread contributes nothing.
+   */
+  lastMessageAt: number | null;
+  lastMessagePreview: string | null;
+  /** Mirrored messages on this identity's direct threads, both directions. */
+  messageCount: number;
 }
 
 /** One thread's membership paired with the age of the read that produced it. */
@@ -102,6 +111,44 @@ export interface LinkedInParticipantBackfillResult {
   /** Distinct identities the seed proved. */
   participants: number;
 }
+
+/**
+ * Every (thread, counterparty) pair where that counterparty is the only one on
+ * the thread — the LinkedIn analog of a WhatsApp 1:1 chat.
+ *
+ * A thread is what carries messages, and only a direct thread's messages are
+ * unambiguously *this* person's history: a timeline entry names no sender, so
+ * folding a ten-person thread into one member's dossier would put nine other
+ * people's words in their mouth. The People page already holds group chats out
+ * of the identity union for the same reason — a group cannot hold a bond.
+ *
+ * Membership decides it, not LinkedIn's `is_group` flag alone: that flag is
+ * null until a thread snapshot reports one, and a thread seeded from stored
+ * messages has membership but no snapshot. The flag still gets a veto, so a
+ * thread LinkedIn calls a group is never direct however little of its
+ * membership has been mirrored.
+ *
+ * The account owner is not a counterparty: their own row is on every thread
+ * they are in, and treating it as one would make every 1:1 thread look like a
+ * pair.
+ */
+const DIRECT_THREADS = sql`
+  direct_threads AS (
+    SELECT tp.thread_id AS threadId, tp.participant_id AS participantId
+    FROM linkedin_thread_participants tp
+    LEFT JOIN linkedin_threads t ON t.thread_id = tp.thread_id
+    LEFT JOIN linkedin_participants p ON p.participant_id = tp.participant_id
+    WHERE coalesce(p.is_self, 0) = 0
+      AND coalesce(t.is_group, 0) = 0
+      AND NOT EXISTS (
+        SELECT 1 FROM linkedin_thread_participants other
+        LEFT JOIN linkedin_participants op ON op.participant_id = other.participant_id
+        WHERE other.thread_id = tp.thread_id
+          AND other.participant_id <> tp.participant_id
+          AND coalesce(op.is_self, 0) = 0
+      )
+  )
+`;
 
 function chunked<T>(items: T[], size: number): T[][] {
   const out: T[][] = [];
@@ -521,8 +568,9 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
 
   /**
    * Every stored LinkedIn identity, each row saying whether it has already been
-   * promoted to a person. The join is on the member id itself — no translation
-   * step — because `linkedin_participants.participant_id` and a `linkedin`
+   * promoted to a person and what its direct threads last carried. The join is
+   * on the member id itself — no translation step — because
+   * `linkedin_participants.participant_id` and a `linkedin`
    * `channel_mappings.channel_user_id` are the same identifier by construction.
    *
    * Promotion is a guardian action against these rows, not something this
@@ -539,6 +587,7 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
     const limitClause =
       opts.limit === null ? sql`` : sql`LIMIT ${opts.limit ?? PARTICIPANTS_READ_LIMIT}`;
     const rows = (await this.db.all(sql`
+      WITH ${DIRECT_THREADS}
       SELECT
         p.participant_id AS participantId,
         p.name AS name,
@@ -548,7 +597,21 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
         (SELECT COUNT(*) FROM linkedin_thread_participants tp
            WHERE tp.participant_id = p.participant_id) AS threadCount,
         cm.person_id AS linkedPersonId,
-        person.display_name AS linkedPersonName
+        person.display_name AS linkedPersonName,
+        (SELECT MAX(coalesce(m.sent_at, m.created_at))
+           FROM linkedin_messages m
+           JOIN direct_threads d ON d.threadId = m.thread_id
+           WHERE d.participantId = p.participant_id) AS lastMessageAt,
+        (SELECT coalesce(nullif(m.text, ''), m.subject)
+           FROM linkedin_messages m
+           JOIN direct_threads d ON d.threadId = m.thread_id
+           WHERE d.participantId = p.participant_id
+           ORDER BY coalesce(m.sent_at, m.created_at) DESC, m.rowid DESC
+           LIMIT 1) AS lastMessagePreview,
+        (SELECT COUNT(*)
+           FROM linkedin_messages m
+           JOIN direct_threads d ON d.threadId = m.thread_id
+           WHERE d.participantId = p.participant_id) AS messageCount
       FROM linkedin_participants p
       LEFT JOIN channel_mappings cm
         ON cm.channel = 'linkedin' AND cm.channel_user_id = p.participant_id
@@ -566,6 +629,9 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
       threadCount: Number(r.threadCount ?? 0),
       linkedPersonId: (r.linkedPersonId as string | null) ?? null,
       linkedPersonName: (r.linkedPersonName as string | null) ?? null,
+      lastMessageAt: r.lastMessageAt == null ? null : Number(r.lastMessageAt),
+      lastMessagePreview: (r.lastMessagePreview as string | null) ?? null,
+      messageCount: Number(r.messageCount ?? 0),
     }));
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ import { SessionsRepository } from "./db/repositories/sessions.js";
 import { PersonMappingRepository } from "./db/repositories/person-mapping.js";
 import { LinkedInStoreRepository } from "./db/repositories/linkedin-store.js";
 import { WhatsAppStoreRepository } from "./db/repositories/whatsapp-store.js";
+import { LinkedInAccounts } from "./channels/linkedin-accounts.js";
 import { WhatsAppAccounts } from "./channels/whatsapp-accounts.js";
 import { SentinelLogRepository } from "./db/repositories/sentinel-log.js";
 import { ApprovalsRepository } from "./db/repositories/approvals.js";
@@ -227,6 +228,7 @@ async function main() {
   const whatsAppStoreRepo = new WhatsAppStoreRepository(db);
   const whatsAppAccounts = new WhatsAppAccounts(whatsAppStoreRepo);
   const linkedInStoreRepo = new LinkedInStoreRepository(db);
+  const linkedInAccounts = new LinkedInAccounts(linkedInStoreRepo);
   const sentinelLogRepo = new SentinelLogRepository(db);
   const approvalsRepo = new ApprovalsRepository(db);
   const settingsRepo = new SettingsRepository(db);
@@ -1148,6 +1150,7 @@ async function main() {
       whatsAppStoreRepo,
       whatsAppAccounts,
       linkedInStoreRepo,
+      linkedInAccounts,
       webchatRepo,
       webhookInvocationsRepo,
       approvalsRepo,

--- a/packages/core/src/test/helpers.ts
+++ b/packages/core/src/test/helpers.ts
@@ -51,6 +51,7 @@ import { SessionsRepository } from "../db/repositories/sessions.js";
 import { PersonMappingRepository } from "../db/repositories/person-mapping.js";
 import { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
 import { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
+import { LinkedInAccounts } from "../channels/linkedin-accounts.js";
 import { WhatsAppAccounts } from "../channels/whatsapp-accounts.js";
 import { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
 import { ApprovalsRepository } from "../db/repositories/approvals.js";
@@ -374,6 +375,7 @@ export async function buildTestDeps(
   const whatsAppStoreRepo = new WhatsAppStoreRepository(db);
   const whatsAppAccounts = new WhatsAppAccounts(whatsAppStoreRepo);
   const linkedInStoreRepo = new LinkedInStoreRepository(db);
+  const linkedInAccounts = new LinkedInAccounts(linkedInStoreRepo);
   const sentinelLogRepo = new SentinelLogRepository(db);
   const approvalsRepo = new ApprovalsRepository(db);
   const settingsRepo = new SettingsRepository(db);
@@ -533,6 +535,7 @@ export async function buildTestDeps(
     whatsAppStoreRepo,
     whatsAppAccounts,
     linkedInStoreRepo,
+    linkedInAccounts,
     sentinelLogRepo,
     approvalsRepo,
     approvalHandler,


### PR DESCRIPTION
## What this PR does

A mirrored LinkedIn participant is a person Rome has met, and the union does not carry them. `linkedin_participants` holds the identity while `/api/identities` reads persons, senders, and WhatsApp accounts, so an inbox the poller has mirrored for weeks contributes nothing to the page that places people.

LinkedIn joins as the union's second mirror. #47 already made that an entry in `mirrorPlanes` rather than another special case in the union, and #56 already gave `LinkedInAccounts` the answer to *who* — so what is left is the activity read, the direct-thread rule behind it, and the wiring.

## Design & Invariants

**Adding a mirror is an entry in `mirrorPlanes`.** `LinkedInAccounts` gains `TalkAccountActivity` and the union gains one line. Ownership, aliasing, the newest-word fold and the display-name ladder are the rules already written, and nothing in the route learns what a member id looks like.

**A group thread is nobody's history.** A `TimelineEntry` names no sender, so a ten-person thread folded into one member's dossier puts nine other people's words in their mouth. A participant's activity comes from their direct threads — the threads holding no other counterparty. A member Rome only shares group threads with is absent from `listActivity` rather than zeroed, which is the contract's own "silent", so the union reads them as `neverMessaged` through the same branch WhatsApp's untouched contacts take.

**Membership decides "direct", and `is_group` keeps a veto.** LinkedIn's flag stays null until a thread snapshot reports one, and a thread seeded from stored messages has membership but no snapshot — so the flag alone cannot answer. It still overrules, so a thread LinkedIn calls a group is never direct however little of its membership has been mirrored.

**`listAddresses` is what a channel stores; `resolve` is what takes the rest.** The union folds a stored table of identifiers, and `TalkAccounts` says an identifier missing from the address map may still be a form the channel accepts. LinkedIn derives a member id from a profile URL naming it and holds no row for the URL, so a guardian who pasted a profile link into a mapping wrote a form only `resolve` reads. Left unresolved that mapping is a second row for someone the page already shows, with half their history hanging off it. The misses go out in one batch against a plane that shares the read already in flight, so they cost one read rather than one each.

The alternative — deriving the member id in the union, as the pre-account-plane version of this PR did — puts one channel's identifier grammar back in a route that had just been cleared of it, and answers only for LinkedIn. Asking the channel also gives WhatsApp the same reach: a mapping written as a bare phone number now folds onto the contact holding that number.

**Null stays a useful answer.** A vanity URL (`/in/ada-lovelace`) is the form the guardian's own mapping is conferred in at connect time, and it names no member. `resolve` answers null and the identifier stays its own row, rather than being narrowed at write time into something the mirror cannot key on.

**The account owner is not an identity to place.** Their own participant row sits on every thread they are in, and offering it puts the guardian on the page as a stranger to themselves. `LinkedInAccounts` already held `isSelf` rows out of the listing.

**Sharing an in-flight read is not a cache, and now says so once.** It moves out of `WhatsAppAccounts` into `sharedRead`, so the second mirror inherits the behaviour instead of copying the reasoning. The window closes when the read settles, which is what makes a listing, its addresses and its activity one read of one mirror.

**The participant mirror is never copied into persons.** `/api/linkedin/participants` keeps serving its existing consumer untouched, and the union reads the table unbounded because it pages its own answer.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 3948 pass in `packages/core`, 5667 across the monorepo. New coverage: a participant's direct-thread activity in both directions, a group thread counting for nobody, a snapshot-less thread still reading as direct, an InMail subject standing in for empty text, a thread LinkedIn flags as a group staying one whatever its membership says, `listActivity` omitting a group-only member rather than zeroing them, an unplaced participant as an unknown row under their member id, a group-only participant arriving silent and held behind the toggle, the account owner absent from every row, LinkedIn history projected onto a promoted person, a mapping written as a profile URL folding onto the member id it names, a sentinel sender under that URL folding onto the same row, a vanity URL staying its own row, and `sharedRead` across overlap, settle and failure
- [x] `biome check` clean on every touched path
- [ ] `pnpm dev:all` — the Docker socket is not reachable for this user, so the container boot check did not run. The DI wiring it would exercise is the same two lines `buildTestDeps` constructs on every route test.

## Not in this PR

- The merged timeline — the PR stacked on this one.
- A member's own words in a group thread. Attributing them needs a sender on `TimelineEntry`, which is a contract change, so a group-only participant reads as silent.
- A headline stays on `linkedin_participants` and belongs in the person's memory profile. `channel_mappings` has no column for it and gains none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
