### PR TITLE
docs(coding): scope the guardian gate to owner-privileged routes

### DIFF
--- a/rome_apps/coding/src/skills/app_creation/REFERENCE.md
+++ b/rome_apps/coding/src/skills/app_creation/REFERENCE.md
@@ -533,18 +533,17 @@ export function createApiHandler(ctx: RomeAppContext): RomeAppApiHandler {
   identity, the single trustworthy "who is calling" answer:
   `{ kind: "guardian"; userId; via: "cookie" | "loopback" }` |
   `{ kind: "visitor"; accountId; email }` | `{ kind: "anonymous" }`.
-  The host enforces the app's access mode **before** dispatch: on a private
-  app only the guardian reaches the handler, on a shared app the guardian and
-  the allow-listed visitors, on a public app anyone. A request that reaches
-  the handler is already authorized to use the app. Do **not** gate the whole
-  handler on `caller.kind` — a blanket
-  `if (request.caller.kind !== "guardian") return 403` rejects every visitor
-  and public caller, so sharing the app stops working. Gate only
-  owner-privileged routes — settings writes, agent dispatch, destructive
-  operations — with
+  The host already enforces the app's access mode **before** dispatch: on a
+  private app only the guardian reaches the handler, on a shared app the
+  guardian and the allow-listed visitors, on a public app anyone. A request
+  that reaches the handler is already authorized to use the app, so most
+  handlers need no caller check at all. Read `caller.kind` only when the app
+  differentiates between the guardian and visitors — an owner-privileged
+  route (settings writes, agent dispatch, destructive operations) gated with
   `if (request.caller.kind !== "guardian") return Response.json({ error: "forbidden" }, { status: 403 })`,
-  and leave the app's ordinary read and interaction routes open to whoever
-  the host admitted.
+  or per-visitor data keyed on `caller.email`. Never gate the whole handler
+  this way — that rejects every visitor and public caller, so sharing the
+  app stops working.
   Never derive identity from headers yourself — the host strips identity
   headers (`X-Rome-User-Id`, `x-rome-visitor-*`) before dispatch, and on a
   public app any surviving header is attacker-controlled. In the web UI,

--- a/rome_apps/coding/src/skills/app_creation/REFERENCE.md
+++ b/rome_apps/coding/src/skills/app_creation/REFERENCE.md
@@ -533,8 +533,18 @@ export function createApiHandler(ctx: RomeAppContext): RomeAppApiHandler {
   identity, the single trustworthy "who is calling" answer:
   `{ kind: "guardian"; userId; via: "cookie" | "loopback" }` |
   `{ kind: "visitor"; accountId; email }` | `{ kind: "anonymous" }`.
-  Gate owner-only routes with
-  `if (request.caller.kind !== "guardian") return Response.json({ error: "forbidden" }, { status: 401 })`.
+  The host enforces the app's access mode **before** dispatch: on a private
+  app only the guardian reaches the handler, on a shared app the guardian and
+  the allow-listed visitors, on a public app anyone. A request that reaches
+  the handler is already authorized to use the app. Do **not** gate the whole
+  handler on `caller.kind` — a blanket
+  `if (request.caller.kind !== "guardian") return 403` rejects every visitor
+  and public caller, so sharing the app stops working. Gate only
+  owner-privileged routes — settings writes, agent dispatch, destructive
+  operations — with
+  `if (request.caller.kind !== "guardian") return Response.json({ error: "forbidden" }, { status: 403 })`,
+  and leave the app's ordinary read and interaction routes open to whoever
+  the host admitted.
   Never derive identity from headers yourself — the host strips identity
   headers (`X-Rome-User-Id`, `x-rome-visitor-*`) before dispatch, and on a
   public app any surviving header is attacker-controlled. In the web UI,


### PR DESCRIPTION
## What this PR does

Sharing an app did nothing for its API. Apps generated by the `app_creation` skill open their handler with a blanket `if (request.caller.kind !== "guardian") return 403` guard, so an allow-listed visitor or a public caller got `{"error":"forbidden"}` on every route even after the guardian granted access. The frontend still loaded, because static assets carry no such guard, so the symptom read as "the app works but its backend is unreachable". On one live instance, 13 of the installed generated apps carry this guard (dev-desk, competitor-radar, people-enrichment, …), and `curl https://<domain>/api/apps/dev-desk/state` on a public app returned the handler's 403.

The guard comes from REFERENCE.md. The old bullet showed the gate snippet with no statement of what the host already enforces, and the generator applied the snippet to the whole handler. This PR rewrites the bullet: the host enforces the app's access mode before dispatch, a request that reaches the handler is already authorized to use the app, and most handlers need no caller check at all. A handler reads `caller.kind` only when the app differentiates between the guardian and visitors — an owner-privileged route such as settings writes or agent dispatch, or per-visitor data keyed on `caller.email`. The example status also moves from 401 to 403, since the caller is identified but not privileged.

## Design & Invariants

The host edge is the single admission point for app API routes: private admits the guardian, shared admits the guardian and allow-listed visitors, public admits anyone. A handler trusts the edge for admission and reads the caller only to differentiate roles. A handler that re-checks admission cancels the guardian's sharing choice.

## Test plan

- [x] `scripts/check-pr-title.sh` on the PR title.
- [x] Doc-only change — `rome_apps/coding/dist` is gitignored and rebuilds from src, so no stale copy ships from the repo.
- [ ] Regenerate an app with the updated skill and confirm the handler adds no blanket caller check.

## Not in this PR

- Already-installed generated apps keep the baked-in guard — each needs a regeneration or a one-line patch (dev-desk on the hosted VM is the known case).
- The `RomeAppCaller` docstring in `packages/app-runtime-sdk` shows the owner-only gate example without the blanket-gate warning — separate PR, since that package publishes to npm.
- No platform change — the edge already opens `/api/apps/<appId>/*` when access is granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)