### PR TITLE
feat(core): aggregate the cross-account timeline

### DIFF
--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -20,6 +20,7 @@
     "./discord-broker": "./src/discord-broker.ts",
     "./favors": "./src/favors.ts",
     "./identities": "./src/identities.ts",
+    "./people": "./src/people.ts",
     "./persons": "./src/persons.ts"
   },
   "scripts": {

--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -1,0 +1,38 @@
+// The People surface's contract. This module holds the timeline read — one
+// person's history across every account they are linked to.
+//
+// The entry shape, the ordering and the cursor are the identity union's, and
+// they are re-exported rather than restated. The two surfaces page the same
+// entries: a stream row's `latest` is the head of the timeline the same row
+// opens, and a cursor written against one has to name a position in the other.
+// A second definition of either is a page boundary the two ends disagree about.
+
+import { TIMELINE_PAGE_DEFAULT_LIMIT, TIMELINE_PAGE_MAX_LIMIT } from "./identities.js";
+
+export {
+  compareTimelineEntries,
+  isAfterTimelineCursor,
+  latestDynamic,
+  parseTimelineCursor,
+  timelineCursor,
+  TIMELINE_PAGE_DEFAULT_LIMIT,
+  TIMELINE_PAGE_MAX_LIMIT,
+  type TimelineEntry,
+  type TimelinePage,
+} from "./identities.js";
+
+/**
+ * The page size a `?limit=` value asks for: clamped to
+ * {@link TIMELINE_PAGE_MAX_LIMIT}, and the default for anything that does not
+ * name a positive count — absent, empty, zero, negative, or not a number.
+ *
+ * Never zero. A limit of zero answers an empty page with no cursor, which a
+ * caller cannot tell from an exhausted timeline, so it would silently truncate
+ * the history rather than reporting a bad request.
+ */
+export function timelinePageLimit(raw: string | number | null | undefined): number {
+  const requested = Number(raw);
+  return Number.isFinite(requested) && requested >= 1
+    ? Math.min(Math.floor(requested), TIMELINE_PAGE_MAX_LIMIT)
+    : TIMELINE_PAGE_DEFAULT_LIMIT;
+}

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -33,6 +33,7 @@ import { systemUpgradeRoutes } from "./routes/system-upgrade.js";
 import { personsRoutes } from "./routes/persons.js";
 import { linkedinThreadsRoutes } from "./routes/linkedin-threads.js";
 import { identitiesRoutes } from "./routes/identities.js";
+import { peopleRoutes } from "./routes/people.js";
 import { whatsappContactsRoutes } from "./routes/whatsapp-contacts.js";
 import { sentinelLogRoutes } from "./routes/sentinel-log.js";
 import { webhookInvocationsRoutes } from "./routes/webhook-invocations.js";
@@ -148,6 +149,7 @@ export function buildApp(
   api.route("/", eventCatalogRoutes(deps));
   api.route("/", personsRoutes(deps));
   api.route("/", identitiesRoutes(deps));
+  api.route("/", peopleRoutes(deps));
   api.route("/", whatsappContactsRoutes(deps));
   api.route("/", linkedinThreadsRoutes(deps));
   api.route("/", sentinelLogRoutes(deps));

--- a/packages/core/src/api/routes/people.test.ts
+++ b/packages/core/src/api/routes/people.test.ts
@@ -1,0 +1,473 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import type { TimelinePage } from "@rome/api-types/people";
+import { peopleRoutes } from "./people.js";
+import { createTestDb, buildTestDeps, type TestDb, type TestDeps } from "../../test/helpers.js";
+import { seedBaseline, type BaselineIds } from "../../test/seeds.js";
+import { romeAgentMessages } from "../../db/schema.js";
+import { STRANGER_PERSON_ID } from "../../constants.js";
+
+// GET /people/:id/messages — one person's history merged across every account
+// they are linked to. These tests pin what the merge answers over real stores:
+// which of the overlapping ones an account's entries come from, that a channel
+// filter narrows to one, and that walking the cursor visits each entry once.
+
+const WA_JID = "15550009999@s.whatsapp.net";
+const WA_LID = "88881111@lid";
+const TG_THREAD = "tg-timeline";
+const GROUP_THREAD = "tg-group-timeline";
+
+const at = (iso: string) => new Date(iso);
+const textContent = (text: string) => JSON.stringify([{ type: "text", content: text }]);
+
+describe("People timeline API", () => {
+  let testDb: TestDb;
+  let deps: TestDeps;
+  let app: Hono;
+  let baseline: BaselineIds;
+  let personId: string;
+  let telegramSessionId: string;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    baseline = await seedBaseline(testDb.db);
+    deps = await buildTestDeps(testDb.db);
+    app = new Hono().route("/", peopleRoutes(deps));
+
+    personId = await deps.personMappingRepo.create({
+      displayName: "Nadia Cross",
+      bondLevel: "acquaintance",
+      approved: true,
+      channelMappings: [
+        { channel: "whatsapp", channelUserId: WA_JID },
+        { channel: "telegram", channelUserId: TG_THREAD },
+      ],
+    });
+
+    // WhatsApp: a mirrored direct thread, plus a group chat she is not read
+    // through, plus a reaction the timeline does not render.
+    await deps.whatsAppStoreRepo.upsertContacts([
+      { jid: WA_JID, phoneNumber: "15550009999", name: "Nadia Cross" },
+    ]);
+    await deps.whatsAppStoreRepo.upsertMessages([
+      {
+        id: "wa-old",
+        chatJid: WA_JID,
+        senderJid: WA_JID,
+        fromMe: false,
+        timestamp: at("2026-08-01T09:00:00Z"),
+        type: "text",
+        text: "are we still on for friday",
+        hasMedia: false,
+      },
+      {
+        id: "wa-reply",
+        chatJid: WA_JID,
+        senderJid: WA_JID,
+        fromMe: true,
+        timestamp: at("2026-08-01T09:05:00Z"),
+        type: "text",
+        text: "yes — 7pm",
+        hasMedia: false,
+      },
+      {
+        id: "wa-react",
+        chatJid: WA_JID,
+        senderJid: WA_JID,
+        fromMe: false,
+        timestamp: at("2026-08-01T09:06:00Z"),
+        type: "reaction",
+        text: "👍",
+        hasMedia: false,
+        reactsToId: "wa-reply",
+      },
+      {
+        id: "wa-group",
+        chatJid: "120363000000000009@g.us",
+        senderJid: WA_JID,
+        fromMe: false,
+        timestamp: at("2026-08-02T10:00:00Z"),
+        type: "text",
+        text: "posted in the group",
+        hasMedia: false,
+      },
+    ]);
+
+    // Telegram: no mirror, so her direct conversation is the channel session's
+    // own transcript.
+    const conversation = await deps.webchatRepo.ensureChannelConversation({
+      channel: "telegram",
+      threadId: TG_THREAD,
+      threadType: "private",
+      agentName: "main",
+    });
+    await deps.webchatRepo.addConversationMessage({
+      sessionId: conversation.id,
+      role: "user",
+      content: textContent("did you see the invite"),
+      platformMessageId: "tg-100",
+      senderId: TG_THREAD,
+      senderName: "Nadia Cross",
+      createdAt: at("2026-08-03T08:00:00Z"),
+    });
+    telegramSessionId = conversation.id;
+    await testDb.db.insert(romeAgentMessages).values({
+      id: "tg-100-reply",
+      sessionId: conversation.id,
+      role: "assistant",
+      content: textContent("just did — replying now"),
+      createdAt: at("2026-08-03T08:01:00Z"),
+    });
+  });
+
+  afterEach(() => testDb.close());
+
+  async function fetchTimeline(id: string, query = ""): Promise<TimelinePage> {
+    const res = await app.request(`/people/${id}/messages${query}`);
+    expect(res.status).toBe(200);
+    return (await res.json()) as TimelinePage;
+  }
+
+  it("returns entries across every account of the person, newest first", async () => {
+    const page = await fetchTimeline(personId);
+    expect(page.entries.map((entry) => [entry.source, entry.body])).toEqual([
+      ["telegram", "just did — replying now"],
+      ["telegram", "did you see the invite"],
+      ["whatsapp", "yes — 7pm"],
+      ["whatsapp", "are we still on for friday"],
+    ]);
+    expect(page.entries.map((entry) => entry.direction)).toEqual([
+      "outbound",
+      "inbound",
+      "outbound",
+      "inbound",
+    ]);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("leaves out group conversations and reactions", async () => {
+    const bodies = (await fetchTimeline(personId)).entries.map((entry) => entry.body);
+    expect(bodies).not.toContain("posted in the group");
+    expect(bodies).not.toContain("👍");
+  });
+
+  it("pages by nextCursor with no duplicate and no missing entry", async () => {
+    const whole = (await fetchTimeline(personId)).entries;
+
+    const walked: TimelinePage["entries"] = [];
+    let query = "?limit=1";
+    for (let page = 0; page < 10; page += 1) {
+      const next = await fetchTimeline(personId, query);
+      expect(next.entries).toHaveLength(1);
+      walked.push(...next.entries);
+      if (next.nextCursor === null) break;
+      query = `?limit=1&cursor=${encodeURIComponent(next.nextCursor)}`;
+    }
+    expect(walked).toEqual(whole);
+  });
+
+  it("resumes inside a second that two stores both wrote to", async () => {
+    // Whole seconds collide across stores, so the cursor has to name an entry
+    // rather than a moment: resuming from the bare timestamp would drop
+    // whatever else landed in the same second.
+    const collide = at("2026-08-07T11:11:11Z");
+    await deps.whatsAppStoreRepo.upsertMessages([
+      {
+        id: "wa-tie-in",
+        chatJid: WA_JID,
+        senderJid: WA_JID,
+        fromMe: false,
+        timestamp: collide,
+        type: "text",
+        text: "whatsapp inbound",
+        hasMedia: false,
+      },
+      {
+        id: "wa-tie-out",
+        chatJid: WA_JID,
+        senderJid: WA_JID,
+        fromMe: true,
+        timestamp: collide,
+        type: "text",
+        text: "whatsapp outbound",
+        hasMedia: false,
+      },
+    ]);
+    await deps.webchatRepo.addConversationMessage({
+      sessionId: telegramSessionId,
+      role: "user",
+      content: textContent("telegram inbound"),
+      platformMessageId: "tg-tie",
+      senderId: TG_THREAD,
+      createdAt: collide,
+    });
+
+    const whole = (await fetchTimeline(personId)).entries;
+    const tied = whole.filter((entry) => entry.timestamp === Math.floor(collide.getTime() / 1000));
+    expect(tied.map((entry) => entry.body)).toEqual([
+      "whatsapp outbound",
+      "telegram inbound",
+      "whatsapp inbound",
+    ]);
+
+    const walked: TimelinePage["entries"] = [];
+    let query = "?limit=1";
+    for (let page = 0; page < 20; page += 1) {
+      const next = await fetchTimeline(personId, query);
+      walked.push(...next.entries);
+      if (next.nextCursor === null) break;
+      query = `?limit=1&cursor=${encodeURIComponent(next.nextCursor)}`;
+    }
+    expect(walked).toEqual(whole);
+  });
+
+  it("narrows to one source with ?channel=", async () => {
+    const page = await fetchTimeline(personId, "?channel=whatsapp");
+    expect(page.entries.map((entry) => entry.source)).toEqual(["whatsapp", "whatsapp"]);
+
+    // A channel the person holds no account on is an empty history rather than
+    // a bad request — channels are open-ended.
+    expect((await fetchTimeline(personId, "?channel=discord")).entries).toEqual([]);
+  });
+
+  it("gives a sender with only sentinel history both halves of the exchange", async () => {
+    const sentinelOnly = await deps.personMappingRepo.create({
+      displayName: "Sentinel Only",
+      bondLevel: "other",
+      approved: true,
+      channelMappings: [{ channel: "telegram", channelUserId: "tg-triaged" }],
+    });
+    await deps.sentinelLogRepo.create({
+      messageId: "tg-900",
+      channel: "telegram",
+      channelUserId: "tg-triaged",
+      displayName: "Sentinel Only",
+      threadId: "tg-triaged",
+      text: "is this the right number for bookings?",
+      action: "replied",
+      response: "it is — sending you the link",
+    });
+
+    const page = await fetchTimeline(sentinelOnly);
+    expect(page.entries.map((entry) => [entry.direction, entry.body])).toEqual([
+      ["outbound", "it is — sending you the link"],
+      ["inbound", "is this the right number for bookings?"],
+    ]);
+  });
+
+  it("reads a mirrored account from the mirror and never twice", async () => {
+    // One WhatsApp exchange, written down three times: by the mirror, by Rome's
+    // own transcript of the channel session, and by the sentinel that triaged
+    // it. Production stores the same words in all three; the wording differs
+    // here only so the assertion can say which store answered.
+    const conversation = await deps.webchatRepo.ensureChannelConversation({
+      channel: "whatsapp",
+      threadId: WA_JID,
+      threadType: "private",
+      agentName: "main",
+    });
+    await deps.webchatRepo.addConversationMessage({
+      sessionId: conversation.id,
+      role: "notification",
+      content: textContent("as the transcript has it"),
+      platformMessageId: "wa-old",
+      senderId: WA_JID,
+      createdAt: at("2026-08-01T09:00:02Z"),
+    });
+    await deps.sentinelLogRepo.create({
+      messageId: "wa-old",
+      channel: "whatsapp",
+      channelUserId: WA_JID,
+      threadId: WA_JID,
+      text: "as the sentinel logged it",
+      action: "replied",
+      response: "as the sentinel answered it",
+    });
+
+    const whatsapp = (await fetchTimeline(personId, "?channel=whatsapp")).entries;
+    expect(whatsapp.map((entry) => entry.body)).toEqual([
+      "yes — 7pm",
+      "are we still on for friday",
+    ]);
+  });
+
+  it("falls back to the channel transcript for an account no mirror holds", async () => {
+    // The same overlap without a mirror: the transcript outranks the sentinel,
+    // so the exchange reads as Rome's own record of it.
+    const triaged = await deps.personMappingRepo.create({
+      displayName: "Triaged Talker",
+      bondLevel: "other",
+      approved: true,
+      channelMappings: [{ channel: "telegram", channelUserId: "tg-both" }],
+    });
+    const conversation = await deps.webchatRepo.ensureChannelConversation({
+      channel: "telegram",
+      threadId: "tg-both",
+      threadType: "private",
+      agentName: "main",
+    });
+    await deps.webchatRepo.addConversationMessage({
+      sessionId: conversation.id,
+      role: "notification",
+      content: textContent("as the transcript has it"),
+      platformMessageId: "tg-800",
+      senderId: "tg-both",
+      createdAt: at("2026-08-04T08:00:00Z"),
+    });
+    await deps.sentinelLogRepo.create({
+      messageId: "tg-800",
+      channel: "telegram",
+      channelUserId: "tg-both",
+      threadId: "tg-both",
+      text: "as the sentinel logged it",
+      action: "replied",
+      response: "as the sentinel answered it",
+    });
+
+    const bodies = (await fetchTimeline(triaged)).entries.map((entry) => entry.body);
+    expect(bodies).toEqual(["as the transcript has it"]);
+  });
+
+  it("holds a sentinel row back when the thread it names is a group", async () => {
+    const inGroup = await deps.personMappingRepo.create({
+      displayName: "Group Talker",
+      bondLevel: "other",
+      approved: true,
+      channelMappings: [{ channel: "telegram", channelUserId: "tg-in-group" }],
+    });
+    await deps.webchatRepo.ensureChannelConversation({
+      channel: "telegram",
+      threadId: GROUP_THREAD,
+      threadType: "group",
+      agentName: "main",
+    });
+    await deps.sentinelLogRepo.create({
+      messageId: "tg-901",
+      channel: "telegram",
+      channelUserId: "tg-in-group",
+      threadId: GROUP_THREAD,
+      text: "said in a group",
+      action: "ignored",
+    });
+    await deps.sentinelLogRepo.create({
+      messageId: "tg-902",
+      channel: "telegram",
+      channelUserId: "tg-in-group",
+      threadId: "tg-in-group",
+      text: "said to rome",
+      action: "ignored",
+    });
+
+    const bodies = (await fetchTimeline(inGroup)).entries.map((entry) => entry.body);
+    expect(bodies).toEqual(["said to rome"]);
+  });
+
+  it("reads one account through every address the channel folds onto it", async () => {
+    // She is mapped under the LID, and the conversation hangs off the phone
+    // JID. Both address one account, so the timeline is one conversation.
+    await deps.whatsAppStoreRepo.upsertContacts([
+      { jid: WA_LID, phoneNumber: "15550009999", notify: "Nadia" },
+    ]);
+    const byLid = await deps.personMappingRepo.create({
+      displayName: "Nadia By LID",
+      bondLevel: "other",
+      approved: true,
+      channelMappings: [{ channel: "whatsapp", channelUserId: WA_LID }],
+    });
+
+    const page = await fetchTimeline(byLid);
+    expect(page.entries.map((entry) => entry.body)).toEqual([
+      "yes — 7pm",
+      "are we still on for friday",
+    ]);
+  });
+
+  it("reads LinkedIn direct threads and leaves group threads out", async () => {
+    const member = "ACoAAtimeline01";
+    await deps.linkedInStoreRepo.upsertThreads([
+      { threadId: "li-direct", threadUrl: "https://x/li-direct", unread: false },
+      { threadId: "li-group", threadUrl: "https://x/li-group", unread: false },
+      { threadId: "li-unread-group", threadUrl: "https://x/li-ug", unread: false },
+    ]);
+    await deps.linkedInStoreRepo.markThreadSynced("li-direct", { isGroup: false });
+    // Flagged a group before its membership was read whole, so the flag is the
+    // only thing that keeps it out.
+    await deps.linkedInStoreRepo.markThreadSynced("li-unread-group", { isGroup: true });
+    await deps.linkedInStoreRepo.upsertThreadParticipants("li-direct", [
+      { participantId: member, name: "Priya Nair", isSelf: false },
+      { participantId: "ACoAAself", name: "Guardian", isSelf: true },
+    ]);
+    await deps.linkedInStoreRepo.upsertThreadParticipants("li-group", [
+      { participantId: member, name: "Priya Nair", isSelf: false },
+      { participantId: "ACoAAself", name: "Guardian", isSelf: true },
+      { participantId: "ACoAAthird", name: "Someone Else", isSelf: false },
+    ]);
+    await deps.linkedInStoreRepo.upsertThreadParticipants("li-unread-group", [
+      { participantId: member, name: "Priya Nair", isSelf: false },
+      { participantId: "ACoAAself", name: "Guardian", isSelf: true },
+    ]);
+    await deps.linkedInStoreRepo.upsertMessages([
+      {
+        messageId: "li-1",
+        threadId: "li-direct",
+        sentAt: at("2026-08-05T12:00:00Z"),
+        senderIsSelf: false,
+        text: "sent you a note about the role",
+      },
+      {
+        messageId: "li-2",
+        threadId: "li-direct",
+        sentAt: at("2026-08-05T12:30:00Z"),
+        senderIsSelf: true,
+        text: "thanks — reading it now",
+      },
+      {
+        messageId: "li-3",
+        threadId: "li-group",
+        sentAt: at("2026-08-06T12:00:00Z"),
+        senderIsSelf: false,
+        text: "posted in the group thread",
+      },
+      {
+        messageId: "li-4",
+        threadId: "li-unread-group",
+        sentAt: at("2026-08-06T13:00:00Z"),
+        senderIsSelf: false,
+        text: "posted in the unread group",
+      },
+    ]);
+    const priya = await deps.personMappingRepo.create({
+      displayName: "Priya Nair",
+      bondLevel: "acquaintance",
+      approved: true,
+      channelMappings: [{ channel: "linkedin", channelUserId: member }],
+    });
+
+    const page = await fetchTimeline(priya);
+    expect(page.entries.map((entry) => [entry.source, entry.direction, entry.body])).toEqual([
+      ["linkedin", "outbound", "thanks — reading it now"],
+      ["linkedin", "inbound", "sent you a note about the role"],
+    ]);
+  });
+
+  it("answers 404 for an unknown person and for the stranger sentinel", async () => {
+    expect((await app.request("/people/nobody-here/messages")).status).toBe(404);
+    expect((await app.request(`/people/${STRANGER_PERSON_ID}/messages`)).status).toBe(404);
+    expect(baseline.persons.strangerId).toBe(STRANGER_PERSON_ID);
+  });
+
+  it("refuses a cursor that is not one", async () => {
+    const res = await app.request(`/people/${personId}/messages?cursor=not-a-cursor`);
+    expect(res.status).toBe(400);
+  });
+
+  it("answers an empty page for a person with no accounts", async () => {
+    const unreachable = await deps.personMappingRepo.create({
+      displayName: "No Channels",
+      bondLevel: "other",
+      approved: true,
+      channelMappings: [],
+    });
+    expect(await fetchTimeline(unreachable)).toEqual({ entries: [], nextCursor: null });
+  });
+});

--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -1,0 +1,49 @@
+import { Hono } from "hono";
+import { parseTimelineCursor, timelinePageLimit } from "@rome/api-types/people";
+import { STRANGER_PERSON_ID } from "../../constants.js";
+import { readPersonTimeline } from "../../people/timeline.js";
+import { personTimelineAccounts, personTimelineSources } from "../../people/timeline-sources.js";
+import type { ApiDeps } from "../deps.js";
+
+// The People surface's timeline read. What a page of history is, how it is
+// ordered and how it resumes are the contract's (@rome/api-types/people);
+// which stores it is merged from is `src/people/`. This route is the join
+// between a person id and those two, and holds no rule of its own.
+
+export function peopleRoutes(deps: ApiDeps): Hono {
+  const app = new Hono();
+
+  app.get("/people/:id/messages", async (c) => {
+    const id = c.req.param("id");
+    // The stranger sentinel is a row in the persons table rather than a person,
+    // and every dismissed identity is mapped onto it. Answering for it would
+    // merge the history of everyone the guardian has ever dismissed into one
+    // timeline.
+    const person = id === STRANGER_PERSON_ID ? null : await deps.personMappingRepo.findById(id);
+    if (!person) return c.json({ error: "Unknown person" }, 404);
+
+    const rawCursor = c.req.query("cursor");
+    const cursor = parseTimelineCursor(rawCursor);
+    if (rawCursor != null && rawCursor !== "" && cursor === null) {
+      return c.json({ error: "cursor is not a timeline cursor" }, 400);
+    }
+
+    // A channel this person holds no account on answers an empty page rather
+    // than a 400: channels are open — a Rome App brings its own — so there is
+    // no set of names to check one against, and "no history there" is the true
+    // answer for every name that is not a typo.
+    const channel = c.req.query("channel");
+    const accounts = (await personTimelineAccounts(deps, person.channelMappings)).filter(
+      (account) => !channel || account.channel === channel,
+    );
+
+    return c.json(
+      await readPersonTimeline(personTimelineSources(deps), accounts, {
+        cursor,
+        limit: timelinePageLimit(c.req.query("limit")),
+      }),
+    );
+  });
+
+  return app;
+}

--- a/packages/core/src/people/timeline-sources.ts
+++ b/packages/core/src/people/timeline-sources.ts
@@ -1,0 +1,258 @@
+// One adapter per message store a person's history can come from, and the
+// order they claim an account in. The seam and the merge are in timeline.ts;
+// the SQL plumbing every adapter here shares is in timeline-sql.ts.
+//
+// Direct threads only. Each adapter scopes itself by the account's own
+// addresses, so a group conversation — addressed by the group rather than by
+// the person — never reaches a person's timeline.
+
+import { sql } from "drizzle-orm";
+import type { TalkAccounts } from "../channels/accounts.js";
+import type { DrizzleDb } from "../db/index.js";
+import type { MessagePart } from "../types.js";
+import type { TimelineAccount, TimelineSource } from "./timeline.js";
+import { accountPairs, addressesOn, inList, sqlTimelineSource } from "./timeline-sql.js";
+
+/**
+ * The stores a person's timeline is read from, in the order they claim an
+ * account.
+ *
+ * The order is the precedence the seam's {@link TimelineSource} contract
+ * describes: a channel mirror holds the conversation as the channel has it, so
+ * it outranks Rome's own transcript of the same messages, which in turn
+ * outranks the sentinel's triage record. An account only the sentinel saw still
+ * gets its exchanges — the sentinel is last, not excluded.
+ *
+ * The cost of that precedence: an account with a mirrored conversation shows
+ * the conversation, and the sentinel's own record of an exchange inside it
+ * stays behind Rome's reply as the channel delivered it.
+ */
+export function personTimelineSources(deps: { db: DrizzleDb }): TimelineSource[] {
+  return [
+    whatsAppMirrorSource(deps.db),
+    linkedInMirrorSource(deps.db),
+    agentMessagesSource(deps.db),
+    sentinelLogSource(deps.db),
+  ];
+}
+
+/** `wa_messages`, the WhatsApp thread as the mirror holds it. */
+export function whatsAppMirrorSource(db: DrizzleDb): TimelineSource {
+  return sqlTimelineSource({
+    name: "wa_messages",
+    db,
+    view(accounts) {
+      const chats = inList(sql`m.chat_jid`, addressesOn(accounts, "whatsapp"));
+      if (chats === null) return null;
+      return sql`
+        SELECT
+          'whatsapp' AS source,
+          m.chat_jid AS address,
+          m.timestamp AS at,
+          CASE WHEN m.from_me THEN 1 ELSE 0 END AS outbound,
+          m.chat_jid || ':' || m.id AS ref,
+          m.text AS body
+        FROM wa_messages m
+        WHERE ${chats}
+          AND m.chat_jid NOT LIKE '%@g.us'
+          -- A reaction answers a line rather than being one, and the identity
+          -- union already leaves it out of what an identity last did. Carrying
+          -- it here would let a row preview one event and open on another.
+          AND coalesce(m.type, '') <> 'reaction'`;
+    },
+  });
+}
+
+/** `linkedin_messages`, restricted to threads that are a conversation between
+ *  two people. */
+export function linkedInMirrorSource(db: DrizzleDb): TimelineSource {
+  return sqlTimelineSource({
+    name: "linkedin_messages",
+    db,
+    view(accounts) {
+      const memberIds = addressesOn(accounts, "linkedin");
+      const members = inList(sql`tp.participant_id`, memberIds);
+      const alsoOnThread = inList(sql`a.participant_id`, memberIds);
+      if (members === null || alsoOnThread === null) return null;
+      return sql`
+        SELECT
+          'linkedin' AS source,
+          -- The thread's member the caller asked about. A thread reaches this
+          -- view because one of them is on it, so the subquery always finds
+          -- one; min() settles the case where the person holds two member ids
+          -- and both are, which would otherwise be one message twice.
+          (SELECT min(a.participant_id)
+             FROM linkedin_thread_participants a
+             WHERE a.thread_id = m.thread_id
+               AND ${alsoOnThread}
+          ) AS address,
+          coalesce(m.sent_at, m.created_at) AS at,
+          CASE WHEN m.sender_is_self THEN 1 ELSE 0 END AS outbound,
+          m.thread_id || ':' || m.message_id AS ref,
+          m.text AS body
+        FROM linkedin_messages m
+        JOIN linkedin_threads t ON t.thread_id = m.thread_id
+        WHERE m.thread_id IN (
+            SELECT tp.thread_id FROM linkedin_thread_participants tp WHERE ${members}
+          )
+          -- LinkedIn's own flag is null until a thread has been snapshotted, so
+          -- the membership decides the threads it has not answered for yet.
+          AND coalesce(t.is_group, 0) = 0
+          AND (
+            SELECT count(*) FROM linkedin_thread_participants x WHERE x.thread_id = m.thread_id
+          ) <= 2`;
+    },
+  });
+}
+
+/**
+ * `rome_agent_messages` on a channel session — what Rome was told and what it
+ * said back, for every channel with no mirror of its own.
+ *
+ * Reached through the session's channel address: a channel session is keyed by
+ * the thread it belongs to, so a session addressed by the account is that
+ * account's direct conversation, and a group's session is addressed by the
+ * group and never matches.
+ */
+export function agentMessagesSource(db: DrizzleDb): TimelineSource {
+  return sqlTimelineSource({
+    name: "rome_agent_messages",
+    db,
+    view(accounts) {
+      const addressed = accountPairs(accounts, sql`s.source_channel`, sql`s.source_thread_id`);
+      if (addressed === null) return null;
+      return sql`
+        SELECT
+          s.source_channel AS source,
+          s.source_thread_id AS address,
+          m.created_at AS at,
+          CASE WHEN m.role = 'assistant' THEN 1 ELSE 0 END AS outbound,
+          'agent:' || m.id AS ref,
+          m.content AS body
+        FROM rome_agent_messages m
+        JOIN rome_sessions s ON s.id = m.session_id
+        WHERE s.type = 'channel'
+          AND ${addressed}
+          -- 'notification' is an inbound message that did not wake the agent;
+          -- it is still something the person said. 'trace' is the turn's
+          -- machinery and belongs to no conversation.
+          AND m.role IN ('user', 'assistant', 'notification')`;
+    },
+    body: messageContentText,
+  });
+}
+
+/**
+ * `sentinel_log` — the triage record, and the only place an exchange the
+ * sentinel handled alone is written down.
+ *
+ * One row is two entries: what the sender said, and what Rome answered.
+ */
+export function sentinelLogSource(db: DrizzleDb): TimelineSource {
+  return sqlTimelineSource({
+    name: "sentinel_log",
+    db,
+    view(accounts) {
+      const addressed = accountPairs(accounts, sql`l.channel`, sql`l.channel_user_id`);
+      if (addressed === null) return null;
+      // A log row names its sender but not whether they were alone. The
+      // session that recorded the same thread does, so a thread Rome knows to
+      // be a group is what the scope subtracts — a row whose thread no session
+      // covers is a direct exchange until something says otherwise.
+      const direct = sql`
+        ${addressed}
+        AND NOT EXISTS (
+          SELECT 1 FROM rome_sessions s
+          WHERE s.type = 'channel'
+            AND s.source_channel = l.channel
+            AND s.source_thread_id = l.thread_id
+            AND s.source_thread_type = 'group'
+        )`;
+      return sql`
+        SELECT
+          l.channel AS source,
+          l.channel_user_id AS address,
+          l.created_at AS at,
+          0 AS outbound,
+          'sentinel:' || l.id AS ref,
+          l.text AS body
+        FROM sentinel_log l
+        WHERE ${direct}
+        UNION ALL
+        SELECT
+          l.channel,
+          l.channel_user_id,
+          l.created_at,
+          1,
+          'sentinel:' || l.id || ':reply',
+          l.response
+        FROM sentinel_log l
+        WHERE ${direct} AND l.response IS NOT NULL AND l.response <> ''`;
+    },
+  });
+}
+
+/**
+ * Every account a person is reachable at, with every address the channel folds
+ * onto it.
+ *
+ * Two mappings that name two addressings of one account collapse to one
+ * account, so a person mapped under both a WhatsApp phone JID and its `@lid`
+ * form reads one timeline rather than two halves of one.
+ *
+ * A channel with no account plane contributes the mapping's own address and
+ * nothing else, which is all the channel can say about who it can reach.
+ */
+export async function personTimelineAccounts(
+  deps: { whatsAppAccounts: TalkAccounts },
+  mappings: readonly { channel: string; channelUserId: string }[],
+): Promise<TimelineAccount[]> {
+  const planes = new Map<string, TalkAccounts>([["whatsapp", deps.whatsAppAccounts]]);
+
+  const addressesByChannel = new Map<string, Map<string, string>>();
+  for (const [channel, accounts] of planes) {
+    // Reading a plane costs a full address-book read, so a person with no
+    // mapping on the channel never pays for one.
+    if (!mappings.some((mapping) => mapping.channel === channel)) continue;
+    addressesByChannel.set(channel, await accounts.listAddresses());
+  }
+
+  const byAccount = new Map<string, TimelineAccount>();
+  for (const mapping of mappings) {
+    const addresses = addressesByChannel.get(mapping.channel);
+    const accountId = addresses?.get(mapping.channelUserId) ?? mapping.channelUserId;
+    const key = `${mapping.channel}\n${accountId}`;
+    if (byAccount.has(key)) continue;
+    const folded = addresses
+      ? [...addresses].filter(([, id]) => id === accountId).map(([address]) => address)
+      : [];
+    byAccount.set(key, {
+      channel: mapping.channel,
+      addresses: [...new Set([mapping.channelUserId, ...folded])],
+    });
+  }
+  return [...byAccount.values()];
+}
+
+/** The line a stored agent message renders as: its text parts, joined.
+ *  Non-text parts (cards, recaps, errors) carry no conversation, and content
+ *  that does not parse is a row with nothing to show rather than a failed read. */
+function messageContentText(raw: string | null): string | null {
+  if (raw === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  const text = parsed
+    .filter((part): part is Extract<MessagePart, { type: "text" }> => {
+      if (typeof part !== "object" || part === null) return false;
+      const candidate = part as { type?: unknown; content?: unknown };
+      return candidate.type === "text" && typeof candidate.content === "string";
+    })
+    .map((part) => part.content)
+    .join("\n");
+  return text.length > 0 ? text : null;
+}

--- a/packages/core/src/people/timeline-sql.ts
+++ b/packages/core/src/people/timeline-sql.ts
@@ -1,0 +1,140 @@
+// The SQL half of the timeline seam: a store that lives in this database
+// becomes a {@link TimelineSource} by describing its rows as timeline entries
+// once, and this module pages, orders and scopes them.
+
+import { sql, type SQL } from "drizzle-orm";
+import type { TimelineEntry } from "@rome/api-types/people";
+import type { DrizzleDb } from "../db/index.js";
+import type { TimelineAccount, TimelineSource, TimelineRead } from "./timeline.js";
+
+/**
+ * A store's rows as timeline entries: a SELECT producing exactly the columns
+ * `source`, `address`, `at`, `outbound`, `ref`, `body`.
+ *
+ * - `source` is the channel the entry arrived on, and `address` the account
+ *   address it belongs to. Together they are how {@link sqlTimelineSource}
+ *   answers which accounts the store holds, so both have to name the account
+ *   the caller asked about rather than whatever the row stores.
+ * - `at` is epoch seconds, `outbound` is 1 for something Rome said and 0 for
+ *   something it was told, `body` is the line to render or NULL.
+ * - `ref` must be unique across everything the store can put on one person's
+ *   timeline. Ids that are unique only within a conversation (a WhatsApp
+ *   message id, a LinkedIn message id) are qualified by the conversation.
+ */
+export type TimelineViewSql = SQL;
+
+/**
+ * A {@link TimelineSource} over one SQL view.
+ *
+ * `view` returns null when the request can hold nothing — no accounts on a
+ * channel this store serves — and the store then answers empty without a query.
+ *
+ * `body` maps the view's `body` column to the rendered line, for a store whose
+ * text is not stored as text. It runs on the page, not on the scope, so it can
+ * be as expensive as the parse it wraps.
+ */
+export function sqlTimelineSource(options: {
+  name: string;
+  db: DrizzleDb;
+  view(accounts: readonly TimelineAccount[]): TimelineViewSql | null;
+  body?(raw: string | null): string | null;
+}): TimelineSource {
+  const { name, db, view } = options;
+  return {
+    name,
+
+    async holds(accounts) {
+      const rows = view(accounts);
+      if (rows === null) return [];
+      const found = (await db.all(sql`SELECT DISTINCT source, address FROM (${rows})`)) as Array<
+        Record<string, unknown>
+      >;
+      const held = new Set(found.map((row) => addressKey(String(row.source), String(row.address))));
+      return accounts.filter((account) =>
+        account.addresses.some((address) => held.has(addressKey(account.channel, address))),
+      );
+    },
+
+    async read(request: TimelineRead) {
+      const rows = view(request.accounts);
+      if (rows === null) return [];
+      const page = (await db.all(sql`
+        SELECT source, at, outbound, ref, body
+        FROM (${rows})
+        WHERE ${afterCursor(request.cursor)}
+        ORDER BY at DESC, outbound DESC, source ASC, ref ASC
+        LIMIT ${Math.max(1, Math.floor(request.limit))}
+      `)) as Array<Record<string, unknown>>;
+      return page.map((row) => {
+        const body = (row.body as string | null) ?? null;
+        return {
+          source: String(row.source),
+          timestamp: Number(row.at),
+          direction: Number(row.outbound) === 1 ? ("outbound" as const) : ("inbound" as const),
+          ref: String(row.ref),
+          body: options.body ? options.body(body) : body,
+        };
+      });
+    },
+  };
+}
+
+const addressKey = (channel: string, address: string) => `${channel}\n${address}`;
+
+/**
+ * The rows that fall strictly after `cursor`, in the order the ORDER BY above
+ * imposes — which is `compareTimelineEntries` read as SQL.
+ *
+ * The whole tuple, not `at < cursor.timestamp`: a second holds more than one
+ * entry, and resuming from the bare timestamp drops the rest of that second.
+ *
+ * The two text comparisons ride SQLite's BINARY collation, which orders UTF-8
+ * by byte and therefore by code point — the same answer `compareCodePoints`
+ * gives, which is what makes a cursor mean one position on both ends.
+ */
+function afterCursor(cursor: TimelineEntry | null): SQL {
+  if (cursor === null) return sql`1 = 1`;
+  const outbound = cursor.direction === "outbound" ? 1 : 0;
+  return sql`
+    at < ${cursor.timestamp}
+    OR (at = ${cursor.timestamp}
+        AND (outbound < ${outbound}
+             OR (outbound = ${outbound}
+                 AND (source > ${cursor.source}
+                      OR (source = ${cursor.source} AND ref > ${cursor.ref})))))`;
+}
+
+/** `column IN (…)` over `values`, or null when there is nothing to match —
+ *  `IN ()` is not SQL, and a caller that emitted it would fail the whole read
+ *  rather than answer the empty page an empty scope means. */
+export function inList(column: SQL, values: readonly string[]): SQL | null {
+  if (values.length === 0) return null;
+  return sql`${column} IN (${sql.join(
+    values.map((value) => sql`${value}`),
+    sql`, `,
+  )})`;
+}
+
+/** Every address of every account, for a store that serves one channel. */
+export function addressesOn(accounts: readonly TimelineAccount[], channel: string): string[] {
+  return accounts.filter((account) => account.channel === channel).flatMap((a) => a.addresses);
+}
+
+/** `(channel, address)` matched as a pair, so an address on one channel never
+ *  selects a row another channel stores under the same string. */
+export function accountPairs(
+  accounts: readonly TimelineAccount[],
+  channelColumn: SQL,
+  addressColumn: SQL,
+): SQL | null {
+  const clauses = accounts
+    .map((account) => {
+      const addresses = inList(addressColumn, account.addresses);
+      return addresses === null
+        ? null
+        : sql`(${channelColumn} = ${account.channel} AND ${addresses})`;
+    })
+    .filter((clause): clause is SQL => clause !== null);
+  if (clauses.length === 0) return null;
+  return sql`(${sql.join(clauses, sql` OR `)})`;
+}

--- a/packages/core/src/people/timeline.test.ts
+++ b/packages/core/src/people/timeline.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import {
+  compareTimelineEntries,
+  isAfterTimelineCursor,
+  parseTimelineCursor,
+  type TimelineEntry,
+} from "@rome/api-types/people";
+import { readPersonTimeline, type TimelineAccount, type TimelineSource } from "./timeline.js";
+
+// The merge above the stores: what a page is, how it resumes, and which store
+// owns an account. Every source here is a fake, so nothing below is about SQL —
+// a store that answers the seam's contract is a store this merge can page.
+
+const account = (channel: string, ...addresses: string[]): TimelineAccount => ({
+  channel,
+  addresses,
+});
+
+const entry = (
+  source: string,
+  timestamp: number,
+  ref: string,
+  direction: "inbound" | "outbound" = "inbound",
+): TimelineEntry => ({ source, timestamp, ref, direction, body: `${ref}@${timestamp}` });
+
+/**
+ * A store held in memory, answering the seam exactly as its contract asks:
+ * only entries strictly after the cursor, in order, at most `limit` of them.
+ */
+function fakeSource(
+  name: string,
+  held: Record<string, TimelineEntry[]>,
+  calls: string[] = [],
+): TimelineSource & { calls: string[] } {
+  const addressesHeld = new Set(Object.keys(held));
+  return {
+    name,
+    calls,
+    async holds(accounts) {
+      return accounts.filter((a) => a.addresses.some((address) => addressesHeld.has(address)));
+    },
+    async read(request) {
+      calls.push(name);
+      const entries = request.accounts
+        .flatMap((a) => a.addresses)
+        .flatMap((address) => held[address] ?? []);
+      return entries
+        .filter((e) => request.cursor === null || isAfterTimelineCursor(e, request.cursor))
+        .sort(compareTimelineEntries)
+        .slice(0, request.limit);
+    },
+  };
+}
+
+describe("readPersonTimeline", () => {
+  const whatsapp = fakeSource("wa", {
+    "wa-1": [entry("whatsapp", 300, "wa:c"), entry("whatsapp", 100, "wa:a")],
+  });
+  const telegram = fakeSource("tg", {
+    "tg-1": [entry("telegram", 200, "tg:b"), entry("telegram", 400, "tg:d")],
+  });
+  const accounts = [account("whatsapp", "wa-1"), account("telegram", "tg-1")];
+
+  it("merges every account of a person into one newest-first page", async () => {
+    const page = await readPersonTimeline([whatsapp, telegram], accounts, { limit: 10 });
+    expect(page.entries.map((e) => e.ref)).toEqual(["tg:d", "wa:c", "tg:b", "wa:a"]);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("pages by nextCursor with no duplicate and no missing entry", async () => {
+    const whole = (await readPersonTimeline([whatsapp, telegram], accounts, { limit: 10 })).entries;
+
+    const walked: TimelineEntry[] = [];
+    let cursor: TimelineEntry | null = null;
+    for (let page = 0; page < 10; page += 1) {
+      const next = await readPersonTimeline([whatsapp, telegram], accounts, { cursor, limit: 1 });
+      walked.push(...next.entries);
+      if (next.nextCursor === null) break;
+      cursor = parseTimelineCursor(next.nextCursor);
+      expect(cursor).not.toBeNull();
+    }
+    expect(walked).toEqual(whole);
+  });
+
+  it("resumes inside a second rather than after it", async () => {
+    // Four entries share one timestamp, so a cursor carrying the timestamp
+    // alone could only resume before or after all of them.
+    const crowded = fakeSource("crowd", {
+      "c-1": [
+        entry("whatsapp", 100, "a"),
+        entry("whatsapp", 100, "b", "outbound"),
+        entry("whatsapp", 100, "c"),
+        entry("whatsapp", 100, "d"),
+      ],
+    });
+    const one = [account("whatsapp", "c-1")];
+    const first = await readPersonTimeline([crowded], one, { limit: 2 });
+    const rest = await readPersonTimeline([crowded], one, {
+      cursor: parseTimelineCursor(first.nextCursor),
+      limit: 10,
+    });
+    expect([...first.entries, ...rest.entries].map((e) => e.ref)).toEqual(["b", "a", "c", "d"]);
+    expect(rest.nextCursor).toBeNull();
+  });
+
+  it("reports a next page whenever one exists", async () => {
+    // The page is full and the history is exhausted at the same entry: a
+    // caller told there is more reads one empty page, a caller told there is
+    // not loses everything after it.
+    const exact = await readPersonTimeline([whatsapp, telegram], accounts, { limit: 4 });
+    expect(exact.entries).toHaveLength(4);
+    expect(exact.nextCursor).toBeNull();
+
+    const short = await readPersonTimeline([whatsapp, telegram], accounts, { limit: 3 });
+    expect(short.nextCursor).not.toBeNull();
+  });
+
+  it("gives an account to the first store that holds it and asks no other", async () => {
+    const calls: string[] = [];
+    const mirror = fakeSource("mirror", { "wa-1": [entry("whatsapp", 500, "mirrored")] }, calls);
+    const transcript = fakeSource(
+      "transcript",
+      { "wa-1": [entry("whatsapp", 500, "transcribed")] },
+      calls,
+    );
+    const page = await readPersonTimeline([mirror, transcript], [account("whatsapp", "wa-1")], {
+      limit: 10,
+    });
+    expect(page.entries.map((e) => e.ref)).toEqual(["mirrored"]);
+    expect(calls).toEqual(["mirror"]);
+  });
+
+  it("falls through to a later store for an account the earlier one lacks", async () => {
+    const mirror = fakeSource("mirror", { "wa-1": [entry("whatsapp", 500, "mirrored")] });
+    const transcript = fakeSource("transcript", { "tg-1": [entry("telegram", 400, "typed")] });
+    const page = await readPersonTimeline([mirror, transcript], accounts, { limit: 10 });
+    expect(page.entries.map((e) => e.ref)).toEqual(["mirrored", "typed"]);
+  });
+
+  it("takes a new store as one more adapter, with nothing above it changed", async () => {
+    // What "adding a source is one adapter" means: a store of a kind this file
+    // has never heard of, appended to the list, and its entries page with the
+    // rest through the same cursor.
+    const app = fakeSource("some-rome-app", {
+      "app-1": [entry("bookings", 250, "booking:7", "outbound")],
+    });
+    const page = await readPersonTimeline(
+      [whatsapp, telegram, app],
+      [...accounts, account("bookings", "app-1")],
+      { limit: 10 },
+    );
+    expect(page.entries.map((e) => e.ref)).toEqual(["tg:d", "wa:c", "booking:7", "tg:b", "wa:a"]);
+  });
+
+  it("answers an empty page for a person with no accounts", async () => {
+    const page = await readPersonTimeline([whatsapp, telegram], [], { limit: 10 });
+    expect(page).toEqual({ entries: [], nextCursor: null });
+  });
+});

--- a/packages/core/src/people/timeline.ts
+++ b/packages/core/src/people/timeline.ts
@@ -1,0 +1,131 @@
+// A person's history, merged across every account they are linked to. The
+// entry shape, the ordering and the cursor are the contract's
+// (@rome/api-types/people); this module is the seam the stores plug into and
+// the merge above it.
+
+import {
+  compareTimelineEntries,
+  isAfterTimelineCursor,
+  timelineCursor,
+  type TimelineEntry,
+  type TimelinePage,
+} from "@rome/api-types/people";
+
+/**
+ * One account a person is reachable at, as a timeline read addresses it.
+ *
+ * `addresses` is every identifier the channel folds onto that account — a
+ * WhatsApp contact is reachable under both a phone JID and a `@lid` JID, and
+ * history hangs off either. A store that reads only the identifier the person
+ * mapping happens to name would answer an empty timeline for a conversation
+ * that plainly exists.
+ */
+export interface TimelineAccount {
+  channel: string;
+  /** Non-empty. Order carries no meaning. */
+  addresses: string[];
+}
+
+export interface TimelineRead {
+  /** Only accounts this source holds — see {@link TimelineSource.holds}. */
+  accounts: readonly TimelineAccount[];
+  cursor: TimelineEntry | null;
+  limit: number;
+}
+
+/**
+ * One message store, as a person's timeline reads it.
+ *
+ * Adding a store is one implementation of this interface listed alongside the
+ * others; nothing above here knows how many there are or what they read.
+ *
+ * The two methods exist because the stores overlap rather than partition. One
+ * inbound WhatsApp message is a `wa_messages` row, a `rome_agent_messages` row
+ * on the channel session, and — when the sentinel triaged it — a `sentinel_log`
+ * row as well. Merging all three renders one message three times, and the
+ * copies carry different ids at different timestamps, so no after-the-fact
+ * dedupe survives a page boundary. Instead each account's timeline comes from
+ * exactly one store: {@link holds} is asked in order, and the first store that
+ * holds an account owns it.
+ */
+export interface TimelineSource {
+  /** Stable, for tests and logs. Never {@link TimelineEntry.source}, which
+   *  names the channel an entry arrived on — one store serves several. */
+  readonly name: string;
+
+  /** Which of `accounts` this store holds any entry for. Order and identity of
+   *  the returned accounts are the caller's own; a store returns the elements
+   *  it was given. */
+  holds(accounts: readonly TimelineAccount[]): Promise<TimelineAccount[]>;
+
+  /**
+   * This store's newest entries for `accounts`, at most `limit` of them, every
+   * one strictly after `cursor`, in {@link compareTimelineEntries} order.
+   *
+   * "Strictly after `cursor`" is the store's own obligation and not the
+   * merge's: a store that answered its newest `limit` entries and left the
+   * filtering above it would spend that budget on entries the caller has
+   * already seen, and the entries it dropped to make room are the ones no page
+   * ever shows.
+   */
+  read(request: TimelineRead): Promise<TimelineEntry[]>;
+}
+
+/**
+ * One page of `accounts`' merged history, newest first, resuming after
+ * `cursor`.
+ *
+ * `nextCursor` is null only when the whole remaining history fit. Filter
+ * `accounts` before calling to narrow the page to one channel — every entry a
+ * store produces belongs to the account it was read for, so the accounts are
+ * the only scope there is.
+ */
+export async function readPersonTimeline(
+  sources: readonly TimelineSource[],
+  accounts: readonly TimelineAccount[],
+  options: { cursor?: TimelineEntry | null; limit: number },
+): Promise<TimelinePage> {
+  const cursor = options.cursor ?? null;
+  const limit = Math.max(1, Math.floor(options.limit));
+
+  const pages = await Promise.all(
+    // One extra entry per store, which is what makes `nextCursor` honest: a
+    // page of exactly `limit` merged entries is otherwise indistinguishable
+    // from an exhausted history, and answering null there truncates the
+    // timeline at a boundary the client cannot resume past.
+    (await assignAccounts(sources, accounts)).map(([source, held]) =>
+      source.read({ accounts: held, cursor, limit: limit + 1 }),
+    ),
+  );
+
+  // Every store answered its own newest `limit + 1`, so any of the merged
+  // newest `limit` that a store could contribute is among the entries it sent.
+  const merged = pages
+    .flat()
+    .filter((entry) => cursor === null || isAfterTimelineCursor(entry, cursor))
+    .sort(compareTimelineEntries);
+  const entries = merged.slice(0, limit);
+  const oldest = entries.at(-1);
+  return {
+    entries,
+    nextCursor: merged.length > entries.length && oldest ? timelineCursor(oldest) : null,
+  };
+}
+
+/** Each store paired with the accounts it owns: the first store that holds an
+ *  account takes it, and no later store is offered it. */
+async function assignAccounts(
+  sources: readonly TimelineSource[],
+  accounts: readonly TimelineAccount[],
+): Promise<Array<[TimelineSource, TimelineAccount[]]>> {
+  const assigned: Array<[TimelineSource, TimelineAccount[]]> = [];
+  let unclaimed = [...accounts];
+  for (const source of sources) {
+    if (unclaimed.length === 0) break;
+    const held = new Set(await source.holds(unclaimed));
+    const taken = unclaimed.filter((account) => held.has(account));
+    if (taken.length > 0) assigned.push([source, taken]);
+    unclaimed = unclaimed.filter((account) => !held.has(account));
+  }
+  return assigned;
+}


### PR DESCRIPTION
Closes #59.

## What this PR does

A person is reachable on several accounts and their history is written down in several stores — the WhatsApp mirror, the LinkedIn mirror, the channel session's own transcript, the sentinel log. Nothing could answer "what has this person said to Rome?" without a caller issuing four reads and reconciling them itself, and the same message appears in three of those stores under three different ids.

`GET /api/people/:id/messages` answers it: one page of a person's history, newest first, merged across every account they are linked to, resumable by an opaque cursor and narrowable with `?channel=`.

## Design & Invariants

**The seam.** A store plugs in behind `TimelineSource` (`src/people/timeline.ts`). Adding one is that adapter plus a line in the list — nothing above it counts the stores or knows what they read. A store that lives in this database becomes a source by describing its rows as timeline entries once (`source, address, at, outbound, ref, body`); the scope, the order and the cursor are written once above that in `timeline-sql.ts`.

**One store per account, chosen before anything is read.** The stores overlap rather than partition: one inbound WhatsApp message is a `wa_messages` row, a `rome_agent_messages` row on the channel session, and — when the sentinel triaged it — a `sentinel_log` row. Each account's timeline therefore comes from exactly one store, the first in precedence order that holds it: mirror, then Rome's transcript, then the sentinel. The alternative — merge everything and dedupe by platform message id — cannot work here, because the copies sit at different timestamps and a duplicate pair straddling a page boundary has nothing to dedupe against. The cost is stated in the code: an account with a mirrored conversation shows Rome's reply as the channel delivered it, not as the sentinel recorded it.

**The cursor names an entry, not a second** — in SQL as well as in the contract. Whole seconds collide across stores and a reply is recorded against the message it answers, so resuming from a bare timestamp drops the rest of the second. The predicate is `compareTimelineEntries` read as SQL, riding SQLite's BINARY collation so both ends of a cursor mean one position.

**A page is a true prefix.** Every store answers its own newest `limit + 1` entries strictly after the cursor, so the merged newest `limit` cannot miss an entry a store was holding, and a page of exactly `limit` entries is distinguishable from an exhausted history.

**Direct threads only.** Each adapter scopes itself by the account's own addresses — a chat JID, a session's channel address, a two-member LinkedIn thread — so a conversation addressed by a group never reaches a person's timeline. The sentinel log names a sender but not whether they were alone, so a thread a channel session records as a group is what its scope subtracts.

**One account, every address.** A person mapped under a WhatsApp `@lid` reads the conversation that hangs off the phone JID: the accounts are resolved through the channel's account plane (`TalkAccounts.listAddresses`), the same fold the identity union reads.

The entry shape, the ordering and the cursor helpers are re-exported from `@rome/api-types/identities` into the new `@rome/api-types/people` rather than restated — a stream row's `latest` is the head of the timeline that row opens, and a second definition of either is a page boundary the two ends disagree about.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 5,725 tests, all passing
- [x] `src/people/timeline.test.ts` — the merge over fake sources: cross-account order, cursor walk, resuming inside a crowded second, precedence, and a store of an unheard-of kind appended to the list with nothing above it changed
- [x] `src/api/routes/people.test.ts` — the route over real stores: WhatsApp + channel-transcript merge, LinkedIn direct threads with two kinds of group thread excluded, a cursor walk across a second two stores both wrote to, `?channel=`, sentinel-only exchanges carrying both halves, precedence over a three-way overlap, `@lid` folding, 404s and a rejected cursor
- [x] Each of the load-bearing rules mutation-checked — precedence order, the LinkedIn group filter, and the same-second branch of the cursor predicate each fail a test when broken
- [ ] `pnpm dev:all` container boot — Docker is unavailable in this environment; `buildApp`'s own tests cover the route registration

## Not in this PR

- Group threads, live provider fetches and send endpoints — out of scope per the issue.
- The rest of the `/people` contract (`PersonResource`, the account directory) — #60, #61 and the writes that follow.
- The dashboard still reads `/api/identities/:id/timeline`; repointing it is #66.
- A sentinel exchange inside an account that also has mirrored or transcribed history stays behind that store's record of the same exchange. Closing it needs the sentinel's reply to carry the platform id of the message it sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)