### PR TITLE
feat(core): resolve account display names through one seam

### DIFF
--- a/packages/core/src/api/deps.ts
+++ b/packages/core/src/api/deps.ts
@@ -5,6 +5,7 @@ import type { PersonMappingRepository } from "../db/repositories/person-mapping.
 import type { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
 import type { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
 import type { WhatsAppAccounts } from "../channels/whatsapp-accounts.js";
+import type { AccountNames } from "../channels/account-names.js";
 import type { WebChatRepository } from "../db/repositories/webchat.js";
 import type { WebhookInvocationsRepository } from "../db/repositories/webhook-invocations.js";
 import type { ApprovalsRepository } from "../db/repositories/approvals.js";
@@ -77,6 +78,10 @@ export interface ApiDeps {
   whatsAppAccounts: WhatsAppAccounts;
   /** Durable mirror of the LinkedIn inbox + message history (People tab). */
   linkedInStoreRepo: LinkedInStoreRepository;
+  /** What each platform calls an account, over every mirror and the sentinel
+   *  log's push names — the display name a person or account serializer puts
+   *  on the wire. */
+  accountNames: AccountNames;
   webchatRepo: WebChatRepository;
   webhookInvocationsRepo: WebhookInvocationsRepository;
   approvalsRepo: ApprovalsRepository;

--- a/packages/core/src/api/deps.ts
+++ b/packages/core/src/api/deps.ts
@@ -78,9 +78,9 @@ export interface ApiDeps {
   whatsAppAccounts: WhatsAppAccounts;
   /** Durable mirror of the LinkedIn inbox + message history (People tab). */
   linkedInStoreRepo: LinkedInStoreRepository;
-  /** What each platform calls an account, over every mirror and the sentinel
-   *  log's push names — the display name a person or account serializer puts
-   *  on the wire. */
+  /** What each platform calls an account, over every address book Rome mirrors
+   *  and the names senders put on their own messages — the display name a
+   *  person or account serializer puts on the wire. */
   accountNames: AccountNames;
   webchatRepo: WebChatRepository;
   webhookInvocationsRepo: WebhookInvocationsRepository;

--- a/packages/core/src/api/routes/identities.ts
+++ b/packages/core/src/api/routes/identities.ts
@@ -51,7 +51,8 @@ interface MirrorIdentity {
   channelUserId: string;
   /** Every address the account answers to, `channelUserId` included. */
   aliases: string[];
-  displayName: string;
+  /** What the channel calls the account, or null when it holds no name. */
+  name: string | null;
   latest: IdentityDynamic | null;
   messageCount: number;
 }
@@ -168,7 +169,7 @@ async function readMirrors(deps: ApiDeps): Promise<MirrorIdentity[]> {
         channel,
         channelUserId: account.id,
         aliases: (aliasesOf.get(account.id) ?? [account.id]).sort(compareCodePoints),
-        displayName: account.label,
+        name: account.name,
         latest:
           seen == null
             ? null
@@ -293,8 +294,9 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
     return out;
   };
 
-  /** Best name on record for an identity with no person row: the mirror's name,
-   *  then what the sender called themselves, then the raw identifier. */
+  /** Best name on record for an identity with no person row: the channel's own
+   *  name for it, then what the sender called themselves, then the raw
+   *  identifier. */
   const displayNameFor = (channel: string, channelUserId: string): string => {
     const key = identityKey(channel, channelUserId);
     const fromSentinel = (sentinel.get(key) ?? []).reduce<SentinelActivity | null>(
@@ -303,7 +305,7 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
       null,
     );
     return (
-      mirrorByAlias.get(key)?.displayName ??
+      mirrorByAlias.get(key)?.name ??
       fromSentinel?.displayName ??
       canonicalId(channel, channelUserId)
     );
@@ -410,7 +412,7 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
     const activity = activityFor(identity.channel, identity.channelUserId);
     rows.push({
       id: channelIdentityId(identity.channel, identity.channelUserId),
-      displayName: identity.displayName,
+      displayName: displayNameFor(identity.channel, identity.channelUserId),
       level: "unknown",
       channels: identity.aliases.map((alias) => ({
         channel: identity.channel,

--- a/packages/core/src/channels/account-names.test.ts
+++ b/packages/core/src/channels/account-names.test.ts
@@ -117,12 +117,7 @@ describe("AccountNames", () => {
     const matrix = {
       resolve: async (identifier: string) =>
         identifier === "@ada:matrix.org"
-          ? {
-              id: identifier as AccountId,
-              label: "Ada on Matrix",
-              name: "Ada on Matrix",
-              identifiers: {},
-            }
+          ? { id: identifier as AccountId, name: "Ada on Matrix", identifiers: {} }
           : null,
     };
     const withMatrix = new AccountNames({ matrix }, { listLatestDisplayNames: async () => [] });

--- a/packages/core/src/channels/account-names.test.ts
+++ b/packages/core/src/channels/account-names.test.ts
@@ -3,7 +3,8 @@ import { createTestDb, type TestDb } from "../test/helpers.js";
 import { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
 import { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
 import { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
-import { AccountNames, createAccountNames, type ProviderNames } from "./account-names.js";
+import { AccountNames, createAccountNames } from "./account-names.js";
+import type { AccountId } from "./accounts.js";
 import { LinkedInAccounts } from "./linkedin-accounts.js";
 import { WhatsAppAccounts } from "./whatsapp-accounts.js";
 
@@ -112,12 +113,19 @@ describe("AccountNames", () => {
     ).toEqual(["Alan T", "Ada Lovelace", NAMELESS]);
   });
 
-  it("takes a new provider as one adapter, with no change to the call", async () => {
-    const matrix: ProviderNames = {
-      displayName: async (channelUserId) =>
-        channelUserId === "@ada:matrix.org" ? "Ada on Matrix" : null,
+  it("takes a new provider as one account plane, with no change to the call", async () => {
+    const matrix = {
+      resolve: async (identifier: string) =>
+        identifier === "@ada:matrix.org"
+          ? {
+              id: identifier as AccountId,
+              label: "Ada on Matrix",
+              name: "Ada on Matrix",
+              identifiers: {},
+            }
+          : null,
     };
-    const withMatrix = new AccountNames({ matrix }, { displayName: async () => null });
+    const withMatrix = new AccountNames({ matrix }, { listLatestDisplayNames: async () => [] });
 
     expect(await withMatrix.displayName("matrix", "@ada:matrix.org")).toBe("Ada on Matrix");
     expect(await withMatrix.displayName("matrix", "@grace:matrix.org")).toBe("@grace:matrix.org");

--- a/packages/core/src/channels/account-names.test.ts
+++ b/packages/core/src/channels/account-names.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb, type TestDb } from "../test/helpers.js";
+import { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
+import { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
+import { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
+import { AccountNames, createAccountNames, type ProviderNames } from "./account-names.js";
+import { LinkedInAccounts } from "./linkedin-accounts.js";
+import { WhatsAppAccounts } from "./whatsapp-accounts.js";
+
+const PHONE = "15550007777@s.whatsapp.net";
+const LID = "88817260077@lid";
+const NAMELESS = "15550001111@s.whatsapp.net";
+const MEMBER = "ACoAAAda0001";
+
+const sentinelMessage = (
+  channel: string,
+  channelUserId: string,
+  displayName: string | undefined,
+) => ({
+  messageId: `${channel}-${channelUserId}-${displayName ?? "anon"}`,
+  channel,
+  channelUserId,
+  displayName,
+  text: "hello",
+  action: "escalated" as const,
+});
+
+describe("AccountNames", () => {
+  let testDb: TestDb;
+  let whatsAppStore: WhatsAppStoreRepository;
+  let linkedInStore: LinkedInStoreRepository;
+  let sentinelLogRepo: SentinelLogRepository;
+  let names: AccountNames;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    whatsAppStore = new WhatsAppStoreRepository(testDb.db);
+    linkedInStore = new LinkedInStoreRepository(testDb.db);
+    sentinelLogRepo = new SentinelLogRepository(testDb.db);
+    names = createAccountNames({
+      whatsAppAccounts: new WhatsAppAccounts(whatsAppStore),
+      linkedInAccounts: new LinkedInAccounts(linkedInStore),
+      sentinelLogRepo,
+    });
+
+    await whatsAppStore.upsertContacts([
+      { jid: PHONE, phoneNumber: "15550007777", name: "Ada Lovelace" },
+      { jid: LID, phoneNumber: "15550007777" },
+      { jid: NAMELESS, phoneNumber: "15550001111", name: "", notify: "", verifiedName: "" },
+    ]);
+    await linkedInStore.upsertThreads([
+      {
+        threadId: "t1",
+        threadUrl: "https://www.linkedin.com/messaging/thread/t1/",
+        personName: "Grace Hopper",
+        unread: false,
+      },
+    ]);
+    await linkedInStore.upsertThreadParticipants("t1", [
+      {
+        participantId: MEMBER,
+        name: "Grace Hopper",
+        headline: "Rear Admiral",
+        type: "member",
+        isSelf: false,
+      },
+    ]);
+    await sentinelLogRepo.create(sentinelMessage("telegram", "5512345", "Alan T"));
+  });
+
+  afterEach(() => testDb.close());
+
+  it("names an account on every channel through one call", async () => {
+    expect(await names.displayName("whatsapp", PHONE)).toBe("Ada Lovelace");
+    expect(await names.displayName("linkedin", MEMBER)).toBe("Grace Hopper");
+    expect(await names.displayName("telegram", "5512345")).toBe("Alan T");
+  });
+
+  it("answers the same name to every addressing the channel folds together", async () => {
+    expect(await names.displayName("whatsapp", LID)).toBe("Ada Lovelace");
+  });
+
+  it("falls back to the raw identifier when nothing holds a name", async () => {
+    expect(await names.displayName("whatsapp", NAMELESS)).toBe(NAMELESS);
+    expect(await names.displayName("whatsapp", "15559999999@s.whatsapp.net")).toBe(
+      "15559999999@s.whatsapp.net",
+    );
+    expect(await names.displayName("telegram", "5599999")).toBe("5599999");
+  });
+
+  it("takes the push name when the mirror holds no name, and never over one", async () => {
+    await sentinelLogRepo.create(sentinelMessage("whatsapp", NAMELESS, "Bobby"));
+    await sentinelLogRepo.create(sentinelMessage("whatsapp", PHONE, "Ada on her phone"));
+
+    expect(await names.displayName("whatsapp", NAMELESS)).toBe("Bobby");
+    expect(await names.displayName("whatsapp", PHONE)).toBe("Ada Lovelace");
+  });
+
+  it("keeps the last name a sender gave when a later message carried none", async () => {
+    await sentinelLogRepo.create(sentinelMessage("telegram", "5512345", undefined));
+
+    expect(await names.displayName("telegram", "5512345")).toBe("Alan T");
+  });
+
+  it("names a listing in the order asked", async () => {
+    expect(
+      await names.displayNames([
+        { channel: "telegram", channelUserId: "5512345" },
+        { channel: "whatsapp", channelUserId: LID },
+        { channel: "whatsapp", channelUserId: NAMELESS },
+      ]),
+    ).toEqual(["Alan T", "Ada Lovelace", NAMELESS]);
+  });
+
+  it("takes a new provider as one adapter, with no change to the call", async () => {
+    const matrix: ProviderNames = {
+      displayName: async (channelUserId) =>
+        channelUserId === "@ada:matrix.org" ? "Ada on Matrix" : null,
+    };
+    const withMatrix = new AccountNames({ matrix }, { displayName: async () => null });
+
+    expect(await withMatrix.displayName("matrix", "@ada:matrix.org")).toBe("Ada on Matrix");
+    expect(await withMatrix.displayName("matrix", "@grace:matrix.org")).toBe("@grace:matrix.org");
+  });
+});

--- a/packages/core/src/channels/account-names.test.ts
+++ b/packages/core/src/channels/account-names.test.ts
@@ -89,7 +89,7 @@ describe("AccountNames", () => {
     expect(await names.displayName("telegram", "5599999")).toBe("5599999");
   });
 
-  it("takes the push name when the mirror holds no name, and never over one", async () => {
+  it("takes the name a sender sent when the mirror holds none, and never over one", async () => {
     await sentinelLogRepo.create(sentinelMessage("whatsapp", NAMELESS, "Bobby"));
     await sentinelLogRepo.create(sentinelMessage("whatsapp", PHONE, "Ada on her phone"));
 

--- a/packages/core/src/channels/account-names.ts
+++ b/packages/core/src/channels/account-names.ts
@@ -9,114 +9,66 @@ import type { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
 import type { TalkAccounts } from "./accounts.js";
 
 /**
- * One provider's answer to what it calls an account.
+ * What to call an account, on any channel.
  *
- * Null means the provider holds no name for the account — not that the account
- * is unknown, and never an identifier of its own standing in for a name. The
- * fallback is {@link AccountNames}'s to run, once, for every provider.
- */
-export interface ProviderNames {
-  displayName(channelUserId: string): Promise<string | null>;
-}
-
-/** The names a channel's mirror already holds, as its account plane reports
- *  them. Every addressing the channel resolves is accepted, so which form a
- *  caller happens to hold does not decide whether a name comes back. */
-export function mirrorNames(accounts: TalkAccounts): ProviderNames {
-  return {
-    async displayName(channelUserId: string): Promise<string | null> {
-      return named((await accounts.resolve(channelUserId))?.name);
-    },
-  };
-}
-
-/** What senders have called themselves on their own messages, per channel.
- *  Null when nothing a channel delivered carried a name. */
-export interface PushNames {
-  displayName(channel: string, channelUserId: string): Promise<string | null>;
-}
-
-/**
- * A push name resolves to a display name only after the account's own mirror
- * has been asked, so this is the same lookup for a name Rome has no address
- * book for as for one it does. Providers are keyed by channel; a channel with
- * no entry — one Rome only ever sees senders on — falls straight through.
+ * A channel joins by implementing the account plane, which is what a channel
+ * that mirrors an address book owes anyway. A channel Rome only ever sees
+ * senders on implements nothing and falls through to their push names.
  */
 export class AccountNames {
   constructor(
-    private readonly providers: Readonly<Record<string, ProviderNames>>,
-    private readonly pushNames: PushNames,
+    private readonly providers: Readonly<Record<string, Pick<TalkAccounts, "resolve">>>,
+    private readonly pushNames: Pick<SentinelLogRepository, "listLatestDisplayNames">,
   ) {}
 
   /**
-   * What to call this account: the name its platform holds, then the name its
-   * sender put on a message, then the identifier itself — never an empty
-   * string, so a caller always has something to render.
+   * The name its platform holds, then the name its sender put on a message,
+   * then the identifier itself — never an empty string, so a caller always has
+   * something to render.
    *
    * A channel that addresses one account several ways answers its platform's
-   * name to every one of them. Neither fallback can: a push name is filed
-   * under the addressing its message arrived on, and the last resort only
-   * echoes what it was asked. A caller that folds addressings itself asks with
-   * the account's own address.
+   * name to every one of them. Neither fallback can: a push name is filed under
+   * the addressing its message arrived on, and the last resort only echoes what
+   * it was asked. A caller that folds addressings itself asks with the
+   * account's own address.
    */
   async displayName(channel: string, channelUserId: string): Promise<string> {
-    const fromProvider = await this.providers[channel]?.displayName(channelUserId);
-    if (fromProvider != null) return fromProvider;
-    return (await this.pushNames.displayName(channel, channelUserId)) ?? channelUserId;
+    const [name] = await this.displayNames([{ channel, channelUserId }]);
+    return name;
   }
 
   /**
    * The same answers for a listing, positionally — one name per account, in the
    * order asked.
    *
-   * This is the call a directory read wants. A mirror answers `resolve` from a
-   * read of the whole address book, so naming a listing one await at a time
-   * costs one such read per row; asking together lets the mirrors serve the
-   * page from the reads already in flight.
+   * This is the call a directory read wants. Every mirror is asked at once, so
+   * a channel that answers from a read of its whole address book serves the
+   * page from one such read rather than one per row, and the sentinel log is
+   * read once, and only where a mirror left a name unanswered.
    */
-  displayNames(accounts: Array<{ channel: string; channelUserId: string }>): Promise<string[]> {
-    return Promise.all(
-      accounts.map((account) => this.displayName(account.channel, account.channelUserId)),
+  async displayNames(accounts: Array<{ channel: string; channelUserId: string }>) {
+    const mirrored = await Promise.all(
+      accounts.map(
+        (account) => this.providers[account.channel]?.resolve(account.channelUserId) ?? null,
+      ),
+    );
+    const names = mirrored.map((account) => named(account?.name));
+    if (names.every((name) => name != null)) return names as string[];
+
+    const pushNames = await this.readPushNames();
+    return names.map(
+      (name, i) => name ?? pushNames.get(key(accounts[i])) ?? accounts[i].channelUserId,
     );
   }
-}
 
-/**
- * The names the sentinel log recorded, from the newest message each sender put
- * one on.
- *
- * The log is read whole, and reads in flight are shared, so naming a page of
- * accounts is one read rather than one per account. That is not a cache: the
- * window closes the moment the read settles, so a name a message just carried
- * is never held back behind a stale one.
- */
-export class SentinelPushNames implements PushNames {
-  constructor(private readonly log: SentinelLogRepository) {}
-
-  private reading: Promise<Map<string, string>> | null = null;
-
-  async displayName(channel: string, channelUserId: string): Promise<string | null> {
-    return (await this.load()).get(`${channel}\n${channelUserId}`) ?? null;
-  }
-
-  private load(): Promise<Map<string, string>> {
-    if (this.reading) return this.reading;
-    const reading = this.read();
-    this.reading = reading;
-    const done = () => {
-      if (this.reading === reading) this.reading = null;
-    };
-    reading.then(done, done);
-    return reading;
-  }
-
-  private async read(): Promise<Map<string, string>> {
-    const names = new Map<string, string>();
-    for (const row of await this.log.listLatestDisplayNames()) {
+  /** The name each sender last put on a message, by account. */
+  private async readPushNames(): Promise<Map<string, string>> {
+    const pushNames = new Map<string, string>();
+    for (const row of await this.pushNames.listLatestDisplayNames()) {
       const name = named(row.displayName);
-      if (name) names.set(`${row.channel}\n${row.channelUserId}`, name);
+      if (name) pushNames.set(key(row), name);
     }
-    return names;
+    return pushNames;
   }
 }
 
@@ -128,16 +80,16 @@ export function createAccountNames(deps: {
   sentinelLogRepo: SentinelLogRepository;
 }): AccountNames {
   return new AccountNames(
-    {
-      whatsapp: mirrorNames(deps.whatsAppAccounts),
-      linkedin: mirrorNames(deps.linkedInAccounts),
-    },
-    new SentinelPushNames(deps.sentinelLogRepo),
+    { whatsapp: deps.whatsAppAccounts, linkedin: deps.linkedInAccounts },
+    deps.sentinelLogRepo,
   );
 }
 
+const key = (account: { channel: string; channelUserId: string }) =>
+  `${account.channel}\n${account.channelUserId}`;
+
 /** A name, or null where there is only blank space. A stored empty string is a
- *  provider holding no name, not a name that renders as nothing. */
+ *  platform holding no name, not a name that renders as nothing. */
 function named(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;

--- a/packages/core/src/channels/account-names.ts
+++ b/packages/core/src/channels/account-names.ts
@@ -13,12 +13,12 @@ import type { TalkAccounts } from "./accounts.js";
  *
  * A channel joins by implementing `TalkAccounts`, which is what a channel that
  * mirrors an address book owes anyway. A channel Rome only ever sees senders on
- * implements nothing and falls through to their push names.
+ * implements nothing and falls through to the names those senders sent.
  */
 export class AccountNames {
   constructor(
     private readonly providers: Readonly<Record<string, Pick<TalkAccounts, "resolve">>>,
-    private readonly pushNames: Pick<SentinelLogRepository, "listLatestDisplayNames">,
+    private readonly senderNames: Pick<SentinelLogRepository, "listLatestDisplayNames">,
   ) {}
 
   /**
@@ -27,10 +27,10 @@ export class AccountNames {
    * something to render.
    *
    * A channel that addresses one account several ways answers its platform's
-   * name to every one of them. Neither fallback can: a push name is filed under
-   * the addressing its message arrived on, and the last resort only echoes what
-   * it was asked. A caller that folds addressings itself asks with the
-   * account's own address.
+   * name to every one of them. Neither fallback can: a sender's own name is
+   * filed under the addressing its message arrived on, and the last resort only
+   * echoes what it was asked. A caller that folds addressings itself asks with
+   * the account's own address.
    */
   async displayName(channel: string, channelUserId: string): Promise<string> {
     const [name] = await this.displayNames([{ channel, channelUserId }]);
@@ -55,20 +55,18 @@ export class AccountNames {
     const names = mirrored.map((account) => named(account?.name));
     if (names.every((name) => name != null)) return names as string[];
 
-    const pushNames = await this.readPushNames();
-    return names.map(
-      (name, i) => name ?? pushNames.get(key(accounts[i])) ?? accounts[i].channelUserId,
-    );
+    const sent = await this.readSenderNames();
+    return names.map((name, i) => name ?? sent.get(key(accounts[i])) ?? accounts[i].channelUserId);
   }
 
   /** The name each sender last put on a message, by account. */
-  private async readPushNames(): Promise<Map<string, string>> {
-    const pushNames = new Map<string, string>();
-    for (const row of await this.pushNames.listLatestDisplayNames()) {
+  private async readSenderNames(): Promise<Map<string, string>> {
+    const senderNames = new Map<string, string>();
+    for (const row of await this.senderNames.listLatestDisplayNames()) {
       const name = named(row.displayName);
-      if (name) pushNames.set(key(row), name);
+      if (name) senderNames.set(key(row), name);
     }
-    return pushNames;
+    return senderNames;
   }
 }
 

--- a/packages/core/src/channels/account-names.ts
+++ b/packages/core/src/channels/account-names.ts
@@ -1,0 +1,144 @@
+// What every platform calls its accounts, behind one call. `TalkAccounts`
+// (accounts.ts) is one channel's account plane; this is the display-name half
+// of all of them folded together, so a caller holding a (channel,
+// channelUserId) pair — the identity of an account, per
+// docs/concepts/identity.md — never learns which mirror answers for which
+// channel, nor that some channels have no mirror at all.
+
+import type { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
+import type { TalkAccounts } from "./accounts.js";
+
+/**
+ * One provider's answer to what it calls an account.
+ *
+ * Null means the provider holds no name for the account — not that the account
+ * is unknown, and never an identifier of its own standing in for a name. The
+ * fallback is {@link AccountNames}'s to run, once, for every provider.
+ */
+export interface ProviderNames {
+  displayName(channelUserId: string): Promise<string | null>;
+}
+
+/** The names a channel's mirror already holds, as its account plane reports
+ *  them. Every addressing the channel resolves is accepted, so which form a
+ *  caller happens to hold does not decide whether a name comes back. */
+export function mirrorNames(accounts: TalkAccounts): ProviderNames {
+  return {
+    async displayName(channelUserId: string): Promise<string | null> {
+      return named((await accounts.resolve(channelUserId))?.name);
+    },
+  };
+}
+
+/** What senders have called themselves on their own messages, per channel.
+ *  Null when nothing a channel delivered carried a name. */
+export interface PushNames {
+  displayName(channel: string, channelUserId: string): Promise<string | null>;
+}
+
+/**
+ * A push name resolves to a display name only after the account's own mirror
+ * has been asked, so this is the same lookup for a name Rome has no address
+ * book for as for one it does. Providers are keyed by channel; a channel with
+ * no entry — one Rome only ever sees senders on — falls straight through.
+ */
+export class AccountNames {
+  constructor(
+    private readonly providers: Readonly<Record<string, ProviderNames>>,
+    private readonly pushNames: PushNames,
+  ) {}
+
+  /**
+   * What to call this account: the name its platform holds, then the name its
+   * sender put on a message, then the identifier itself — never an empty
+   * string, so a caller always has something to render.
+   *
+   * A channel that addresses one account several ways answers its platform's
+   * name to every one of them. Neither fallback can: a push name is filed
+   * under the addressing its message arrived on, and the last resort only
+   * echoes what it was asked. A caller that folds addressings itself asks with
+   * the account's own address.
+   */
+  async displayName(channel: string, channelUserId: string): Promise<string> {
+    const fromProvider = await this.providers[channel]?.displayName(channelUserId);
+    if (fromProvider != null) return fromProvider;
+    return (await this.pushNames.displayName(channel, channelUserId)) ?? channelUserId;
+  }
+
+  /**
+   * The same answers for a listing, positionally — one name per account, in the
+   * order asked.
+   *
+   * This is the call a directory read wants. A mirror answers `resolve` from a
+   * read of the whole address book, so naming a listing one await at a time
+   * costs one such read per row; asking together lets the mirrors serve the
+   * page from the reads already in flight.
+   */
+  displayNames(accounts: Array<{ channel: string; channelUserId: string }>): Promise<string[]> {
+    return Promise.all(
+      accounts.map((account) => this.displayName(account.channel, account.channelUserId)),
+    );
+  }
+}
+
+/**
+ * The names the sentinel log recorded, from the newest message each sender put
+ * one on.
+ *
+ * The log is read whole, and reads in flight are shared, so naming a page of
+ * accounts is one read rather than one per account. That is not a cache: the
+ * window closes the moment the read settles, so a name a message just carried
+ * is never held back behind a stale one.
+ */
+export class SentinelPushNames implements PushNames {
+  constructor(private readonly log: SentinelLogRepository) {}
+
+  private reading: Promise<Map<string, string>> | null = null;
+
+  async displayName(channel: string, channelUserId: string): Promise<string | null> {
+    return (await this.load()).get(`${channel}\n${channelUserId}`) ?? null;
+  }
+
+  private load(): Promise<Map<string, string>> {
+    if (this.reading) return this.reading;
+    const reading = this.read();
+    this.reading = reading;
+    const done = () => {
+      if (this.reading === reading) this.reading = null;
+    };
+    reading.then(done, done);
+    return reading;
+  }
+
+  private async read(): Promise<Map<string, string>> {
+    const names = new Map<string, string>();
+    for (const row of await this.log.listLatestDisplayNames()) {
+      const name = named(row.displayName);
+      if (name) names.set(`${row.channel}\n${row.channelUserId}`, name);
+    }
+    return names;
+  }
+}
+
+/** The channels Rome mirrors an address book for. A provider joins the
+ *  directory here, and every caller keeps asking the same one question. */
+export function createAccountNames(deps: {
+  whatsAppAccounts: TalkAccounts;
+  linkedInAccounts: TalkAccounts;
+  sentinelLogRepo: SentinelLogRepository;
+}): AccountNames {
+  return new AccountNames(
+    {
+      whatsapp: mirrorNames(deps.whatsAppAccounts),
+      linkedin: mirrorNames(deps.linkedInAccounts),
+    },
+    new SentinelPushNames(deps.sentinelLogRepo),
+  );
+}
+
+/** A name, or null where there is only blank space. A stored empty string is a
+ *  provider holding no name, not a name that renders as nothing. */
+function named(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}

--- a/packages/core/src/channels/account-names.ts
+++ b/packages/core/src/channels/account-names.ts
@@ -1,9 +1,9 @@
 // What every platform calls its accounts, behind one call. `TalkAccounts`
-// (accounts.ts) is one channel's account plane; this is the display-name half
-// of all of them folded together, so a caller holding a (channel,
-// channelUserId) pair — the identity of an account, per
-// docs/concepts/identity.md — never learns which mirror answers for which
-// channel, nor that some channels have no mirror at all.
+// (accounts.ts) is one channel's address book; this is the display-name half of
+// all of them folded together, so a caller holding a (channel, channelUserId)
+// pair — the identity of an account, per docs/concepts/identity.md — never
+// learns which address book answers for which channel, nor that some channels
+// have none at all.
 
 import type { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
 import type { TalkAccounts } from "./accounts.js";
@@ -11,9 +11,9 @@ import type { TalkAccounts } from "./accounts.js";
 /**
  * What to call an account, on any channel.
  *
- * A channel joins by implementing the account plane, which is what a channel
- * that mirrors an address book owes anyway. A channel Rome only ever sees
- * senders on implements nothing and falls through to their push names.
+ * A channel joins by implementing `TalkAccounts`, which is what a channel that
+ * mirrors an address book owes anyway. A channel Rome only ever sees senders on
+ * implements nothing and falls through to their push names.
  */
 export class AccountNames {
   constructor(

--- a/packages/core/src/channels/account-paging.ts
+++ b/packages/core/src/channels/account-paging.ts
@@ -6,9 +6,11 @@ import type { Account } from "./accounts.js";
  * provider paginates server-side pages there and does not use this.
  */
 
-/** Case-insensitive substring match over the label and every identifier value. */
+/** Case-insensitive substring match over the name and every identifier value.
+ *  An account the platform holds no name for is still found by any identifier
+ *  it carries. */
 function matches(account: Account, needle: string): boolean {
-  if (account.label.toLowerCase().includes(needle)) return true;
+  if (account.name != null && account.name.toLowerCase().includes(needle)) return true;
   for (const value of Object.values(account.identifiers)) {
     if (value.toLowerCase().includes(needle)) return true;
   }

--- a/packages/core/src/channels/accounts.ts
+++ b/packages/core/src/channels/accounts.ts
@@ -28,19 +28,12 @@ export type AccountId = string & { readonly __brand: "AccountId" };
 export interface Account {
   id: AccountId;
   /**
-   * Human-readable, for display and search. Never an identity key. It is
-   * {@link name} where the platform holds one, and one of the account's
-   * identifiers written for a human — a phone number, a member id — where it
-   * holds none, so a label always renders.
-   */
-  label: string;
-  /**
-   * The name the platform holds for the account, or null when it holds none.
+   * What the platform calls the account, or null when it holds no name for it.
    *
-   * A caller that would rather fall back to something of its own than to an
-   * identifier — the name a sender put on a message, say — needs to tell a
-   * name from a rendered number, and {@link label} has already made that
-   * choice.
+   * Never an identifier standing in for a name. A caller that has to render
+   * something falls back on its own terms — to a name the account's sender put
+   * on a message, or to an identifier written for a human — and it cannot
+   * choose if a name and a rendered identifier arrive as one value.
    */
   name: string | null;
   /**

--- a/packages/core/src/channels/accounts.ts
+++ b/packages/core/src/channels/accounts.ts
@@ -27,8 +27,22 @@ export type AccountId = string & { readonly __brand: "AccountId" };
 
 export interface Account {
   id: AccountId;
-  /** Human-readable, for display and search. Never an identity key. */
+  /**
+   * Human-readable, for display and search. Never an identity key. It is
+   * {@link name} where the platform holds one, and one of the account's
+   * identifiers written for a human — a phone number, a member id — where it
+   * holds none, so a label always renders.
+   */
   label: string;
+  /**
+   * The name the platform holds for the account, or null when it holds none.
+   *
+   * A caller that would rather fall back to something of its own than to an
+   * identifier — the name a sender put on a message, say — needs to tell a
+   * name from a rendered number, and {@link label} has already made that
+   * choice.
+   */
+  name: string | null;
   /**
    * Searchable facts. Never used to address the account.
    *

--- a/packages/core/src/channels/linkedin-accounts.test.ts
+++ b/packages/core/src/channels/linkedin-accounts.test.ts
@@ -57,10 +57,10 @@ describe("LinkedInAccounts", () => {
     expect((await accounts.resolve(fromUrl!.id))!.id).toBe(fromUrl!.id);
   });
 
-  it("describes an account by label and namespaced identifier", async () => {
+  it("describes an account by name and namespaced identifier", async () => {
     const account = (await accounts.resolve("ACoAAAda0001"))!;
 
-    expect(account.label).toBe("Ada Lovelace");
+    expect(account.name).toBe("Ada Lovelace");
     expect(account.identifiers).toEqual({ "linkedin:member_id": "ACoAAAda0001" });
   });
 
@@ -86,14 +86,14 @@ describe("LinkedInAccounts", () => {
 
   it("pages and filters by query", async () => {
     const first = await accounts.listAccounts({ limit: 1 });
-    expect(first.accounts.map((a) => a.label)).toEqual(["Ada Lovelace"]);
+    expect(first.accounts.map((a) => a.name)).toEqual(["Ada Lovelace"]);
     expect(first.nextCursor).toBeDefined();
 
     const second = await accounts.listAccounts({ limit: 1, cursor: first.nextCursor });
-    expect(second.accounts.map((a) => a.label)).toEqual(["Grace Hopper"]);
+    expect(second.accounts.map((a) => a.name)).toEqual(["Grace Hopper"]);
     expect(second.nextCursor).toBeUndefined();
 
-    const byLabel = await accounts.listAccounts({ limit: 50, query: "hopper" });
-    expect(byLabel.accounts.map((a) => a.id)).toEqual(["ACoAAGrace002"]);
+    const byName = await accounts.listAccounts({ limit: 50, query: "hopper" });
+    expect(byName.accounts.map((a) => a.id)).toEqual(["ACoAAGrace002"]);
   });
 });

--- a/packages/core/src/channels/linkedin-accounts.ts
+++ b/packages/core/src/channels/linkedin-accounts.ts
@@ -64,9 +64,15 @@ function memberIdFrom(identifier: string): string | null {
 }
 
 function toAccount(row: LinkedInParticipantContactRow): Account {
+  // A headline is not a name, but it is text LinkedIn holds about the member
+  // rather than an identifier of theirs, so it stands as one here: a caller
+  // that falls through to the member id has nothing better to show than
+  // `ACoAA…`.
+  const name = row.name || row.headline || null;
   return {
     id: row.participantId as AccountId,
-    label: row.name || row.headline || row.participantId,
+    label: name ?? row.participantId,
+    name,
     identifiers: { "linkedin:member_id": row.participantId },
   };
 }

--- a/packages/core/src/channels/linkedin-accounts.ts
+++ b/packages/core/src/channels/linkedin-accounts.ts
@@ -64,15 +64,13 @@ function memberIdFrom(identifier: string): string | null {
 }
 
 function toAccount(row: LinkedInParticipantContactRow): Account {
-  // A headline is not a name, but it is text LinkedIn holds about the member
-  // rather than an identifier of theirs, so it stands as one here: a caller
-  // that falls through to the member id has nothing better to show than
-  // `ACoAA…`.
-  const name = row.name || row.headline || null;
   return {
     id: row.participantId as AccountId,
-    label: name ?? row.participantId,
-    name,
+    // A headline is not a name, but it is text LinkedIn holds about the member
+    // rather than an identifier of theirs, so it stands as one here: a caller
+    // that falls through to the member id has nothing better to show than
+    // `ACoAA…`.
+    name: row.name || row.headline || null,
     identifiers: { "linkedin:member_id": row.participantId },
   };
 }

--- a/packages/core/src/channels/whatsapp-accounts.test.ts
+++ b/packages/core/src/channels/whatsapp-accounts.test.ts
@@ -57,7 +57,7 @@ describe("WhatsAppAccounts", () => {
 
     const page = await accounts.listAccounts({ limit: 50 });
     expect(page.accounts).toHaveLength(1);
-    expect(page.accounts[0].label).toBe("One Contact");
+    expect(page.accounts[0].name).toBe("One Contact");
     expect(page.accounts[0].identifiers).toEqual({
       phone: "15550007777",
       "whatsapp:lid": LID,
@@ -75,7 +75,7 @@ describe("WhatsAppAccounts", () => {
     const page = await accounts.listAccounts({ limit: 50 });
     expect(page.accounts).toHaveLength(1);
     expect(page.accounts[0].id).toBe("15550009999@s.whatsapp.net");
-    expect(page.accounts[0].label).toBe("Split Contact");
+    expect(page.accounts[0].name).toBe("Split Contact");
     expect((await accounts.resolve("99900099999@lid"))!.id).toBe("15550009999@s.whatsapp.net");
   });
 
@@ -123,11 +123,12 @@ describe("WhatsAppAccounts", () => {
     expect([...activity.keys()]).toEqual([PHONE]);
   });
 
-  it("labels an unnamed account with its number as a person writes one", async () => {
+  it("holds no name for an unnamed account, and still carries its number", async () => {
     await repo.upsertContacts([{ jid: PHONE, phoneNumber: "15550007777" }]);
 
     const page = await accounts.listAccounts({ limit: 50 });
-    expect(page.accounts[0].label).toBe("+1 (555) 000-7777");
+    expect(page.accounts[0].name).toBeNull();
+    expect(page.accounts[0].identifiers.phone).toBe("15550007777");
   });
 
   it("answers a listing, its addresses and its activity from one read", async () => {
@@ -185,7 +186,7 @@ describe("WhatsAppAccounts", () => {
     ]);
 
     const page = await accounts.listAccounts({ limit: Number.NaN });
-    expect(page.accounts.map((a) => a.label)).toEqual(["Ada", "Bea"]);
+    expect(page.accounts.map((a) => a.name)).toEqual(["Ada", "Bea"]);
     expect(page.nextCursor).toBeUndefined();
   });
 
@@ -207,17 +208,17 @@ describe("WhatsAppAccounts", () => {
     ]);
 
     const first = await accounts.listAccounts({ limit: 2 });
-    expect(first.accounts.map((a) => a.label)).toEqual(["Ada", "Bea"]);
+    expect(first.accounts.map((a) => a.name)).toEqual(["Ada", "Bea"]);
     expect(first.nextCursor).toBeDefined();
 
     const second = await accounts.listAccounts({ limit: 2, cursor: first.nextCursor });
-    expect(second.accounts.map((a) => a.label)).toEqual(["Cy"]);
+    expect(second.accounts.map((a) => a.name)).toEqual(["Cy"]);
     expect(second.nextCursor).toBeUndefined();
 
-    const byLabel = await accounts.listAccounts({ limit: 50, query: "be" });
-    expect(byLabel.accounts.map((a) => a.label)).toEqual(["Bea"]);
+    const byName = await accounts.listAccounts({ limit: 50, query: "be" });
+    expect(byName.accounts.map((a) => a.name)).toEqual(["Bea"]);
 
     const byIdentifier = await accounts.listAccounts({ limit: 50, query: "15550000003" });
-    expect(byIdentifier.accounts.map((a) => a.label)).toEqual(["Cy"]);
+    expect(byIdentifier.accounts.map((a) => a.name)).toEqual(["Cy"]);
   });
 });

--- a/packages/core/src/channels/whatsapp-accounts.ts
+++ b/packages/core/src/channels/whatsapp-accounts.ts
@@ -213,20 +213,19 @@ function toAccount(id: AccountId, group: WhatsAppContactRow[]): Account {
   if (lid) identifiers["whatsapp:lid"] = lid;
 
   // Field-major, not row-major: a saved name on any row of the account beats a
-  // push name on another, and every name beats falling back to the number.
+  // push name on another.
   const pick = (field: (row: WhatsAppContactRow) => string | null) =>
     firstNonEmpty(...group.map(field));
-  const label =
+  const name =
     pick((row) => row.name) ??
     pick((row) => row.notify) ??
     pick((row) => row.verifiedName) ??
-    pick((row) => row.chatName) ??
-    // No name on record anywhere: the number, written the way a person writes
-    // one. The raw JID is a last resort, not a label.
-    formatWhatsAppPhone(pick((row) => row.phoneNumber) ?? id) ??
-    id;
+    pick((row) => row.chatName);
+  // No name on record anywhere: the number, written the way a person writes
+  // one. The raw JID is a last resort, not a label.
+  const label = name ?? formatWhatsAppPhone(pick((row) => row.phoneNumber) ?? id) ?? id;
 
-  return { id, label, identifiers };
+  return { id, label, name, identifiers };
 }
 
 /** Every index key the account answers to, including its own id. */

--- a/packages/core/src/channels/whatsapp-accounts.ts
+++ b/packages/core/src/channels/whatsapp-accounts.ts
@@ -1,4 +1,3 @@
-import { formatWhatsAppPhone } from "@rome/api-types/identities";
 import type { Account, AccountId, TalkAccounts } from "./accounts.js";
 import type { AccountActivity, TalkAccountActivity } from "./account-activity.js";
 import { pageAccounts } from "./account-paging.js";
@@ -212,8 +211,8 @@ function toAccount(id: AccountId, group: WhatsAppContactRow[]): Account {
     .sort()[0];
   if (lid) identifiers["whatsapp:lid"] = lid;
 
-  // Field-major, not row-major: a saved name on any row of the account beats a
-  // push name on another.
+  // Field-major, not row-major: a saved name on any row of the account beats
+  // the name the contact sent on another.
   const pick = (field: (row: WhatsAppContactRow) => string | null) =>
     firstNonEmpty(...group.map(field));
   const name =
@@ -221,11 +220,8 @@ function toAccount(id: AccountId, group: WhatsAppContactRow[]): Account {
     pick((row) => row.notify) ??
     pick((row) => row.verifiedName) ??
     pick((row) => row.chatName);
-  // No name on record anywhere: the number, written the way a person writes
-  // one. The raw JID is a last resort, not a label.
-  const label = name ?? formatWhatsAppPhone(pick((row) => row.phoneNumber) ?? id) ?? id;
 
-  return { id, label, name, identifiers };
+  return { id, name, identifiers };
 }
 
 /** Every index key the account answers to, including its own id. */

--- a/packages/core/src/db/repositories/sentinel-log.ts
+++ b/packages/core/src/db/repositories/sentinel-log.ts
@@ -1,4 +1,4 @@
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 import { sentinelLog } from "../schema.js";
 import type { DrizzleDb } from "../index.js";
@@ -36,6 +36,36 @@ export class SentinelLogRepository {
 
   async findUnreviewed() {
     return this.db.select().from(sentinelLog).where(eq(sentinelLog.reviewed, false));
+  }
+
+  /**
+   * The newest name each sender has put on a message, one row per (channel,
+   * channel user id). Senders who have never carried a name are absent, and no
+   * row carries an empty one.
+   *
+   * Read whole rather than one sender at a time: the callers are directory
+   * reads that name every account they list.
+   */
+  async listLatestDisplayNames(): Promise<
+    Array<{ channel: string; channelUserId: string; displayName: string }>
+  > {
+    // Bare display_name rides SQLite's guarantee that with a lone MAX()
+    // aggregate the other selected columns come from the row that supplied the
+    // max — i.e. the newest message names the sender. The max is taken over the
+    // named rows alone, so a later message that carried no name leaves the name
+    // the sender last gave standing.
+    const rows = (await this.db.all(sql`
+      SELECT channel, channel_user_id AS channelUserId, display_name AS displayName,
+             MAX(created_at) AS namedAt
+      FROM sentinel_log
+      WHERE display_name IS NOT NULL AND trim(display_name) <> ''
+      GROUP BY channel, channel_user_id
+    `)) as Array<Record<string, unknown>>;
+    return rows.map((row) => ({
+      channel: String(row.channel),
+      channelUserId: String(row.channelUserId),
+      displayName: String(row.displayName),
+    }));
   }
 
   async markReviewed(ids: string[]) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,6 +52,8 @@ import { PersonMappingRepository } from "./db/repositories/person-mapping.js";
 import { LinkedInStoreRepository } from "./db/repositories/linkedin-store.js";
 import { WhatsAppStoreRepository } from "./db/repositories/whatsapp-store.js";
 import { WhatsAppAccounts } from "./channels/whatsapp-accounts.js";
+import { createAccountNames } from "./channels/account-names.js";
+import { LinkedInAccounts } from "./channels/linkedin-accounts.js";
 import { SentinelLogRepository } from "./db/repositories/sentinel-log.js";
 import { ApprovalsRepository } from "./db/repositories/approvals.js";
 import { SettingsRepository } from "./db/repositories/settings.js";
@@ -227,7 +229,13 @@ async function main() {
   const whatsAppStoreRepo = new WhatsAppStoreRepository(db);
   const whatsAppAccounts = new WhatsAppAccounts(whatsAppStoreRepo);
   const linkedInStoreRepo = new LinkedInStoreRepository(db);
+  const linkedInAccounts = new LinkedInAccounts(linkedInStoreRepo);
   const sentinelLogRepo = new SentinelLogRepository(db);
+  const accountNames = createAccountNames({
+    whatsAppAccounts,
+    linkedInAccounts,
+    sentinelLogRepo,
+  });
   const approvalsRepo = new ApprovalsRepository(db);
   const settingsRepo = new SettingsRepository(db);
 
@@ -1148,6 +1156,7 @@ async function main() {
       whatsAppStoreRepo,
       whatsAppAccounts,
       linkedInStoreRepo,
+      accountNames,
       webchatRepo,
       webhookInvocationsRepo,
       approvalsRepo,

--- a/packages/core/src/test/helpers.ts
+++ b/packages/core/src/test/helpers.ts
@@ -52,6 +52,8 @@ import { PersonMappingRepository } from "../db/repositories/person-mapping.js";
 import { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
 import { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
 import { WhatsAppAccounts } from "../channels/whatsapp-accounts.js";
+import { createAccountNames } from "../channels/account-names.js";
+import { LinkedInAccounts } from "../channels/linkedin-accounts.js";
 import { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
 import { ApprovalsRepository } from "../db/repositories/approvals.js";
 import { SettingsRepository } from "../db/repositories/settings.js";
@@ -374,7 +376,13 @@ export async function buildTestDeps(
   const whatsAppStoreRepo = new WhatsAppStoreRepository(db);
   const whatsAppAccounts = new WhatsAppAccounts(whatsAppStoreRepo);
   const linkedInStoreRepo = new LinkedInStoreRepository(db);
+  const linkedInAccounts = new LinkedInAccounts(linkedInStoreRepo);
   const sentinelLogRepo = new SentinelLogRepository(db);
+  const accountNames = createAccountNames({
+    whatsAppAccounts,
+    linkedInAccounts,
+    sentinelLogRepo,
+  });
   const approvalsRepo = new ApprovalsRepository(db);
   const settingsRepo = new SettingsRepository(db);
   const policiesRepo = new PoliciesRepository(db);
@@ -533,6 +541,7 @@ export async function buildTestDeps(
     whatsAppStoreRepo,
     whatsAppAccounts,
     linkedInStoreRepo,
+    accountNames,
     sentinelLogRepo,
     approvalsRepo,
     approvalHandler,


### PR DESCRIPTION
Closes #58.

## What this PR does

Every surface that shows an account works out what to call it for itself. Each one has to know which mirror holds the answer for which channel, what that mirror's rows are called, and what to do when no mirror holds the account at all. The `/people` and `/accounts` serializers coming next would be the third and fourth such site.

`AccountNames` answers it in one call over `(channel, channelUserId)`: the name the platform holds, then the name the sender put on their own message, then the identifier itself. WhatsApp, LinkedIn, and a sender the sentinel log saw on a channel with no address book all go through the same call, and a listing is named in one batch.

## Design & Invariants

The vocabulary is the one in [`docs/concepts/identity.md`](docs/concepts/identity.md) — an account is a platform-owned identity keyed by channel plus platform user id.

- **One fallback chain, run once.** A provider answers with a name or null. Null means the platform holds no name, never an identifier of its own standing in for one, so the chain is the directory's to run for every provider. A name is never empty: a caller always has something to render.
- **Adding a provider is one `TalkAccounts`.** The directory reads providers through `TalkAccounts.resolve` — the address-book contract a mirroring channel owes anyway (#56) — so joining is that implementation plus one entry in `createAccountNames`, and no caller changes. A unit test builds a directory over a fake `matrix` implementation to show it.
- **Names come through `TalkAccounts`, not the mirror's rows.** Which addressings fold onto one account is that contract's answer (#56), so a WhatsApp account answers the same name to its LID and to its phone JID. The two fallbacks cannot do that: a sender's own name is filed under the addressing its message arrived on, and the last resort only echoes what it was asked.
- **`Account` carries one name, and it is nullable.** `Account.label` is gone. It was a second total answer — always renderable, because it fell back to an identifier written for a human — and it disagreed with this one: a nameless WhatsApp contact was `+1 (555) 000-7777` there and the name its sender sent here. `AccountNames.displayName` is the total answer now, and the better one, because it reaches a name no address book holds. The account plane keeps only what its platform knows, and rendering an identifier for a human belongs to whoever renders.
- **Reads stay whole.** A mirror answers `resolve` from a read of its whole address book, so `displayNames` asks every mirror at once and a page costs one such read per channel rather than one per row. The sentinel log is read once per call, and only where a mirror left a name unanswered.

The alternative was to keep `label` as the provider's answer. It never reaches the sender's own name: a contact row whose name fields are all empty already renders as its number, so a sender who called themselves "Bobby" would show as `+1 (555) 000-1111`. That also fails the acceptance criterion on this issue — the chain has to end at the raw identifier. Rendering a number for display stays available through `formatWhatsAppPhone` in `@rome/api-types/identities`, which `PeoplePage.tsx` already imports and calls on a raw JID.

The identities union keeps its own `displayNameFor`, now reading `Account.name` and running the same three-step chain. It names rows from mirror snapshots it has already loaded, so routing it through the seam would trade a map lookup per row for a full address-book read per row, and #69 retires it. No dashboard page fetches `/api/identities` yet — only its comparators are under test — so the union's answer for a nameless contact is not on screen anywhere.

## Test plan

- [x] `pnpm --filter @rome/core exec vitest run src/channels/account-names.test.ts` — 7 tests: a name on each of the three sources through one call, the same name under a folded LID, a nameless contact falling back to its raw JID, a sender's own name taken only where the mirror holds none, a name kept when a later message carried none, batch order, and a fake `TalkAccounts` added with no caller change.
- [x] `pnpm typecheck`
- [x] `pnpm test:unit:core` — 3938 tests pass, including the account-plane and identity-union suites the `label` fold touches.
- [x] `biome check packages/core/src` — clean but for two findings that predate this branch.
- [ ] `pnpm dev:all` — the Docker daemon refuses this environment's user. The DI wiring this PR adds runs in `buildTestDeps`, which fronts the core suite above.

## Not in this PR

- The `/people` and `/accounts` routes (#60, #61) — this is the seam they read through.
- Alias folding for the names senders send. One is found under the addressing its message arrived on, which `displayName` states. Folding one across a channel's addressings means reading `TalkAccounts.listAddresses` whole, and the directory reads that will want it are the listings in #60 and #61.
- The identities union's own name derivation, retired with the union in #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




