### PR TITLE
feat(core): put LinkedIn history on the merged timeline

### DIFF
--- a/packages/core/src/api/routes/identities.test.ts
+++ b/packages/core/src/api/routes/identities.test.ts
@@ -635,6 +635,7 @@ describe("Identities API", () => {
     const SELF = "ACoAASelf0003";
     const LINUS = "ACoAALinus004";
     const ADA_URL = `https://www.linkedin.com/in/${ADA}/`;
+    const VANITY_URL = "https://www.linkedin.com/in/ada-lovelace/";
 
     const participant = (participantId: string, name: string, isSelf = false) => ({
       participantId,
@@ -780,6 +781,105 @@ describe("Identities API", () => {
       // placement writes.
       expect(matching[0].id).toBe(`channel:linkedin:${ADA}`);
       expect(matching[0].latest?.preview).toBe("from the url form");
+    });
+    describe("timeline", () => {
+      async function fetchTimeline(id: string, query = ""): Promise<TimelinePage> {
+        const res = await app.request(`/identities/${encodeURIComponent(id)}/timeline${query}`);
+        expect(res.status).toBe(200);
+        return (await res.json()) as TimelinePage;
+      }
+
+      it("reads a direct thread for an identity with no person row", async () => {
+        const page = await fetchTimeline(`channel:linkedin:${ADA}`);
+        // Refs carry the thread, because a LinkedIn message id is unique
+        // within a thread and this list merges a person's threads.
+        expect(page.entries.map((entry) => entry.ref)).toEqual(["li-ada:m-2", "li-ada:m-1"]);
+        expect(page.entries[0]).toMatchObject({
+          source: "linkedin",
+          body: "thanks",
+          direction: "outbound",
+        });
+        expect(page.entries[1]!.direction).toBe("inbound");
+      });
+
+      it("merges LinkedIn into a person's other channels, newest first", async () => {
+        await deps.personMappingRepo.addChannelMapping(
+          baseline.persons.innerCircleId,
+          "linkedin",
+          ADA,
+          "Ada Lovelace",
+        );
+        const page = await fetchTimeline(`person:${baseline.persons.innerCircleId}`);
+        const sources = page.entries.map((entry) => entry.source);
+        expect(sources).toContain("linkedin");
+        expect(sources).toContain("telegram");
+        const timestamps = page.entries.map((entry) => entry.timestamp);
+        expect([...timestamps].sort((a, b) => b - a)).toEqual(timestamps);
+      });
+
+      it("reads the mirror through a mapping written as a profile URL", async () => {
+        const personId = await deps.personMappingRepo.create({
+          displayName: "Ada Lovelace",
+          bondLevel: "acquaintance",
+          approved: true,
+          channelMappings: [{ channel: "linkedin", channelUserId: ADA_URL }],
+        });
+        const page = await fetchTimeline(`person:${personId}`);
+        expect(page.entries.map((entry) => entry.ref)).toEqual(["li-ada:m-2", "li-ada:m-1"]);
+      });
+
+      it("renders an InMail's subject with the body it was sent apart from", async () => {
+        await deps.linkedInStoreRepo.upsertMessages([
+          liMessage("li-linus", "m-inmail", "2026-08-17T13:00:00Z", "Are you open to a chat?", {
+            subject: "An opportunity",
+          }),
+        ]);
+        const page = await fetchTimeline(`channel:linkedin:${LINUS}`);
+        expect(page.entries[0]!.body).toBe("An opportunity\nAre you open to a chat?");
+      });
+
+      it("falls back to the sentinel log for a mapping that names no member", async () => {
+        // A vanity URL is the form the guardian's own mapping is conferred in,
+        // and it can never appear in the participant mirror — so the sentinel
+        // log is where that identity's history actually is.
+        await deps.sentinelLogRepo.create({
+          messageId: "msg-vanity-1",
+          channel: "linkedin",
+          channelUserId: VANITY_URL,
+          displayName: "Ada Lovelace",
+          text: "sent under a vanity handle",
+          action: "replied",
+          response: "answered",
+        });
+        const personId = await deps.personMappingRepo.create({
+          displayName: "Vanity Ada",
+          bondLevel: "acquaintance",
+          approved: true,
+          channelMappings: [{ channel: "linkedin", channelUserId: VANITY_URL }],
+        });
+
+        const page = await fetchTimeline(`person:${personId}`);
+        expect(page.entries.map((entry) => entry.body)).toEqual([
+          "answered",
+          "sent under a vanity handle",
+        ]);
+      });
+
+      it("pages a participant's direct threads without repeating an entry", async () => {
+        const refs: string[] = [];
+        let cursor: string | null = null;
+        for (let page = 0; page < 5; page += 1) {
+          const answer: TimelinePage = await fetchTimeline(
+            `channel:linkedin:${ADA}`,
+            `?limit=1${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
+          );
+          refs.push(...answer.entries.map((entry) => entry.ref));
+          cursor = answer.nextCursor;
+          if (!cursor) break;
+        }
+        expect(cursor).toBeNull();
+        expect(refs).toEqual(["li-ada:m-2", "li-ada:m-1"]);
+      });
     });
   });
 });

--- a/packages/core/src/api/routes/identities.ts
+++ b/packages/core/src/api/routes/identities.ts
@@ -154,7 +154,9 @@ export function identitiesRoutes(deps: ApiDeps): Hono {
     // WhatsApp addresses one person by two jids (a phone one and a `@lid`
     // one), and history can sit under either. Resolving the mapping to every
     // alias is what keeps a person mapped to the phone jid from showing an
-    // empty timeline while their thread hangs off the lid.
+    // empty timeline while their thread hangs off the lid. LinkedIn's two
+    // forms need no such read: a profile URL resolves to its member id by
+    // derivation, inside `readChannelWindow`.
     const aliases = channels.some((mapping) => mapping.channel === "whatsapp")
       ? await whatsAppAliases(deps)
       : new Map<string, string[]>();
@@ -205,12 +207,12 @@ export function identitiesRoutes(deps: ApiDeps): Hono {
  * Every dynamic one channel identity has, newest first, from whichever store
  * holds that channel's history.
  *
- * The WhatsApp mirror holds full threads; the sentinel log holds one row per
- * exchange another channel saw — what arrived, and Rome's reply when it made
- * one. A mirrored channel reads its mirror and not the sentinel log, because
- * the sentinel row and the mirrored message are the same message seen twice.
- * Adding a producer is adding a branch here: the entries it returns are already
- * in the generic shape.
+ * The WhatsApp and LinkedIn mirrors hold full threads; the sentinel log holds
+ * one row per exchange another channel saw — what arrived, and Rome's reply
+ * when it made one. A mirrored channel reads its mirror and not the sentinel
+ * log, because the sentinel row and the mirrored message are the same message
+ * seen twice. Adding a producer is adding a branch here: the entries it
+ * returns are already in the generic shape.
  *
  * Reads one row past the page so the caller can tell "this is everything" from
  * "this is a page", and answers `saturated` when it hit that cap.
@@ -270,6 +272,34 @@ async function readChannelWindow(
         body: message.text,
         direction: message.fromMe ? ("outbound" as const) : ("inbound" as const),
         ref: message.id,
+      })),
+      rows: messages.length,
+    };
+  }
+
+  // A LinkedIn mapping is written in whichever form the write that created it
+  // had, and only the member-id forms can name a mirrored participant. The
+  // vanity-URL form — how the guardian's own mapping is conferred at connect
+  // time — names none, so it falls through to the sentinel log below, which is
+  // where its history actually is.
+  const memberId = mapping.channel === "linkedin" ? linkedInMemberId(mapping.channelUserId) : null;
+  if (memberId != null) {
+    const messages = await deps.linkedInStoreRepo.getParticipantMessages(memberId, window);
+    return {
+      entries: messages.map((message) => ({
+        source: "linkedin",
+        timestamp: message.timestamp,
+        // An InMail carries its subject apart from its body, and some carry
+        // only a subject — the same fold the channel applies on the way in.
+        body: message.subject
+          ? `${message.subject}\n${message.text ?? ""}`.trim()
+          : (message.text ?? null),
+        direction: message.senderIsSelf ? ("outbound" as const) : ("inbound" as const),
+        // LinkedIn message ids are unique within a thread, not within an
+        // account, and this list merges a person's threads — an unqualified id
+        // would collide with another thread's and lose one of the pair to the
+        // cursor.
+        ref: `${message.threadId}:${message.messageId}`,
       })),
       rows: messages.length,
     };

--- a/packages/core/src/db/repositories/linkedin-store.test.ts
+++ b/packages/core/src/db/repositories/linkedin-store.test.ts
@@ -920,6 +920,53 @@ describe("LinkedInStoreRepository", () => {
       expect(await repo.listParticipants({ limit: 2 })).toHaveLength(2);
       expect(await repo.listParticipants({ limit: null })).toHaveLength(3);
     });
+
+    it("reads one participant's direct-thread messages across every thread", async () => {
+      await repo.upsertThreads([thread("t-inmail", new Date("2026-08-18T20:00:00Z"))]);
+      await repo.upsertThreadParticipants("t-inmail", [ada, self]);
+      await repo.upsertMessages([
+        message("t-inmail", "m-1", "2026-08-18T10:00:00Z", "body", { subject: "An offer" }),
+      ]);
+
+      const messages = await repo.getParticipantMessages(ada.participantId);
+      // One person, two direct threads, one list — and the id repeated across
+      // them, which is why the caller carries the thread with it.
+      expect(messages.map((m) => `${m.threadId}:${m.messageId}`)).toEqual([
+        "t-inmail:m-1",
+        "t-direct:m-1",
+        "t-direct:m-2",
+      ]);
+      expect(messages.find((m) => m.threadId === "t-inmail")?.subject).toBe("An offer");
+      expect(messages.find((m) => m.messageId === "m-2")?.senderIsSelf).toBe(true);
+      // The group thread's message is nobody's history here.
+      expect(messages.some((m) => m.threadId === "t-group")).toBe(false);
+    });
+
+    it("windows a participant's messages by whole seconds", async () => {
+      const noon = "2026-08-19T12:00:00Z";
+      await repo.upsertMessages([
+        message("t-direct", "m-noon-a", noon, "a"),
+        message("t-direct", "m-noon-b", noon, "b"),
+      ]);
+
+      const before = await repo.getParticipantMessages(ada.participantId, {
+        before: seconds(noon),
+      });
+      expect(before.map((m) => m.messageId)).toEqual(["m-1", "m-2"]);
+
+      // `at` with no limit is how a caller completes a second a cap cut
+      // through, so it must answer the whole second however small the page was.
+      const at = await repo.getParticipantMessages(ada.participantId, {
+        at: seconds(noon),
+        limit: null,
+      });
+      expect(at.map((m) => m.messageId).sort()).toEqual(["m-noon-a", "m-noon-b"]);
+    });
+
+    it("answers empty for a participant no direct thread holds", async () => {
+      expect(await repo.getParticipantMessages(grace.participantId)).toEqual([]);
+      expect(await repo.getParticipantMessages("ACoAANobody0000")).toEqual([]);
+    });
   });
 });
 

--- a/packages/core/src/db/repositories/linkedin-store.ts
+++ b/packages/core/src/db/repositories/linkedin-store.ts
@@ -97,6 +97,19 @@ export interface LinkedInParticipantContactRow {
   messageCount: number;
 }
 
+/** One mirrored message on a participant's direct threads. */
+export interface LinkedInParticipantMessageRow {
+  /** LinkedIn message ids are unique within a thread, not within an account,
+   *  so a reader that merges threads has to carry the thread with the id. */
+  threadId: string;
+  messageId: string;
+  /** Unix seconds — sent_at when LinkedIn reported one, else first-seen. */
+  timestamp: number;
+  text: string | null;
+  subject: string | null;
+  senderIsSelf: boolean;
+}
+
 /** One thread's membership paired with the age of the read that produced it. */
 export interface LinkedInThreadParticipantSet {
   participants: LinkedInParticipantRow[];
@@ -634,6 +647,56 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
       lastMessagePreview: (r.lastMessagePreview as string | null) ?? null,
       messageCount: Number(r.messageCount ?? 0),
     }));
+  }
+
+  /**
+   * One participant's mirrored history: every message on their direct threads,
+   * both directions, oldest→newest.
+   *
+   * Across threads rather than within one, because a person can hold more than
+   * one direct thread (an InMail beside an ordinary conversation) and their
+   * dossier is one list. `before` and `at` bound the window by timestamp:
+   * `before` excludes that second and everything after it, `at` restricts the
+   * read to exactly that second. A caller paging a merged order that timestamps
+   * alone cannot settle reads the boundary second with `at` and no limit,
+   * because a cap applied inside a second drops whichever of its messages the
+   * cap did not reach.
+   */
+  async getParticipantMessages(
+    participantId: string,
+    opts: { limit?: number | null; before?: number; at?: number } = {},
+  ): Promise<LinkedInParticipantMessageRow[]> {
+    const limitClause =
+      opts.limit === null ? sql`` : sql`LIMIT ${Math.min(Math.max(opts.limit ?? 50, 1), 500)}`;
+    const at = sql`coalesce(m.sent_at, m.created_at)`;
+    const beforeClause = opts.before != null ? sql`AND ${at} < ${opts.before}` : sql``;
+    const atClause = opts.at != null ? sql`AND ${at} = ${opts.at}` : sql``;
+    const rows = (await this.db.all(sql`
+      WITH ${DIRECT_THREADS}
+      SELECT
+        m.thread_id AS threadId,
+        m.message_id AS messageId,
+        ${at} AS timestamp,
+        m.text AS text,
+        m.subject AS subject,
+        m.sender_is_self AS senderIsSelf
+      FROM linkedin_messages m
+      JOIN direct_threads d ON d.threadId = m.thread_id
+      WHERE d.participantId = ${participantId} ${beforeClause} ${atClause}
+      ORDER BY ${at} DESC, m.rowid DESC
+      ${limitClause}
+    `)) as Array<Record<string, unknown>>;
+
+    return rows
+      .map((r) => ({
+        threadId: String(r.threadId),
+        messageId: String(r.messageId),
+        timestamp: Number(r.timestamp),
+        text: (r.text as string | null) ?? null,
+        subject: (r.subject as string | null) ?? null,
+        senderIsSelf: Boolean(r.senderIsSelf),
+      }))
+      .reverse();
   }
 
   /** One thread's participants with their person-level facts, by member id. */


### PR DESCRIPTION
Last of five. Stacked on #49 — **review and merge #46, #47, #48 and #49 first**. This PR's base is #49's branch, so the diff shows only this PR's own commit.

## What this PR does

A LinkedIn identity's row on the People page carries what was last said, and opening it shows nothing. The timeline reads the WhatsApp mirror and the sentinel log, and the LinkedIn mirror is neither, so a person promoted from the inbox has a dossier the poller filled and the page cannot read.

## Design & Invariants

**One participant's direct threads are one list.** A person can hold more than one — an InMail beside an ordinary conversation — and their dossier is one list, so `getParticipantMessages` reads across threads rather than within one. The direct-thread rule is #48's, unchanged: a timeline entry names no sender, so a group thread's messages are not attributable to one of its members.

**A `ref` is unique across everything one source puts on one timeline.** A LinkedIn message id is unique within a thread rather than within an account, so the entry carries `<threadId>:<messageId>`. An unqualified id compares equal to its twin in another thread, serializes to the same cursor, and loses one of the pair on resume — the failure `@rome/api-types/identities` documents on `TimelineEntry`.

**An InMail's subject rides with its body.** Some carry only a subject, so the entry folds them the same way the channel does on the way in.

**A mapping that names no member reads the sentinel log.** Only the member-id forms can name a mirrored participant, and the vanity-URL form the guardian's own mapping is conferred in names none. That identity falls through to the sentinel log, which is where its history actually is, rather than reading an empty mirror. The decision is a pure function — `linkedInMemberId` answering null — so it costs no query.

**The whole-second window is the mirror's, not the caller's.** `getParticipantMessages` takes the same `{limit, before, at}` contract `getMessages` does, because the cursor's second has to be re-readable whole whichever producer holds it.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — core 3940, web 1091, ui 528, apps green. New coverage: a direct thread read for an identity with no person row, LinkedIn merged into a person's other channels newest first, the mirror read through a mapping written as a profile URL, an InMail's subject rendered with its body, a vanity-URL mapping falling back to the sentinel log, thread-qualified refs paging without repeating, one participant's messages read across two direct threads, the group thread excluded from that read, the whole-second window, and an empty answer for a participant no direct thread holds
- [x] `biome check` clean on every touched path
- [x] Probed `buildApp` at its real mount points — `GET /api/identities` and `GET /api/identities/:id/timeline` both answer 200
- [ ] `pnpm dev:all` not run — the Docker socket is not reachable from this environment
- [ ] Not exercised against live WhatsApp/LinkedIn accounts

## Not in this PR

- Nothing in the dashboard reads these endpoints. The page rebuild is separate.
- The union is built in memory and sorted per request. Bounded by the response, not by the work — worth pushing into SQL when this stops being a single-guardian dashboard, and the endpoint's shape allows that without a client change.
- Sends still go through the existing WhatsApp and LinkedIn routes. The timeline is read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
