### PR TITLE
feat(core): merge one identity's channels into a single timeline

### DIFF
--- a/packages/api-types/src/identities.ts
+++ b/packages/api-types/src/identities.ts
@@ -1,6 +1,7 @@
 // The People page's unified identity contract: one row shape for every
 // identity Rome has met — curated persons, unmapped senders still sitting in
-// the sentinel log, and WhatsApp address-book contacts nobody has placed yet.
+// the sentinel log, and the mirrored address books nobody has placed yet
+// (WhatsApp contacts, LinkedIn participants).
 //
 // The pieces live here rather than in core because three implementations have
 // to agree on them at once: the `/api/identities` route that computes the
@@ -155,7 +156,8 @@ export interface IdentityRow {
    * Every channel identity this row stands for, aliases included.
    *
    * One person can reach a channel under more than one identifier — a WhatsApp
-   * contact is one row under both its phone jid and its `@lid` jid — and the
+   * contact is one row under both its phone jid and its `@lid` jid, a LinkedIn
+   * member under both a bare member id and a profile URL naming it — and the
    * union consolidates them. All of them belong here, not just whichever the
    * store picked as representative: {@link identityMatchesQuery} searches this
    * list, so an omitted alias is a contact the guardian cannot find by the
@@ -179,13 +181,17 @@ export interface IdentityRow {
    * timeline does not carry it, and an exchange Rome replied to counts the
    * reply. So this is not the length of {@link TimelinePage}, and a client that
    * treats it as one will disagree with the timeline it paged.
+   *
+   * A group conversation contributes to neither: a timeline entry names no
+   * sender, so nothing said in a room of ten people is attributable to one of
+   * them, and the union leaves group threads out of every identity's history.
    */
   messageCount: number;
   /**
-   * A WhatsApp address-book contact that has never said (or been sent)
-   * anything. Only ever true on level "unknown"; the page hides these behind
-   * a toggle so a 9,000-contact address book doesn't bury the four senders
-   * actually waiting.
+   * A mirrored address-book identity — a WhatsApp contact, a LinkedIn
+   * participant — that has never said (or been sent) anything. Only ever true
+   * on level "unknown"; the page hides these behind a toggle so a
+   * 9,000-contact address book doesn't bury the four senders actually waiting.
    */
   neverMessaged: boolean;
 }

--- a/packages/core/src/api/routes/identities.test.ts
+++ b/packages/core/src/api/routes/identities.test.ts
@@ -8,22 +8,70 @@ import { seedBaseline, type BaselineIds } from "../../test/seeds.js";
 import { persons, sentinelLog } from "../../db/schema.js";
 import { STRANGER_PERSON_ID } from "../../constants.js";
 
-// GET /identities is the People page's one read: a union of curated persons and
-// the senders the sentinel log saw but nobody placed, all in the shared
-// IdentityRow shape. These tests pin the union's behavior — what shows up, under
-// which typed id and level, and that reading never writes.
+// GET /identities is the People page's one read: a union of curated persons,
+// unmapped sentinel-log senders, and unlinked WhatsApp contacts, all in the
+// shared IdentityRow shape. These tests pin the union's behavior — what shows
+// up, under which typed id and level, and that reading never writes.
+
+const SILENT_JID = "15550001111@s.whatsapp.net";
+const TALKING_JID = "15550002222@s.whatsapp.net";
+const LINKED_JID = "15550003333@s.whatsapp.net";
+const GROUP_JID = "120363000000000001@g.us";
 
 describe("Identities API", () => {
   let testDb: TestDb;
   let deps: TestDeps;
   let app: Hono;
   let baseline: BaselineIds;
+  let waOnlyPersonId: string;
 
   beforeEach(async () => {
     testDb = createTestDb();
     baseline = await seedBaseline(testDb.db);
     deps = await buildTestDeps(testDb.db);
     app = new Hono().route("/", identitiesRoutes(deps));
+
+    // The WhatsApp mirror: a silent address-book contact, a talking unlinked
+    // contact, a contact linked to a curated person, and a group chat.
+    await deps.whatsAppStoreRepo.upsertContacts([
+      { jid: SILENT_JID, phoneNumber: "15550001111", name: "Silent Sam" },
+      { jid: TALKING_JID, phoneNumber: "15550002222", notify: "Talky Tina" },
+      { jid: LINKED_JID, phoneNumber: "15550003333", name: "Alice WA" },
+    ]);
+    await deps.whatsAppStoreRepo.upsertChats([
+      { jid: GROUP_JID, name: "Sunday hikes", isGroup: true },
+    ]);
+    await deps.whatsAppStoreRepo.upsertMessages([
+      {
+        id: "wa-1",
+        chatJid: TALKING_JID,
+        senderJid: TALKING_JID,
+        fromMe: false,
+        timestamp: new Date("2026-08-17T10:00:00Z"),
+        type: "text",
+        text: "hello from tina",
+        hasMedia: false,
+      },
+      {
+        id: "wa-2",
+        chatJid: LINKED_JID,
+        senderJid: LINKED_JID,
+        fromMe: false,
+        timestamp: new Date("2026-08-17T11:00:00Z"),
+        type: "text",
+        text: "hello from alice's wa",
+        hasMedia: false,
+      },
+    ]);
+    // A curated person known only through WhatsApp, so the mirror is the only
+    // history their row can carry. Baseline's Alice is deliberately not reused
+    // here: she also has sentinel history, which is its own test below.
+    waOnlyPersonId = await deps.personMappingRepo.create({
+      displayName: "WhatsApp Only",
+      bondLevel: "acquaintance",
+      approved: true,
+      channelMappings: [{ channel: "whatsapp", channelUserId: LINKED_JID }],
+    });
   });
 
   afterEach(() => testDb.close());
@@ -34,8 +82,10 @@ describe("Identities API", () => {
     return (await res.json()) as IdentityPage;
   }
 
+  /** The rows of the first page, with silent contacts included — what most of
+   *  these tests assert over. */
   async function fetchRows(): Promise<IdentityRow[]> {
-    return (await fetchPage()).identities;
+    return (await fetchPage("?includeNeverMessaged=true")).identities;
   }
 
   it("returns curated persons as person-form rows with their level and channels", async () => {
@@ -53,13 +103,59 @@ describe("Identities API", () => {
     expect(guardian?.level).toBe("guardian");
   });
 
+  it("projects WhatsApp history onto the person a contact is linked to", async () => {
+    const rows = await fetchRows();
+    const person = rows.find((r) => r.id === `person:${waOnlyPersonId}`)!;
+    expect(person.latest?.preview).toBe("hello from alice's wa");
+    expect(person.latest?.source).toBe("whatsapp");
+    expect(person.messageCount).toBeGreaterThan(0);
+    // The linked contact never shows up a second time as an unknown row.
+    expect(rows.find((r) => r.id === `channel:whatsapp:${LINKED_JID}`)).toBeUndefined();
+  });
+
+  it("takes the newest word when a person has history on two surfaces", async () => {
+    // Baseline stamps Alice's sentinel entry at seed time; her WhatsApp mirror
+    // row is older, so the sentinel is what her row reports.
+    await deps.personMappingRepo.addChannelMapping(
+      baseline.persons.innerCircleId,
+      "whatsapp",
+      TALKING_JID,
+      "Alice WA",
+    );
+    const rows = await fetchRows();
+    const alice = rows.find((r) => r.id === `person:${baseline.persons.innerCircleId}`)!;
+    expect(alice.latest?.preview).not.toBe("hello from tina");
+    expect(alice.latest?.source).toBe("telegram");
+  });
+
   it("returns unmapped sentinel senders as unknown channel-form rows", async () => {
     const rows = await fetchRows();
     const unknown = rows.find((r) => r.id === "channel:telegram:tg-stranger-999");
     expect(unknown).toBeDefined();
     expect(unknown!.level).toBe("unknown");
+    expect(unknown!.neverMessaged).toBe(false);
     // A mapped sender is a person, never also a channel row.
     expect(rows.find((r) => r.id === "channel:telegram:tg-alice")).toBeUndefined();
+  });
+
+  it("returns unlinked WhatsApp contacts as unknown rows, flagging the silent ones", async () => {
+    const rows = await fetchRows();
+    const silent = rows.find((r) => r.id === `channel:whatsapp:${SILENT_JID}`);
+    expect(silent).toBeDefined();
+    expect(silent!.level).toBe("unknown");
+    expect(silent!.displayName).toBe("Silent Sam");
+    expect(silent!.neverMessaged).toBe(true);
+
+    const talking = rows.find((r) => r.id === `channel:whatsapp:${TALKING_JID}`);
+    expect(talking).toBeDefined();
+    expect(talking!.displayName).toBe("Talky Tina");
+    expect(talking!.neverMessaged).toBe(false);
+    expect(talking!.latest?.preview).toBe("hello from tina");
+  });
+
+  it("excludes group chats — a group cannot hold a bond", async () => {
+    const rows = await fetchRows();
+    expect(rows.find((r) => r.id.includes(GROUP_JID))).toBeUndefined();
   });
 
   it("renders each stranger mapping as its own channel-form row, never the sentinel person", async () => {
@@ -88,14 +184,30 @@ describe("Identities API", () => {
 
   it("carries each identity's newest dynamic, naming the surface it came from", async () => {
     const rows = await fetchRows();
-    const unknown = rows.find((r) => r.id === "channel:telegram:tg-stranger-999")!;
-    expect(unknown.latest?.source).toBe("telegram");
-    expect(unknown.latest?.preview).toBe("who are you");
-    expect(unknown.messageCount).toBe(1);
-    // Nothing has ever been said to Bob, so his row carries no dynamic at all.
-    expect(
-      rows.find((r) => r.id === `person:${baseline.persons.acquaintanceId}`)!.latest,
-    ).toBeNull();
+    const tina = rows.find((r) => r.id === `channel:whatsapp:${TALKING_JID}`)!;
+    expect(tina.latest).toEqual({
+      source: "whatsapp",
+      timestamp: Math.floor(new Date("2026-08-17T10:00:00Z").getTime() / 1000),
+      preview: "hello from tina",
+    });
+    expect(rows.find((r) => r.id === `channel:whatsapp:${SILENT_JID}`)!.latest).toBeNull();
+  });
+
+  it("leaves never-messaged contacts out of the default page", async () => {
+    const page = await fetchPage();
+    expect(page.identities.find((r) => r.id === `channel:whatsapp:${SILENT_JID}`)).toBeUndefined();
+  });
+
+  it("still counts the silent contacts the default page hides", async () => {
+    // The toggle governs the rows, never the numbers: the offer to show them is
+    // the only place this count is read, and it is made from the view that
+    // hides them.
+    const hidden = await fetchPage();
+    const shown = await fetchPage("?includeNeverMessaged=true");
+    expect(hidden.neverMessagedTotal).toBe(shown.neverMessagedTotal);
+    expect(hidden.neverMessagedTotal).toBeGreaterThan(0);
+    expect(hidden.totals).toEqual(shown.totals);
+    expect(hidden.counts).toEqual(shown.counts);
   });
 
   it("takes the newest word across a person's channels, and counts them all", async () => {
@@ -142,28 +254,63 @@ describe("Identities API", () => {
     expect(res.status).toBe(400);
   });
 
-  it("answers a search over names and channel identifiers", async () => {
-    const byName = await fetchPage("?q=bob");
-    expect(byName.identities.map((r) => r.id)).toEqual([
-      `person:${baseline.persons.acquaintanceId}`,
+  it("is one row for a WhatsApp contact its owner and its history address differently", async () => {
+    // The address book consolidates a phone jid and a `@lid` jid into one
+    // contact. A person mapped to one of them and a sentinel row under the
+    // other is one identity, not a curated person plus an unknown sender.
+    const phoneJid = "15550007777@s.whatsapp.net";
+    const lidJid = "88817260077@lid";
+    await deps.whatsAppStoreRepo.upsertContacts([
+      { jid: phoneJid, phoneNumber: "15550007777", name: "One Contact" },
+      { jid: lidJid, phoneNumber: "15550007777", name: "One Contact" },
     ]);
+    await deps.sentinelLogRepo.create({
+      messageId: "msg-lid-1",
+      channel: "whatsapp",
+      channelUserId: lidJid,
+      displayName: "One Contact",
+      text: "from the lid address",
+      action: "ignored",
+    });
+    const personId = await deps.personMappingRepo.create({
+      displayName: "One Contact",
+      bondLevel: "acquaintance",
+      approved: true,
+      channelMappings: [{ channel: "whatsapp", channelUserId: phoneJid }],
+    });
 
-    const byChannelId = await fetchPage("?q=tg-stranger-999");
-    expect(byChannelId.identities.map((r) => r.id)).toEqual(["channel:telegram:tg-stranger-999"]);
+    const rows = await fetchRows();
+    expect(rows.filter((r) => r.channels.some((ch) => ch.channelUserId === lidJid))).toHaveLength(
+      1,
+    );
+    expect(rows.find((r) => r.id === `channel:whatsapp:${lidJid}`)).toBeUndefined();
+    const person = rows.find((r) => r.id === `person:${personId}`)!;
+    expect(person.channels.map((ch) => ch.channelUserId).sort()).toEqual([lidJid, phoneJid].sort());
+    expect(person.latest?.preview).toBe("from the lid address");
+  });
+
+  it("answers a search over names and channel identifiers, silent contacts included", async () => {
+    const byName = await fetchPage("?q=silent");
+    expect(byName.identities.map((r) => r.id)).toEqual([`channel:whatsapp:${SILENT_JID}`]);
+
+    const byNumber = await fetchPage("?q=15550001111");
+    expect(byNumber.identities.map((r) => r.id)).toEqual([`channel:whatsapp:${SILENT_JID}`]);
   });
 
   it("answers for one identity by id, whatever page it would land on", async () => {
-    const page = await fetchPage(`?id=${encodeURIComponent("channel:telegram:tg-stranger-999")}`);
-    expect(page.identities.map((r) => r.id)).toEqual(["channel:telegram:tg-stranger-999"]);
+    const page = await fetchPage(`?id=${encodeURIComponent(`channel:whatsapp:${SILENT_JID}`)}`);
+    expect(page.identities.map((r) => r.id)).toEqual([`channel:whatsapp:${SILENT_JID}`]);
     expect(page.nextCursor).toBeNull();
   });
 
   it("pages by activity, and the cursor resumes without repeating a row", async () => {
-    const first = await fetchPage("?limit=2");
+    const first = await fetchPage("?includeNeverMessaged=true&limit=2");
     expect(first.identities).toHaveLength(2);
     expect(first.nextCursor).not.toBeNull();
 
-    const second = await fetchPage(`?limit=2&cursor=${encodeURIComponent(first.nextCursor!)}`);
+    const second = await fetchPage(
+      `?includeNeverMessaged=true&limit=2&cursor=${encodeURIComponent(first.nextCursor!)}`,
+    );
     // A cursor the route ignored would answer an empty page here, and every
     // "no repeats" assertion below would hold vacuously.
     expect(second.identities.length).toBeGreaterThan(0);
@@ -177,33 +324,39 @@ describe("Identities API", () => {
   });
 
   it("counts every level over the whole union, not the page it returned", async () => {
-    const full = await fetchPage();
+    const full = await fetchPage("?includeNeverMessaged=true");
     // One row per page, so a count taken over the page would report at most one
     // of anything — the failure the Unknown chip's signal depends on avoiding.
-    const firstOfMany = await fetchPage("?limit=1");
+    const firstOfMany = await fetchPage("?includeNeverMessaged=true&limit=1");
     expect(firstOfMany.identities).toHaveLength(1);
     expect(firstOfMany.counts).toEqual(full.counts);
     expect(firstOfMany.totals).toEqual(full.totals);
+    expect(firstOfMany.neverMessagedTotal).toEqual(full.neverMessagedTotal);
     expect(full.counts.unknown).toBe(
       full.identities.filter((row) => row.level === "unknown" && row.latest !== null).length,
     );
   });
 
-  it("leaves the guardian out of the chip counts, but not the totals", async () => {
-    const page = await fetchPage();
+  it("leaves the guardian and silent contacts out of the chip counts, but not the totals", async () => {
+    const page = await fetchPage("?includeNeverMessaged=true");
     expect(page.counts.guardian).toBe(0);
     // The directory's headings count the rows they show, guardian included —
     // a heading over one visible row that reads 0 is the number being wrong.
     expect(page.totals.guardian).toBe(
       page.identities.filter((row) => row.level === "guardian").length,
     );
+    expect(page.totals.unknown).toBeGreaterThan(page.counts.unknown);
+    expect(page.neverMessagedTotal).toBeGreaterThan(0);
+    // A contact that has never said anything is not waiting on a decision.
+    const silent = page.identities.filter((row) => row.neverMessaged);
+    expect(silent.length).toBe(page.neverMessagedTotal);
   });
 
   it("filters by level before paging, so a level's view is the whole union", async () => {
-    const page = await fetchPage("?level=unknown");
+    const page = await fetchPage("?level=unknown&includeNeverMessaged=true");
     expect(page.identities.every((row) => row.level === "unknown")).toBe(true);
     // The other chips keep their numbers while one chip's view is on screen.
-    const all = await fetchPage();
+    const all = await fetchPage("?includeNeverMessaged=true");
     expect(page.counts).toEqual(all.counts);
   });
 
@@ -214,7 +367,7 @@ describe("Identities API", () => {
       "tg-spammer",
       "Spammer",
     );
-    const page = await fetchPage("?level=all");
+    const page = await fetchPage("?level=all&includeNeverMessaged=true");
     expect(page.identities.some((row) => row.level === "unknown")).toBe(false);
     expect(page.identities.some((row) => row.level === "stranger")).toBe(false);
   });
@@ -230,16 +383,17 @@ describe("Identities API", () => {
     expect(after.length).toBe(before.length);
   });
 
-  it("sorts identities with a dynamic newest first, and the rest last", async () => {
+  it("sorts talked-to identities newest first and silent ones last", async () => {
     const rows = await fetchRows();
     const at = (id: string) => rows.findIndex((r) => r.id === id);
-    // Alice's sentinel history is the newest thing in the baseline, and Bob has
-    // none at all.
-    expect(at(`person:${baseline.persons.innerCircleId}`)).toBeLessThan(
-      at(`person:${baseline.persons.acquaintanceId}`),
-    );
-    const firstSilent = rows.findIndex((row) => row.latest === null);
-    expect(firstSilent).toBeGreaterThan(0);
-    expect(rows.slice(firstSilent).every((row) => row.latest === null)).toBe(true);
+    // The WhatsApp-only person's message (11:00) is newer than Tina's (10:00);
+    // Silent Sam said nothing and sorts after everyone with history.
+    expect(at(`person:${waOnlyPersonId}`)).toBeLessThan(at(`channel:whatsapp:${TALKING_JID}`));
+    const silentIndex = at(`channel:whatsapp:${SILENT_JID}`);
+    for (const row of rows) {
+      if (row.latest != null) {
+        expect(at(row.id)).toBeLessThan(silentIndex);
+      }
+    }
   });
 });

--- a/packages/core/src/api/routes/identities.test.ts
+++ b/packages/core/src/api/routes/identities.test.ts
@@ -9,9 +9,10 @@ import { persons, sentinelLog } from "../../db/schema.js";
 import { STRANGER_PERSON_ID } from "../../constants.js";
 
 // GET /identities is the People page's one read: a union of curated persons,
-// unmapped sentinel-log senders, and unlinked WhatsApp contacts, all in the
-// shared IdentityRow shape. These tests pin the union's behavior — what shows
-// up, under which typed id and level, and that reading never writes.
+// unmapped sentinel-log senders, and the mirrored address books nobody has
+// placed yet — WhatsApp contacts and LinkedIn participants — all in the shared
+// IdentityRow shape. These tests pin the union's behavior: what shows up, under
+// which typed id and level, and that reading never writes.
 
 const SILENT_JID = "15550001111@s.whatsapp.net";
 const TALKING_JID = "15550002222@s.whatsapp.net";
@@ -395,5 +396,162 @@ describe("Identities API", () => {
         expect(at(row.id)).toBeLessThan(silentIndex);
       }
     }
+  });
+  // LinkedIn is the union's second mirror, and it folds identities on its own
+  // terms: a member id is the identity, a profile URL naming one is the same
+  // identity, and only a direct thread's messages are attributable to one
+  // person. These pin that it lands in the same row shape as WhatsApp.
+  describe("LinkedIn identities", () => {
+    const ADA = "ACoAAAda0001";
+    const GRACE = "ACoAAGrace002";
+    const SELF = "ACoAASelf0003";
+    const LINUS = "ACoAALinus004";
+    const ADA_URL = `https://www.linkedin.com/in/${ADA}/`;
+
+    const participant = (participantId: string, name: string, isSelf = false) => ({
+      participantId,
+      name,
+      headline: null,
+      type: "member",
+      isSelf,
+    });
+
+    const liMessage = (
+      threadId: string,
+      messageId: string,
+      at: string,
+      text: string | null,
+      overrides: { senderIsSelf?: boolean; subject?: string | null } = {},
+    ) => ({
+      messageId,
+      threadId,
+      sentAt: new Date(at),
+      senderIsSelf: overrides.senderIsSelf ?? false,
+      text,
+      subject: overrides.subject ?? null,
+    });
+
+    const ada = participant(ADA, "Ada Lovelace");
+    const grace = participant(GRACE, "Grace Hopper");
+    const linus = participant(LINUS, "Linus Linked");
+    const me = participant(SELF, "Me Myself", true);
+
+    beforeEach(async () => {
+      const thread = (threadId: string) => ({
+        threadId,
+        threadUrl: `https://www.linkedin.com/messaging/thread/${threadId}/`,
+        unread: false,
+      });
+      await deps.linkedInStoreRepo.upsertThreads([
+        thread("li-ada"),
+        thread("li-group"),
+        thread("li-linus"),
+      ]);
+      await deps.linkedInStoreRepo.upsertThreadParticipants("li-ada", [ada, me]);
+      await deps.linkedInStoreRepo.upsertThreadParticipants("li-group", [ada, grace, me]);
+      await deps.linkedInStoreRepo.upsertThreadParticipants("li-linus", [linus, me]);
+      await deps.linkedInStoreRepo.upsertMessages([
+        liMessage("li-ada", "m-1", "2026-08-17T09:00:00Z", "hello from ada"),
+        liMessage("li-ada", "m-2", "2026-08-17T09:30:00Z", "thanks", { senderIsSelf: true }),
+        liMessage("li-group", "m-1", "2026-08-18T09:00:00Z", "a blast to everyone"),
+        liMessage("li-linus", "m-1", "2026-08-17T12:30:00Z", "hi from linus"),
+      ]);
+    });
+
+    it("returns an unplaced participant as an unknown row under their member id", async () => {
+      const row = (await fetchRows()).find((r) => r.id === `channel:linkedin:${ADA}`);
+      expect(row).toBeDefined();
+      expect(row!.level).toBe("unknown");
+      expect(row!.displayName).toBe("Ada Lovelace");
+      expect(row!.neverMessaged).toBe(false);
+      // Both directions of the direct thread, newest word first.
+      expect(row!.latest).toEqual({
+        source: "linkedin",
+        timestamp: Math.floor(new Date("2026-08-17T09:30:00Z").getTime() / 1000),
+        preview: "thanks",
+      });
+      expect(row!.messageCount).toBe(2);
+    });
+
+    it("counts a group thread as nobody's news — a group cannot hold a bond", async () => {
+      const rows = await fetchRows();
+      const grace_ = rows.find((r) => r.id === `channel:linkedin:${GRACE}`)!;
+      // Grace posts only in the group, so she is a mirrored identity with
+      // nothing attributable to her: silent, and held behind the toggle.
+      expect(grace_.latest).toBeNull();
+      expect(grace_.neverMessaged).toBe(true);
+      const hidden = await fetchPage();
+      expect(hidden.identities.some((r) => r.id === `channel:linkedin:${GRACE}`)).toBe(false);
+      // And the group's newer message is not Ada's either.
+      const ada_ = rows.find((r) => r.id === `channel:linkedin:${ADA}`)!;
+      expect(ada_.latest!.timestamp).toBeLessThan(
+        Math.floor(new Date("2026-08-18T09:00:00Z").getTime() / 1000),
+      );
+    });
+
+    it("never offers the account owner as an identity to place", async () => {
+      const rows = await fetchRows();
+      expect(rows.some((r) => r.channels.some((ch) => ch.channelUserId === SELF))).toBe(false);
+    });
+
+    it("projects LinkedIn history onto the person a participant was promoted into", async () => {
+      const personId = await deps.personMappingRepo.create({
+        displayName: "Linus Linked",
+        bondLevel: "acquaintance",
+        approved: true,
+        channelMappings: [{ channel: "linkedin", channelUserId: LINUS }],
+      });
+
+      const rows = await fetchRows();
+      const person = rows.find((r) => r.id === `person:${personId}`)!;
+      expect(person.latest?.preview).toBe("hi from linus");
+      expect(person.latest?.source).toBe("linkedin");
+      expect(person.messageCount).toBe(1);
+      // The promoted participant never shows up a second time as an unknown row.
+      expect(rows.find((r) => r.id === `channel:linkedin:${LINUS}`)).toBeUndefined();
+    });
+
+    it("is one row for a participant whose mapping names their profile URL", async () => {
+      // Promotion writes the bare member id, but the guardian's own mapping is
+      // conferred at connect time as a URL, and an inbound message resolves its
+      // sender's URL to a member id. All name one identity, and comparing them
+      // as strings would show one person as two rows.
+      const personId = await deps.personMappingRepo.create({
+        displayName: "Ada Lovelace",
+        bondLevel: "acquaintance",
+        approved: true,
+        channelMappings: [{ channel: "linkedin", channelUserId: ADA_URL }],
+      });
+
+      const rows = await fetchRows();
+      expect(rows.filter((r) => r.channels.some((ch) => ch.channelUserId === ADA))).toHaveLength(1);
+      expect(rows.find((r) => r.id === `channel:linkedin:${ADA}`)).toBeUndefined();
+      const person = rows.find((r) => r.id === `person:${personId}`)!;
+      expect(person.latest?.preview).toBe("thanks");
+      // The mapping's own form leads, so a client mutating the row addresses
+      // the mapping that exists rather than the one it wishes existed.
+      expect(person.channels.map((ch) => ch.channelUserId)).toEqual([ADA_URL, ADA]);
+    });
+
+    it("folds a sentinel sender onto the participant whose URL it named", async () => {
+      await deps.sentinelLogRepo.create({
+        messageId: "msg-li-1",
+        channel: "linkedin",
+        channelUserId: ADA_URL,
+        displayName: "Ada Lovelace",
+        text: "from the url form",
+        action: "ignored",
+      });
+
+      const rows = await fetchRows();
+      const matching = rows.filter((r) =>
+        r.channels.some((ch) => ch.channel === "linkedin" && ch.channelUserId === ADA),
+      );
+      expect(matching).toHaveLength(1);
+      // The row is offered under the member id, which is the identifier a
+      // placement writes.
+      expect(matching[0].id).toBe(`channel:linkedin:${ADA}`);
+      expect(matching[0].latest?.preview).toBe("from the url form");
+    });
   });
 });

--- a/packages/core/src/api/routes/identities.test.ts
+++ b/packages/core/src/api/routes/identities.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
 import { eq } from "drizzle-orm";
-import type { IdentityPage, IdentityRow } from "@rome/api-types/identities";
+import type { IdentityPage, IdentityRow, TimelinePage } from "@rome/api-types/identities";
 import { identitiesRoutes } from "./identities.js";
 import { createTestDb, buildTestDeps, type TestDb, type TestDeps } from "../../test/helpers.js";
 import { seedBaseline, type BaselineIds } from "../../test/seeds.js";
@@ -13,6 +13,9 @@ import { STRANGER_PERSON_ID } from "../../constants.js";
 // placed yet — WhatsApp contacts and LinkedIn participants — all in the shared
 // IdentityRow shape. These tests pin the union's behavior: what shows up, under
 // which typed id and level, and that reading never writes.
+//
+// GET /identities/:id/timeline is the dossier's read: one identity's history,
+// merged across its channels and paged.
 
 const SILENT_JID = "15550001111@s.whatsapp.net";
 const TALKING_JID = "15550002222@s.whatsapp.net";
@@ -397,6 +400,231 @@ describe("Identities API", () => {
       }
     }
   });
+  describe("person timeline", () => {
+    async function fetchTimeline(id: string, query = ""): Promise<TimelinePage> {
+      const res = await app.request(`/identities/${encodeURIComponent(id)}/timeline${query}`);
+      expect(res.status).toBe(200);
+      return (await res.json()) as TimelinePage;
+    }
+
+    it("merges a person's channels into one newest-first timeline", async () => {
+      // Alice already carries sentinel history on Telegram; this gives her a
+      // newer WhatsApp thread, so both producers have to land in one list.
+      await deps.personMappingRepo.addChannelMapping(
+        baseline.persons.innerCircleId,
+        "whatsapp",
+        TALKING_JID,
+        "Alice WA",
+      );
+      await deps.whatsAppStoreRepo.upsertMessages([
+        {
+          id: "wa-out",
+          chatJid: TALKING_JID,
+          senderJid: null,
+          fromMe: true,
+          timestamp: new Date("2026-08-17T10:05:00Z"),
+          type: "text",
+          text: "on my way",
+          hasMedia: false,
+        },
+      ]);
+
+      const page = await fetchTimeline(`person:${baseline.persons.innerCircleId}`);
+      expect(page.entries.map((entry) => entry.source)).toContain("whatsapp");
+      expect(page.entries.map((entry) => entry.source)).toContain("telegram");
+      const timestamps = page.entries.map((entry) => entry.timestamp);
+      expect([...timestamps].sort((a, b) => b - a)).toEqual(timestamps);
+
+      const outbound = page.entries.find((entry) => entry.ref === "wa-out")!;
+      expect(outbound).toMatchObject({
+        source: "whatsapp",
+        body: "on my way",
+        direction: "outbound",
+      });
+      // Rome's own reply on Telegram is the other outbound entry: the sentinel
+      // log records both halves of an exchange, and the dossier shows both.
+      const reply = page.entries.find((entry) => entry.body === "hello")!;
+      expect(reply).toMatchObject({ source: "telegram", direction: "outbound" });
+      expect(
+        page.entries
+          .filter((entry) => entry.direction === "outbound")
+          .map((entry) => entry.ref)
+          .sort(),
+      ).toEqual(["wa-out", `sentinel:${baseline.sentinelLog.repliedId}:reply`].sort());
+    });
+
+    it("sorts a reply above the message it answers, sharing its second", async () => {
+      const page = await fetchTimeline(`person:${baseline.persons.innerCircleId}`);
+      const reply = page.entries.findIndex((entry) => entry.body === "hello");
+      const inbound = page.entries.findIndex((entry) => entry.body === "hi");
+      expect(reply).toBeGreaterThanOrEqual(0);
+      expect(reply).toBeLessThan(inbound);
+    });
+
+    it("answers for a channel-form identity that has no person row", async () => {
+      const page = await fetchTimeline(`channel:whatsapp:${TALKING_JID}`);
+      expect(page.entries.map((entry) => entry.ref)).toEqual(["wa-1"]);
+      expect(page.entries[0]!.direction).toBe("inbound");
+    });
+
+    it("stops at the end of a thread that fits in one page", async () => {
+      const first = await fetchTimeline(`channel:whatsapp:${TALKING_JID}`, "?limit=1");
+      expect(first.entries).toHaveLength(1);
+      // One message in the thread: the page is complete, so there is nothing to
+      // resume from.
+      expect(first.nextCursor).toBeNull();
+    });
+
+    it("pages through a single channel's history past the first page", async () => {
+      // The common case: one channel, more history than a page. Each producer
+      // answers capped at the page size, so "is there more" cannot be read off
+      // the merged length alone.
+      await deps.whatsAppStoreRepo.upsertMessages(
+        [1, 2, 3, 4, 5].map((n) => ({
+          id: `wa-long-${n}`,
+          chatJid: SILENT_JID,
+          senderJid: SILENT_JID,
+          fromMe: false,
+          timestamp: new Date(Date.UTC(2026, 7, 17, 12, n)),
+          type: "text",
+          text: `message ${n}`,
+          hasMedia: false,
+        })),
+      );
+
+      const seen: string[] = [];
+      let cursor: string | null = null;
+      for (let page = 0; page < 5; page += 1) {
+        const body: TimelinePage = await fetchTimeline(
+          `channel:whatsapp:${SILENT_JID}`,
+          `?limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
+        );
+        seen.push(...body.entries.map((entry) => entry.ref));
+        cursor = body.nextCursor;
+        if (!cursor) break;
+      }
+
+      expect(cursor).toBeNull();
+      expect(seen).toEqual(["wa-long-5", "wa-long-4", "wa-long-3", "wa-long-2", "wa-long-1"]);
+      expect(new Set(seen).size).toBe(seen.length);
+    });
+
+    it("keeps every entry of a second that straddles a page boundary", async () => {
+      // Timestamps are whole seconds and collide, so a cursor that named only
+      // the second would drop whatever else shared it.
+      const sameSecond = new Date("2026-08-17T13:00:00Z");
+      await deps.whatsAppStoreRepo.upsertMessages(
+        ["a", "b", "c"].map((suffix) => ({
+          id: `wa-tie-${suffix}`,
+          chatJid: SILENT_JID,
+          senderJid: SILENT_JID,
+          fromMe: false,
+          timestamp: sameSecond,
+          type: "text",
+          text: `tie ${suffix}`,
+          hasMedia: false,
+        })),
+      );
+
+      const first = await fetchTimeline(`channel:whatsapp:${SILENT_JID}`, "?limit=2");
+      expect(first.nextCursor).not.toBeNull();
+      const second = await fetchTimeline(
+        `channel:whatsapp:${SILENT_JID}`,
+        `?limit=2&cursor=${encodeURIComponent(first.nextCursor!)}`,
+      );
+      const refs = [...first.entries, ...second.entries].map((entry) => entry.ref);
+      expect(refs).toEqual(["wa-tie-a", "wa-tie-b", "wa-tie-c"].sort());
+      expect(new Set(refs).size).toBe(3);
+    });
+
+    it("pages a second that holds more entries than a page, losing none", async () => {
+      // Four messages in one second with a two-entry page: the cursor's second
+      // has to be re-read whole, because the order inside it is not the order
+      // the store can page by.
+      const sameSecond = new Date("2026-08-17T15:00:00Z");
+      await deps.whatsAppStoreRepo.upsertMessages(
+        ["a", "b", "c", "d"].map((suffix) => ({
+          id: `wa-crowd-${suffix}`,
+          chatJid: SILENT_JID,
+          senderJid: SILENT_JID,
+          fromMe: false,
+          timestamp: sameSecond,
+          type: "text",
+          text: `crowd ${suffix}`,
+          hasMedia: false,
+        })),
+      );
+
+      const refs: string[] = [];
+      let cursor: string | null = null;
+      for (let page = 0; page < 10; page += 1) {
+        const query: string = `?limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`;
+        const answer: TimelinePage = await fetchTimeline(`channel:whatsapp:${SILENT_JID}`, query);
+        refs.push(...answer.entries.map((entry) => entry.ref));
+        cursor = answer.nextCursor;
+        if (!cursor) break;
+      }
+      expect(cursor).toBeNull();
+      expect(refs.sort()).toEqual(["wa-crowd-a", "wa-crowd-b", "wa-crowd-c", "wa-crowd-d"]);
+    });
+
+    it("rejects a cursor that is not a timeline cursor", async () => {
+      const res = await app.request(
+        `/identities/${encodeURIComponent(`channel:whatsapp:${TALKING_JID}`)}/timeline?cursor=1234`,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("reads a WhatsApp thread through whichever alias the person is mapped to", async () => {
+      // One person, two addresses: the address book consolidates them, and the
+      // thread may hang off either. A mapping onto the phone jid still has to
+      // find history recorded against the `@lid` one.
+      const phoneJid = "15550009999@s.whatsapp.net";
+      const lidJid = "88817260012@lid";
+      await deps.whatsAppStoreRepo.upsertContacts([
+        { jid: phoneJid, phoneNumber: "15550009999", name: "Two Addresses" },
+        { jid: lidJid, phoneNumber: "15550009999", name: "Two Addresses" },
+      ]);
+      await deps.whatsAppStoreRepo.upsertMessages([
+        {
+          id: "wa-lid-1",
+          chatJid: lidJid,
+          senderJid: lidJid,
+          fromMe: false,
+          timestamp: new Date("2026-08-17T14:00:00Z"),
+          type: "text",
+          text: "sent from the lid thread",
+          hasMedia: false,
+        },
+      ]);
+      const personId = await deps.personMappingRepo.create({
+        displayName: "Two Addresses",
+        bondLevel: "acquaintance",
+        approved: true,
+        channelMappings: [{ channel: "whatsapp", channelUserId: phoneJid }],
+      });
+
+      const page = await fetchTimeline(`person:${personId}`);
+      expect(page.entries.map((entry) => entry.ref)).toEqual(["wa-lid-1"]);
+    });
+
+    it("is empty, not an error, for an identity nothing was ever said to", async () => {
+      const page = await fetchTimeline(`channel:whatsapp:${SILENT_JID}`);
+      expect(page.entries).toEqual([]);
+      expect(page.nextCursor).toBeNull();
+    });
+
+    it("rejects an id that is neither typed form, and 404s an unknown person", async () => {
+      expect((await app.request("/identities/not-an-id/timeline")).status).toBe(400);
+      expect((await app.request("/identities/person%3Anobody/timeline")).status).toBe(404);
+    });
+  });
+
+  // LinkedIn is the union's second mirror, and it folds identities on its own
+  // terms: a member id is the identity, a profile URL naming one is the same
+  // identity, and only a direct thread's messages are attributable to one
+  // person. These pin that it lands in the same row shape as WhatsApp.
+
   // LinkedIn is the union's second mirror, and it folds identities on its own
   // terms: a member id is the identity, a profile URL naming one is the same
   // identity, and only a direct thread's messages are attributable to one

--- a/packages/core/src/api/routes/identities.ts
+++ b/packages/core/src/api/routes/identities.ts
@@ -10,16 +10,19 @@ import {
   parseIdentityFilterLevel,
   personIdentityId,
   sliceIdentityPage,
+  whatsAppDisplayName,
+  type IdentityChannel,
   type IdentityDynamic,
   type IdentityRow,
 } from "@rome/api-types/identities";
 import { STRANGER_PERSON_ID } from "../../constants.js";
 import type { ApiDeps } from "../deps.js";
 
-// The People page's one read: a union of curated persons and the senders the
-// sentinel log saw but nobody placed, every row in the shared `IdentityRow`
-// shape and carrying its newest dynamic. A read — no person row is
-// materialized here, ever; writes stay on the `/persons/*` mutation routes.
+// The People page's one read: a union of curated persons, unmapped senders from
+// the sentinel log, and the WhatsApp contacts nobody has placed yet, every row
+// in the shared `IdentityRow` shape and carrying its newest dynamic. A read —
+// no person row is materialized here, ever; writes stay on the `/persons/*`
+// mutation routes.
 
 interface SentinelActivity {
   channel: string;
@@ -27,6 +30,28 @@ interface SentinelActivity {
   displayName: string | null;
   lastMessage: string | null;
   lastMessageAt: number | null;
+  messageCount: number;
+}
+
+/**
+ * One identity a channel mirror already holds, in the one shape the union
+ * reads mirrors through.
+ *
+ * WhatsApp's address book answers in its own columns. Projecting it onto this
+ * makes every rule below channel-agnostic: adding a second mirror is a branch
+ * in {@link readMirror}, not another special case in the union.
+ */
+interface MirrorIdentity {
+  channel: string;
+  /** The identifier a mapping or a placement should name — the form the
+   *  channel's own `channel_mappings` rows are keyed by. */
+  channelUserId: string;
+  /** Every identifier this identity answers to, `channelUserId` included. */
+  aliases: string[];
+  displayName: string;
+  /** The person this identity was already promoted into, or null. */
+  linkedPersonId: string | null;
+  latest: IdentityDynamic | null;
   messageCount: number;
 }
 
@@ -70,8 +95,14 @@ export function identitiesRoutes(deps: ApiDeps): Hono {
     matching.sort(compareIdentityRows);
 
     // Everything below the query is the page's business, not the union's: the
-    // level, the cursor, and `?id=` all scope which rows come back while the
-    // counts stay whole-union.
+    // level, the silent contacts, the cursor, and `?id=` all scope which rows
+    // come back while the counts stay whole-union. Pruning the silent ones here
+    // instead would answer `neverMessagedTotal: 0` in the very view whose
+    // toggle that number is for.
+    //
+    // A search does reach them: the toggle holds the address book out of the
+    // browsing views, not out of a lookup for a name or number the guardian
+    // typed.
     return c.json(
       sliceIdentityPage(matching, {
         cursor: parsedCursor,
@@ -86,8 +117,65 @@ export function identitiesRoutes(deps: ApiDeps): Hono {
   return app;
 }
 
+/**
+ * Every identity the channel mirrors already hold, projected onto one shape.
+ *
+ * Read whole, not through the address-book endpoint's bound: this answer is
+ * paged, and an identity past a cutoff is one the guardian cannot find, that no
+ * count includes, and whose alias group the cutoff may have split.
+ */
+async function readMirror(deps: ApiDeps): Promise<MirrorIdentity[]> {
+  const contacts = await deps.whatsAppStoreRepo.listContacts({ limit: null });
+
+  const identities: MirrorIdentity[] = [];
+  for (const contact of contacts) {
+    // Group chats are conversations, not identities — they cannot hold a bond.
+    if (contact.isGroup) continue;
+    identities.push({
+      channel: "whatsapp",
+      channelUserId: contact.jid,
+      aliases: contact.aliases.length > 0 ? contact.aliases : [contact.jid],
+      displayName: whatsAppDisplayName(contact) ?? contact.jid,
+      linkedPersonId: contact.linkedPersonId,
+      latest:
+        contact.lastMessageAt == null
+          ? null
+          : {
+              source: "whatsapp",
+              timestamp: contact.lastMessageAt,
+              preview: contact.lastMessagePreview,
+            },
+      messageCount: contact.messageCount,
+    });
+  }
+  return identities;
+}
+
 /** The full union, unordered and unfiltered. */
 async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
+  const mirror = await readMirror(deps);
+  const mirrorByAlias = new Map<string, MirrorIdentity>();
+  for (const identity of mirror) {
+    for (const alias of identity.aliases) {
+      mirrorByAlias.set(activityKey(identity.channel, alias), identity);
+    }
+  }
+
+  // One mirrored identity is one identity however many identifiers address it,
+  // so every one of them answers to the representative form. Without this the
+  // same person is both a curated person (mapped to one form) and an unknown
+  // sender (a sentinel row under another) — two rows the page cannot merge and
+  // the guardian cannot tell apart.
+  //
+  // WhatsApp consolidates a phone jid and a `@lid` jid in the store, so the
+  // fold is a lookup against what it consolidated.
+  const canonicalId = (channel: string, channelUserId: string): string =>
+    mirrorByAlias.get(activityKey(channel, channelUserId))?.channelUserId ?? channelUserId;
+  const identityKey = (channel: string, channelUserId: string) =>
+    activityKey(channel, canonicalId(channel, channelUserId));
+  const mirrorFor = (channel: string, channelUserId: string) =>
+    mirrorByAlias.get(identityKey(channel, channelUserId));
+
   // Bare display_name/text ride SQLite's guarantee that with a lone MAX()
   // aggregate the other selected columns come from the row that supplied the
   // max — i.e. the newest message names the sender.
@@ -103,7 +191,7 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
     GROUP BY channel, channel_user_id
   `)) as Array<Record<string, unknown>>;
 
-  const sentinel = new Map<string, SentinelActivity>();
+  const sentinel = new Map<string, SentinelActivity[]>();
   const senders: SentinelActivity[] = [];
   for (const row of sentinelRows) {
     const activity: SentinelActivity = {
@@ -115,24 +203,82 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
       messageCount: Number(row.messageCount ?? 0),
     };
     senders.push(activity);
-    sentinel.set(activityKey(activity.channel, activity.channelUserId), activity);
+    const key = identityKey(activity.channel, activity.channelUserId);
+    const group = sentinel.get(key);
+    if (group) group.push(activity);
+    else sentinel.set(key, [activity]);
   }
 
+  // The newest word wins across both histories: a channel mirror holds the full
+  // thread, the sentinel log holds what every channel saw. Both are read across
+  // every alias of the identity, so which identifier a mapping happens to name
+  // never decides what the row shows.
   const activityFor = (channel: string, channelUserId: string): ChannelActivity => {
-    const entry = sentinel.get(activityKey(channel, channelUserId));
+    const key = identityKey(channel, channelUserId);
+    const mirrored = mirrorByAlias.get(key);
+    const sentinelEntries = sentinel.get(key) ?? [];
+    const sentinelDynamic = sentinelEntries.reduce<IdentityDynamic | null>(
+      (best, entry) =>
+        newer(
+          best,
+          entry.lastMessageAt == null
+            ? null
+            : { source: channel, timestamp: entry.lastMessageAt, preview: entry.lastMessage },
+        ),
+      null,
+    );
+    const sentinelCount = sentinelEntries.reduce((sum, entry) => sum + entry.messageCount, 0);
     return {
-      latest:
-        entry?.lastMessageAt == null
-          ? null
-          : { source: channel, timestamp: entry.lastMessageAt, preview: entry.lastMessage },
-      messageCount: entry?.messageCount ?? 0,
+      latest: newer(sentinelDynamic, mirrored?.latest ?? null),
+      // The mirror's count when there is one: a mirrored message and the
+      // sentinel row that saw it are one message, and adding them would count
+      // every exchange twice.
+      messageCount: mirrored != null ? mirrored.messageCount : sentinelCount,
     };
   };
 
-  /** Best name on record for an identity with no person row: what the sender
-   *  called themselves, then the raw channel user id. */
-  const displayNameFor = (channel: string, channelUserId: string): string =>
-    sentinel.get(activityKey(channel, channelUserId))?.displayName ?? channelUserId;
+  /**
+   * Every identifier a row's channels answer to.
+   *
+   * A mirrored identity is one identity under several identifiers, and a
+   * mapping names only one of them. The contract asks for all of them because
+   * a search reads this list: an omitted alias is a contact the guardian
+   * cannot reach by the phone number they know. The mapping's own form leads,
+   * so a client mutating the row addresses the mapping that exists.
+   */
+  const channelsOf = (channels: IdentityChannel[]): IdentityChannel[] => {
+    const seen = new Set<string>();
+    const out: IdentityChannel[] = [];
+    const add = (channel: string, channelUserId: string) => {
+      const key = activityKey(channel, channelUserId);
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push({ channel, channelUserId });
+    };
+    for (const channel of channels) {
+      add(channel.channel, channel.channelUserId);
+      for (const alias of mirrorFor(channel.channel, channel.channelUserId)?.aliases ?? []) {
+        add(channel.channel, alias);
+      }
+    }
+    return out;
+  };
+
+  /** Best name on record for an identity with no person row: the mirror's name,
+   *  then what the sender called themselves, then the raw identifier. */
+  const displayNameFor = (channel: string, channelUserId: string): string => {
+    const key = identityKey(channel, channelUserId);
+    const fromSentinel = (sentinel.get(key) ?? []).reduce<SentinelActivity | null>(
+      (best, entry) =>
+        best == null || (entry.lastMessageAt ?? 0) > (best.lastMessageAt ?? 0) ? entry : best,
+      null,
+    );
+    return (
+      mirrorByAlias.get(key)?.displayName ??
+      fromSentinel?.displayName ??
+      canonicalId(channel, channelUserId)
+    );
+  };
 
   // One statement, so an identity moving between two people mid-read cannot
   // land under both of them.
@@ -142,21 +288,42 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
   const rows: IdentityRow[] = [];
   const mapped = new Set<string>();
 
+  // Which person owns each identity, decided once before any row is built. The
+  // unique index already holds one mapping per identifier, but two people can
+  // map two aliases of one identity, and that identity is one row: the lowest
+  // person id takes it, so the union never shows or counts it twice, and shows
+  // the same one on every read.
+  const ownerOf = new Map<string, string>();
   for (const person of persons) {
     for (const mapping of person.channelMappings) {
-      mapped.add(activityKey(mapping.channel, mapping.channelUserId));
+      const key = identityKey(mapping.channel, mapping.channelUserId);
+      if (!ownerOf.has(key)) ownerOf.set(key, person.id);
+    }
+  }
+
+  for (const person of persons) {
+    const owned = person.channelMappings.filter(
+      (mapping) => ownerOf.get(identityKey(mapping.channel, mapping.channelUserId)) === person.id,
+    );
+    for (const mapping of person.channelMappings) {
+      mapped.add(identityKey(mapping.channel, mapping.channelUserId));
     }
 
     if (person.id === STRANGER_PERSON_ID) {
       // The sentinel is a person row, but each dismissed identity is its own
       // row on the ladder — a channel-form id, so recovering one is the same
       // move that places an unknown sender.
-      for (const mapping of person.channelMappings) {
+      for (const mapping of owned) {
         rows.push({
-          id: channelIdentityId(mapping.channel, mapping.channelUserId),
+          id: channelIdentityId(
+            mapping.channel,
+            canonicalId(mapping.channel, mapping.channelUserId),
+          ),
           displayName: displayNameFor(mapping.channel, mapping.channelUserId),
           level: "stranger",
-          channels: [{ channel: mapping.channel, channelUserId: mapping.channelUserId }],
+          channels: channelsOf([
+            { channel: mapping.channel, channelUserId: mapping.channelUserId },
+          ]),
           ...activityFor(mapping.channel, mapping.channelUserId),
           neverMessaged: false,
         });
@@ -164,7 +331,9 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
       continue;
     }
 
-    const activity = person.channelMappings
+    // Only the identities this person owns contribute: an alias another person
+    // already took is that person's history, not a second copy of it here.
+    const activity = owned
       .map((mapping) => activityFor(mapping.channel, mapping.channelUserId))
       .reduce<ChannelActivity>(
         (best, next) => ({
@@ -178,27 +347,46 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
       id: personIdentityId(person.id),
       displayName: person.displayName,
       level: person.bondLevel === "guardian" ? "guardian" : normalizeBondLevel(person.bondLevel),
-      channels: person.channelMappings.map((mapping) => ({
-        channel: mapping.channel,
-        channelUserId: mapping.channelUserId,
-      })),
+      channels: channelsOf(person.channelMappings),
       ...activity,
       neverMessaged: false,
     });
   }
 
-  // Unknown = seen but never placed.
+  // Unknown = seen (or synced) but never placed. Senders first…
   for (const sender of senders) {
-    const key = activityKey(sender.channel, sender.channelUserId);
+    const key = identityKey(sender.channel, sender.channelUserId);
     if (mapped.has(key)) continue;
     mapped.add(key);
     rows.push({
-      id: channelIdentityId(sender.channel, sender.channelUserId),
+      id: channelIdentityId(sender.channel, canonicalId(sender.channel, sender.channelUserId)),
       displayName: displayNameFor(sender.channel, sender.channelUserId),
       level: "unknown",
-      channels: [{ channel: sender.channel, channelUserId: sender.channelUserId }],
+      channels: channelsOf([{ channel: sender.channel, channelUserId: sender.channelUserId }]),
       ...activityFor(sender.channel, sender.channelUserId),
       neverMessaged: false,
+    });
+  }
+
+  // …then mirrored identities the sentinel never saw. `neverMessaged` marks the
+  // silent ones so the page can keep a 9,000-contact address book out of the
+  // stream while search still reaches it.
+  for (const identity of mirror) {
+    if (identity.linkedPersonId != null) continue;
+    const key = identityKey(identity.channel, identity.channelUserId);
+    if (mapped.has(key)) continue;
+    mapped.add(key);
+    const activity = activityFor(identity.channel, identity.channelUserId);
+    rows.push({
+      id: channelIdentityId(identity.channel, identity.channelUserId),
+      displayName: identity.displayName,
+      level: "unknown",
+      channels: identity.aliases.map((alias) => ({
+        channel: identity.channel,
+        channelUserId: alias,
+      })),
+      ...activity,
+      neverMessaged: activity.latest == null,
     });
   }
 

--- a/packages/core/src/api/routes/identities.ts
+++ b/packages/core/src/api/routes/identities.ts
@@ -15,14 +15,15 @@ import {
   type IdentityDynamic,
   type IdentityRow,
 } from "@rome/api-types/identities";
+import { linkedInMemberId } from "../../channels/linkedin-sync.js";
 import { STRANGER_PERSON_ID } from "../../constants.js";
 import type { ApiDeps } from "../deps.js";
 
 // The People page's one read: a union of curated persons, unmapped senders from
-// the sentinel log, and the WhatsApp contacts nobody has placed yet, every row
-// in the shared `IdentityRow` shape and carrying its newest dynamic. A read —
-// no person row is materialized here, ever; writes stay on the `/persons/*`
-// mutation routes.
+// the sentinel log, and the mirrored address books nobody has placed yet —
+// WhatsApp contacts and LinkedIn participants — every row in the shared
+// `IdentityRow` shape and carrying its newest dynamic. A read — no person row is
+// materialized here, ever; writes stay on the `/persons/*` mutation routes.
 
 interface SentinelActivity {
   channel: string;
@@ -37,9 +38,11 @@ interface SentinelActivity {
  * One identity a channel mirror already holds, in the one shape the union
  * reads mirrors through.
  *
- * WhatsApp's address book answers in its own columns. Projecting it onto this
- * makes every rule below channel-agnostic: adding a second mirror is a branch
- * in {@link readMirror}, not another special case in the union.
+ * WhatsApp's address book and LinkedIn's participant table answer the same
+ * question — who this account can reach, and what was last said — in their own
+ * columns. Projecting both onto this makes every rule below channel-agnostic:
+ * adding a third mirror is a branch in {@link readMirror}, not another special
+ * case in the union.
  */
 interface MirrorIdentity {
   channel: string;
@@ -100,7 +103,7 @@ export function identitiesRoutes(deps: ApiDeps): Hono {
     // instead would answer `neverMessagedTotal: 0` in the very view whose
     // toggle that number is for.
     //
-    // A search does reach them: the toggle holds the address book out of the
+    // A search does reach them: the toggle holds the address books out of the
     // browsing views, not out of a lookup for a name or number the guardian
     // typed.
     return c.json(
@@ -120,12 +123,15 @@ export function identitiesRoutes(deps: ApiDeps): Hono {
 /**
  * Every identity the channel mirrors already hold, projected onto one shape.
  *
- * Read whole, not through the address-book endpoint's bound: this answer is
+ * Read whole, not through the address-book endpoints' bounds: this answer is
  * paged, and an identity past a cutoff is one the guardian cannot find, that no
  * count includes, and whose alias group the cutoff may have split.
  */
 async function readMirror(deps: ApiDeps): Promise<MirrorIdentity[]> {
-  const contacts = await deps.whatsAppStoreRepo.listContacts({ limit: null });
+  const [contacts, participants] = await Promise.all([
+    deps.whatsAppStoreRepo.listContacts({ limit: null }),
+    deps.linkedInStoreRepo.listParticipants({ limit: null }),
+  ]);
 
   const identities: MirrorIdentity[] = [];
   for (const contact of contacts) {
@@ -148,6 +154,31 @@ async function readMirror(deps: ApiDeps): Promise<MirrorIdentity[]> {
       messageCount: contact.messageCount,
     });
   }
+  for (const participant of participants) {
+    // The account owner is not an identity to place. Their own row sits in
+    // every thread they are in, and offering it would put the guardian on the
+    // page as a stranger to themselves.
+    if (participant.isSelf) continue;
+    identities.push({
+      channel: "linkedin",
+      channelUserId: participant.participantId,
+      // One member id, one form. A profile URL naming the same member folds
+      // onto it by derivation rather than by a stored alias — see
+      // `canonicalId` in the union.
+      aliases: [participant.participantId],
+      displayName: participant.name ?? participant.participantId,
+      linkedPersonId: participant.linkedPersonId,
+      latest:
+        participant.lastMessageAt == null
+          ? null
+          : {
+              source: "linkedin",
+              timestamp: participant.lastMessageAt,
+              preview: participant.lastMessagePreview,
+            },
+      messageCount: participant.messageCount,
+    });
+  }
   return identities;
 }
 
@@ -167,10 +198,15 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
   // sender (a sentinel row under another) — two rows the page cannot merge and
   // the guardian cannot tell apart.
   //
-  // WhatsApp consolidates a phone jid and a `@lid` jid in the store, so the
-  // fold is a lookup against what it consolidated.
-  const canonicalId = (channel: string, channelUserId: string): string =>
-    mirrorByAlias.get(activityKey(channel, channelUserId))?.channelUserId ?? channelUserId;
+  // Two channels reach that form two ways. WhatsApp consolidates a phone jid
+  // and a `@lid` jid in the store, so the fold is a lookup. LinkedIn's forms —
+  // a bare member id and a profile URL carrying one — fold by derivation, so
+  // an identifier the mirror has never seen still lands on the right key.
+  const canonicalId = (channel: string, channelUserId: string): string => {
+    const derived =
+      channel === "linkedin" ? (linkedInMemberId(channelUserId) ?? channelUserId) : channelUserId;
+    return mirrorByAlias.get(activityKey(channel, derived))?.channelUserId ?? derived;
+  };
   const identityKey = (channel: string, channelUserId: string) =>
     activityKey(channel, canonicalId(channel, channelUserId));
   const mirrorFor = (channel: string, channelUserId: string) =>

--- a/packages/core/src/api/routes/identities.ts
+++ b/packages/core/src/api/routes/identities.ts
@@ -4,26 +4,37 @@ import {
   channelIdentityId,
   compareCodePoints,
   compareIdentityRows,
+  compareTimelineEntries,
   identityMatchesQuery,
+  isAfterTimelineCursor,
   normalizeBondLevel,
   parseIdentityCursor,
   parseIdentityFilterLevel,
+  parseIdentityId,
+  parseTimelineCursor,
   personIdentityId,
   sliceIdentityPage,
+  timelineCursor,
   whatsAppDisplayName,
+  TIMELINE_PAGE_DEFAULT_LIMIT,
+  TIMELINE_PAGE_MAX_LIMIT,
   type IdentityChannel,
   type IdentityDynamic,
   type IdentityRow,
+  type TimelineEntry,
+  type TimelinePage,
 } from "@rome/api-types/identities";
 import { linkedInMemberId } from "../../channels/linkedin-sync.js";
 import { STRANGER_PERSON_ID } from "../../constants.js";
 import type { ApiDeps } from "../deps.js";
 
-// The People page's one read: a union of curated persons, unmapped senders from
-// the sentinel log, and the mirrored address books nobody has placed yet —
-// WhatsApp contacts and LinkedIn participants — every row in the shared
-// `IdentityRow` shape and carrying its newest dynamic. A read — no person row is
-// materialized here, ever; writes stay on the `/persons/*` mutation routes.
+// The People page's two reads. `/identities` is a union of curated persons,
+// unmapped senders from the sentinel log, and the mirrored address books
+// nobody has placed yet — WhatsApp contacts and LinkedIn participants — every
+// row in the shared `IdentityRow` shape and carrying its newest dynamic.
+// `/identities/:id/timeline` merges one identity's dynamics across its
+// channels. Both are reads — no person row is materialized here, ever; writes
+// stay on the `/persons/*` mutation routes.
 
 interface SentinelActivity {
   channel: string;
@@ -117,7 +128,212 @@ export function identitiesRoutes(deps: ApiDeps): Hono {
     );
   });
 
+  // One identity's dynamics, merged across its channels, newest first. Entries
+  // are generic: a producer fills `{source, timestamp, body, direction, ref}`,
+  // so a Rome App that starts contributing history needs no shape change here.
+  app.get("/identities/:id/timeline", async (c) => {
+    const parsed = parseIdentityId(c.req.param("id"));
+    if (!parsed) return c.json({ error: "id must be a person: or channel: identity id" }, 400);
+
+    const channels =
+      parsed.kind === "channel"
+        ? [{ channel: parsed.channel, channelUserId: parsed.channelUserId }]
+        : ((await deps.personMappingRepo.findById(parsed.personId))?.channelMappings ?? null);
+    if (channels === null) return c.json({ error: "Unknown person" }, 404);
+
+    const limit = Math.min(
+      Math.max(parsePositiveInt(c.req.query("limit")) ?? TIMELINE_PAGE_DEFAULT_LIMIT, 1),
+      TIMELINE_PAGE_MAX_LIMIT,
+    );
+    const rawCursor = c.req.query("cursor");
+    const cursor = parseTimelineCursor(rawCursor);
+    if (rawCursor != null && rawCursor !== "" && cursor === null) {
+      return c.json({ error: "cursor is not a timeline cursor" }, 400);
+    }
+
+    // WhatsApp addresses one person by two jids (a phone one and a `@lid`
+    // one), and history can sit under either. Resolving the mapping to every
+    // alias is what keeps a person mapped to the phone jid from showing an
+    // empty timeline while their thread hangs off the lid.
+    const aliases = channels.some((mapping) => mapping.channel === "whatsapp")
+      ? await whatsAppAliases(deps)
+      : new Map<string, string[]>();
+
+    // Deduplicated, because one person can hold two aliases of one contact as
+    // two mappings — the unique index is per identifier, not per identity —
+    // and reading a thread twice would put every one of its entries on the
+    // timeline twice.
+    const targets = new Map<string, { channel: string; channelUserId: string }>();
+    for (const mapping of channels) {
+      const ids =
+        mapping.channel === "whatsapp"
+          ? (aliases.get(mapping.channelUserId) ?? [mapping.channelUserId])
+          : [mapping.channelUserId];
+      for (const channelUserId of ids) {
+        targets.set(activityKey(mapping.channel, channelUserId), {
+          channel: mapping.channel,
+          channelUserId,
+        });
+      }
+    }
+
+    const reads = await Promise.all(
+      [...targets.values()].map((target) => readChannelTimeline(deps, target, { limit, cursor })),
+    );
+
+    // Every producer answers with its own newest `limit + 1`, so the merged
+    // page is the newest of the union and one producer alone can prove more
+    // exists. `saturated` is that proof: without it, a single-channel identity
+    // — the common case — could never report a next page, because its own
+    // answer is capped at the page size and nothing would ever exceed it.
+    const entries = reads.flatMap((read) => read.entries).sort(compareTimelineEntries);
+    const saturated = reads.some((read) => read.saturated);
+    const page = entries.slice(0, limit);
+    const oldest = page.at(-1);
+    const body: TimelinePage = {
+      entries: page,
+      nextCursor:
+        (entries.length > page.length || saturated) && oldest ? timelineCursor(oldest) : null,
+    };
+    return c.json(body);
+  });
+
   return app;
+}
+
+/**
+ * Every dynamic one channel identity has, newest first, from whichever store
+ * holds that channel's history.
+ *
+ * The WhatsApp mirror holds full threads; the sentinel log holds one row per
+ * exchange another channel saw — what arrived, and Rome's reply when it made
+ * one. A mirrored channel reads its mirror and not the sentinel log, because
+ * the sentinel row and the mirrored message are the same message seen twice.
+ * Adding a producer is adding a branch here: the entries it returns are already
+ * in the generic shape.
+ *
+ * Reads one row past the page so the caller can tell "this is everything" from
+ * "this is a page", and answers `saturated` when it hit that cap.
+ *
+ * Reads in whole seconds, never part of one. The merged order settles a second
+ * on `(direction, source, ref)`, which is not an order any producer can page by
+ * in SQL, so a second the cap cuts through leaves entries that no later page
+ * can reach: the next read returns the same rows the cap reached, the cursor
+ * filter drops every one as already sent, and the timeline ends early. So the
+ * cursor's own second is re-read whole and filtered to what follows the cursor,
+ * and the oldest second a capped read touched is completed before it is used.
+ */
+async function readChannelTimeline(
+  deps: ApiDeps,
+  mapping: { channel: string; channelUserId: string },
+  opts: { limit: number; cursor: TimelineEntry | null },
+): Promise<{ entries: TimelineEntry[]; saturated: boolean }> {
+  const fetchLimit = opts.limit + 1;
+  const cursor = opts.cursor;
+  const read = (window: { limit: number | null; before?: number; at?: number }) =>
+    readChannelWindow(deps, mapping, window);
+
+  const [boundary, capped] = await Promise.all([
+    cursor ? read({ limit: null, at: cursor.timestamp }) : null,
+    read({ limit: fetchLimit, before: cursor?.timestamp }),
+  ]);
+
+  const saturated = capped.rows >= fetchLimit;
+  let older = capped.entries;
+  if (saturated && older.length > 0) {
+    const oldestSecond = Math.min(...older.map((entry) => entry.timestamp));
+    const whole = await read({ limit: null, at: oldestSecond });
+    older = [...older.filter((entry) => entry.timestamp !== oldestSecond), ...whole.entries];
+  }
+
+  const resumed =
+    boundary && cursor
+      ? boundary.entries.filter((entry) => isAfterTimelineCursor(entry, cursor))
+      : [];
+  return { entries: [...resumed, ...older], saturated };
+}
+
+/** One producer's rows for a timestamp window, projected onto timeline entries.
+ *  `rows` counts what the store returned, which is what a cap is measured
+ *  against — a sentinel row can carry two entries. */
+async function readChannelWindow(
+  deps: ApiDeps,
+  mapping: { channel: string; channelUserId: string },
+  window: { limit: number | null; before?: number; at?: number },
+): Promise<{ entries: TimelineEntry[]; rows: number }> {
+  if (mapping.channel === "whatsapp") {
+    const messages = await deps.whatsAppStoreRepo.getMessages(mapping.channelUserId, window);
+    return {
+      entries: messages.map((message) => ({
+        source: "whatsapp",
+        timestamp: message.timestamp,
+        body: message.text,
+        direction: message.fromMe ? ("outbound" as const) : ("inbound" as const),
+        ref: message.id,
+      })),
+      rows: messages.length,
+    };
+  }
+
+  const beforeClause = window.before != null ? sql`AND created_at < ${window.before}` : sql``;
+  const atClause = window.at != null ? sql`AND created_at = ${window.at}` : sql``;
+  const limitClause = window.limit == null ? sql`` : sql`LIMIT ${window.limit}`;
+  const rows = (await deps.db.all(sql`
+    SELECT id, text, response, action, created_at AS createdAt
+    FROM sentinel_log
+    WHERE channel = ${mapping.channel} AND channel_user_id = ${mapping.channelUserId}
+      ${beforeClause} ${atClause}
+    ORDER BY created_at DESC
+    ${limitClause}
+  `)) as Array<{
+    id: number | string;
+    text: string | null;
+    response: string | null;
+    action: string | null;
+    createdAt: number | null;
+  }>;
+
+  const entries: TimelineEntry[] = [];
+  for (const row of rows) {
+    const timestamp = Number(row.createdAt ?? 0);
+    entries.push({
+      source: mapping.channel,
+      timestamp,
+      body: row.text,
+      direction: "inbound",
+      ref: `sentinel:${row.id}`,
+    });
+    // A replied row carries what Rome said back. Without it the dossier reads
+    // as one side of a conversation Rome was half of.
+    if (row.action === "replied" && row.response) {
+      entries.push({
+        source: mapping.channel,
+        timestamp,
+        body: row.response,
+        direction: "outbound",
+        ref: `sentinel:${row.id}:reply`,
+      });
+    }
+  }
+
+  return { entries, rows: rows.length };
+}
+
+/**
+ * Every jid one WhatsApp identity answers to, keyed by each of them.
+ *
+ * The address book consolidates a person's phone jid and `@lid` jid into one
+ * contact, but a mapping may name either. Reading history for all of them is
+ * what keeps the choice of alias out of what the guardian sees.
+ */
+async function whatsAppAliases(deps: ApiDeps): Promise<Map<string, string[]>> {
+  const contacts = await deps.whatsAppStoreRepo.listContacts({ limit: null });
+  const byJid = new Map<string, string[]>();
+  for (const contact of contacts) {
+    const aliases = contact.aliases.length > 0 ? contact.aliases : [contact.jid];
+    for (const alias of aliases) byJid.set(alias, aliases);
+  }
+  return byJid;
 }
 
 /**

--- a/packages/core/src/api/routes/linkedin-threads.test.ts
+++ b/packages/core/src/api/routes/linkedin-threads.test.ts
@@ -34,6 +34,9 @@ const ADA: LinkedInParticipantContactRow = {
   threadCount: 2,
   linkedPersonId: null,
   linkedPersonName: null,
+  lastMessageAt: 1_776_000_000,
+  lastMessagePreview: "See you Thursday",
+  messageCount: 2,
 };
 
 function buildDeps(threads = [THREAD], participants = [ADA]): ApiDeps {

--- a/packages/core/src/channels/linkedin-sync.ts
+++ b/packages/core/src/channels/linkedin-sync.ts
@@ -39,17 +39,42 @@ export interface LinkedInMessageInput {
   reactionCount?: number | null;
 }
 
-// The obfuscated member id inside a mirrored profile URL —
-// `https://www.linkedin.com/in/ACoAA…/`. A vanity handle (`/in/ada-lovelace`)
-// deliberately does not match: it is a public alias, not the member id these
+// The obfuscated member id LinkedIn gives an account, in the two forms the
+// mirror ever holds one: bare, and inside a profile URL
+// (`https://www.linkedin.com/in/ACoAA…/`). A vanity handle (`/in/ada-lovelace`)
+// deliberately matches neither: it is a public alias, not the member id these
 // tables key on, and storing one would break the correspondence with
 // `channel_mappings.channel_user_id`.
-const MEMBER_ID_IN_PROFILE_URL = /\/in\/(ACoAA[A-Za-z0-9_-]+)/;
+const MEMBER_ID = /ACoAA[A-Za-z0-9_-]+/;
+const MEMBER_ID_IN_PROFILE_URL = new RegExp(`/in/(${MEMBER_ID.source})`);
+const BARE_MEMBER_ID = new RegExp(`^${MEMBER_ID.source}$`);
 
 /** The bare LinkedIn member id inside a stored profile URL, or null. */
 export function linkedInMemberIdFromProfileUrl(url: string | null | undefined): string | null {
   if (!url) return null;
   return MEMBER_ID_IN_PROFILE_URL.exec(url)?.[1] ?? null;
+}
+
+/**
+ * The member id a stored LinkedIn identifier names, or null when it names none.
+ *
+ * A `linkedin` `channel_mappings.channel_user_id` is written in whichever form
+ * the write that created it had: promotion writes the bare member id, an
+ * inbound message resolves its sender's profile URL to one, and the guardian's
+ * own mapping is conferred at connect time as a vanity URL that carries no
+ * member id at all. All but the last name the same identity, and a reader that
+ * compared them as strings would show one person as two rows and read their
+ * history under only one of them.
+ *
+ * Null is the answer for the vanity form, and it is a useful one: it says the
+ * identifier cannot appear in `linkedin_participants` — that table is primary
+ * keyed by the bare member id — so a reader knows the mirror holds nothing for
+ * it without asking.
+ */
+export function linkedInMemberId(channelUserId: string | null | undefined): string | null {
+  if (!channelUserId) return null;
+  if (BARE_MEMBER_ID.test(channelUserId)) return channelUserId;
+  return linkedInMemberIdFromProfileUrl(channelUserId);
 }
 
 /** One identity in a thread's participant list, per the thread snapshot. */

--- a/packages/core/src/db/repositories/linkedin-store.test.ts
+++ b/packages/core/src/db/repositories/linkedin-store.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { sql } from "drizzle-orm";
 import { createTestDb, type TestDb } from "../../test/helpers.js";
-import { LinkedInStoreRepository, linkedInMemberIdFromProfileUrl } from "./linkedin-store.js";
+import {
+  LinkedInStoreRepository,
+  linkedInMemberId,
+  linkedInMemberIdFromProfileUrl,
+} from "./linkedin-store.js";
 import { PersonMappingRepository } from "./person-mapping.js";
 
 describe("LinkedInStoreRepository", () => {
@@ -807,6 +811,116 @@ describe("LinkedInStoreRepository", () => {
       });
     });
   });
+
+  // The identity union reads a participant as a person-shaped row: who they
+  // are, what was last said, and how much of it there is. "What was said" is
+  // the direct threads only — a timeline entry names no sender, so a group
+  // thread's messages cannot be attributed to one of its members.
+  describe("participant activity", () => {
+    const ada = {
+      participantId: "ACoAAAda0001",
+      name: "Ada Lovelace",
+      headline: "Engineer",
+      type: "member",
+      isSelf: false,
+    };
+    const grace = {
+      participantId: "ACoAAGrace002",
+      name: "Grace Hopper",
+      headline: null,
+      type: "member",
+      isSelf: false,
+    };
+    const self = {
+      participantId: "ACoAASelf0003",
+      name: "Me Myself",
+      headline: null,
+      type: "member",
+      isSelf: true,
+    };
+
+    const message = (
+      threadId: string,
+      messageId: string,
+      at: string,
+      text: string | null,
+      overrides: { senderIsSelf?: boolean; subject?: string | null } = {},
+    ) => ({
+      messageId,
+      threadId,
+      sentAt: new Date(at),
+      senderName: "Ada Lovelace",
+      senderProfileUrl: `https://www.linkedin.com/in/${ada.participantId}/`,
+      senderHeadline: null,
+      senderType: "member",
+      senderIsSelf: overrides.senderIsSelf ?? false,
+      text,
+      subject: overrides.subject ?? null,
+      reactionCount: null,
+    });
+
+    const seconds = (at: string) => Math.floor(Date.parse(at) / 1000);
+
+    beforeEach(async () => {
+      await repo.upsertThreads([
+        thread("t-direct", new Date("2026-08-19T20:00:00Z")),
+        thread("t-group", new Date("2026-08-20T20:00:00Z")),
+      ]);
+      await repo.upsertThreadParticipants("t-direct", [ada, self]);
+      await repo.upsertThreadParticipants("t-group", [ada, grace, self]);
+      await repo.upsertMessages([
+        message("t-direct", "m-1", "2026-08-19T10:00:00Z", "hello from the 1:1"),
+        message("t-direct", "m-2", "2026-08-19T11:00:00Z", "on my way", { senderIsSelf: true }),
+        message("t-group", "m-3", "2026-08-20T10:00:00Z", "hello everyone"),
+      ]);
+    });
+
+    it("reports a direct thread's newest message, both directions counted", async () => {
+      const row = (await repo.listParticipants()).find(
+        (r) => r.participantId === ada.participantId,
+      )!;
+      expect(row.lastMessageAt).toBe(seconds("2026-08-19T11:00:00Z"));
+      expect(row.lastMessagePreview).toBe("on my way");
+      expect(row.messageCount).toBe(2);
+    });
+
+    it("leaves a group thread out of a member's activity", async () => {
+      const rows = await repo.listParticipants();
+      // Grace is only ever on the group thread, so nothing is attributable to
+      // her — the newer group message is not her news, and never Ada's either.
+      expect(rows.find((r) => r.participantId === grace.participantId)).toMatchObject({
+        lastMessageAt: null,
+        lastMessagePreview: null,
+        messageCount: 0,
+      });
+      const ada_ = rows.find((r) => r.participantId === ada.participantId)!;
+      expect(ada_.lastMessageAt).toBeLessThan(seconds("2026-08-20T10:00:00Z"));
+    });
+
+    it("counts a thread LinkedIn calls a group as one, whatever its membership says", async () => {
+      // The flag gets a veto over the membership: a two-row participant set on
+      // a thread the snapshot flagged as a group is a set that was read before
+      // the rest of the members were.
+      await repo.upsertThreads([thread("t-flagged", new Date("2026-08-21T20:00:00Z"))]);
+      await repo.markThreadSynced("t-flagged", { isGroup: true });
+      await repo.upsertThreadParticipants("t-flagged", [grace, self]);
+      await repo.upsertMessages([
+        message("t-flagged", "m-4", "2026-08-21T10:00:00Z", "in a group"),
+      ]);
+
+      const row = (await repo.listParticipants()).find(
+        (r) => r.participantId === grace.participantId,
+      )!;
+      expect(row.messageCount).toBe(0);
+    });
+
+    it("bounds the participant read by default, and reads it whole on request", async () => {
+      // The paged identity union cannot inherit a cutoff: an identity past it
+      // is one the guardian cannot find and no count includes.
+      expect(await repo.listParticipants({ limit: 2 })).toHaveLength(2);
+      expect(await repo.listParticipants({ limit: null })).toHaveLength(3);
+    });
+  });
 });
 
 describe("linkedInMemberIdFromProfileUrl", () => {
@@ -825,5 +939,22 @@ describe("linkedInMemberIdFromProfileUrl", () => {
     expect(linkedInMemberIdFromProfileUrl("https://www.linkedin.com/company/acme/")).toBeNull();
     expect(linkedInMemberIdFromProfileUrl(null)).toBeNull();
     expect(linkedInMemberIdFromProfileUrl("")).toBeNull();
+  });
+});
+
+describe("linkedInMemberId", () => {
+  it("accepts both forms a stored channel identity is written in", () => {
+    expect(linkedInMemberId("ACoAAAda0001")).toBe("ACoAAAda0001");
+    expect(linkedInMemberId("https://www.linkedin.com/in/ACoAAAda0001/")).toBe("ACoAAAda0001");
+  });
+
+  it("refuses the vanity form, which names no mirrored participant", () => {
+    // `linkedin_participants` is primary keyed by the bare member id, so null
+    // here tells a reader the mirror holds nothing for this identifier without
+    // asking — and the guardian's own mapping is conferred in exactly this form.
+    expect(linkedInMemberId("https://www.linkedin.com/in/ada-lovelace/")).toBeNull();
+    expect(linkedInMemberId("linkedin:self")).toBeNull();
+    expect(linkedInMemberId(null)).toBeNull();
+    expect(linkedInMemberId("")).toBeNull();
   });
 });

--- a/packages/core/src/db/repositories/linkedin-store.ts
+++ b/packages/core/src/db/repositories/linkedin-store.ts
@@ -6,7 +6,7 @@ import {
   linkedinThreads,
 } from "../schema.js";
 import type { DrizzleDb } from "../index.js";
-import { linkedInMemberIdFromProfileUrl } from "../../channels/linkedin-sync.js";
+import { linkedInMemberId, linkedInMemberIdFromProfileUrl } from "../../channels/linkedin-sync.js";
 import type {
   LinkedInHistoryMessage,
   LinkedInMessageInput,
@@ -17,10 +17,10 @@ import type {
   LinkedInThreadInput,
 } from "../../channels/linkedin-sync.js";
 
-// The member-id form lives with the poller/store contract, not here: it is the
-// identity both sides of the mirror agree on. Re-exported so callers reading
-// participant rows reach it from the same module those rows come from.
-export { linkedInMemberIdFromProfileUrl };
+// The member-id forms live with the poller/store contract, not here: they are
+// the identity both sides of the mirror agree on. Re-exported so callers
+// reading participant rows reach them from the same module those rows come from.
+export { linkedInMemberId, linkedInMemberIdFromProfileUrl };
 
 const UPSERT_CHUNK = 200;
 const HISTORY_READ_LIMIT = 1000;
@@ -86,6 +86,15 @@ export interface LinkedInParticipantContactRow {
   /** The person this identity was promoted into, or null when unpromoted. */
   linkedPersonId: string | null;
   linkedPersonName: string | null;
+  /**
+   * Unix seconds of the newest message on this identity's direct threads, or
+   * null when the mirror holds none. See {@link DIRECT_THREADS} for why a group
+   * thread contributes nothing.
+   */
+  lastMessageAt: number | null;
+  lastMessagePreview: string | null;
+  /** Mirrored messages on this identity's direct threads, both directions. */
+  messageCount: number;
 }
 
 /** One thread's membership paired with the age of the read that produced it. */
@@ -102,6 +111,44 @@ export interface LinkedInParticipantBackfillResult {
   /** Distinct identities the seed proved. */
   participants: number;
 }
+
+/**
+ * Every (thread, counterparty) pair where that counterparty is the only one on
+ * the thread — the LinkedIn analog of a WhatsApp 1:1 chat.
+ *
+ * A thread is what carries messages, and only a direct thread's messages are
+ * unambiguously *this* person's history: a timeline entry names no sender, so
+ * folding a ten-person thread into one member's dossier would put nine other
+ * people's words in their mouth. The People page already holds group chats out
+ * of the identity union for the same reason — a group cannot hold a bond.
+ *
+ * Membership decides it, not LinkedIn's `is_group` flag alone: that flag is
+ * null until a thread snapshot reports one, and a thread seeded from stored
+ * messages has membership but no snapshot. The flag still gets a veto, so a
+ * thread LinkedIn calls a group is never direct however little of its
+ * membership has been mirrored.
+ *
+ * The account owner is not a counterparty: their own row is on every thread
+ * they are in, and treating it as one would make every 1:1 thread look like a
+ * pair.
+ */
+const DIRECT_THREADS = sql`
+  direct_threads AS (
+    SELECT tp.thread_id AS threadId, tp.participant_id AS participantId
+    FROM linkedin_thread_participants tp
+    LEFT JOIN linkedin_threads t ON t.thread_id = tp.thread_id
+    LEFT JOIN linkedin_participants p ON p.participant_id = tp.participant_id
+    WHERE coalesce(p.is_self, 0) = 0
+      AND coalesce(t.is_group, 0) = 0
+      AND NOT EXISTS (
+        SELECT 1 FROM linkedin_thread_participants other
+        LEFT JOIN linkedin_participants op ON op.participant_id = other.participant_id
+        WHERE other.thread_id = tp.thread_id
+          AND other.participant_id <> tp.participant_id
+          AND coalesce(op.is_self, 0) = 0
+      )
+  )
+`;
 
 function chunked<T>(items: T[], size: number): T[][] {
   const out: T[][] = [];
@@ -521,16 +568,27 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
 
   /**
    * Every stored LinkedIn identity, each row saying whether it has already been
-   * promoted to a person. The join is on the member id itself — no translation
-   * step — because `linkedin_participants.participant_id` and a `linkedin`
+   * promoted to a person and what its direct threads last carried. The join is
+   * on the member id itself — no translation step — because
+   * `linkedin_participants.participant_id` and a `linkedin`
    * `channel_mappings.channel_user_id` are the same identifier by construction.
    *
    * Promotion is a guardian action against these rows, not something this
    * repository performs: a LinkedIn inbox holds many identities that should
    * never enter the curated person graph, so nothing here writes `persons`.
+   *
+   * Bounded by default, for the endpoint that hands the list to a client in one
+   * payload. `{ limit: null }` reads it whole, for the identity union, which
+   * pages its own answer and therefore cannot inherit a cutoff: a truncated
+   * read there is an identity missing from a search and from every count.
    */
-  async listParticipants(): Promise<LinkedInParticipantContactRow[]> {
+  async listParticipants(
+    opts: { limit?: number | null } = {},
+  ): Promise<LinkedInParticipantContactRow[]> {
+    const limit = opts.limit === undefined ? PARTICIPANTS_READ_LIMIT : opts.limit;
+    const limitClause = limit == null ? sql`` : sql`LIMIT ${limit}`;
     const rows = (await this.db.all(sql`
+      WITH ${DIRECT_THREADS}
       SELECT
         p.participant_id AS participantId,
         p.name AS name,
@@ -540,13 +598,27 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
         (SELECT COUNT(*) FROM linkedin_thread_participants tp
            WHERE tp.participant_id = p.participant_id) AS threadCount,
         cm.person_id AS linkedPersonId,
-        person.display_name AS linkedPersonName
+        person.display_name AS linkedPersonName,
+        (SELECT MAX(coalesce(m.sent_at, m.created_at))
+           FROM linkedin_messages m
+           JOIN direct_threads d ON d.threadId = m.thread_id
+           WHERE d.participantId = p.participant_id) AS lastMessageAt,
+        (SELECT coalesce(nullif(m.text, ''), m.subject)
+           FROM linkedin_messages m
+           JOIN direct_threads d ON d.threadId = m.thread_id
+           WHERE d.participantId = p.participant_id
+           ORDER BY coalesce(m.sent_at, m.created_at) DESC, m.rowid DESC
+           LIMIT 1) AS lastMessagePreview,
+        (SELECT COUNT(*)
+           FROM linkedin_messages m
+           JOIN direct_threads d ON d.threadId = m.thread_id
+           WHERE d.participantId = p.participant_id) AS messageCount
       FROM linkedin_participants p
       LEFT JOIN channel_mappings cm
         ON cm.channel = 'linkedin' AND cm.channel_user_id = p.participant_id
       LEFT JOIN persons person ON person.id = cm.person_id
       ORDER BY lower(coalesce(p.name, p.participant_id)) ASC, p.participant_id ASC
-      LIMIT ${PARTICIPANTS_READ_LIMIT}
+      ${limitClause}
     `)) as Array<Record<string, unknown>>;
 
     return rows.map((r) => ({
@@ -558,6 +630,9 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
       threadCount: Number(r.threadCount ?? 0),
       linkedPersonId: (r.linkedPersonId as string | null) ?? null,
       linkedPersonName: (r.linkedPersonName as string | null) ?? null,
+      lastMessageAt: r.lastMessageAt == null ? null : Number(r.lastMessageAt),
+      lastMessagePreview: (r.lastMessagePreview as string | null) ?? null,
+      messageCount: Number(r.messageCount ?? 0),
     }));
   }
 

--- a/packages/core/src/db/repositories/whatsapp-store.test.ts
+++ b/packages/core/src/db/repositories/whatsapp-store.test.ts
@@ -32,6 +32,19 @@ describe("WhatsAppStoreRepository", () => {
     expect(alice?.messageCount).toBe(0);
   });
 
+  it("bounds the address-book read by default, and reads it whole on request", async () => {
+    // The paged identity union cannot inherit a cutoff: a contact past it is
+    // one the guardian cannot find and no count includes.
+    await repo.upsertContacts([
+      { jid: "a1@s.whatsapp.net", phoneNumber: "1", name: "One" },
+      { jid: "a2@s.whatsapp.net", phoneNumber: "2", name: "Two" },
+      { jid: "a3@s.whatsapp.net", phoneNumber: "3", name: "Three" },
+    ]);
+
+    expect(await repo.listContacts({ limit: 2 })).toHaveLength(2);
+    expect(await repo.listContacts({ limit: null })).toHaveLength(3);
+  });
+
   it("hides nameless LID-only contacts but keeps LIDs with a phone identity", async () => {
     await repo.upsertContacts([
       { jid: "raw-lid@lid" },

--- a/packages/core/src/db/repositories/whatsapp-store.ts
+++ b/packages/core/src/db/repositories/whatsapp-store.ts
@@ -335,13 +335,23 @@ export class WhatsAppStoreRepository implements WhatsAppSyncSink {
     return consolidateByIdentity(mapped);
   }
 
-  /** Recent messages for one chat, oldest→newest (newest at the bottom). */
+  /**
+   * Recent messages for one chat, oldest→newest (newest at the bottom).
+   *
+   * `before` and `at` bound the window by timestamp: `before` excludes that
+   * second and everything after it, `at` restricts the read to exactly that
+   * second. A caller paging a merged order that timestamps alone cannot settle
+   * reads the boundary second with `at` and no limit, because a cap applied
+   * inside a second drops whichever of its messages the cap did not reach.
+   */
   async getMessages(
     chatJid: string,
-    opts: { limit?: number; before?: number } = {},
+    opts: { limit?: number | null; before?: number; at?: number } = {},
   ): Promise<WhatsAppMessageRow[]> {
-    const limit = Math.min(Math.max(opts.limit ?? 50, 1), 500);
+    const limitClause =
+      opts.limit === null ? sql`` : sql`LIMIT ${Math.min(Math.max(opts.limit ?? 50, 1), 500)}`;
     const beforeClause = opts.before != null ? sql`AND timestamp < ${opts.before}` : sql``;
+    const atClause = opts.at != null ? sql`AND timestamp = ${opts.at}` : sql``;
     const rows = (await this.db.all(sql`
       SELECT m.id AS id, m.sender_jid AS senderJid,
         coalesce(sc.name, sc.notify, sc.verified_name) AS senderName,
@@ -351,9 +361,9 @@ export class WhatsAppStoreRepository implements WhatsAppSyncSink {
         reacts_to_id AS reactsToId
       FROM wa_messages m
       LEFT JOIN wa_contacts sc ON sc.jid = m.sender_jid
-      WHERE m.chat_jid = ${chatJid} ${beforeClause}
+      WHERE m.chat_jid = ${chatJid} ${beforeClause} ${atClause}
       ORDER BY m.timestamp DESC, m.rowid DESC
-      LIMIT ${limit}
+      ${limitClause}
     `)) as Array<Record<string, unknown>>;
 
     return rows

--- a/packages/core/src/db/repositories/whatsapp-store.ts
+++ b/packages/core/src/db/repositories/whatsapp-store.ts
@@ -86,6 +86,7 @@ function consolidateByIdentity(rows: WhatsAppContactRow[]): WhatsAppContactRow[]
     );
     merged.push({
       ...primary,
+      aliases: group.flatMap((r) => r.aliases),
       phoneNumber: coalesceField(group, "phoneNumber"),
       name: coalesceField(group, "name"),
       notify: coalesceField(group, "notify"),
@@ -104,6 +105,15 @@ function consolidateByIdentity(rows: WhatsAppContactRow[]): WhatsAppContactRow[]
 
 export interface WhatsAppContactRow {
   jid: string;
+  /**
+   * Every jid this row stands for, the representative `jid` included.
+   *
+   * One person reachable at both a phone jid and a `@lid` jid is one contact
+   * here, but a channel mapping may name either address. Readers that resolve
+   * a mapping to activity or history match against these rather than `jid`,
+   * so which alias was mapped stops being visible.
+   */
+  aliases: string[];
   phoneNumber: string | null;
   name: string | null;
   notify: string | null;
@@ -251,8 +261,16 @@ export class WhatsAppStoreRepository implements WhatsAppSyncSink {
   /**
    * The synced address book, newest-conversation-first then alphabetical,
    * each row annotated with whether it has been promoted to a `persons` entry.
+   *
+   * Bounded by default, for the endpoint that hands the list to a client in one
+   * payload. `{ limit: null }` reads it whole, for a caller that pages its own
+   * answer and therefore cannot inherit a cutoff: a truncated read there is a
+   * contact missing from a search, uncounted, and — because the cut can fall
+   * inside an alias group — a contact split in two.
    */
-  async listContacts(): Promise<WhatsAppContactRow[]> {
+  async listContacts(opts: { limit?: number | null } = {}): Promise<WhatsAppContactRow[]> {
+    const limit = opts.limit === undefined ? CONTACTS_READ_LIMIT : opts.limit;
+    const limitClause = limit == null ? sql`` : sql`LIMIT ${limit}`;
     const rows = (await this.db.all(sql`
       WITH wa_threads AS (
         SELECT jid FROM wa_contacts
@@ -294,11 +312,12 @@ export class WhatsAppStoreRepository implements WhatsAppSyncSink {
       )
       ORDER BY (lastMessageAt IS NULL) ASC, lastMessageAt DESC,
         lower(coalesce(c.name, c.notify, c.verified_name, ch.name, c.phone_number, t.jid)) ASC
-      LIMIT ${CONTACTS_READ_LIMIT}
+      ${limitClause}
     `)) as Array<Record<string, unknown>>;
 
     const mapped = rows.map((r) => ({
       jid: String(r.jid),
+      aliases: [String(r.jid)],
       phoneNumber: (r.phoneNumber as string | null) ?? null,
       name: (r.name as string | null) ?? null,
       notify: (r.notify as string | null) ?? null,


### PR DESCRIPTION
Fourth of five. Stacked on #48 — **review and merge #46, #47 and #48 first**. This PR's base is #48's branch, so the diff shows only this PR's own commit.

## What this PR does

An identity's history is scattered across the stores that hold it. The WhatsApp mirror holds full threads, the sentinel log holds one row per exchange another channel saw, and nothing merges them, so the People page can show who someone is but not what happened with them.

`GET /api/identities/:id/timeline` answers that merge, newest first and paged.

## Design & Invariants

**Entries are generic.** A producer fills `{source, timestamp, body, direction, ref}`, so a Rome App that starts contributing history needs no shape change here.

**A mirrored channel reads its mirror, never the sentinel log too.** A sentinel row and the mirrored message it saw are the same message, and reading both would double every exchange.

**A page is bounded, the answer is not.** Every producer reads one row past the page and reports whether it hit that cap, so "there is more" is a fact about the database rather than about the merged length. Without it a single-channel identity — the common case — can never page past the first page, because its own answer is capped at the page size and nothing ever exceeds it.

**A producer reads in whole seconds, never part of one.** The merged order settles a second on `(direction, source, ref)`, which is not an order any producer can page by in SQL, so a second the cap cuts through strands entries no later page can reach: the next read returns the same rows the cap reached, the cursor drops every one as already sent, and the timeline ends early. The cursor's second is re-read whole, and the oldest second a capped read touched is completed before use. That is what `getMessages`'s new `at` window is for.

**The cursor names an entry, not a second.** Timestamps are whole seconds and collide across producers, and a reply Rome sent shares the second of the message it answers.

**A reply sits above the line it answers.** The sentinel log records both halves of an exchange, and a dossier showing only the inbound half reads as one side of a conversation Rome was half of.

**A person holding two aliases of one contact reads their thread once.** The unique index is per identifier rather than per identity, so a person can legitimately hold both, and reading the thread twice would put every one of its entries on the page twice.

**A WhatsApp thread is read through every alias.** A person mapped to the phone jid still has to find history recorded against the `@lid` one.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run` in `packages/core` — 479 pass across the touched areas. New coverage: two producers merged into one newest-first list, a reply sorted above the message it answers in the same second, a channel-form identity with no person row, a thread that fits in one page reporting no cursor, a single channel paged past the first page, every entry of a second that straddles a page boundary, a second holding more entries than a page losing none, a thread read through the alias the person is not mapped to, an empty timeline rather than an error, and 400/404 on a malformed id and an unknown person
- [x] `biome check` clean on every touched path

## Not in this PR

- LinkedIn's mirror on the timeline — the PR stacked on this one. A LinkedIn identity reads the sentinel log until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
