### PR TITLE
feat(core): add a channel account contract

### DIFF
--- a/packages/core/src/channels/account-paging.ts
+++ b/packages/core/src/channels/account-paging.ts
@@ -1,0 +1,39 @@
+import type { Account } from "./accounts.js";
+
+/**
+ * The in-memory half of `TalkAccounts.listAccounts`, for channels that mirror
+ * the whole address book locally and page over it here. A channel whose
+ * provider paginates server-side pages there and does not use this.
+ */
+
+/** Case-insensitive substring match over the label and every identifier value. */
+function matches(account: Account, needle: string): boolean {
+  if (account.label.toLowerCase().includes(needle)) return true;
+  for (const value of Object.values(account.identifiers)) {
+    if (value.toLowerCase().includes(needle)) return true;
+  }
+  return false;
+}
+
+/**
+ * One page of an already-ordered account list. The cursor is an offset into the
+ * filtered list — opaque to the caller, and rejected back to the first page
+ * when it does not parse, so a corrupt value cannot walk off the end silently.
+ */
+export function pageAccounts(
+  accounts: Account[],
+  input: { query?: string; cursor?: string; limit: number },
+): { accounts: Account[]; nextCursor?: string } {
+  const needle = input.query?.trim().toLowerCase();
+  const filtered = needle ? accounts.filter((a) => matches(a, needle)) : accounts;
+
+  const parsed = input.cursor == null ? 0 : Number(input.cursor);
+  const start = Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
+  const limit = Math.max(1, Math.floor(input.limit));
+  const end = start + limit;
+
+  return {
+    accounts: filtered.slice(start, end),
+    nextCursor: end < filtered.length ? String(end) : undefined,
+  };
+}

--- a/packages/core/src/channels/account-paging.ts
+++ b/packages/core/src/channels/account-paging.ts
@@ -15,10 +15,21 @@ function matches(account: Account, needle: string): boolean {
   return false;
 }
 
+// Page size used when a caller passes a limit that is not a number at all. A
+// route that builds one from a query string can produce NaN, and answering that
+// with an empty page would be indistinguishable from an exhausted listing.
+const FALLBACK_LIMIT = 50;
+
 /**
  * One page of an already-ordered account list. The cursor is an offset into the
  * filtered list — opaque to the caller, and rejected back to the first page
  * when it does not parse, so a corrupt value cannot walk off the end silently.
+ *
+ * Offset paging assumes the listing holds still. It does not: a WhatsApp
+ * account moves to the front when a message arrives, so an inbound message
+ * between two pages shifts every later account down and one of them is skipped
+ * or repeated. A caller that needs every account exactly once reads the whole
+ * listing in one page rather than walking cursors across a live mirror.
  */
 export function pageAccounts(
   accounts: Account[],
@@ -29,7 +40,9 @@ export function pageAccounts(
 
   const parsed = input.cursor == null ? 0 : Number(input.cursor);
   const start = Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
-  const limit = Math.max(1, Math.floor(input.limit));
+  const limit = Number.isFinite(input.limit)
+    ? Math.max(1, Math.floor(input.limit))
+    : FALLBACK_LIMIT;
   const end = start + limit;
 
   return {

--- a/packages/core/src/channels/accounts.ts
+++ b/packages/core/src/channels/accounts.ts
@@ -45,6 +45,11 @@ export interface TalkAccounts {
    * One page of the channel's accounts, in a stable order. `query` matches the
    * label and the identifier values. `cursor` is opaque and comes from a prior
    * page. A missing `nextCursor` means the listing is exhausted.
+   *
+   * The order is stable, the listing underneath it is not. A channel may order
+   * by activity, so an account can move between two pages and be skipped or
+   * repeated. A caller that needs every account exactly once asks for one page
+   * large enough to hold the listing.
    */
   listAccounts(input: {
     query?: string;

--- a/packages/core/src/channels/accounts.ts
+++ b/packages/core/src/channels/accounts.ts
@@ -1,0 +1,58 @@
+/**
+ * The account plane of a channel. `ProviderAdapter` (adapter.ts) is the
+ * message plane — it moves text. This is the address book behind it: who a
+ * channel can reach, and which of the identifiers a channel hands out name one
+ * and the same account.
+ *
+ * The four invariants below are the contract. The types cannot carry them, and
+ * every implementation owes all four:
+ *
+ * - **I1 Uniqueness.** Exactly one {@link Account} per real account. The same
+ *   `id` means the same account. Callers never fold aliases themselves.
+ * - **I2 Stability.** `id` does not change for the life of the account — not
+ *   across a restart, a re-sync, a message arriving on a different addressing,
+ *   or a change to any identifier the account is reachable on.
+ * - **I3 Opacity.** Callers never parse or construct an `id`. This is what lets
+ *   a channel change its canonical form later without touching a consumer.
+ * - **I4 Total resolution.** Every identifier the channel can receive a message
+ *   on resolves to that account's `id`.
+ *
+ * An account answers *who*. What happened — a last message, a count, a preview
+ * — is a separate read, keyed by {@link AccountId}, and does not belong here.
+ */
+
+/** Opaque provider-owned account address. Callers may persist and round-trip
+ * this value, but must never parse, construct, or compare parts of one. */
+export type AccountId = string & { readonly __brand: "AccountId" };
+
+export interface Account {
+  id: AccountId;
+  /** Human-readable, for display and search. Never an identity key. */
+  label: string;
+  /**
+   * Searchable facts. Never used to address the account.
+   *
+   * `email`, `phone`, `username` and `profile_url` are reserved and mean the
+   * same thing on every channel. Every other key is namespaced by its channel
+   * — `whatsapp:lid`, `linkedin:member_id`. One value per key: an account
+   * holding a second value of the same kind qualifies the key (`email:work`).
+   */
+  identifiers: Record<string, string>;
+}
+
+export interface TalkAccounts {
+  /**
+   * One page of the channel's accounts, in a stable order. `query` matches the
+   * label and the identifier values. `cursor` is opaque and comes from a prior
+   * page. A missing `nextCursor` means the listing is exhausted.
+   */
+  listAccounts(input: {
+    query?: string;
+    cursor?: string;
+    limit: number;
+  }): Promise<{ accounts: Account[]; nextCursor?: string }>;
+
+  /** The account an identifier belongs to, or null. Accepts any identifier the
+   *  channel can receive on — and an {@link AccountId}, which round-trips. */
+  resolve(identifier: string): Promise<Account | null>;
+}

--- a/packages/core/src/channels/linkedin-accounts.test.ts
+++ b/packages/core/src/channels/linkedin-accounts.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb, type TestDb } from "../test/helpers.js";
+import { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
+import { LinkedInAccounts } from "./linkedin-accounts.js";
+
+const ada = {
+  participantId: "ACoAAAda0001",
+  name: "Ada Lovelace",
+  headline: "Engineer",
+  type: "member",
+  isSelf: false,
+};
+const grace = {
+  participantId: "ACoAAGrace002",
+  name: "Grace Hopper",
+  headline: "Rear Admiral",
+  type: "member",
+  isSelf: false,
+};
+const self = {
+  participantId: "ACoAASelf0003",
+  name: "Me Myself",
+  headline: null,
+  type: "member",
+  isSelf: true,
+};
+
+describe("LinkedInAccounts", () => {
+  let testDb: TestDb;
+  let repo: LinkedInStoreRepository;
+  let accounts: LinkedInAccounts;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    repo = new LinkedInStoreRepository(testDb.db);
+    accounts = new LinkedInAccounts(repo);
+    await repo.upsertThreads([
+      {
+        threadId: "t1",
+        threadUrl: "https://www.linkedin.com/messaging/thread/t1/",
+        personName: "Ada Lovelace",
+        unread: false,
+      },
+    ]);
+    await repo.upsertThreadParticipants("t1", [ada, grace, self]);
+  });
+
+  afterEach(() => testDb.close());
+
+  it("resolves a profile URL and a bare member id to one account", async () => {
+    const fromUrl = await accounts.resolve("https://www.linkedin.com/in/ACoAAAda0001/");
+    const fromId = await accounts.resolve("ACoAAAda0001");
+
+    expect(fromUrl).not.toBeNull();
+    expect(fromUrl!.id).toBe("ACoAAAda0001");
+    expect(fromId!.id).toBe(fromUrl!.id);
+    expect((await accounts.resolve(fromUrl!.id))!.id).toBe(fromUrl!.id);
+  });
+
+  it("describes an account by label and namespaced identifier", async () => {
+    const account = (await accounts.resolve("ACoAAAda0001"))!;
+
+    expect(account.label).toBe("Ada Lovelace");
+    expect(account.identifiers).toEqual({ "linkedin:member_id": "ACoAAAda0001" });
+  });
+
+  it("excludes the guardian's own row", async () => {
+    const page = await accounts.listAccounts({ limit: 50 });
+
+    expect(page.accounts.map((a) => a.id)).toEqual(["ACoAAAda0001", "ACoAAGrace002"]);
+    expect(await accounts.resolve("ACoAASelf0003")).toBeNull();
+  });
+
+  it("returns null for an unknown identifier", async () => {
+    expect(await accounts.resolve("ACoAANobody999")).toBeNull();
+    expect(await accounts.resolve("https://www.linkedin.com/in/ada-lovelace/")).toBeNull();
+    expect(await accounts.resolve("")).toBeNull();
+  });
+
+  it("pages and filters by query", async () => {
+    const first = await accounts.listAccounts({ limit: 1 });
+    expect(first.accounts.map((a) => a.label)).toEqual(["Ada Lovelace"]);
+    expect(first.nextCursor).toBeDefined();
+
+    const second = await accounts.listAccounts({ limit: 1, cursor: first.nextCursor });
+    expect(second.accounts.map((a) => a.label)).toEqual(["Grace Hopper"]);
+    expect(second.nextCursor).toBeUndefined();
+
+    const byLabel = await accounts.listAccounts({ limit: 50, query: "hopper" });
+    expect(byLabel.accounts.map((a) => a.id)).toEqual(["ACoAAGrace002"]);
+  });
+});

--- a/packages/core/src/channels/linkedin-accounts.ts
+++ b/packages/core/src/channels/linkedin-accounts.ts
@@ -1,0 +1,63 @@
+import type { Account, AccountId, TalkAccounts } from "./accounts.js";
+import { pageAccounts } from "./account-paging.js";
+import { linkedInMemberIdFromProfileUrl } from "./linkedin-sync.js";
+import type {
+  LinkedInParticipantContactRow,
+  LinkedInStoreRepository,
+} from "../db/repositories/linkedin-store.js";
+
+/**
+ * `TalkAccounts` over the LinkedIn inbox mirror (`linkedin_participants`).
+ *
+ * LinkedIn hands out two identifiers for one member — the bare member id
+ * (`ACoAA…`) and the profile URL that contains it — and the second folds onto
+ * the first by derivation, with no lookup and no stored row. That is why the
+ * fold stays behind this class: a caller holding a profile URL asks `resolve`
+ * rather than learning to read a URL, and WhatsApp answers the same question
+ * from a stored alias set without either caller knowing the difference (I3).
+ *
+ * The guardian's own `isSelf` row is not an account: it names the viewer, not
+ * someone the channel reaches.
+ */
+export class LinkedInAccounts implements TalkAccounts {
+  constructor(private readonly store: LinkedInStoreRepository) {}
+
+  async listAccounts(input: {
+    query?: string;
+    cursor?: string;
+    limit: number;
+  }): Promise<{ accounts: Account[]; nextCursor?: string }> {
+    return pageAccounts(await this.load(), input);
+  }
+
+  async resolve(identifier: string): Promise<Account | null> {
+    const memberId = memberIdFrom(identifier);
+    if (!memberId) return null;
+    const accounts = await this.load();
+    return accounts.find((account) => account.id === memberId) ?? null;
+  }
+
+  private async load(): Promise<Account[]> {
+    const rows = await this.store.listParticipants({ limit: null });
+    return rows.filter((row) => !row.isSelf).map(toAccount);
+  }
+}
+
+/**
+ * The member id an identifier names, or null. A profile URL yields the id it
+ * embeds. Anything else is taken as a bare member id, which is what an
+ * `AccountId` is, so an id round-trips.
+ */
+function memberIdFrom(identifier: string): string | null {
+  const trimmed = identifier.trim();
+  if (!trimmed) return null;
+  return linkedInMemberIdFromProfileUrl(trimmed) ?? trimmed;
+}
+
+function toAccount(row: LinkedInParticipantContactRow): Account {
+  return {
+    id: row.participantId as AccountId,
+    label: row.name || row.headline || row.participantId,
+    identifiers: { "linkedin:member_id": row.participantId },
+  };
+}

--- a/packages/core/src/channels/whatsapp-accounts.test.ts
+++ b/packages/core/src/channels/whatsapp-accounts.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb } from "../test/helpers.js";
+import type { DrizzleDb } from "../db/index.js";
+import { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
+import { WhatsAppAccounts } from "./whatsapp-accounts.js";
+
+const PHONE = "15550007777@s.whatsapp.net";
+const LID = "88817260077@lid";
+
+const message = (id: string, jid: string, at: string, text: string) => ({
+  id,
+  chatJid: jid,
+  senderJid: jid,
+  fromMe: false,
+  timestamp: new Date(at),
+  type: "text",
+  text,
+  hasMedia: false,
+});
+
+describe("WhatsAppAccounts", () => {
+  let db: DrizzleDb;
+  let close: () => void;
+  let repo: WhatsAppStoreRepository;
+  let accounts: WhatsAppAccounts;
+
+  beforeEach(() => {
+    const t = createTestDb();
+    db = t.db;
+    close = t.close;
+    repo = new WhatsAppStoreRepository(db);
+    accounts = new WhatsAppAccounts(repo);
+  });
+
+  afterEach(() => close());
+
+  it("keeps one id when a message lands on the other addressing", async () => {
+    await repo.upsertContacts([
+      { jid: PHONE, phoneNumber: "15550007777", name: "One Contact" },
+      { jid: LID, phoneNumber: "15550007777", name: "One Contact" },
+    ]);
+    await repo.upsertMessages([message("a", PHONE, "2026-08-20T10:00:00Z", "on phone")]);
+    const before = (await accounts.resolve(PHONE))!.id;
+
+    await repo.upsertMessages([message("b", LID, "2026-08-21T10:00:00Z", "on lid")]);
+
+    expect((await accounts.resolve(PHONE))!.id).toBe(before);
+    expect((await accounts.resolve(LID))!.id).toBe(before);
+    expect((await accounts.resolve(before))!.id).toBe(before);
+  });
+
+  it("folds both addressings into a single account", async () => {
+    await repo.upsertContacts([
+      { jid: PHONE, phoneNumber: "15550007777", name: "One Contact" },
+      { jid: LID, phoneNumber: "15550007777" },
+    ]);
+
+    const page = await accounts.listAccounts({ limit: 50 });
+    expect(page.accounts).toHaveLength(1);
+    expect(page.accounts[0].label).toBe("One Contact");
+    expect(page.accounts[0].identifiers).toEqual({
+      phone: "15550007777",
+      "whatsapp:lid": LID,
+    });
+  });
+
+  it("folds an address-book row that has not learned its phone number yet", async () => {
+    // The store groups on the stored number, so these two rows stay separate
+    // cards. They are still one account, and one account is one `Account`.
+    await repo.upsertContacts([
+      { jid: "15550009999@s.whatsapp.net", name: "Split Contact" },
+      { jid: "99900099999@lid", phoneNumber: "15550009999" },
+    ]);
+
+    const page = await accounts.listAccounts({ limit: 50 });
+    expect(page.accounts).toHaveLength(1);
+    expect(page.accounts[0].id).toBe("15550009999@s.whatsapp.net");
+    expect(page.accounts[0].label).toBe("Split Contact");
+    expect((await accounts.resolve("99900099999@lid"))!.id).toBe("15550009999@s.whatsapp.net");
+  });
+
+  it("resolves a device-suffixed JID and a bare phone number", async () => {
+    await repo.upsertContacts([{ jid: PHONE, phoneNumber: "15550007777", name: "One Contact" }]);
+
+    expect((await accounts.resolve("15550007777:7@s.whatsapp.net"))!.id).toBe(PHONE);
+    expect((await accounts.resolve("+1 555-000-7777"))!.id).toBe(PHONE);
+  });
+
+  it("excludes group chats", async () => {
+    await repo.upsertContacts([{ jid: PHONE, phoneNumber: "15550007777", name: "One Contact" }]);
+    await repo.upsertChats([{ jid: "12345-67890@g.us", name: "Team", isGroup: true }]);
+
+    const page = await accounts.listAccounts({ limit: 50 });
+    expect(page.accounts.map((a) => a.id)).toEqual([PHONE]);
+    expect(await accounts.resolve("12345-67890@g.us")).toBeNull();
+  });
+
+  it("returns null for an unknown identifier", async () => {
+    await repo.upsertContacts([{ jid: PHONE, phoneNumber: "15550007777", name: "One Contact" }]);
+
+    expect(await accounts.resolve("15550001111@s.whatsapp.net")).toBeNull();
+    expect(await accounts.resolve("00000000000@lid")).toBeNull();
+    expect(await accounts.resolve("")).toBeNull();
+  });
+
+  it("pages and filters by query", async () => {
+    await repo.upsertContacts([
+      { jid: "15550000001@s.whatsapp.net", phoneNumber: "15550000001", name: "Ada" },
+      { jid: "15550000002@s.whatsapp.net", phoneNumber: "15550000002", name: "Bea" },
+      { jid: "15550000003@s.whatsapp.net", phoneNumber: "15550000003", name: "Cy" },
+    ]);
+
+    const first = await accounts.listAccounts({ limit: 2 });
+    expect(first.accounts.map((a) => a.label)).toEqual(["Ada", "Bea"]);
+    expect(first.nextCursor).toBeDefined();
+
+    const second = await accounts.listAccounts({ limit: 2, cursor: first.nextCursor });
+    expect(second.accounts.map((a) => a.label)).toEqual(["Cy"]);
+    expect(second.nextCursor).toBeUndefined();
+
+    const byLabel = await accounts.listAccounts({ limit: 50, query: "be" });
+    expect(byLabel.accounts.map((a) => a.label)).toEqual(["Bea"]);
+
+    const byIdentifier = await accounts.listAccounts({ limit: 50, query: "15550000003" });
+    expect(byIdentifier.accounts.map((a) => a.label)).toEqual(["Cy"]);
+  });
+});

--- a/packages/core/src/channels/whatsapp-accounts.test.ts
+++ b/packages/core/src/channels/whatsapp-accounts.test.ts
@@ -103,6 +103,27 @@ describe("WhatsAppAccounts", () => {
     expect(await accounts.resolve("")).toBeNull();
   });
 
+  it("answers a limit that is not a number with a page, not a false exhaustion", async () => {
+    await repo.upsertContacts([
+      { jid: "15550000001@s.whatsapp.net", phoneNumber: "15550000001", name: "Ada" },
+      { jid: "15550000002@s.whatsapp.net", phoneNumber: "15550000002", name: "Bea" },
+    ]);
+
+    const page = await accounts.listAccounts({ limit: Number.NaN });
+    expect(page.accounts.map((a) => a.label)).toEqual(["Ada", "Bea"]);
+    expect(page.nextCursor).toBeUndefined();
+  });
+
+  it("moves a named LID row onto the phone form once the mirror learns the number", async () => {
+    // A documented open gap, pinned so the follow-up sees it move rather than
+    // trusting an `AccountId` persisted before the number arrived.
+    await repo.upsertContacts([{ jid: "named-lid@lid", name: "Lia" }]);
+    expect((await accounts.resolve("named-lid@lid"))!.id).toBe("named-lid@lid");
+
+    await repo.upsertContacts([{ jid: "named-lid@lid", phoneNumber: "15551234567" }]);
+    expect((await accounts.resolve("named-lid@lid"))!.id).toBe("15551234567@s.whatsapp.net");
+  });
+
   it("pages and filters by query", async () => {
     await repo.upsertContacts([
       { jid: "15550000001@s.whatsapp.net", phoneNumber: "15550000001", name: "Ada" },

--- a/packages/core/src/channels/whatsapp-accounts.ts
+++ b/packages/core/src/channels/whatsapp-accounts.ts
@@ -53,9 +53,16 @@ function firstNonEmpty(...values: Array<string | null>): string | null {
  *
  * Group chats (`@g.us`) are not accounts.
  *
- * One clause of I2 stays open here: an account that changes its phone number
- * gets a new id, because the mirror stores no key that outlives the digits.
- * Closing it needs a durable stored account key, not a different addressing.
+ * Two gaps stay open, both because the mirror stores no key that outlives the
+ * digits an id is built from. Closing either needs a durable stored account
+ * key, not a different choice of addressing, and code that persists an
+ * `AccountId` has to survive both:
+ *
+ * - An account that changes its phone number gets a new id (I2).
+ * - A named LID row carrying no phone number addresses itself. Its id moves to
+ *   the phone-number form once the mirror learns the number (I2), and until
+ *   then a phone-number row for the same person is a second `Account` (I1).
+ *   Nothing links the two but the name, and names are not identity.
  */
 export class WhatsAppAccounts implements TalkAccounts {
   constructor(private readonly store: WhatsAppStoreRepository) {}
@@ -85,6 +92,12 @@ export class WhatsAppAccounts implements TalkAccounts {
    * phone number a row carries, so a row that has not learned its number yet
    * stays separate. Re-keying on the canonical id here collapses those too —
    * one `Account` per account, whatever the mirror's row shape (I1).
+   *
+   * Every call reads the whole address book and rebuilds the index, so walking
+   * pages costs one full read per page and `resolve` costs one per identifier.
+   * That is bounded by address-book size and holds no stale rows. A caller that
+   * resolves per message wants a cache, and the cache belongs behind this port,
+   * where it can be invalidated on a sync rather than guessed at by the caller.
    */
   private async load(): Promise<{ accounts: Account[]; byKey: Map<string, Account> }> {
     const rows = (await this.store.listContacts({ limit: null })).filter(

--- a/packages/core/src/channels/whatsapp-accounts.ts
+++ b/packages/core/src/channels/whatsapp-accounts.ts
@@ -1,0 +1,169 @@
+import type { Account, AccountId, TalkAccounts } from "./accounts.js";
+import { pageAccounts } from "./account-paging.js";
+import type {
+  WhatsAppContactRow,
+  WhatsAppStoreRepository,
+} from "../db/repositories/whatsapp-store.js";
+
+const PHONE_JID_DOMAIN = "@s.whatsapp.net";
+
+// A phone number written as a person writes one. Anything else — a name, a
+// LinkedIn member id that happens to contain digits — is not a phone identifier
+// and must not be stripped down to one.
+const BARE_PHONE = /^\+?[\d\s()-]+$/;
+
+/** Digits of a phone identifier — a `@s.whatsapp.net` JID or a bare number. */
+function phoneDigits(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const user = value.endsWith(PHONE_JID_DOMAIN)
+    ? value.slice(0, -PHONE_JID_DOMAIN.length).replace(/:.*$/, "")
+    : value;
+  if (!BARE_PHONE.test(user)) return null;
+  const digits = user.replace(/\D/g, "");
+  return digits.length > 0 ? digits : null;
+}
+
+/** A JID with its `:device` suffix stripped, so every device folds onto one user. */
+function normalizeJid(value: string): string {
+  const at = value.indexOf("@");
+  if (at < 0) return value;
+  return `${value.slice(0, at).replace(/:.*$/, "")}${value.slice(at)}`;
+}
+
+function isGroupJid(value: string): boolean {
+  return value.endsWith("@g.us");
+}
+
+function firstNonEmpty(...values: Array<string | null>): string | null {
+  for (const v of values) if (v != null && v !== "") return v;
+  return null;
+}
+
+/**
+ * `TalkAccounts` over the WhatsApp address-book mirror (`wa_contacts`).
+ *
+ * WhatsApp addresses one person two ways — the phone-number JID
+ * (`<pn>@s.whatsapp.net`) and the privacy LID (`<lid>@lid`) — and the mirror
+ * holds a row for each. The canonical form is the phone-number JID, and it is
+ * built from the account's digits rather than picked from whichever row exists,
+ * so learning the second addressing later never moves the id (I2) while either
+ * addressing still resolves to it (I4). Preferring the LID would invert that: a
+ * LID can only be found, never derived, so every account's id would move the
+ * first time a conversation arrived.
+ *
+ * Group chats (`@g.us`) are not accounts.
+ *
+ * One clause of I2 stays open here: an account that changes its phone number
+ * gets a new id, because the mirror stores no key that outlives the digits.
+ * Closing it needs a durable stored account key, not a different addressing.
+ */
+export class WhatsAppAccounts implements TalkAccounts {
+  constructor(private readonly store: WhatsAppStoreRepository) {}
+
+  async listAccounts(input: {
+    query?: string;
+    cursor?: string;
+    limit: number;
+  }): Promise<{ accounts: Account[]; nextCursor?: string }> {
+    const { accounts } = await this.load();
+    return pageAccounts(accounts, input);
+  }
+
+  async resolve(identifier: string): Promise<Account | null> {
+    if (!identifier || isGroupJid(identifier)) return null;
+    const { byKey } = await this.load();
+    for (const key of lookupKeys(identifier)) {
+      const hit = byKey.get(key);
+      if (hit) return hit;
+    }
+    return null;
+  }
+
+  /**
+   * Every account, plus the index every identifier resolves through. The store
+   * already folds a person's two addressings onto one card, but it folds on the
+   * phone number a row carries, so a row that has not learned its number yet
+   * stays separate. Re-keying on the canonical id here collapses those too —
+   * one `Account` per account, whatever the mirror's row shape (I1).
+   */
+  private async load(): Promise<{ accounts: Account[]; byKey: Map<string, Account> }> {
+    const rows = (await this.store.listContacts({ limit: null })).filter(
+      (row) => !row.isGroup && !isGroupJid(row.jid),
+    );
+
+    const grouped = new Map<AccountId, WhatsAppContactRow[]>();
+    for (const row of rows) {
+      const id = accountIdOf(row);
+      const existing = grouped.get(id);
+      if (existing) existing.push(row);
+      else grouped.set(id, [row]);
+    }
+
+    const accounts: Account[] = [];
+    const byKey = new Map<string, Account>();
+    for (const [id, group] of grouped) {
+      const account = toAccount(id, group);
+      accounts.push(account);
+      for (const key of accountKeys(id, group)) byKey.set(key, account);
+    }
+    return { accounts, byKey };
+  }
+}
+
+/**
+ * The account's canonical address. A row's stored phone number is the first
+ * answer; a phone-number JID carries its own digits when the number column is
+ * still empty. A LID-only row has neither, so it addresses itself until the
+ * mirror learns its number.
+ */
+function accountIdOf(row: WhatsAppContactRow): AccountId {
+  const digits = phoneDigits(row.phoneNumber) ?? phoneDigits(row.jid);
+  return (digits ? `${digits}${PHONE_JID_DOMAIN}` : normalizeJid(row.jid)) as AccountId;
+}
+
+function toAccount(id: AccountId, group: WhatsAppContactRow[]): Account {
+  const identifiers: Record<string, string> = {};
+  const digits = phoneDigits(id);
+  if (digits) identifiers.phone = digits;
+
+  const lid = group
+    .flatMap((row) => row.aliases)
+    .map(normalizeJid)
+    .filter((jid) => jid.endsWith("@lid"))
+    .sort()[0];
+  if (lid) identifiers["whatsapp:lid"] = lid;
+
+  // Field-major, not row-major: a saved name on any row of the account beats a
+  // push name on another, and every name beats falling back to the number.
+  const pick = (field: (row: WhatsAppContactRow) => string | null) =>
+    firstNonEmpty(...group.map(field));
+  const label =
+    pick((row) => row.name) ??
+    pick((row) => row.notify) ??
+    pick((row) => row.verifiedName) ??
+    pick((row) => row.chatName) ??
+    pick((row) => row.phoneNumber) ??
+    id;
+
+  return { id, label, identifiers };
+}
+
+/** Every index key the account answers to, including its own id. */
+function accountKeys(id: AccountId, group: WhatsAppContactRow[]): string[] {
+  const keys = [`jid:${id}`];
+  const digits = phoneDigits(id);
+  if (digits) keys.push(`pn:${digits}`);
+  for (const row of group) {
+    for (const alias of row.aliases) keys.push(`jid:${normalizeJid(alias)}`);
+  }
+  return keys;
+}
+
+/** The keys an inbound identifier could match, most specific first. */
+function lookupKeys(identifier: string): string[] {
+  const keys: string[] = [];
+  const digits = phoneDigits(identifier);
+  if (digits) keys.push(`pn:${digits}`);
+  keys.push(`jid:${normalizeJid(identifier)}`);
+  return keys;
+}

--- a/packages/core/src/db/repositories/linkedin-store.test.ts
+++ b/packages/core/src/db/repositories/linkedin-store.test.ts
@@ -606,6 +606,13 @@ describe("LinkedInStoreRepository", () => {
         expect(rows[0].threadCount).toBe(1);
       });
 
+      it("bounds the participant read by default and reads it whole on limit: null", async () => {
+        expect(await repo.listParticipants({ limit: 1 })).toHaveLength(1);
+        expect(await repo.listParticipants({ limit: null })).toHaveLength(2);
+        // The no-argument call is what `/api/linkedin/participants` makes.
+        expect(await repo.listParticipants()).toHaveLength(2);
+      });
+
       it("promoting writes a person and a linkedin mapping carrying the member id", async () => {
         await people.createWithChannelMapping(
           "ada-lovelace",

--- a/packages/core/src/db/repositories/linkedin-store.ts
+++ b/packages/core/src/db/repositories/linkedin-store.ts
@@ -528,8 +528,16 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
    * Promotion is a guardian action against these rows, not something this
    * repository performs: a LinkedIn inbox holds many identities that should
    * never enter the curated person graph, so nothing here writes `persons`.
+   *
+   * `limit` defaults to a generous cap that suits a single-payload endpoint.
+   * Pass `null` to read the table whole, which is what a caller that paginates
+   * the result itself wants.
    */
-  async listParticipants(): Promise<LinkedInParticipantContactRow[]> {
+  async listParticipants(
+    opts: { limit?: number | null } = {},
+  ): Promise<LinkedInParticipantContactRow[]> {
+    const limitClause =
+      opts.limit === null ? sql`` : sql`LIMIT ${opts.limit ?? PARTICIPANTS_READ_LIMIT}`;
     const rows = (await this.db.all(sql`
       SELECT
         p.participant_id AS participantId,
@@ -546,7 +554,7 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
         ON cm.channel = 'linkedin' AND cm.channel_user_id = p.participant_id
       LEFT JOIN persons person ON person.id = cm.person_id
       ORDER BY lower(coalesce(p.name, p.participant_id)) ASC, p.participant_id ASC
-      LIMIT ${PARTICIPANTS_READ_LIMIT}
+      ${limitClause}
     `)) as Array<Record<string, unknown>>;
 
     return rows.map((r) => ({

--- a/packages/core/src/db/repositories/whatsapp-store.test.ts
+++ b/packages/core/src/db/repositories/whatsapp-store.test.ts
@@ -32,6 +32,19 @@ describe("WhatsAppStoreRepository", () => {
     expect(alice?.messageCount).toBe(0);
   });
 
+  it("bounds the address-book read by default and reads it whole on limit: null", async () => {
+    await repo.upsertContacts([
+      { jid: "15550000001@s.whatsapp.net", phoneNumber: "15550000001", name: "Ada" },
+      { jid: "15550000002@s.whatsapp.net", phoneNumber: "15550000002", name: "Bea" },
+      { jid: "15550000003@s.whatsapp.net", phoneNumber: "15550000003", name: "Cy" },
+    ]);
+
+    expect(await repo.listContacts({ limit: 2 })).toHaveLength(2);
+    expect(await repo.listContacts({ limit: null })).toHaveLength(3);
+    // The no-argument call is what `/api/whatsapp/contacts` makes.
+    expect(await repo.listContacts()).toHaveLength(3);
+  });
+
   it("hides nameless LID-only contacts but keeps LIDs with a phone identity", async () => {
     await repo.upsertContacts([
       { jid: "raw-lid@lid" },

--- a/packages/core/src/db/repositories/whatsapp-store.ts
+++ b/packages/core/src/db/repositories/whatsapp-store.ts
@@ -33,7 +33,7 @@ function chunked<T>(items: T[], size: number): T[][] {
  * (`@g.us`) never share a phone number and key on their own JID, so they never
  * merge.
  */
-function identityKey(r: WhatsAppContactRow): string {
+function identityKey(r: WhatsAppContactAliasRow): string {
   if (!r.isGroup && r.phoneNumber) {
     const digits = r.phoneNumber.replace(/\D/g, "");
     if (digits) return `pn:${digits}`;
@@ -42,10 +42,10 @@ function identityKey(r: WhatsAppContactRow): string {
 }
 
 /** First non-empty value of `key` across the group, or null. */
-function coalesceField<K extends keyof WhatsAppContactRow>(
-  group: WhatsAppContactRow[],
+function coalesceField<K extends keyof WhatsAppContactAliasRow>(
+  group: WhatsAppContactAliasRow[],
   key: K,
-): WhatsAppContactRow[K] | null {
+): WhatsAppContactAliasRow[K] | null {
   for (const r of group) {
     const v = r[key];
     if (v != null && v !== "") return v;
@@ -60,9 +60,11 @@ function coalesceField<K extends keyof WhatsAppContactRow>(
  * card's identity (the conversation-bearing one when a chat exists, so opening
  * the chat still resolves its messages) and fold the missing pieces in from its
  * siblings: the address-book name, a person link, and the richer message history.
+ * Every JID that went into the group is kept in `aliases`, sorted, so a caller
+ * that needs the whole addressing set does not have to re-derive the grouping.
  */
-function consolidateByIdentity(rows: WhatsAppContactRow[]): WhatsAppContactRow[] {
-  const groups = new Map<string, WhatsAppContactRow[]>();
+function consolidateByIdentity(rows: WhatsAppContactAliasRow[]): WhatsAppContactRow[] {
+  const groups = new Map<string, WhatsAppContactAliasRow[]>();
   for (const r of rows) {
     const k = identityKey(r);
     const g = groups.get(k);
@@ -72,8 +74,9 @@ function consolidateByIdentity(rows: WhatsAppContactRow[]): WhatsAppContactRow[]
 
   const merged: WhatsAppContactRow[] = [];
   for (const group of groups.values()) {
+    const aliases = group.map((r) => r.jid).sort();
     if (group.length === 1) {
-      merged.push(group[0]);
+      merged.push({ ...group[0], aliases });
       continue;
     }
     const primary = group[0];
@@ -97,6 +100,7 @@ function consolidateByIdentity(rows: WhatsAppContactRow[]): WhatsAppContactRow[]
       lastMessageAt: latest.lastMessageAt,
       lastMessagePreview: latest.lastMessagePreview,
       messageCount: group.reduce((n, r) => n + r.messageCount, 0),
+      aliases,
     });
   }
   return merged;
@@ -117,7 +121,15 @@ export interface WhatsAppContactRow {
   lastMessageAt: number | null;
   lastMessagePreview: string | null;
   messageCount: number;
+  /**
+   * Every JID folded into this card, sorted — the phone-number form, the LID
+   * form, or both. Always contains `jid`.
+   */
+  aliases: string[];
 }
+
+/** One address-book JID as the query reads it, before grouping folds aliases. */
+type WhatsAppContactAliasRow = Omit<WhatsAppContactRow, "aliases">;
 
 export interface WhatsAppMessageRow {
   id: string;
@@ -251,8 +263,15 @@ export class WhatsAppStoreRepository implements WhatsAppSyncSink {
   /**
    * The synced address book, newest-conversation-first then alphabetical,
    * each row annotated with whether it has been promoted to a `persons` entry.
+   *
+   * `limit` bounds the address-book rows read before grouping folds aliases,
+   * so the returned card count can be smaller. It defaults to a generous cap
+   * that suits a single-payload endpoint. Pass `null` to read the table whole,
+   * which is what a caller that paginates the result itself wants.
    */
-  async listContacts(): Promise<WhatsAppContactRow[]> {
+  async listContacts(opts: { limit?: number | null } = {}): Promise<WhatsAppContactRow[]> {
+    const limitClause =
+      opts.limit === null ? sql`` : sql`LIMIT ${opts.limit ?? CONTACTS_READ_LIMIT}`;
     const rows = (await this.db.all(sql`
       WITH wa_threads AS (
         SELECT jid FROM wa_contacts
@@ -294,7 +313,7 @@ export class WhatsAppStoreRepository implements WhatsAppSyncSink {
       )
       ORDER BY (lastMessageAt IS NULL) ASC, lastMessageAt DESC,
         lower(coalesce(c.name, c.notify, c.verified_name, ch.name, c.phone_number, t.jid)) ASC
-      LIMIT ${CONTACTS_READ_LIMIT}
+      ${limitClause}
     `)) as Array<Record<string, unknown>>;
 
     const mapped = rows.map((r) => ({


### PR DESCRIPTION
## What this PR does

Channels have a contract for the message plane (`ProviderAdapter`) and nothing for accounts. Every consumer that needs to know whether two identifiers name the same account re-derives the answer itself, and the identity union's four confirmed defects all trace back to that gap: message counts doubling when one person holds two aliases, duplicate rows sharing one id, an alias leaking onto another person's row, and a row id that flips when a message lands on the other addressing.

This adds `TalkAccounts` — an opaque `AccountId`, an `Account`, and a two-method port — and implements it for the two channels that already mirror an address book. There is no consumer yet. The union switches over in a follow-up.

## Design & Invariants

The types cannot carry the contract, so the four invariants live in the doc comments on `packages/core/src/channels/accounts.ts`:

- **I1 Uniqueness.** Exactly one `Account` per real account. Callers never fold aliases themselves.
- **I2 Stability.** `id` does not change for the life of the account.
- **I3 Opacity.** Callers never parse or construct an `id`.
- **I4 Total resolution.** Every identifier the channel can receive a message on resolves to that account's `id`.

I3 is what makes the other three enforceable: because no consumer may read an id, each channel keeps its own answer to "same account?" private. That difference is visible between the two adapters. WhatsApp folds two addressings by looking up a stored alias set. LinkedIn folds a profile URL onto a bare member id by derivation, with no lookup and no stored row. A caller sees one `resolve` and cannot tell which is which.

**1. `identifiers` arity — single-value, namespaced keys.** `Record<string, string>` allows one value per key. WhatsApp, LinkedIn, Discord and Telegram all fit. It breaks on an account with two emails, which LinkedIn can produce. Widening to `string[]` later is a breaking change across every adapter, so the escape hatch is a qualified key (`email`, `email:work`) rather than a wider type. `email`, `phone`, `username` and `profile_url` are reserved and mean the same thing on every channel. Every other key is namespaced by its channel: `whatsapp:lid`, `linkedin:member_id`.

**2. The types live in `packages/core`, not `TalkFeatureMap`.** Joining `TalkFeatureMap` makes this a published `@rome-os/app-runtime` API. Adding an optional feature key is additive and non-breaking, so the cost is not the key — it is that the shape becomes an external commitment before a single consumer has exercised it. This PR ships no consumer. The follow-up that consumes the contract is the first thing that can show whether `resolve` returning a whole `Account` is right, whether the cursor belongs in the contract, and whether activity really stays out. Landing in `packages/core/src/channels/accounts.ts` keeps every correction cheap until then, and promotion to `TalkFeatureMap` stays a pure addition afterwards. This also keeps the PR out of the release-please publish path.

**3. WhatsApp's canonical form — the phone-number JID, constructed.** The current code picks whichever alias carried the most recent message, which is exactly why the id flips. The choice here is the `@s.whatsapp.net` form, **built from the account's digits rather than picked from whichever row exists**. That distinction is what carries I2: the id is a function of the account's digits, so learning the second addressing later never moves it, and it does not depend on the phone-number row existing.

Preferring the `@lid` form inverts the failure. A LID can only be found, never derived, so an account known first from the address book would take a `@s.whatsapp.net` id and then move to a `@lid` id the first time a conversation arrived — an I2 break on essentially every contact, in the normal sync order. The phone form also matches the `channel_user_id` already in `channel_mappings`, so the follow-up joins without a migration.

**On the LID-durability claim, which did not survive checking.** The premise for preferring LID was that it survives a phone-number change. I verified the API half locally: Baileys 7.0.0-rc.9 does expose `sock.signalRepository.lidMapping` with `getLIDForPN` / `getPNForLID` / `getLIDsForPNs` and `LIDMapping = { pn, lid }` (`lib/Signal/lid-mapping.d.ts`, `lib/Types/Auth.d.ts:22`). The durability half I could not confirm. Baileys' own FAQ defines a LID only as "a per-user, anonymized identifier WhatsApp assigns to each account" and says nothing about a number change, and the third-party docs that call it "the most stable identifier" do not address the case either. So LID is not chosen here on an unverified premise.

That leaves two gaps genuinely open, both stated in the adapter's doc comment rather than implied away:

- **An account that changes its phone number gets a new id** (I2).
- **A named LID row carrying no phone number addresses itself.** Its id moves to the phone-number form once the mirror learns the number (I2), and until then a phone-number row for the same person is a second `Account` (I1). Nothing links the two but the name, and names are not identity, so merging on one would reproduce the "alias leaking onto a different person's row" defect.

Both have the same root: the mirror stores no key that outlives the digits an id is built from. Closing either needs a durable stored account key — a table that assigns an id once and accumulates aliases — which is a migration this PR excludes. Choosing the LID form would not have closed them either. It would have traded a rare break for a common one.

**Activity stays out of `TalkAccounts`.** `Account` answers *who*, activity answers *what happened*, and merging them is why the current read drags three correlated subqueries per contact. Activity stays in the store repositories and the follow-up reads it separately, keyed by `AccountId`. That read is cheap to add there because `listContacts` / `listParticipants` already compute it in the same query, and because `AccountId` is the WhatsApp canonical JID and the LinkedIn bare member id — the keys those rows already carry.

**Two characteristics worth naming for the follow-up.** `load()` reads the whole mirror and rebuilds the index on every call, so walking pages costs one full read per page and `resolve` costs one per identifier. That is bounded at address-book size and never serves a stale row, but a per-message caller wants a cache, and the cache belongs behind the port where a sync can invalidate it. Separately, the cursor is an offset, and the WhatsApp listing is ordered by activity — an inbound message between two pages shifts later accounts down, so one can be skipped or repeated. A caller that needs every account exactly once asks for a single page large enough to hold the listing. A keyset cursor would fix it properly, but it has to key on `(lastMessageAt, id)` rather than `id` alone, which means exposing the ordering key through the port — a contract change worth making with a consumer in hand.

The store reads gained `{ limit?: number | null }` so a paged caller can read whole. The default is unchanged, so `/api/whatsapp/contacts` and `/api/linkedin/participants` keep their bounded single payload. `WhatsAppContactRow` gained `aliases`, the sorted set of JIDs folded into a card, which is what lets `resolve` answer on either addressing. It is additive to the endpoint's JSON.

## Test plan

- [x] `pnpm typecheck` — clean across every workspace.
- [x] `pnpm test:unit` — 3897 core tests pass, and 528 / 1091 / 89 / 39 / 25 in the other packages. No failures.
- [x] `biome check` on all ten touched files — clean, using the nixpkgs binary from the devShell.
- [x] The required regression test: `resolve()` returns the same id after a message lands on the other addressing, both addressings resolve to it, and the id round-trips.
- [x] Confirmed that test guards a live defect. Against the pre-contract read the id does flip, `15550007777@s.whatsapp.net` → `88817260077@lid`, reproduced directly before writing the adapter.
- [x] One account per account when the store's own grouping splits it — the row that has not learned its phone number yet still folds in.
- [x] Device-suffixed JID (`:7`) and a bare `+1 555-000-7777` both resolve.
- [x] Exclusions: WhatsApp `@g.us` and LinkedIn `isSelf` are not accounts and do not resolve.
- [x] `resolve()` returns null for an unknown identifier, an unknown LID, and an empty string.
- [x] LinkedIn profile URL and bare member id resolve to one account. A vanity handle does not.
- [x] Paging and query filtering over label and identifier values, on both adapters.
- [x] Bounded default vs `{ limit: null }` whole read, on both store reads.
- [x] A limit that is not a number returns a page rather than an empty one that looks exhausted.
- [x] The named-LID-only id move is pinned by a test, so the follow-up sees it rather than trusting a persisted `AccountId`.
- [ ] Not exercised in a browser — this PR adds no UI and no route.

## Not in this PR

- `identities.ts` and the union — the follow-up consumes the contract and fixes all four defects.
- Any `channel_mappings` migration. The unique index on `(channel, channel_user_id)` is untouched.
- The durable stored account key that would close both open gaps.
- A keyset cursor. Offset paging assumes the listing holds still, which is documented rather than fixed.
- Activity as part of `TalkAccounts` — it stays a separate read, keyed by `AccountId`.
- Person-level merging across channels — `channel_mappings` owns that.
- Promotion to `TalkFeatureMap` — additive, and cheaper once a consumer has proven the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

