### PR TITLE
fix(connections): open provider sign-in in the system browser

### DIFF
--- a/packages/core/src/api/routes/auth-verify.e2e.test.ts
+++ b/packages/core/src/api/routes/auth-verify.e2e.test.ts
@@ -178,6 +178,22 @@ describe("/api/auth/verify", () => {
     expect(res.status).toBe(401);
   });
 
+  it("returns 204 for the connect return leg without a cookie", async () => {
+    const host = buildHost(await stubDeps([]));
+    const res = await verifyRequest(host, "/api/setups/return");
+    expect(res.status).toBe(204);
+  });
+
+  it("keeps the rest of /api/setups/* private", async () => {
+    // The return leg is listed as an exact path, so the sibling routes a
+    // browser must never reach on its own stay behind the cookie.
+    const host = buildHost(await stubDeps([]));
+    for (const uri of ["/api/setups/abc", "/api/setups/abc/input", "/api/setups/abc/cancel"]) {
+      const res = await verifyRequest(host, uri);
+      expect(res.status, uri).toBe(401);
+    }
+  });
+
   it("accepts a raw guardian session explicitly injected by a Native client", async () => {
     const host = buildHost(await stubDeps([]));
     const session = createGuardianSession("native-account");

--- a/packages/core/src/api/routes/auth.ts
+++ b/packages/core/src/api/routes/auth.ts
@@ -52,6 +52,14 @@ const PUBLIC_API_PATHS = [
   "/api/onboard/*",
   "/api/instance/enroll/*",
   "/api/oauth/*",
+  // The connect return leg. The desktop shell hands provider sign-in to the
+  // system browser (the Electron window has no platform authenticator, so a
+  // passkey second factor cannot complete there), and that browser carries no
+  // guardian cookie. Exact path, not a prefix: the rest of /api/setups/* stays
+  // private. `state` only correlates the leg back to a setup still parked at
+  // `awaiting-redirect` — the credential exchange itself needs the handoff, the
+  // PKCE verifier and the instance token, none of which cross this boundary.
+  "/api/setups/return",
   // Share Chat — login-free public read of a frozen chat snapshot. The
   // token in the path is the credential; management stays under /api/chat/*.
   "/api/share/*",

--- a/packages/core/src/api/routes/setups.test.ts
+++ b/packages/core/src/api/routes/setups.test.ts
@@ -660,8 +660,12 @@ describe("OAuth redirect setup + return leg (#1611)", () => {
     expect(registry.find("github")).toHaveLength(1);
   });
 
-  it("rejects a return leg after cancel and leaves zero durable state", async () => {
-    const { app, registry } = oauthHarness();
+  it("keeps a cancelled redirect state owned and leaves zero durable state", async () => {
+    const redeem = vi.fn(async (handoff: string) => ({
+      credential: { material: { accessToken: `tok-${handoff}` }, expiresAt: "never" as const },
+      profile: { login: "octocat" },
+    }));
+    const { app, registry } = oauthHarness({ redeem });
     const { json } = await startOAuth(app);
     const cancel = await app.request(`/setups/${json.cid}/cancel`, {
       method: "POST",
@@ -671,7 +675,13 @@ describe("OAuth redirect setup + return leg (#1611)", () => {
     expect(cancel.status).toBe(200);
 
     const ret = await deliverReturn(app, { state: "st-oauth-1", handoff: "h1" });
-    expect(ret.status).toBe(404);
+    expect(ret.status).toBe(409);
+    expect(await ret.json()).toMatchObject({
+      matched: true,
+      accepted: false,
+      state: { status: "cancelled" },
+    });
+    expect(redeem).not.toHaveBeenCalled();
     expect(registry.find("github")).toHaveLength(0);
   });
 

--- a/packages/core/src/api/routes/setups.test.ts
+++ b/packages/core/src/api/routes/setups.test.ts
@@ -601,7 +601,7 @@ describe("OAuth redirect setup + return leg (#1611)", () => {
     expect(grant?.profile).toEqual({ login: "octocat" });
   });
 
-  it("rejects a duplicate return leg after the setup is done (AC2)", async () => {
+  it("keeps ownership of a delivered return leg so a reload cannot reach sign-in (AC2)", async () => {
     let redeemCount = 0;
     const { app, registry } = oauthHarness({
       redeem: async (handoff) => {
@@ -617,16 +617,22 @@ describe("OAuth redirect setup + return leg (#1611)", () => {
     expect(first.status).toBe(200);
     await pollDone(app, json.cid);
 
-    // A late/duplicate return leg finds no suspended setup → not matched, no
-    // second confer.
+    // A duplicate leg — the callback page is now one that stays put in the
+    // system browser, so a plain reload sends the same state again. The setup
+    // still owns it, so this resolves HERE rather than reading as a flow that
+    // never started a setup and falling through to the sign-in redeem.
     const dup = await deliverReturn(app, { state: "st-oauth-1", handoff: "h1" });
-    expect(dup.status).toBe(404);
-    expect((await dup.json()) as { matched: boolean }).toMatchObject({ matched: false });
+    expect(dup.status).toBe(409);
+    expect(await dup.json()).toMatchObject({
+      matched: true,
+      accepted: false,
+      state: { status: "done" },
+    });
     expect(redeemCount).toBe(1);
     expect(registry.find("github")).toHaveLength(1);
   });
 
-  it("rejects a return leg delivered mid-redeem without corrupting state (AC2)", async () => {
+  it("keeps ownership mid-redeem so a reload cannot race the redemption (AC2)", async () => {
     let resolveRedeem!: (v: { credential: Credential; profile?: ProfileRecord }) => void;
     let redeemCount = 0;
     const { app, registry } = oauthHarness({
@@ -646,10 +652,18 @@ describe("OAuth redirect setup + return leg (#1611)", () => {
       state: { status: "presenting" },
     });
 
-    // A second leg arriving while the coroutine is past awaiting-redirect finds
-    // no suspended setup — rejected, not double-redeemed.
+    // A second leg arriving while the coroutine is past awaiting-redirect —
+    // a reload of the callback page mid-redemption. Still owned, so it is
+    // reported as already-delivered rather than as an unmatched state: the
+    // caller must not fall through to the sign-in redeem and race the redeem
+    // that is in flight right here.
     const second = await deliverReturn(app, { state: "st-oauth-1", handoff: "h2" });
-    expect(second.status).toBe(404);
+    expect(second.status).toBe(409);
+    expect(await second.json()).toMatchObject({
+      matched: true,
+      accepted: false,
+      state: { status: "presenting" },
+    });
     expect(redeemCount).toBe(1);
 
     resolveRedeem({

--- a/packages/core/src/api/routes/setups.ts
+++ b/packages/core/src/api/routes/setups.ts
@@ -110,11 +110,14 @@ export function setupsRoutes(deps: ApiDeps): Hono {
   // the higher setup layer through it would invert the layering — the primitive
   // reaching up into the layer above it.
   //
-  // `matched:false` signals no setup owns this state (unknown/expired/already-
-  // consumed, or a sign-in that never started a setup) — the caller falls
-  // through to the sign-in redeem, which shares the same OAuth primitive. A
-  // cancelled setup deliberately remains a match with `accepted:false`, so its
-  // late callback cannot be mistaken for sign-in and import the credential.
+  // `matched:false` signals no setup owns this state (unknown/expired, or a
+  // sign-in that never started a setup) — the caller falls through to the
+  // sign-in redeem, which shares the same OAuth primitive. A setup that has
+  // already taken a leg, or was cancelled holding one, deliberately stays a
+  // match with `accepted:false`: the callback page persists in the system
+  // browser now, so a reload replays the state, and reading that as sign-in
+  // would import the credential by a second path — racing the redemption in
+  // flight, or contradicting an explicit cancel.
   app.post("/setups/return", async (c) => {
     const blocked = crossOriginBlocked(c);
     if (blocked) return blocked;

--- a/packages/core/src/api/routes/setups.ts
+++ b/packages/core/src/api/routes/setups.ts
@@ -110,10 +110,11 @@ export function setupsRoutes(deps: ApiDeps): Hono {
   // the higher setup layer through it would invert the layering — the primitive
   // reaching up into the layer above it.
   //
-  // `matched:false` signals no live setup is awaiting this state (unknown/
-  // expired/cancelled/already-consumed, or a sign-in that never started a
-  // setup) — the caller falls through to the sign-in redeem, which shares the
-  // same OAuth primitive.
+  // `matched:false` signals no setup owns this state (unknown/expired/already-
+  // consumed, or a sign-in that never started a setup) — the caller falls
+  // through to the sign-in redeem, which shares the same OAuth primitive. A
+  // cancelled setup deliberately remains a match with `accepted:false`, so its
+  // late callback cannot be mistaken for sign-in and import the credential.
   app.post("/setups/return", async (c) => {
     const blocked = crossOriginBlocked(c);
     if (blocked) return blocked;

--- a/packages/core/src/connections/setup/manager.ts
+++ b/packages/core/src/connections/setup/manager.ts
@@ -86,11 +86,14 @@ interface Managed {
   target: SetupTarget;
   grant: string;
   session: SetupSession;
-  /** A redirect state this setup owned when it was cancelled. The terminal
-   *  session already remains reachable for a final poll; retaining this one
-   *  correlation value also prevents a late callback from being mistaken for
-   *  an unrelated sign-in flow. */
-  cancelledRedirectState?: string;
+  /** A redirect state this setup owned, kept past the moment the session stops
+   *  advertising it — cancellation erases the URL, and an accepted leg moves the
+   *  session off `awaiting-redirect`. Either way the correlation is the only
+   *  route back to THIS setup, and without it a repeat delivery reads as a flow
+   *  that never started a setup: the caller then falls through to the sign-in
+   *  redeem, which shares the OAuth primitive and would race the redemption
+   *  already in flight. */
+  ownedRedirectState?: string;
 }
 
 /** The active-setup key: the addressed connection id, or the service name for a
@@ -214,38 +217,53 @@ export class SetupManager {
    * free: once a return leg has resumed a coroutine it is no longer awaiting a
    * redirect, so a double/late delivery finds no live match, and a delivery to a
    * session that already advanced is rejected by the session's own pending-kind
-   * guard. A state retained at cancellation still matches its terminal setup so
-   * the caller cannot mistake that callback for an unrelated sign-in flow.
+   * guard.
    *
-   * Returns `{ cid, service, outcome }` for the setup that owns the state (live
-   * or cancelled), or `null` when no setup owns it (unknown/expired/already-
-   * consumed). `service` names the connection the leg belongs to, so the browser
-   * can return to that connection's own page rather than a fixed destination.
+   * A setup keeps its state after that, so the repeat still matches — with
+   * `accepted:false` and the setup's current state. Not keeping it would report
+   * "no setup owns this", and the callback page treats that as sign-in and
+   * redeems the handoff itself. That page now stays put in the system browser,
+   * so a plain reload is enough to hit it: mid-redemption the two paths race,
+   * and the guardian can be shown a failure while the credential lands.
+   *
+   * Returns `{ cid, service, outcome }` for the setup that owns the state (live,
+   * finished, or cancelled), or `null` when none does (unknown/expired, or a
+   * flow that never started a setup). `service` names the connection the leg
+   * belongs to, so the browser can return to that connection's own page rather
+   * than a fixed destination.
    */
   provideReturnByState(
     state: string,
     payload: Record<string, string>,
   ): { cid: string; service: string; outcome: Promise<SetupInputOutcome> } | null {
-    let cancelled: Managed | null = null;
+    let owner: Managed | null = null;
     for (const managed of this.#byCid.values()) {
       const current = managed.session.state;
       if (current.status === "awaiting-redirect" && redirectStateOf(current.url) === state) {
+        // Claim the correlation before resuming: the session is about to leave
+        // `awaiting-redirect`, and from then on this retained value is the only
+        // thing that can still identify the leg as belonging here.
+        managed.ownedRedirectState = state;
         return {
           cid: managed.cid,
           service: managed.target.service,
           outcome: managed.session.provideReturn(payload),
         };
       }
-      if (managed.cancelledRedirectState === state) cancelled = managed;
+      if (managed.ownedRedirectState === state) owner = managed;
     }
-    if (cancelled) {
+    if (owner) {
+      const current = owner.session.state;
       return {
-        cid: cancelled.cid,
-        service: cancelled.target.service,
+        cid: owner.cid,
+        service: owner.target.service,
         outcome: Promise.resolve({
           accepted: false,
-          reason: "Setup was cancelled.",
-          state: cancelled.session.state,
+          reason:
+            current.status === "cancelled"
+              ? "Setup was cancelled."
+              : "This return leg was already delivered.",
+          state: current,
         }),
       };
     }
@@ -259,13 +277,13 @@ export class SetupManager {
   }
 
   /** Preserve ownership of a parked redirect before cancellation erases the URL
-   *  from the session's public state. This is deliberately in-memory, matching
-   *  the lifetime of setup sessions themselves. */
+   *  from the session's public state. Deliberately in-memory, matching the
+   *  lifetime of setup sessions themselves. */
   #cancelManaged(managed: Managed): Promise<SetupState> {
     const current = managed.session.state;
     if (current.status === "awaiting-redirect") {
       const state = redirectStateOf(current.url);
-      if (state) managed.cancelledRedirectState = state;
+      if (state) managed.ownedRedirectState = state;
     }
     return managed.session.cancel();
   }

--- a/packages/core/src/connections/setup/manager.ts
+++ b/packages/core/src/connections/setup/manager.ts
@@ -86,6 +86,11 @@ interface Managed {
   target: SetupTarget;
   grant: string;
   session: SetupSession;
+  /** A redirect state this setup owned when it was cancelled. The terminal
+   *  session already remains reachable for a final poll; retaining this one
+   *  correlation value also prevents a late callback from being mistaken for
+   *  an unrelated sign-in flow. */
+  cancelledRedirectState?: string;
 }
 
 /** The active-setup key: the addressed connection id, or the service name for a
@@ -142,7 +147,7 @@ export class SetupManager {
     const existing = this.#byKey.get(key);
     if (existing && !existing.session.isTerminal) {
       if (opts.force) {
-        await existing.session.cancel();
+        await this.#cancelManaged(existing);
         // Leave it reachable by cid for a final poll; it is no longer active.
       } else {
         return { cid: existing.cid, state: existing.session.state, reattached: true };
@@ -207,12 +212,13 @@ export class SetupManager {
    * opaque codes, so a match is unambiguous). Because it resolves ONLY a session
    * still parked at `awaiting-redirect`, the idempotency guarantees fall out for
    * free: once a return leg has resumed a coroutine it is no longer awaiting a
-   * redirect, so a double/late delivery — or a delivery after cancel — finds no
-   * match (`null`), and a delivery to a session that already advanced is rejected
-   * by the session's own pending-kind guard. Nothing corrupts the setup state.
+   * redirect, so a double/late delivery finds no live match, and a delivery to a
+   * session that already advanced is rejected by the session's own pending-kind
+   * guard. A state retained at cancellation still matches its terminal setup so
+   * the caller cannot mistake that callback for an unrelated sign-in flow.
    *
-   * Returns `{ cid, service, outcome }` for the matched setup, or `null` when no
-   * live setup is awaiting this `state` (unknown/expired/cancelled/already-
+   * Returns `{ cid, service, outcome }` for the setup that owns the state (live
+   * or cancelled), or `null` when no setup owns it (unknown/expired/already-
    * consumed). `service` names the connection the leg belongs to, so the browser
    * can return to that connection's own page rather than a fixed destination.
    */
@@ -220,6 +226,7 @@ export class SetupManager {
     state: string,
     payload: Record<string, string>,
   ): { cid: string; service: string; outcome: Promise<SetupInputOutcome> } | null {
+    let cancelled: Managed | null = null;
     for (const managed of this.#byCid.values()) {
       const current = managed.session.state;
       if (current.status === "awaiting-redirect" && redirectStateOf(current.url) === state) {
@@ -229,14 +236,38 @@ export class SetupManager {
           outcome: managed.session.provideReturn(payload),
         };
       }
+      if (managed.cancelledRedirectState === state) cancelled = managed;
+    }
+    if (cancelled) {
+      return {
+        cid: cancelled.cid,
+        service: cancelled.target.service,
+        outcome: Promise.resolve({
+          accepted: false,
+          reason: "Setup was cancelled.",
+          state: cancelled.session.state,
+        }),
+      };
     }
     return null;
   }
 
   /** Cancel a setup by id. Returns its terminal state, or null when unknown. */
   cancel(cid: string): Promise<SetupState> | null {
-    const session = this.#byCid.get(cid)?.session;
-    return session ? session.cancel() : null;
+    const managed = this.#byCid.get(cid);
+    return managed ? this.#cancelManaged(managed) : null;
+  }
+
+  /** Preserve ownership of a parked redirect before cancellation erases the URL
+   *  from the session's public state. This is deliberately in-memory, matching
+   *  the lifetime of setup sessions themselves. */
+  #cancelManaged(managed: Managed): Promise<SetupState> {
+    const current = managed.session.state;
+    if (current.status === "awaiting-redirect") {
+      const state = redirectStateOf(current.url);
+      if (state) managed.cancelledRedirectState = state;
+    }
+    return managed.session.cancel();
   }
 
   /** The terminal write: hand the conferral to `registry.confer`, which mints

--- a/packages/web/src/components/connections/oauth-connection-section.test.tsx
+++ b/packages/web/src/components/connections/oauth-connection-section.test.tsx
@@ -14,7 +14,33 @@ afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  // Assigned directly rather than through `stubGlobal` so it cannot leak into a
+  // later test as a phantom desktop shell.
+  Reflect.deleteProperty(window, "rome");
 });
+
+/** Stand in for the desktop preload's bridge, which `isElectronShell` reads. */
+function inDesktopShell(): void {
+  window.rome = {};
+}
+
+/**
+ * A setup parked at the broker hand-off.
+ *
+ * The start response carries `cid` — without it the hook has nothing to poll,
+ * and a card that opened the hand-off would never learn the setup finished in
+ * the other browser. The poll response omits it, matching `GET /api/setups/:cid`.
+ */
+function parkedAtRedirect(url: string) {
+  const state = { status: "awaiting-redirect", url };
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const requested = typeof input === "string" ? input : (input as Request).url;
+    const body = requested.endsWith("/setup")
+      ? { cid: "setup-parked", reattached: false, state }
+      : { state };
+    return new Response(JSON.stringify(body), { status: 200 });
+  });
+}
 
 function githubCard(
   state: GrantState,
@@ -231,5 +257,77 @@ describe("OAuthConnectionSection", () => {
     );
     expect(call).toBeTruthy();
     expect(JSON.parse((call?.[1] as RequestInit).body as string)).toEqual({ force: true });
+  });
+
+  it("hands Connect to the system browser in the desktop shell", async () => {
+    const assign = vi.fn();
+    const open = vi.fn();
+    vi.stubGlobal("location", { ...window.location, assign });
+    vi.stubGlobal("open", open);
+    inDesktopShell();
+    parkedAtRedirect("https://broker/authorize?state=xyz");
+
+    renderSection(githubCard("unauthorized"));
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    // The Electron window has no platform authenticator, so a passkey second
+    // factor cannot complete there — this URL must NOT open in it.
+    await waitFor(() => expect(open).toHaveBeenCalledWith("https://broker/authorize?state=xyz"));
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("hands the manual resume to the system browser too, not just the first attempt", async () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    inDesktopShell();
+    parkedAtRedirect("https://broker/authorize?state=parked");
+
+    renderSection(githubCard("unauthorized", { activeSetupCid: "setup-parked" }));
+    // Cancel only exists on the pending controls, so waiting for it is what
+    // distinguishes the parked card from the plain Connect card underneath.
+    await screen.findByRole("button", { name: "Cancel" });
+    // A passive reattach still must not bounce the guardian anywhere.
+    expect(open).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+    expect(open).toHaveBeenCalledWith("https://broker/authorize?state=parked");
+  });
+
+  it("keeps the manual resume a same-window navigation in a browser", async () => {
+    const assign = vi.fn();
+    const open = vi.fn();
+    vi.stubGlobal("location", { ...window.location, assign });
+    vi.stubGlobal("open", open);
+    parkedAtRedirect("https://broker/authorize?state=parked");
+
+    renderSection(githubCard("unauthorized", { activeSetupCid: "setup-parked" }));
+    await screen.findByRole("button", { name: "Cancel" });
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    // A browser dashboard already has the user's session and extensions; a new
+    // tab would be a gratuitous change to a flow that works.
+    expect(assign).toHaveBeenCalledWith("https://broker/authorize?state=parked");
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("parks Reconnect on the pending controls instead of leaving a re-clickable button", async () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    inDesktopShell();
+    parkedAtRedirect("https://broker/authorize?state=reauth");
+
+    renderSection(
+      githubCard("authorized", {
+        display: { displayName: "Ada Lovelace", handle: null, email: null, avatarUrl: null },
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Reconnect" }));
+    await waitFor(() => expect(open).toHaveBeenCalledWith("https://broker/authorize?state=reauth"));
+
+    // The window stays put now, so the card has to narrate the wait — and
+    // Reconnect must not still be sitting there inviting a second hand-off.
+    expect(await screen.findByRole("button", { name: "Cancel" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Reconnect" })).toBeNull();
+    expect(open).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/components/connections/oauth-connection-section.tsx
+++ b/packages/web/src/components/connections/oauth-connection-section.tsx
@@ -8,7 +8,30 @@ import { ConnectionSlotCard } from "@/components/connection-slot-card";
 import { SetupRenderer } from "@/components/setup/setup-renderer";
 import { useSetup } from "@/components/setup/use-setup";
 import { revokeConnectionGrant } from "@/lib/connections-api";
+import { isElectronShell } from "@/lib/electron-shell";
 import type { ConnectionCard, ConnectionSlot } from "@/lib/connection-cards";
+
+/**
+ * Hand the guardian to the broker.
+ *
+ * In the desktop shell that has to be the SYSTEM browser. The Electron window
+ * is a fresh session with no keychain and no platform authenticator, so an
+ * account whose second factor is a passkey or Touch ID cannot finish signing in
+ * inside the app at all. `window.open` reaches the shell's
+ * `setWindowOpenHandler`, which forwards the URL to the system browser and
+ * denies the Electron window — no preload bridge needed.
+ *
+ * Everywhere else this stays a same-window navigation: a browser dashboard has
+ * the user's own session and extensions already, and a new tab would be a
+ * gratuitous change to a flow that works.
+ */
+function openAuthorizeUrl(url: string): void {
+  if (isElectronShell()) {
+    window.open(url);
+    return;
+  }
+  window.location.assign(url);
+}
 
 /**
  * OAuth (Rome Cloud-brokered) connection slot as a full slot card — the
@@ -76,7 +99,7 @@ export function OAuthConnectionSection({
   useEffect(() => {
     if (redirectUrl && initiatedRef.current) {
       initiatedRef.current = false;
-      window.location.assign(redirectUrl);
+      openAuthorizeUrl(redirectUrl);
     }
   }, [redirectUrl]);
 
@@ -104,6 +127,25 @@ export function OAuthConnectionSection({
     }
     setDisconnecting(false);
   }
+
+  // Shown wherever a setup is parked at `awaiting-redirect` — the unconnected
+  // card AND the connected one, because Reconnect parks there too and the
+  // desktop shell no longer navigates the window away.
+  const pendingRedirectControls = redirectUrl ? (
+    <div className="space-y-2">
+      <p className="text-body text-muted-foreground">
+        {t("connections.oauth.resumePending", { label })}
+      </p>
+      <div className="flex gap-2">
+        <Button size="sm" onClick={() => openAuthorizeUrl(redirectUrl)}>
+          {t("common.connect")}
+        </Button>
+        <Button variant="ghost" size="sm" disabled={setup.busy} onClick={setup.cancel}>
+          {t("common.cancel")}
+        </Button>
+      </div>
+    </div>
+  ) : null;
 
   // Unavailable on this host — render the unconnected card with a disabled
   // control and the reason.
@@ -137,23 +179,13 @@ export function OAuthConnectionSection({
         icon={<ConnectionBrandBadge connection={card.service} />}
       >
         {redirectUrl ? (
-          // A setup parked at the broker hand-off. A freshly-initiated redirect
-          // has already navigated away (the effect above); reaching here is a
-          // passive reattach, so offer manual resume + cancel rather than a
-          // silent bounce.
-          <div className="space-y-2">
-            <p className="text-body text-muted-foreground">
-              {t("connections.oauth.resumePending", { label })}
-            </p>
-            <div className="flex gap-2">
-              <Button size="sm" onClick={() => window.location.assign(redirectUrl)}>
-                {t("common.connect")}
-              </Button>
-              <Button variant="ghost" size="sm" disabled={setup.busy} onClick={setup.cancel}>
-                {t("common.cancel")}
-              </Button>
-            </div>
-          </div>
+          // A setup parked at the broker hand-off. In a browser a
+          // freshly-initiated redirect has already navigated away, so reaching
+          // here is a passive reattach; in the desktop shell the hand-off went
+          // to the system browser and this window stays put, so this is also
+          // what the guardian looks at while they finish over there. Either way
+          // the affordance is the same: reopen, or cancel and escape the flow.
+          pendingRedirectControls
         ) : setup.state && setup.state.status !== "cancelled" ? (
           <SetupRenderer
             service={card.service}
@@ -229,16 +261,18 @@ export function OAuthConnectionSection({
         {expired && (
           <p className="text-ui text-warning-fg">{t("connections.oauth.accessExpired")}</p>
         )}
-        <Button
-          variant={expired ? "default" : "outline"}
-          size="sm"
-          disabled={setup.busy}
-          aria-label={setup.busy ? t("connections.oauth.reconnecting") : undefined}
-          onClick={() => beginConnect(true)}
-        >
-          {setup.busy && <Spinner size="sm" label={t("connections.oauth.reconnecting")} />}
-          {t("connections.oauth.reconnect")}
-        </Button>
+        {pendingRedirectControls ?? (
+          <Button
+            variant={expired ? "default" : "outline"}
+            size="sm"
+            disabled={setup.busy}
+            aria-label={setup.busy ? t("connections.oauth.reconnecting") : undefined}
+            onClick={() => beginConnect(true)}
+          >
+            {setup.busy && <Spinner size="sm" label={t("connections.oauth.reconnecting")} />}
+            {t("connections.oauth.reconnect")}
+          </Button>
+        )}
       </div>
     </ConnectionSlotCard>
   );

--- a/packages/web/src/components/setup/use-setup.test.ts
+++ b/packages/web/src/components/setup/use-setup.test.ts
@@ -39,4 +39,39 @@ describe("useSetup stale-state handling", () => {
     await waitFor(() => expect(result.current.cid).toBeNull());
     expect(result.current.state).toBeNull();
   });
+
+  it("keeps polling while parked at the broker hand-off", async () => {
+    // The desktop shell hands the redirect to the SYSTEM browser and this window
+    // stays put, so the return leg resumes the coroutine somewhere else
+    // entirely. Asking again is the only way this card ever learns it connected
+    // — without it the guardian stares at an unchanged card until the
+    // connections page's own refresh interval comes round.
+    let polls = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      polls += 1;
+      const state =
+        polls > 1
+          ? { status: "done" }
+          : { status: "awaiting-redirect", url: "https://broker/authorize?state=xyz" };
+      return new Response(JSON.stringify({ state }), { status: 200 });
+    });
+    const onDone = vi.fn();
+    const { result } = renderHook(() =>
+      useSetup({
+        idOrService: "github",
+        grant: "user",
+        activeCid: "cid-parked",
+        pollMs: 10,
+        onDone,
+      }),
+    );
+
+    // Reaching `done` with no further input IS the proof: before this polled
+    // `awaiting-redirect`, the hook settled on the parked state and stopped
+    // asking, so the second answer could never arrive. Asserting the
+    // intermediate state instead would race the next tick.
+    await waitFor(() => expect(result.current.state?.status).toBe("done"));
+    expect(polls).toBeGreaterThan(1);
+    expect(onDone).toHaveBeenCalled();
+  });
 });

--- a/packages/web/src/components/setup/use-setup.ts
+++ b/packages/web/src/components/setup/use-setup.ts
@@ -142,11 +142,14 @@ export function useSetup(options: UseSetupOptions): SetupRunner {
     })();
   }, [cid, settle]);
 
-  // Poll while the coroutine awaits an external event (a `presenting` state):
-  // that is the only state that changes without guardian input.
+  // Poll while the coroutine awaits an external event — the states that change
+  // without guardian input on this page. `awaiting-redirect` is one of them
+  // whenever the hand-off went to the system browser (the desktop shell): the
+  // return leg resumes the coroutine in that other browser, so this window
+  // learns the setup connected only by asking.
   useEffect(() => {
     if (!cid) return;
-    if (state && state.status !== "presenting") return;
+    if (state && state.status !== "presenting" && state.status !== "awaiting-redirect") return;
     let cancelled = false;
     const tick = async (): Promise<void> => {
       const next = await getSetupState(cid);
@@ -169,7 +172,7 @@ export function useSetup(options: UseSetupOptions): SetupRunner {
   }, [cid, state, pollMs, settle, reset]);
 
   // Stop the render loop the moment a terminal state lands (defensive; the poll
-  // effect already bails on non-presenting states).
+  // effect already bails on every state it does not watch).
   const settled = state ? isTerminalSetup(state) : false;
   useEffect(() => {
     if (settled) setBusy(false);

--- a/packages/web/src/i18n/locales/en/auth.json
+++ b/packages/web/src/i18n/locales/en/auth.json
@@ -66,6 +66,8 @@
     "description": "Rome is redeeming your OAuth handoff and storing the provider tokens server-side.",
     "deliveredTitle": "Authorization received",
     "deliveredBody": "Rome is finishing the connection. You can close this tab and check it there.",
+    "cancelledTitle": "Connection cancelled",
+    "cancelledBody": "Rome did not complete this connection. You can close this tab and return to Rome.",
     "returnToLogin": "Return to login",
     "errorMissingHandoff": "Missing OAuth handoff code.",
     "errorMissingState": "Missing OAuth state.",

--- a/packages/web/src/i18n/locales/en/auth.json
+++ b/packages/web/src/i18n/locales/en/auth.json
@@ -64,6 +64,8 @@
   "callback": {
     "title": "Finishing sign-in",
     "description": "Rome is redeeming your OAuth handoff and storing the provider tokens server-side.",
+    "deliveredTitle": "Authorization received",
+    "deliveredBody": "Rome is finishing the connection. You can close this tab and check it there.",
     "returnToLogin": "Return to login",
     "errorMissingHandoff": "Missing OAuth handoff code.",
     "errorMissingState": "Missing OAuth state.",

--- a/packages/web/src/i18n/locales/en/auth.json
+++ b/packages/web/src/i18n/locales/en/auth.json
@@ -66,6 +66,8 @@
     "description": "Rome is redeeming your OAuth handoff and storing the provider tokens server-side.",
     "deliveredTitle": "Authorization received",
     "deliveredBody": "Rome is finishing the connection. You can close this tab and check it there.",
+    "connectionFailedTitle": "Connection failed",
+    "connectionFailedBody": "Close this tab and try connecting again from Rome.",
     "cancelledTitle": "Connection cancelled",
     "cancelledBody": "Rome did not complete this connection. You can close this tab and return to Rome.",
     "returnToLogin": "Return to login",

--- a/packages/web/src/i18n/locales/zh-CN/auth.json
+++ b/packages/web/src/i18n/locales/zh-CN/auth.json
@@ -66,6 +66,8 @@
     "description": "Rome 正在兑换 OAuth 凭据并在服务端保存提供方令牌。",
     "deliveredTitle": "授权已收到",
     "deliveredBody": "Rome 正在完成连接。可以关闭此标签页，回到 Rome 查看结果。",
+    "connectionFailedTitle": "连接失败",
+    "connectionFailedBody": "可以关闭此标签页，回到 Rome 重试。",
     "cancelledTitle": "连接已取消",
     "cancelledBody": "Rome 未完成此连接。可以关闭此标签页并返回 Rome。",
     "returnToLogin": "返回登录",

--- a/packages/web/src/i18n/locales/zh-CN/auth.json
+++ b/packages/web/src/i18n/locales/zh-CN/auth.json
@@ -64,6 +64,8 @@
   "callback": {
     "title": "正在完成登录",
     "description": "Rome 正在兑换 OAuth 凭据并在服务端保存提供方令牌。",
+    "deliveredTitle": "授权已收到",
+    "deliveredBody": "Rome 正在完成连接。可以关闭此标签页，回到 Rome 查看结果。",
     "returnToLogin": "返回登录",
     "errorMissingHandoff": "缺少 OAuth 凭据代码。",
     "errorMissingState": "缺少 OAuth state 参数。",

--- a/packages/web/src/i18n/locales/zh-CN/auth.json
+++ b/packages/web/src/i18n/locales/zh-CN/auth.json
@@ -66,6 +66,8 @@
     "description": "Rome 正在兑换 OAuth 凭据并在服务端保存提供方令牌。",
     "deliveredTitle": "授权已收到",
     "deliveredBody": "Rome 正在完成连接。可以关闭此标签页，回到 Rome 查看结果。",
+    "cancelledTitle": "连接已取消",
+    "cancelledBody": "Rome 未完成此连接。可以关闭此标签页并返回 Rome。",
     "returnToLogin": "返回登录",
     "errorMissingHandoff": "缺少 OAuth 凭据代码。",
     "errorMissingState": "缺少 OAuth state 参数。",

--- a/packages/web/src/lib/setup-api.ts
+++ b/packages/web/src/lib/setup-api.ts
@@ -138,11 +138,11 @@ export async function submitSetupInput(
 
 /** The outcome of delivering a redirect return leg (the OAuth callback). */
 export interface SetupReturnResult {
-  /** A setup owns this redirect `state`. This includes a setup cancelled while
-   *  awaiting the redirect: it returns `matched:true, accepted:false` so the
-   *  callback cannot fall through to sign-in redeem. When false, no setup owns
-   *  the state (unknown/expired/already-consumed, or a flow that never started a
-   *  setup, e.g. sign-in). */
+  /** A setup owns this redirect `state` — live, already finished with it, or
+   *  cancelled while holding it. The last two return `matched:true,
+   *  accepted:false` so a replayed leg (a reload of the callback page) cannot
+   *  fall through to the sign-in redeem. When false, no setup owns the state
+   *  (unknown/expired, or a flow that never started a setup, e.g. sign-in). */
   matched: boolean;
   /** Whether THIS delivery resumed the coroutine (200) vs. lost a race to a
    *  concurrent delivery (409, `accepted:false`). Preserved distinct from

--- a/packages/web/src/lib/setup-api.ts
+++ b/packages/web/src/lib/setup-api.ts
@@ -138,10 +138,11 @@ export async function submitSetupInput(
 
 /** The outcome of delivering a redirect return leg (the OAuth callback). */
 export interface SetupReturnResult {
-  /** A live setup was suspended at a redirect awaiting this `state`. When false,
-   *  no setup matched (unknown/expired/cancelled/already-consumed, or a flow that
-   *  never started a setup, e.g. sign-in) — the caller falls through to the
-   *  sign-in redeem (`/oauth/redeem`), which shares the OAuth redeem primitive. */
+  /** A setup owns this redirect `state`. This includes a setup cancelled while
+   *  awaiting the redirect: it returns `matched:true, accepted:false` so the
+   *  callback cannot fall through to sign-in redeem. When false, no setup owns
+   *  the state (unknown/expired/already-consumed, or a flow that never started a
+   *  setup, e.g. sign-in). */
   matched: boolean;
   /** Whether THIS delivery resumed the coroutine (200) vs. lost a race to a
    *  concurrent delivery (409, `accepted:false`). Preserved distinct from

--- a/packages/web/src/pages/CallbackPage.test.tsx
+++ b/packages/web/src/pages/CallbackPage.test.tsx
@@ -49,9 +49,13 @@ function renderCallbackAndTrackLanding(search: string) {
   );
 }
 
-/** Route the fetch mock by URL so the two legs (setup return, legacy redeem) can
- *  be stubbed independently. */
-function stubFetch(handlers: { setupReturn?: () => Response; redeem?: () => Response }) {
+/** Route the fetch mock by URL so the three calls (setup return, legacy redeem,
+ *  identity probe) can be stubbed independently. */
+function stubFetch(handlers: {
+  setupReturn?: () => Response;
+  redeem?: () => Response;
+  identity?: () => Response;
+}) {
   return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = typeof input === "string" ? input : (input as Request).url;
     if (url.includes("/api/setups/return")) {
@@ -62,6 +66,15 @@ function stubFetch(handlers: { setupReturn?: () => Response; redeem?: () => Resp
     }
     if (url.includes("/api/oauth/redeem")) {
       return handlers.redeem?.() ?? new Response("{}", { status: 200 });
+    }
+    if (url.includes("/api/auth/me")) {
+      // Default to a guardian. The probe only decides where a MATCHED setup
+      // lands, and every test written before it existed assumed the dashboard's
+      // own browser — an unspecified shape here would silently take that branch
+      // for the wrong reason.
+      return (
+        handlers.identity?.() ?? new Response(JSON.stringify({ kind: "guardian" }), { status: 200 })
+      );
     }
     return new Response("{}", { status: 200 });
   });
@@ -230,5 +243,75 @@ describe("CallbackPage return-leg routing", () => {
     expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/api/oauth/redeem"))).toBe(
       false,
     );
+  });
+});
+
+// Where a MATCHED setup's return leg lands depends on whether the browser
+// holding it has a dashboard session. The desktop shell hands provider sign-in
+// to the SYSTEM browser, which has none: navigating there would put an
+// AuthGate-protected route in front of a browser that can only answer it with
+// /login — at the end of every successful connect.
+describe("CallbackPage identity routing", () => {
+  const matchedGithubSetup = () =>
+    new Response(
+      JSON.stringify({
+        matched: true,
+        cid: "setup-gh",
+        service: "github",
+        accepted: true,
+        state: { status: "presenting", view: { progress: true } },
+      }),
+      { status: 200 },
+    );
+
+  const identity = (kind: string) => () => new Response(JSON.stringify({ kind }), { status: 200 });
+
+  it("ends on the page when the browser has no session, claiming only delivery", async () => {
+    stubFetch({ setupReturn: matchedGithubSetup, identity: identity("anonymous") });
+    renderCallbackAndTrackLanding("?handoff=h-ext&state=s-ext");
+
+    // A matched setup is typically still `presenting` while it redeems, and the
+    // redeem or the conferral can still fail — so this page must not claim the
+    // connection exists. It cannot wait for `done` either: `/api/setups/:cid`
+    // stays private, so an anonymous browser has nothing to poll.
+    expect(await screen.findByText("Authorization received")).toBeTruthy();
+    expect(screen.queryByText(/Connected/)).toBeNull();
+    // Nowhere to send it — the page has to be the ending.
+    expect(screen.queryByTestId("landed-on")).toBeNull();
+  });
+
+  it("still returns a guardian to the connection's own page", async () => {
+    stubFetch({ setupReturn: matchedGithubSetup, identity: identity("guardian") });
+    renderCallbackAndTrackLanding("?handoff=h-guard&state=s-guard");
+
+    const landed = await screen.findByTestId("landed-on");
+    expect(landed.textContent).toBe("/settings/connections/github");
+  });
+
+  it("treats a visitor as a dashboard session too", async () => {
+    // The check reads `!== "anonymous"` rather than enumerating the kinds that
+    // count: a visitor is as much a browser session as a guardian, and an
+    // enumeration would strand them on the terminal page.
+    stubFetch({ setupReturn: matchedGithubSetup, identity: identity("visitor") });
+    renderCallbackAndTrackLanding("?handoff=h-vis&state=s-vis");
+
+    const landed = await screen.findByTestId("landed-on");
+    expect(landed.textContent).toBe("/settings/connections/github");
+  });
+
+  it("never probes identity on the sign-in leg", async () => {
+    // Sign-in runs BEFORE its own cookie exists, so the probe would answer
+    // "anonymous" for someone who is about to be signed in. It is also why this
+    // check is a bare fetch rather than the auth gate's query: seeding that
+    // cache here would bounce a successful sign-in straight back to /login.
+    const fetchMock = stubFetch({
+      setupReturn: () => new Response(JSON.stringify({ matched: false }), { status: 404 }),
+      redeem: () => new Response(JSON.stringify({ nextPath: "/dashboard" }), { status: 200 }),
+    });
+    renderCallbackAndTrackLanding("?handoff=h-signin&state=s-signin-identity");
+
+    const landed = await screen.findByTestId("landed-on");
+    expect(landed.textContent).toBe("/dashboard");
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/api/auth/me"))).toBe(false);
   });
 });

--- a/packages/web/src/pages/CallbackPage.test.tsx
+++ b/packages/web/src/pages/CallbackPage.test.tsx
@@ -322,6 +322,40 @@ describe("CallbackPage identity routing", () => {
     expect(landed.textContent).toBe("/settings/connections/github");
   });
 
+  const failedGithubSetup = () =>
+    new Response(
+      JSON.stringify({
+        matched: true,
+        cid: "setup-gh",
+        service: "github",
+        accepted: true,
+        state: { status: "failed", reason: "Authorization was declined." },
+      }),
+      { status: 200 },
+    );
+
+  it("tells a sessionless browser the CONNECTION failed, with no login link", async () => {
+    stubFetch({ setupReturn: failedGithubSetup, identity: identity("anonymous") });
+    renderCallbackAndTrackLanding("?handoff=h-denied&state=s-denied-ext");
+
+    // The generic error view offers "Return to login" — the wrong instruction
+    // for someone who was connecting an account, in a browser that has no
+    // session to return to.
+    expect(await screen.findByText("Connection failed")).toBeTruthy();
+    expect(screen.getByText(/Authorization was declined/i)).toBeTruthy();
+    expect(screen.queryByText("Return to login")).toBeNull();
+    expect(screen.queryByTestId("landed-on")).toBeNull();
+  });
+
+  it("keeps the existing error view for a browser that does have a session", async () => {
+    stubFetch({ setupReturn: failedGithubSetup, identity: identity("guardian") });
+    renderCallbackAndTrackLanding("?handoff=h-denied&state=s-denied-web");
+
+    expect(await screen.findByText(/Authorization was declined/i)).toBeTruthy();
+    expect(screen.getByText("Return to login")).toBeTruthy();
+    expect(screen.queryByText("Connection failed")).toBeNull();
+  });
+
   it("never probes identity on the sign-in leg", async () => {
     // Sign-in runs BEFORE its own cookie exists, so the probe would answer
     // "anonymous" for someone who is about to be signed in. It is also why this

--- a/packages/web/src/pages/CallbackPage.test.tsx
+++ b/packages/web/src/pages/CallbackPage.test.tsx
@@ -204,6 +204,29 @@ describe("CallbackPage return-leg routing", () => {
     );
   });
 
+  it("does not redeem a late return owned by a cancelled setup", async () => {
+    const fetchMock = stubFetch({
+      setupReturn: () =>
+        new Response(
+          JSON.stringify({
+            matched: true,
+            cid: "setup-cancelled",
+            service: "github",
+            accepted: false,
+            state: { status: "cancelled" },
+          }),
+          { status: 409 },
+        ),
+    });
+    renderCallback("?handoff=h-cancelled&state=s-cancelled");
+
+    expect(await screen.findByText("Connection cancelled")).toBeTruthy();
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/api/oauth/redeem"))).toBe(
+      false,
+    );
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("/api/auth/me"))).toBe(false);
+  });
+
   it("does NOT dead-end on redeem when the return leg fails ambiguously (5xx)", async () => {
     const fetchMock = stubFetch({
       setupReturn: () => new Response(JSON.stringify({ error: "boom" }), { status: 500 }),

--- a/packages/web/src/pages/CallbackPage.tsx
+++ b/packages/web/src/pages/CallbackPage.tsx
@@ -36,7 +36,11 @@ function connectionPath(service: string | undefined): string {
  *  delivery is the most this browser can honestly report. It cannot wait for
  *  `done` either: `/api/setups/:cid` stays private, so an anonymous browser has
  *  no way to poll for the real outcome. */
-type ReturnOutcome = { redirect: string } | { error: string } | { delivered: true };
+type ReturnOutcome =
+  | { redirect: string }
+  | { error: string }
+  | { delivered: true }
+  | { cancelled: true };
 
 /**
  * Whether this browser holds a dashboard session.
@@ -111,6 +115,10 @@ function handleOAuthReturnOnce(
       ...(providerError ? { error: providerError } : {}),
     });
     if (returned.matched) {
+      // Cancellation still owns its redirect state. Stop here so a late browser
+      // return cannot fall through to the sign-in redeem and import a credential
+      // after the guardian explicitly cancelled the connection in Rome.
+      if (returned.state?.status === "cancelled") return { cancelled: true };
       if (returned.state?.status === "failed") {
         return { error: returned.state.reason || fallbackError };
       }
@@ -187,6 +195,7 @@ export default function CallbackPage() {
   const state = searchParams.get("state");
   const providerError = searchParams.get("error");
   const [error, setError] = useState<string | null>(providerError);
+  const [setupCancelled, setSetupCancelled] = useState(false);
   // The leg reached its setup from a browser with no dashboard session — the
   // system browser the desktop shell handed off to. There is nowhere to
   // navigate it, so the page has to be the ending.
@@ -230,6 +239,10 @@ export default function CallbackPage() {
           setDelivered(true);
           return;
         }
+        if ("cancelled" in outcome) {
+          setSetupCancelled(true);
+          return;
+        }
         navigate(outcome.redirect, { replace: true });
       } catch (returnError) {
         if (cancelled) return;
@@ -253,7 +266,11 @@ export default function CallbackPage() {
     <main className="flex min-h-dvh items-center justify-center bg-surface-muted px-4 pb-safe pt-safe">
       <div className="w-full max-w-md rounded-12 border border-border bg-surface p-6 shadow-1">
         <h1 className="text-title text-foreground">
-          {delivered ? t("callback.deliveredTitle") : t("callback.title")}
+          {setupCancelled
+            ? t("callback.cancelledTitle")
+            : delivered
+              ? t("callback.deliveredTitle")
+              : t("callback.title")}
         </h1>
         {displayError ? (
           <>
@@ -265,6 +282,8 @@ export default function CallbackPage() {
               {t("callback.returnToLogin")}
             </a>
           </>
+        ) : setupCancelled ? (
+          <p className="mt-3 text-body text-muted-foreground">{t("callback.cancelledBody")}</p>
         ) : delivered ? (
           <p className="mt-3 text-body text-muted-foreground">{t("callback.deliveredBody")}</p>
         ) : (

--- a/packages/web/src/pages/CallbackPage.tsx
+++ b/packages/web/src/pages/CallbackPage.tsx
@@ -40,7 +40,14 @@ type ReturnOutcome =
   | { redirect: string }
   | { error: string }
   | { delivered: true }
-  | { cancelled: true };
+  | { cancelled: true }
+  /** A setup this browser owns came back failed, and the browser has no
+   *  dashboard session — the desktop shell's system browser. The generic error
+   *  view offers "Return to login", which is the wrong instruction for someone
+   *  who was connecting an account, not signing in. Scoped to a MATCHED setup:
+   *  an ambiguous return still cannot tell a connect from a sign-in, so it keeps
+   *  the existing handling rather than guessing. */
+  | { connectionFailed: string };
 
 /**
  * Whether this browser holds a dashboard session.
@@ -120,7 +127,9 @@ function handleOAuthReturnOnce(
       // after the guardian explicitly cancelled the connection in Rome.
       if (returned.state?.status === "cancelled") return { cancelled: true };
       if (returned.state?.status === "failed") {
-        return { error: returned.state.reason || fallbackError };
+        const reason = returned.state.reason || fallbackError;
+        if (!(await hasDashboardSession())) return { connectionFailed: reason };
+        return { error: reason };
       }
       // Only a MATCHED setup asks. The sign-in leg below must not probe
       // identity: it runs before its own session exists, so the answer would be
@@ -196,6 +205,9 @@ export default function CallbackPage() {
   const providerError = searchParams.get("error");
   const [error, setError] = useState<string | null>(providerError);
   const [setupCancelled, setSetupCancelled] = useState(false);
+  // A failed connection reported to a browser with no dashboard session: the
+  // reason to show, with no login link under it.
+  const [connectionFailed, setConnectionFailed] = useState<string | null>(null);
   // The leg reached its setup from a browser with no dashboard session — the
   // system browser the desktop shell handed off to. There is nowhere to
   // navigate it, so the page has to be the ending.
@@ -243,6 +255,10 @@ export default function CallbackPage() {
           setSetupCancelled(true);
           return;
         }
+        if ("connectionFailed" in outcome) {
+          setConnectionFailed(outcome.connectionFailed);
+          return;
+        }
         navigate(outcome.redirect, { replace: true });
       } catch (returnError) {
         if (cancelled) return;
@@ -259,20 +275,35 @@ export default function CallbackPage() {
 
   // An up-to-date broker attaches a readable error_description that core
   // relays as-is; a bare RFC 6749 code (deploy skew, older broker) would
-  // otherwise surface verbatim — translate the one users actually hit.
-  const displayError = error === "invalid_grant" ? t("callback.errorInvalidGrant") : error;
+  // otherwise surface verbatim — translate the one users actually hit. A setup
+  // failure can relay the same code, so both readings go through it.
+  const readable = (reason: string | null) =>
+    reason === "invalid_grant" ? t("callback.errorInvalidGrant") : reason;
+  const displayError = readable(error);
+  const displayConnectionFailure = readable(connectionFailed);
 
   return (
     <main className="flex min-h-dvh items-center justify-center bg-surface-muted px-4 pb-safe pt-safe">
       <div className="w-full max-w-md rounded-12 border border-border bg-surface p-6 shadow-1">
         <h1 className="text-title text-foreground">
-          {setupCancelled
-            ? t("callback.cancelledTitle")
-            : delivered
-              ? t("callback.deliveredTitle")
-              : t("callback.title")}
+          {displayConnectionFailure
+            ? t("callback.connectionFailedTitle")
+            : setupCancelled
+              ? t("callback.cancelledTitle")
+              : delivered
+                ? t("callback.deliveredTitle")
+                : t("callback.title")}
         </h1>
-        {displayError ? (
+        {displayConnectionFailure ? (
+          // No login link: this browser was connecting an account, not signing
+          // in, and it has no session to return to anyway.
+          <>
+            <p className="mt-3 text-ui text-destructive-fg">{displayConnectionFailure}</p>
+            <p className="mt-3 text-body text-muted-foreground">
+              {t("callback.connectionFailedBody")}
+            </p>
+          </>
+        ) : displayError ? (
           <>
             <p className="mt-3 text-ui text-destructive-fg">{displayError}</p>
             <a

--- a/packages/web/src/pages/CallbackPage.tsx
+++ b/packages/web/src/pages/CallbackPage.tsx
@@ -26,8 +26,45 @@ function connectionPath(service: string | undefined): string {
 }
 
 /** The outcome of handling one OAuth return leg. `redirect` is where to send the
- *  guardian; `error` is a terminal failure to show instead. */
-type ReturnOutcome = { redirect: string } | { error: string };
+ *  guardian; `error` is a terminal failure to show instead; `delivered` means the
+ *  leg reached its setup from a browser with no dashboard session of its own —
+ *  the desktop shell's hand-off to the system browser — so there is nowhere to
+ *  send it and the page has to be the ending.
+ *
+ *  Deliberately NOT `connected`. A resumed setup is typically still `presenting`
+ *  while it redeems, and the redeem or the conferral commit can still fail —
+ *  delivery is the most this browser can honestly report. It cannot wait for
+ *  `done` either: `/api/setups/:cid` stays private, so an anonymous browser has
+ *  no way to poll for the real outcome. */
+type ReturnOutcome = { redirect: string } | { error: string } | { delivered: true };
+
+/**
+ * Whether this browser holds a dashboard session.
+ *
+ * Deliberately a bare fetch and NOT the `useAuthState` query. That key is owned
+ * by the auth gate — it is the sole fetcher — and is cached with `staleTime:
+ * Infinity`, invalidated only by the login and onboard mutations. Seeding it
+ * from here would let the SIGN-IN leg, which by definition runs before its own
+ * cookie exists, park `needs-signin` in the cache; the gate would then reuse
+ * that stale answer after the redeem and bounce the user back to /login on a
+ * successful sign-in.
+ *
+ * The question is only ever "is this browser anonymous". A `visitor` is as much
+ * a dashboard session as a `guardian`, so this reads as a negative rather than
+ * an enumeration of the kinds that count.
+ */
+async function hasDashboardSession(): Promise<boolean> {
+  try {
+    const response = await fetch("/api/auth/me", { credentials: "same-origin" });
+    if (!response.ok) return true;
+    const identity = (await response.json()) as { kind?: string };
+    return identity.kind !== "anonymous";
+  } catch {
+    // Can't tell: keep the navigation this flow has always done rather than
+    // stranding a dashboard user on a page that tells them to go back to Rome.
+    return true;
+  }
+}
 
 // Dedup by `(state, handoff, providerError)` so React's double-invoked effects
 // deliver each single-use return leg ONCE. Like `redeemRequests`, an entry is
@@ -77,6 +114,10 @@ function handleOAuthReturnOnce(
       if (returned.state?.status === "failed") {
         return { error: returned.state.reason || fallbackError };
       }
+      // Only a MATCHED setup asks. The sign-in leg below must not probe
+      // identity: it runs before its own session exists, so the answer would be
+      // both wrong and useless there.
+      if (!(await hasDashboardSession())) return { delivered: true };
       // The setup consumed the leg and is finishing the redeem; the connection's
       // detail page re-attaches and settles it.
       return { redirect: connectionPath(returned.service) };
@@ -146,6 +187,10 @@ export default function CallbackPage() {
   const state = searchParams.get("state");
   const providerError = searchParams.get("error");
   const [error, setError] = useState<string | null>(providerError);
+  // The leg reached its setup from a browser with no dashboard session — the
+  // system browser the desktop shell handed off to. There is nowhere to
+  // navigate it, so the page has to be the ending.
+  const [delivered, setDelivered] = useState(false);
 
   useEffect(() => {
     // The `state` is the return-leg correlation for BOTH features (connect-setup
@@ -181,6 +226,10 @@ export default function CallbackPage() {
           setError(outcome.error);
           return;
         }
+        if ("delivered" in outcome) {
+          setDelivered(true);
+          return;
+        }
         navigate(outcome.redirect, { replace: true });
       } catch (returnError) {
         if (cancelled) return;
@@ -203,7 +252,9 @@ export default function CallbackPage() {
   return (
     <main className="flex min-h-dvh items-center justify-center bg-surface-muted px-4 pb-safe pt-safe">
       <div className="w-full max-w-md rounded-12 border border-border bg-surface p-6 shadow-1">
-        <h1 className="text-title text-foreground">{t("callback.title")}</h1>
+        <h1 className="text-title text-foreground">
+          {delivered ? t("callback.deliveredTitle") : t("callback.title")}
+        </h1>
         {displayError ? (
           <>
             <p className="mt-3 text-ui text-destructive-fg">{displayError}</p>
@@ -214,6 +265,8 @@ export default function CallbackPage() {
               {t("callback.returnToLogin")}
             </a>
           </>
+        ) : delivered ? (
+          <p className="mt-3 text-body text-muted-foreground">{t("callback.deliveredBody")}</p>
         ) : (
           <p className="mt-3 text-body text-muted-foreground">{t("callback.description")}</p>
         )}


### PR DESCRIPTION
## What this PR does

An account whose GitHub second factor is a passkey or Touch ID cannot connect from the Mac app at all. Connecting navigates the whole Electron window to the provider (`oauth-connection-section.tsx`), and `isUserVerifyingPlatformAuthenticatorAvailable()` returns false in that window. Password plus TOTP works; passkey-only dead-ends.

The hand-off now goes to the system browser, which has the keychain and the accounts the user is already signed in to.

## Design & Invariants

**The return leg is reachable without a session; the rest of the setup surface is not.** `/api/setups/return` joins `PUBLIC_API_PATHS` as an exact path. The handler already read no session — only `state` — so Caddy's `forward_auth` probe was the only thing between a system browser and the setup waiting for it. `state` is a 24-byte opaque code matching one setup still parked at `awaiting-redirect`; the credential exchange needs the handoff, the PKCE verifier and the instance token, none of which cross this boundary. Same shape as the `/api/auth/cloud/*` entry above it, and a test pins that the sibling routes still 401.

**Only the desktop shell opens externally.** A browser dashboard keeps `location.assign` — it already has the user's session and extensions, and a new tab would change a flow that works. One helper serves all three entry points: auto-forward, manual resume, and reconnect.

**`packages/desktop` is untouched.** `setWindowOpenHandler` already forwards renderer `window.open` to `shell.openExternal` and denies the Electron window, scheme check included. Verified on the packaged 1.0.109 that the call survives the preceding `await`, so no preload bridge is needed. Beyond ~5s of transient activation the click is a no-op and the guardian clicks again; the manual resume already covered that.

**The window no longer navigates away, which breaks two things unless handled.** `useSetup` has to poll `awaiting-redirect` — it watched only `presenting`, so the card would sit unchanged until the connections page's own refresh. And reconnect now parks on the same pending controls rather than leaving a Reconnect button to click a second time.

**The callback can land in a browser with no dashboard session.** It navigated to `/settings/connections/<service>`, inside `AuthGate` — in the system browser that is a bounce to `/login` at the end of every successful connect. After a matched setup it asks `/api/auth/me` and shows a terminal state when the answer is anonymous.

That probe is a bare fetch, not `useAuthState`. The auth gate is that query's sole fetcher, it caches with `staleTime: Infinity`, and only the login and onboard mutations invalidate it — seeding it here would let the sign-in leg, which runs before its own cookie exists, park `needs-signin` and bounce a successful sign-in back to `/login`. It reads `!== "anonymous"` rather than enumerating `guardian`, because a `visitor` is as much a dashboard session.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — no errors (19 warnings, all pre-existing in `cdp-client`).
- [x] `pnpm --filter @rome/core test` — 4025 passed, 2 skipped.
- [x] `pnpm --filter rome-web test` — 1100 passed.
- [x] Mutation-checked the identity branch: narrowing it to `=== "guardian"` fails the visitor case; dropping it fails the anonymous case.
- [x] Packaged 1.0.109 smoke test — `window.open` after an `await` reaches the system browser.
- [x] Real connect end to end on a local image (`rome-local:dev`, container recreated onto it):
      Connect opened the system browser, GitHub authorized, the callback landed on
      `Authorization received` rather than `/login`, and the card settled to Connected
      in the app with no manual refresh.
- [x] Probed the opened route against the real Caddy on that instance:
      `/api/setups/return` returns 403 without same-origin headers (the app's own guard)
      and 404 `{"matched":false}` with them — so forward_auth passes it through — while
      `/api/setups/abc` still returns 401.

Draft until that last item is done. It is the only step the unit tests cannot stand in for — the smoke test proved the browser opens, not that the loop closes.

## Not in this PR

- **A preload + IPC bridge.** Only needed if `window.open` were blocked, and it is not. URL validation would then have to allow `http` on loopback for local Pantheon.
- **The release.** A release build freezes its runtime image reference, so an installed app will not pick up a new backend on its own — shipping this needs a desktop release alongside the image.

