### PR TITLE
fix(channels): preserve mention-only messages

### DIFF
--- a/packages/core/src/channels/discord-message-text.test.ts
+++ b/packages/core/src/channels/discord-message-text.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { normalizeDiscordMessageText } from "./discord.js";
+
+const bot = { id: "123", displayName: "Rome" };
+
+describe("normalizeDiscordMessageText", () => {
+  it("preserves a bot-only mention as the visible bot name", () => {
+    expect(normalizeDiscordMessageText("<@123>", bot, true)).toBe("@Rome");
+    expect(normalizeDiscordMessageText("<@!123>", bot, true)).toBe("@Rome");
+  });
+
+  it("strips the bot mention when addressed prose remains", () => {
+    expect(normalizeDiscordMessageText("<@123> please review", bot, true)).toBe("please review");
+  });
+
+  it("does not invent a mention for unrelated empty content", () => {
+    expect(normalizeDiscordMessageText("", bot, false)).toBe("");
+  });
+});

--- a/packages/core/src/channels/discord.ts
+++ b/packages/core/src/channels/discord.ts
@@ -49,6 +49,7 @@ import {
   DISCORD_BROKER_RESPONSE_LIMIT_BYTES,
   normalizeDiscordEndpoint,
 } from "@rome/api-types/discord-broker";
+import { preserveMentionOnlyText } from "./mention-only.js";
 
 interface DiscordRestMessage {
   id: string;
@@ -88,6 +89,16 @@ const HISTORY_CHANNEL_TYPES = new Set([0, 5, 11, 12]);
 function timestampToSnowflake(timestampMs: number): string {
   const discordEpoch = 1420070400000n;
   return ((BigInt(Math.floor(timestampMs)) - discordEpoch) << 22n).toString();
+}
+
+/** Strips the bot mention from prose while preserving a mention-only message. */
+export function normalizeDiscordMessageText(
+  content: string,
+  bot: { id: string; displayName: string } | null,
+  mentionedBot: boolean,
+): string {
+  const text = bot ? content.replace(new RegExp(`<@!?${bot.id}>`, "g"), "").trim() : content;
+  return preserveMentionOnlyText(text, bot !== null && mentionedBot, bot?.displayName);
 }
 
 function restMessageToNormalized(
@@ -775,12 +786,12 @@ export class DiscordAdapter implements ProviderAdapter {
   private async dispatchMessage(message: Message, isDm: boolean, isThread: boolean): Promise<void> {
     if (!this.handler) return;
 
-    // Strip the bot @mention from message text so the agent sees clean input
-    let text = message.content;
-    if (this.client.user) {
-      const botId = this.client.user.id;
-      text = text.replace(new RegExp(`<@!?${botId}>`, "g"), "").trim();
-    }
+    const bot = this.client.user;
+    const text = normalizeDiscordMessageText(
+      message.content,
+      bot,
+      bot ? message.mentions.users.has(bot.id) : false,
+    );
 
     let threadName: string | undefined;
     if (!isDm && "name" in message.channel) {

--- a/packages/core/src/channels/feishu.test.ts
+++ b/packages/core/src/channels/feishu.test.ts
@@ -262,7 +262,7 @@ describe("FeishuAdapter", () => {
     expect(captured[0].threadType).toBe("group");
   });
 
-  it("delivers an @-only group message as a greeting", async () => {
+  it("preserves an @-only group message as the visible bot mention", async () => {
     await channel.emit({
       chatType: "group",
       content: "",
@@ -272,7 +272,7 @@ describe("FeishuAdapter", () => {
     });
 
     expect(captured).toHaveLength(1);
-    expect(captured[0].text).toBe("hello");
+    expect(captured[0].text).toBe("@Rome");
   });
 
   it("ignores group messages that do not mention the bot by default", async () => {

--- a/packages/core/src/channels/feishu.ts
+++ b/packages/core/src/channels/feishu.ts
@@ -16,6 +16,7 @@ import type {
   ConversationId,
   ConversationSettingsControl,
 } from "@rome-os/app-runtime";
+import { preserveMentionOnlyText } from "./mention-only.js";
 
 const log = createLogger("feishu");
 const PROCESSING_REACTION_EMOJI = "Typing";
@@ -226,7 +227,11 @@ export class FeishuAdapter implements ProviderAdapter {
     // MVP: text-bearing messages only. Media-only messages arrive with empty
     // content and are dropped until attachment support lands.
     const resolvedText = resolveMentions(m.content ?? "", m.mentions);
-    const text = resolvedText || (m.rawContentType === "text" && m.mentionedBot ? "hello" : "");
+    const text = preserveMentionOnlyText(
+      resolvedText,
+      m.rawContentType === "text" && m.mentionedBot,
+      this.channel.botIdentity?.name,
+    );
     if (!text) return;
     const threadType = m.chatType === "p2p" ? "private" : "group";
     if (threadType === "group") {

--- a/packages/core/src/channels/mention-only.test.ts
+++ b/packages/core/src/channels/mention-only.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { preserveMentionOnlyText } from "./mention-only.js";
+
+describe("preserveMentionOnlyText", () => {
+  it("restores the visible bot mention when stripping leaves no text", () => {
+    expect(preserveMentionOnlyText("", true, "Project Bot")).toBe("@Project Bot");
+  });
+
+  it("uses Rome when the provider has no bot display name", () => {
+    expect(preserveMentionOnlyText("", true)).toBe("@Rome");
+  });
+
+  it("keeps addressed prose and unrelated empty messages unchanged", () => {
+    expect(preserveMentionOnlyText("please review", true, "Rome")).toBe("please review");
+    expect(preserveMentionOnlyText("", false, "Rome")).toBe("");
+  });
+});

--- a/packages/core/src/channels/mention-only.ts
+++ b/packages/core/src/channels/mention-only.ts
@@ -1,0 +1,9 @@
+/** Preserves a stripped mention-only message as the visible bot mention. */
+export function preserveMentionOnlyText(
+  text: string,
+  mentionedBot: boolean,
+  botName?: string,
+): string {
+  if (text || !mentionedBot) return text;
+  return `@${botName?.trim() || "Rome"}`;
+}


### PR DESCRIPTION
## What this PR does

Mention-only messages lose their only content when a channel adapter strips the bot mention. Feishu replaced that event with `hello`, which changed the stored user input. Discord left it empty, so the shared inbox dropped it.

Both adapters now preserve the visible mention as `@<bot name>` when no prose remains. Messages with prose still reach the agent without the bot mention.

Follow-up to #37.

## Design & Invariants

Channel adapters absorb provider-specific mention syntax before routing. A stripped bot mention remains meaningful when it is the whole message. Empty non-mention events and Feishu media-only events stay empty.

One shared helper owns the fallback so the providers cannot drift.

## Test plan

- [x] `pnpm exec biome check` on all changed files
- [x] `pnpm --filter @rome/core typecheck`
- [x] Focused Feishu, Discord, and shared-helper tests (36 tests)
- [x] `pnpm test:unit` (5,720 tests)
- [ ] `pnpm typecheck` — the local checkout fails in untouched mobile and UI files after the dependency update.
- [ ] `pnpm dev:all` — the existing `rome-rome-1` container already owns host port 80.