### PR TITLE
feat(core): serve the curated people reads

### DIFF
--- a/packages/api-types/src/identities.ts
+++ b/packages/api-types/src/identities.ts
@@ -67,15 +67,20 @@ export function isAssignableBondLevel(value: unknown): value is AssignableBondLe
   return ASSIGNABLE_BOND_LEVELS.includes(value as AssignableBondLevel);
 }
 
+/** A level a person row can actually hold: the ladder minus its two computed
+ *  positions. "unknown" is an identity with no person row and "stranger" is a
+ *  link onto the sentinel, so neither is ever stored on a person. */
+export type PlacedBondLevel = Exclude<BondLadderLevel, "unknown" | "stranger">;
+
 /**
  * Bucket a stored `persons.bondLevel` onto the ladder. The column is free text
  * and older rows carry values outside today's enum (e.g. "colleague"), so
  * every reader has to agree on where those land rather than dropping the row
  * from every group.
  */
-export function normalizeBondLevel(raw: string): BondLadderLevel {
+export function normalizeBondLevel(raw: string): PlacedBondLevel {
   return (BOND_LADDER as readonly string[]).includes(raw) && raw !== "unknown" && raw !== "stranger"
-    ? (raw as BondLadderLevel)
+    ? (raw as PlacedBondLevel)
     : "other";
 }
 
@@ -293,15 +298,28 @@ export function identityMatchesLevel(row: IdentityRow, level: IdentityFilterLeve
     : row.level === level;
 }
 
-/** Parse a `?level=` value, or null when it names no view — an unknown filter
- *  is a client bug, and answering it as "all" would silently show the wrong
- *  rows. */
+/**
+ * Parse a `?level=` value against the levels a surface counts by, or null when
+ * it names no view — an unknown filter is a client bug, and answering it as
+ * "all" would silently show the wrong rows.
+ *
+ * Takes the ladder because the surfaces count by different ones: the union has
+ * a chip for every position, and a listing of curated people has none for the
+ * two positions no person row can hold.
+ */
+export function parseFilterLevel<L extends string>(
+  raw: string | undefined | null,
+  levels: readonly L[],
+): "all" | L | null {
+  if (raw == null || raw === "") return null;
+  if (raw === "all") return "all";
+  return (levels as readonly string[]).includes(raw) ? (raw as L) : null;
+}
+
 export function parseIdentityFilterLevel(
   raw: string | undefined | null,
 ): IdentityFilterLevel | null {
-  if (raw == null || raw === "") return null;
-  if (raw === "all") return "all";
-  return (BOND_LADDER as readonly string[]).includes(raw) ? (raw as BondLadderLevel) : null;
+  return parseFilterLevel(raw, BOND_LADDER);
 }
 
 /** How many identities one page carries when the caller names no limit, and
@@ -422,21 +440,29 @@ export function isAfterTimelineCursor(entry: TimelineEntry, cursor: TimelineEntr
   return compareTimelineEntries(cursor, entry) < 0;
 }
 
+/**
+ * Whether a search box's text is anywhere in what a row can be found by.
+ *
+ * The rule rather than the haystack: each surface knows which of its own
+ * fields are searchable, and every one of them has to normalize the same way
+ * or one typed string finds different rows on each.
+ *
+ * NFC first, the way the orderings normalize: a keyboard that composes "José"
+ * should find a row that stored it decomposed, and the reverse.
+ */
+export function matchesQuery(query: string, haystack: readonly string[]): boolean {
+  const q = query.normalize("NFC").trim().toLowerCase();
+  if (!q) return true;
+  return haystack.join(" ").normalize("NFC").toLowerCase().includes(q);
+}
+
 /** What `?q=` matches: the display name and every channel identifier, so a
  *  phone number or a handle finds a row the guardian named something else. */
 export function identityMatchesQuery(row: IdentityRow, query: string): boolean {
-  // NFC first, the way the orderings normalize: a keyboard that composes "José"
-  // should find a row that stored it decomposed, and the reverse.
-  const q = query.normalize("NFC").trim().toLowerCase();
-  if (!q) return true;
-  const haystack = [
+  return matchesQuery(query, [
     row.displayName,
     ...row.channels.flatMap((channel) => [channel.channel, channel.channelUserId]),
-  ]
-    .join(" ")
-    .normalize("NFC")
-    .toLowerCase();
-  return haystack.includes(q);
+  ]);
 }
 
 /**
@@ -452,7 +478,12 @@ export interface IdentityCursor {
   id: string;
 }
 
-export function identityCursorOf(row: IdentityRow): IdentityCursor {
+/** The ordering tuple, for any row that carries one. Widened past
+ *  {@link IdentityRow} so a second listing of the same rows orders through
+ *  {@link compareIdentityCursors} rather than restating it. */
+export function identityCursorOf(
+  row: Pick<IdentityRow, "id" | "displayName" | "latest">,
+): IdentityCursor {
   return { timestamp: row.latest?.timestamp ?? null, displayName: row.displayName, id: row.id };
 }
 

--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -1,23 +1,36 @@
-// The People surface's contract. This module holds the two reads the surface
-// is built from: the account directory it browses, and one person's history
-// across every account they are linked to.
+// The People surface's contract, in two nouns — a person, and the accounts
+// they are reachable at:
+//
+//   GET /api/people              -> PeopleList (curated people only)
+//   GET /api/people/:id          -> PersonResource
+//   GET /api/people/:id/messages -> TimelinePage
+//   GET /api/accounts            -> AccountDirectory
+//
+// The vocabulary is docs/concepts/identity.md's. Rome never mints an account:
+// an account is platform-owned, named by the pair (channel, channelUserId),
+// and the only identity fact Rome contributes is which person it belongs to.
 //
 // The timeline's entry shape, its ordering and its cursor are the identity
-// union's, and they are re-exported rather than restated. The two surfaces page
-// the same entries: a stream row's `latest` is the head of the timeline the
-// same row opens, and a cursor written against one has to name a position in
-// the other. A second definition of either is a page boundary the two ends
+// union's, and they are re-exported rather than restated. The surfaces page
+// the same entries: a row's `latest` is the head of the timeline the same row
+// opens, and a cursor written against one has to name a position in the
+// other. A second definition of either is a page boundary the two ends
 // disagree about.
 
 import {
   compareIdentityCursors,
   encodeIdentityCursor,
+  identityCursorOf,
   isChannelIdentifier,
+  matchesQuery,
+  normalizeBondLevel,
+  parseFilterLevel,
   parseIdentityCursor,
   TIMELINE_PAGE_DEFAULT_LIMIT,
   TIMELINE_PAGE_MAX_LIMIT,
   type IdentityCursor,
   type IdentityDynamic,
+  type PlacedBondLevel,
 } from "./identities.js";
 import { STRANGER_PERSON_ID } from "./persons.js";
 
@@ -29,6 +42,11 @@ export {
   timelineCursor,
   TIMELINE_PAGE_DEFAULT_LIMIT,
   TIMELINE_PAGE_MAX_LIMIT,
+  // Which level a stored `persons.bondLevel` counts and filters under. The
+  // column is free text — older rows carry levels off today's ladder — so
+  // every reader has to bucket them the same way.
+  normalizeBondLevel,
+  type IdentityDynamic,
   type TimelineEntry,
   type TimelinePage,
 } from "./identities.js";
@@ -223,16 +241,12 @@ export function accountRef(account: { channel: string; channelUserId: string }):
  *  address — so a phone number finds an account the platform named something
  *  else, and a person's name finds the accounts they were placed on. */
 export function accountMatchesQuery(account: DirectoryAccount, query: string): boolean {
-  // NFC first, the way the orderings normalize: a keyboard that composes "José"
-  // should find an account that stored it decomposed, and the reverse.
-  const needle = query.normalize("NFC").trim().toLowerCase();
-  if (!needle) return true;
-  const haystack = [account.displayName, account.personName ?? "", account.channel]
-    .concat(account.addresses)
-    .join(" ")
-    .normalize("NFC")
-    .toLowerCase();
-  return haystack.includes(needle);
+  return matchesQuery(query, [
+    account.displayName,
+    account.personName ?? "",
+    account.channel,
+    ...account.addresses,
+  ]);
 }
 
 /**
@@ -339,4 +353,146 @@ export function sliceAccountDirectory(
     remaining.length > accounts.length && last ? encodeAccountCursor(accountCursorOf(last)) : null;
 
   return { accounts, nextCursor, counts, silentTotal };
+}
+
+/**
+ * One account as it appears under the person linked to it.
+ *
+ * `(channel, channelUserId)` is the account's identity — Rome never mints one,
+ * every pair here is observed from a message or an address-book mirror — and
+ * `displayName` is what the platform calls it, the raw identifier being only
+ * the last resort. The directory's {@link DirectoryAccount} is the same
+ * account seen from the other side, with what Rome decided about it.
+ */
+export interface LinkedAccount {
+  channel: string;
+  channelUserId: string;
+  displayName: string;
+}
+
+/**
+ * A person with their accounts and their activity across all of them.
+ *
+ * `bondLevel` is the stored value, free text included: older rows carry levels
+ * outside today's ladder ("colleague"), and a reader buckets them with
+ * {@link normalizeBondLevel} rather than the contract pretending they cannot
+ * exist.
+ *
+ * `latest` and `messageCount` describe one history — the merged timeline
+ * `GET /api/people/:id/messages` pages. `latest` is {@link latestDynamic} of
+ * it and `messageCount` is how many entries it holds, so the line a row
+ * previews is the line its dossier opens on, and the number beside it counts
+ * what the dossier will show. A group conversation contributes to neither: a
+ * timeline entry names no sender, so nothing said in a room of ten people is
+ * attributable to one of them.
+ */
+export interface PersonResource {
+  id: string;
+  displayName: string;
+  bondLevel: string;
+  accounts: LinkedAccount[];
+  messageCount: number;
+  latest: IdentityDynamic | null;
+}
+
+/**
+ * `GET /api/people` — every curated person, and the numbers its filter chips
+ * show.
+ *
+ * Unpaged, unlike the account directory: curated people are entered one at a
+ * time by a guardian, so the listing is bounded by hand. The account directory
+ * is a mirrored address book of thousands and pages.
+ *
+ * The stranger sentinel never appears. It is a row in the persons table that
+ * dismissed accounts are linked to — structure, not someone the guardian knows
+ * — and `GET /api/people/:id` answers 404 for its id.
+ */
+export interface PeopleList {
+  people: PersonResource[];
+  counts: PersonCounts;
+}
+
+/** The bond levels a curated person can be counted under, in display order —
+ *  every level {@link normalizeBondLevel} can answer, which is the ladder
+ *  minus the two positions no person row holds. */
+export const PERSON_BOND_LEVELS: readonly PlacedBondLevel[] = [
+  "guardian",
+  "inner-circle",
+  "acquaintance",
+  "other",
+];
+
+export type PersonBondLevel = PlacedBondLevel;
+
+/** A level the listing can be filtered and counted by: a bond level, or "all"
+ *  — every curated person whatever their level. */
+export type PersonFilterLevel = "all" | PersonBondLevel;
+
+/**
+ * How many people sit at each level.
+ *
+ * Counted over everything `?q=` matches rather than the rows `?level=`
+ * returned: the chips are how a client moves between the levels, so a count
+ * taken over the returned rows would report zero for every chip but the one
+ * already selected, and the guardian could never leave it.
+ *
+ * "all" is the sum of the others — every level here is one a person is
+ * actually placed at.
+ */
+export interface PersonCounts extends Record<PersonFilterLevel, number> {}
+
+/** Whether a person belongs to a chip's view. */
+export function personMatchesLevel(person: PersonResource, level: PersonFilterLevel): boolean {
+  return level === "all" || normalizeBondLevel(person.bondLevel) === level;
+}
+
+export function parsePersonFilterLevel(raw: string | undefined | null): PersonFilterLevel | null {
+  return parseFilterLevel(raw, PERSON_BOND_LEVELS);
+}
+
+export function countPeople(people: readonly PersonResource[]): PersonCounts {
+  const counts: PersonCounts = {
+    all: 0,
+    guardian: 0,
+    "inner-circle": 0,
+    acquaintance: 0,
+    other: 0,
+  };
+  for (const person of people) {
+    counts[normalizeBondLevel(person.bondLevel)] += 1;
+    counts.all += 1;
+  }
+  return counts;
+}
+
+/**
+ * What `?q=` matches: the person's own name, and every account they hold —
+ * both what the platform calls it and the identifier itself.
+ *
+ * The identifiers are in the haystack because a guardian searches with what
+ * they have: a phone number they were given, a member id pasted from a profile
+ * URL. A saved name would otherwise hide the account they are looking for.
+ */
+export function personMatchesQuery(person: PersonResource, query: string): boolean {
+  return matchesQuery(query, [
+    person.displayName,
+    ...person.accounts.flatMap((account) => [
+      account.displayName,
+      account.channel,
+      account.channelUserId,
+    ]),
+  ]);
+}
+
+/**
+ * The listing's order: newest activity first, people who have never said
+ * anything last, ties broken by name and then id.
+ *
+ * The identity stream's order, not a second one that happens to agree — the
+ * two surfaces list the same rows, so an order defined twice is two answers to
+ * "who is at the top" and, once this listing takes a cursor, a row skipped or
+ * repeated at every page boundary.
+ */
+export function comparePeople(a: PersonResource, b: PersonResource): number {
+  return compareIdentityCursors(identityCursorOf(a), identityCursorOf(b));
 }

--- a/packages/core/src/api/routes/people.test.ts
+++ b/packages/core/src/api/routes/people.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
-import type { TimelinePage } from "@rome/api-types/people";
+import { sql } from "drizzle-orm";
+import {
+  latestDynamic,
+  type PeopleList,
+  type PersonResource,
+  type TimelinePage,
+} from "@rome/api-types/people";
 import { peopleRoutes } from "./people.js";
 import { createTestDb, buildTestDeps, type TestDb, type TestDeps } from "../../test/helpers.js";
 import { seedBaseline, type BaselineIds } from "../../test/seeds.js";
@@ -470,4 +476,282 @@ describe("People timeline API", () => {
     });
     expect(await fetchTimeline(unreachable)).toEqual({ entries: [], nextCursor: null });
   });
+});
+
+// GET /people and GET /people/:id — the curated people, their accounts as each
+// platform names them, and the activity a row shows without opening the
+// dossier. What the numbers count is the point of most of these: a person's
+// history is written down in several overlapping stores, so a row that adds
+// them up reports an inbox nobody has.
+
+describe("People API", () => {
+  const NADIA_JID = "15550001111@s.whatsapp.net";
+  const NADIA_LID = "77771111@lid";
+
+  let testDb: TestDb;
+  let deps: TestDeps;
+  let app: Hono;
+  let baseline: BaselineIds;
+  let nadiaId: string;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    baseline = await seedBaseline(testDb.db);
+    deps = await buildTestDeps(testDb.db);
+    app = new Hono().route("/", peopleRoutes(deps));
+
+    // One WhatsApp account reachable two ways, which the mirror folds onto the
+    // phone JID, and a person mapped under both of them.
+    await deps.whatsAppStoreRepo.upsertContacts([
+      { jid: NADIA_JID, phoneNumber: "15550001111", name: "Nadia Cross" },
+      { jid: NADIA_LID, phoneNumber: "15550001111", notify: "Nadia" },
+    ]);
+    await deps.whatsAppStoreRepo.upsertMessages([
+      {
+        id: "wa-n1",
+        chatJid: NADIA_JID,
+        senderJid: NADIA_JID,
+        fromMe: false,
+        timestamp: at("2026-08-10T09:00:00Z"),
+        type: "text",
+        text: "are we still on for friday",
+        hasMedia: false,
+      },
+      {
+        id: "wa-n2",
+        chatJid: NADIA_JID,
+        senderJid: NADIA_JID,
+        fromMe: true,
+        timestamp: at("2026-08-10T09:05:00Z"),
+        type: "text",
+        text: "yes — 7pm",
+        hasMedia: false,
+      },
+      {
+        id: "wa-n-react",
+        chatJid: NADIA_JID,
+        senderJid: NADIA_JID,
+        fromMe: false,
+        timestamp: at("2026-08-10T09:06:00Z"),
+        type: "reaction",
+        text: "👍",
+        hasMedia: false,
+        reactsToId: "wa-n2",
+      },
+      {
+        id: "wa-n-group",
+        chatJid: "120363000000000011@g.us",
+        senderJid: NADIA_JID,
+        fromMe: false,
+        timestamp: at("2026-08-11T10:00:00Z"),
+        type: "text",
+        text: "posted in the group",
+        hasMedia: false,
+      },
+    ]);
+
+    nadiaId = await deps.personMappingRepo.create({
+      displayName: "Nadia Cross",
+      bondLevel: "acquaintance",
+      approved: true,
+      channelMappings: [
+        { channel: "whatsapp", channelUserId: NADIA_JID },
+        { channel: "whatsapp", channelUserId: NADIA_LID },
+      ],
+    });
+  });
+
+  afterEach(() => testDb.close());
+
+  async function fetchList(query = ""): Promise<PeopleList> {
+    const res = await app.request(`/people${query}`);
+    expect(res.status).toBe(200);
+    return (await res.json()) as PeopleList;
+  }
+
+  async function fetchPerson(id: string): Promise<PersonResource> {
+    const res = await app.request(`/people/${id}`);
+    expect(res.status).toBe(200);
+    return (await res.json()) as PersonResource;
+  }
+
+  it("lists every curated person with their accounts, and never the sentinel", async () => {
+    const { people } = await fetchList();
+    const ids = people.map((person) => person.id);
+
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        baseline.persons.guardianId,
+        baseline.persons.innerCircleId,
+        baseline.persons.acquaintanceId,
+        baseline.persons.otherId,
+        nadiaId,
+      ]),
+    );
+    // The sentinel is the row dismissed accounts are linked to, not someone
+    // the guardian knows.
+    expect(ids).not.toContain(STRANGER_PERSON_ID);
+
+    const alice = people.find((person) => person.id === baseline.persons.innerCircleId);
+    expect(alice?.accounts).toEqual([
+      // Telegram mirrors no address book, so the name is the one the sender put
+      // on their own messages — the directory seam's second fallback.
+      { channel: "telegram", channelUserId: "tg-alice", displayName: "Alice Inner" },
+    ]);
+
+    const carol = people.find((person) => person.id === baseline.persons.otherId);
+    // Nothing has ever named this account, so it is rendered as its identifier
+    // rather than as an empty string.
+    expect(carol?.accounts).toEqual([
+      { channel: "whatsapp", channelUserId: "wa-carol", displayName: "wa-carol" },
+    ]);
+  });
+
+  it("names an account as its platform does, over every addressing of it", async () => {
+    const nadia = await fetchPerson(nadiaId);
+    // One account, two mappings: a client addresses the link it stored, and
+    // both carry the mirror's name for the account rather than the raw jid.
+    expect(nadia.accounts).toEqual([
+      { channel: "whatsapp", channelUserId: NADIA_JID, displayName: "Nadia Cross" },
+      { channel: "whatsapp", channelUserId: NADIA_LID, displayName: "Nadia Cross" },
+    ]);
+  });
+
+  it("answers 404 for the stranger sentinel and for an id naming no person", async () => {
+    expect((await app.request(`/people/${STRANGER_PERSON_ID}`)).status).toBe(404);
+    expect((await app.request("/people/nobody-here")).status).toBe(404);
+    expect(baseline.persons.strangerId).toBe(STRANGER_PERSON_ID);
+  });
+
+  it("keeps a stored bond level the ladder does not name, and counts it as other", async () => {
+    // Older rows carry levels outside today's enum. Rewriting one on the way
+    // out would make a person's own level unreadable.
+    await testDb.db.run(
+      sql`UPDATE persons SET bond_level = 'colleague' WHERE id = ${baseline.persons.otherId}`,
+    );
+
+    expect((await fetchPerson(baseline.persons.otherId)).bondLevel).toBe("colleague");
+
+    const filtered = await fetchList("?level=other");
+    expect(filtered.people.map((person) => person.id)).toContain(baseline.persons.otherId);
+  });
+
+  it("counts the whole match rather than the rows it returned", async () => {
+    const whole = await fetchList();
+    const narrowed = await fetchList("?level=inner-circle");
+
+    expect(narrowed.people.map((person) => person.id)).toEqual([baseline.persons.innerCircleId]);
+    // The chips are how the guardian leaves the level they are on, so every
+    // number stays true while one of them is selected.
+    expect(narrowed.counts).toEqual(whole.counts);
+    expect(whole.counts.guardian).toBe(1);
+    expect(whole.counts["inner-circle"]).toBe(1);
+    expect(whole.counts.acquaintance).toBe(2);
+    expect(whole.counts.other).toBe(1);
+    expect(whole.counts.all).toBe(5);
+  });
+
+  it("narrows the match with ?q=, including by an account's identifier", async () => {
+    const byName = await fetchList("?q=nadia");
+    expect(byName.people.map((person) => person.id)).toEqual([nadiaId]);
+    expect(byName.counts.all).toBe(1);
+    expect(byName.counts.acquaintance).toBe(1);
+
+    // A guardian searches with what they have — the phone number they were
+    // given, not the name Rome saved.
+    const byNumber = await fetchList("?q=15550001111");
+    expect(byNumber.people.map((person) => person.id)).toEqual([nadiaId]);
+  });
+
+  it("refuses a level that names no view", async () => {
+    const res = await app.request("/people?level=colleague");
+    expect(res.status).toBe(400);
+  });
+
+  it("previews the head of the person's own timeline and counts its entries", async () => {
+    const { people } = await fetchList();
+
+    for (const person of people) {
+      const timeline = (await fetchTimelineFor(person.id)).entries;
+      expect(person.latest).toEqual(latestDynamic(timeline));
+      expect(person.messageCount).toBe(timeline.length);
+    }
+  });
+
+  it("counts one account's history once, whatever it is addressed by", async () => {
+    const nadia = await fetchPerson(nadiaId);
+    // Two mappings onto one mirrored account, and one conversation on it: the
+    // reaction and the group message are not entries, and the two addressings
+    // are not two histories.
+    expect(nadia.messageCount).toBe(2);
+    expect(nadia.latest).toEqual({
+      source: "whatsapp",
+      timestamp: Math.floor(at("2026-08-10T09:05:00Z").getTime() / 1000),
+      preview: "yes — 7pm",
+    });
+  });
+
+  it("counts one exchange once when three stores wrote it down", async () => {
+    // The mirror, Rome's own transcript of the channel session, and the
+    // sentinel that triaged it all hold the same WhatsApp message. Adding them
+    // would treble the number beside her name.
+    const conversation = await deps.webchatRepo.ensureChannelConversation({
+      channel: "whatsapp",
+      threadId: NADIA_JID,
+      threadType: "private",
+      agentName: "main",
+    });
+    await deps.webchatRepo.addConversationMessage({
+      sessionId: conversation.id,
+      role: "notification",
+      content: JSON.stringify([{ type: "text", content: "as the transcript has it" }]),
+      platformMessageId: "wa-n1",
+      senderId: NADIA_JID,
+      createdAt: at("2026-08-10T09:00:02Z"),
+    });
+    await deps.sentinelLogRepo.create({
+      messageId: "wa-n1",
+      channel: "whatsapp",
+      channelUserId: NADIA_JID,
+      threadId: NADIA_JID,
+      text: "as the sentinel logged it",
+      action: "replied",
+      response: "as the sentinel answered it",
+    });
+
+    expect((await fetchPerson(nadiaId)).messageCount).toBe(2);
+  });
+
+  it("orders by newest activity, with people who have said nothing last", async () => {
+    const { people } = await fetchList();
+    const silent = people.filter((person) => person.latest === null).map((person) => person.id);
+    const spoken = people.filter((person) => person.latest !== null);
+
+    expect(spoken.map((person) => person.latest?.timestamp)).toEqual(
+      [...spoken.map((person) => person.latest?.timestamp ?? 0)].sort((a, b) => b - a),
+    );
+    expect(people.slice(people.length - silent.length).map((person) => person.id)).toEqual(silent);
+    // The seed has both kinds, so the two assertions above are not vacuous.
+    expect(spoken.length).toBeGreaterThan(1);
+    expect(silent.length).toBeGreaterThan(0);
+  });
+
+  it("answers a person with no accounts as one with no history", async () => {
+    const unreachable = await deps.personMappingRepo.create({
+      displayName: "No Channels",
+      bondLevel: "other",
+      approved: true,
+      channelMappings: [],
+    });
+    const person = await fetchPerson(unreachable);
+    expect(person.accounts).toEqual([]);
+    expect(person.messageCount).toBe(0);
+    expect(person.latest).toBeNull();
+  });
+
+  async function fetchTimelineFor(id: string): Promise<TimelinePage> {
+    const res = await app.request(`/people/${id}/messages?limit=300`);
+    expect(res.status).toBe(200);
+    return (await res.json()) as TimelinePage;
+  }
 });

--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -1,25 +1,57 @@
 import { Hono } from "hono";
-import { parseTimelineCursor, timelinePageLimit } from "@rome/api-types/people";
-import { STRANGER_PERSON_ID } from "../../constants.js";
+import {
+  comparePeople,
+  countPeople,
+  parsePersonFilterLevel,
+  parseTimelineCursor,
+  personMatchesLevel,
+  personMatchesQuery,
+  timelinePageLimit,
+  type PeopleList,
+} from "@rome/api-types/people";
+import { findPerson, readPeople, readPerson } from "../../people/resource.js";
 import { readPersonTimeline } from "../../people/timeline.js";
-import { personTimelineAccounts, personTimelineSources } from "../../people/timeline-sources.js";
+import { personTimelineSources, timelineAccounts } from "../../people/timeline-sources.js";
 import type { ApiDeps } from "../deps.js";
 
-// The People surface's timeline read. What a page of history is, how it is
-// ordered and how it resumes are the contract's (@rome/api-types/people);
-// which stores it is merged from is `src/people/`. This route is the join
-// between a person id and those two, and holds no rule of its own.
+// The People surface's reads. What a person and their accounts are, how the
+// listing orders and counts, and what a page of history is are the contract's
+// (@rome/api-types/people); serializing a person is `src/people/resource.ts`;
+// which stores a history is merged from is the rest of `src/people/`. These
+// handlers parse query parameters and hold no rule of their own.
 
 export function peopleRoutes(deps: ApiDeps): Hono {
   const app = new Hono();
 
+  app.get("/people", async (c) => {
+    const rawLevel = c.req.query("level");
+    const level = parsePersonFilterLevel(rawLevel);
+    if (rawLevel != null && rawLevel !== "" && level === null) {
+      return c.json({ error: `level must name a bond level or "all"` }, 400);
+    }
+
+    // The whole `?q=` match, before `?level=` narrows it: the counts describe
+    // it, and every chip's number has to stay true while another chip is the
+    // one selected.
+    const matching = (await readPeople(deps)).filter((person) =>
+      personMatchesQuery(person, c.req.query("q") ?? ""),
+    );
+
+    return c.json({
+      people: matching
+        .filter((person) => personMatchesLevel(person, level ?? "all"))
+        .sort(comparePeople),
+      counts: countPeople(matching),
+    } satisfies PeopleList);
+  });
+
+  app.get("/people/:id", async (c) => {
+    const person = await readPerson(deps, c.req.param("id"));
+    return person ? c.json(person) : c.json({ error: "Unknown person" }, 404);
+  });
+
   app.get("/people/:id/messages", async (c) => {
-    const id = c.req.param("id");
-    // The stranger sentinel is a row in the persons table rather than a person,
-    // and every dismissed identity is mapped onto it. Answering for it would
-    // merge the history of everyone the guardian has ever dismissed into one
-    // timeline.
-    const person = id === STRANGER_PERSON_ID ? null : await deps.personMappingRepo.findById(id);
+    const person = await findPerson(deps, c.req.param("id"));
     if (!person) return c.json({ error: "Unknown person" }, 404);
 
     const rawCursor = c.req.query("cursor");
@@ -33,15 +65,14 @@ export function peopleRoutes(deps: ApiDeps): Hono {
     // no set of names to check one against, and "no history there" is the true
     // answer for every name that is not a typo.
     const channel = c.req.query("channel");
-    const accounts = (await personTimelineAccounts(deps, person.channelMappings)).filter(
-      (account) => !channel || account.channel === channel,
-    );
+    const [accounts] = await timelineAccounts(deps, [person.channelMappings]);
 
     return c.json(
-      await readPersonTimeline(personTimelineSources(deps), accounts, {
-        cursor,
-        limit: timelinePageLimit(c.req.query("limit")),
-      }),
+      await readPersonTimeline(
+        personTimelineSources(deps),
+        accounts.filter((account) => !channel || account.channel === channel),
+        { cursor, limit: timelinePageLimit(c.req.query("limit")) },
+      ),
     );
   });
 

--- a/packages/core/src/api/routes/persons.ts
+++ b/packages/core/src/api/routes/persons.ts
@@ -34,7 +34,7 @@ export function personsRoutes(deps: ApiDeps): Hono {
   const app = new Hono();
 
   app.get("/persons", async (c) => {
-    const rows = await deps.personMappingRepo.findAll();
+    const rows = await deps.personMappingRepo.findAllWithMappings();
     return c.json(rows);
   });
 

--- a/packages/core/src/db/repositories/person-mapping.ts
+++ b/packages/core/src/db/repositories/person-mapping.ts
@@ -162,33 +162,14 @@ export class PersonMappingRepository {
     return results;
   }
 
-  async findAll() {
-    const rows = await this.db.select().from(persons);
-
-    const results = [];
-    for (const person of rows) {
-      const mappings = await this.db
-        .select()
-        .from(channelMappings)
-        .where(eq(channelMappings.personId, person.id));
-      results.push({
-        ...person,
-        channelMappings: mappings.map((m) => ({
-          channel: m.channel,
-          channelUserId: m.channelUserId,
-        })),
-      });
-    }
-    return results;
-  }
-
   /**
    * Every person with their channel mappings, read as one statement.
    *
-   * One snapshot, unlike {@link findAll}: a mapping moving between two people
-   * mid-read would otherwise land under both of them (or neither), because
-   * each person's mappings arrive in their own autocommit query. The identity
-   * union's whole premise is that an identity has one owner, so it reads this.
+   * One statement rather than one per person, and not only to save the reads:
+   * a mapping moving between two people mid-read would otherwise land under
+   * both of them (or neither), because each person's mappings would arrive in
+   * their own autocommit query. Every reader of this table assumes an identity
+   * has one owner.
    */
   async findAllWithMappings() {
     const rows = await this.db

--- a/packages/core/src/people/activity.ts
+++ b/packages/core/src/people/activity.ts
@@ -1,0 +1,57 @@
+// What each person has done, across every account they are linked to: the
+// newest thing, and how much there is of it — the two numbers a directory row
+// shows without opening the dossier.
+//
+// Read from the same stores as the page in timeline.ts, claimed in the order
+// `assignAccounts` defines and for the reason stated there, and summarized in
+// one read per store however many people are asked about.
+
+import {
+  compareTimelineEntries,
+  latestDynamic,
+  type IdentityDynamic,
+} from "@rome/api-types/people";
+import {
+  assignAccounts,
+  type AccountDigest,
+  type TimelineAccount,
+  type TimelineSource,
+} from "./timeline.js";
+
+/** A person's history at a glance. `latest` is null exactly when
+ *  `messageCount` is zero — a person nobody has ever written to. */
+export interface PersonActivity {
+  latest: IdentityDynamic | null;
+  messageCount: number;
+}
+
+/**
+ * One activity per group of accounts, in the order the groups were given.
+ *
+ * Positional, and over every group at once: the stores are read for all of
+ * them together, so a listing of curated people costs the same handful of
+ * queries as a single person.
+ */
+export async function readPeopleActivity(
+  sources: readonly TimelineSource[],
+  accountsByPerson: readonly (readonly TimelineAccount[])[],
+): Promise<PersonActivity[]> {
+  const digests = new Map<TimelineAccount, AccountDigest>();
+  for (const [source, held] of await assignAccounts(sources, accountsByPerson.flat())) {
+    for (const digest of await source.digest(held)) digests.set(digest.account, digest);
+  }
+
+  return accountsByPerson.map((accounts) => {
+    const held = accounts
+      .map((account) => digests.get(account))
+      .filter((digest) => digest !== undefined);
+    return {
+      // Through `latestDynamic`, over entries in the timeline's own order, so
+      // a person whose two accounts last spoke in the same second previews the
+      // entry their merged timeline opens on rather than whichever account the
+      // fold reached first.
+      latest: latestDynamic(held.map((digest) => digest.latest).sort(compareTimelineEntries)),
+      messageCount: held.reduce((total, digest) => total + digest.messageCount, 0),
+    };
+  });
+}

--- a/packages/core/src/people/resource.ts
+++ b/packages/core/src/people/resource.ts
@@ -1,0 +1,95 @@
+// Person rows as the contract's `PersonResource`: their accounts named as each
+// platform names them, and their activity read across all of them.
+//
+// Here rather than in the route because every write on this surface answers
+// with the person it changed — create, link, unlink, transfer, dismiss, merge —
+// so a serializer living in one handler is a serializer the next five copy.
+//
+// The stranger sentinel is a row in the persons table that every dismissed
+// account is linked to, not someone the guardian knows. It is excluded here,
+// once, so no route can serve it by forgetting to.
+
+import type { PersonResource } from "@rome/api-types/people";
+import { STRANGER_PERSON_ID } from "../constants.js";
+import type { AccountNames } from "../channels/account-names.js";
+import type { TalkAccounts } from "../channels/accounts.js";
+import type { DrizzleDb } from "../db/index.js";
+import type { PersonMappingRepository } from "../db/repositories/person-mapping.js";
+import { readPeopleActivity } from "./activity.js";
+import { personTimelineSources, timelineAccounts } from "./timeline-sources.js";
+
+export interface PeopleReadDeps {
+  db: DrizzleDb;
+  personMappingRepo: Pick<PersonMappingRepository, "findAllWithMappings" | "findById">;
+  whatsAppAccounts: TalkAccounts;
+  accountNames: Pick<AccountNames, "displayNames">;
+}
+
+/** A person as the repository reads them: the row and the accounts linked to
+ *  it. */
+export type PersonRow = Awaited<ReturnType<PersonMappingRepository["findAllWithMappings"]>>[number];
+
+/** Every curated person. */
+export async function readPeople(deps: PeopleReadDeps): Promise<PersonResource[]> {
+  const persons = (await deps.personMappingRepo.findAllWithMappings()).filter(
+    (person) => person.id !== STRANGER_PERSON_ID,
+  );
+  return serialize(deps, persons);
+}
+
+/** One curated person, or null when the id names none. */
+export async function readPerson(deps: PeopleReadDeps, id: string): Promise<PersonResource | null> {
+  const person = await findPerson(deps, id);
+  return person && (await serialize(deps, [person]))[0];
+}
+
+/** The person an id names, as stored — for a caller that needs the mappings
+ *  rather than the resource. Null for the sentinel, which is structure. */
+export async function findPerson(
+  deps: Pick<PeopleReadDeps, "personMappingRepo">,
+  id: string,
+): Promise<PersonRow | null> {
+  return id === STRANGER_PERSON_ID ? null : await deps.personMappingRepo.findById(id);
+}
+
+/**
+ * Costs the same handful of reads whether it is given one person or every one
+ * of them — one address-book read per channel, one display-name read per
+ * provider, one summary read per message store — so the listing never grows a
+ * per-person query.
+ */
+async function serialize(
+  deps: PeopleReadDeps,
+  persons: readonly PersonRow[],
+): Promise<PersonResource[]> {
+  // One mapping is one account on the wire, so a client can address the link
+  // it sees. The activity fold is the one place two mappings of a single
+  // account collapse — reporting one person's history twice would be a wrong
+  // number, whereas showing both addressings is only what the guardian stored.
+  const refs = persons.flatMap((person) => person.channelMappings);
+
+  // Independent of each other, and both reach the same channel mirrors: read
+  // together, a mirror that folds its whole address book per call serves both
+  // from one read of it instead of two.
+  const [accountsByPerson, names] = await Promise.all([
+    timelineAccounts(
+      deps,
+      persons.map((person) => person.channelMappings),
+    ),
+    deps.accountNames.displayNames(refs),
+  ]);
+  const activity = await readPeopleActivity(personTimelineSources(deps), accountsByPerson);
+
+  let next = 0;
+  return persons.map((person, i) => ({
+    id: person.id,
+    displayName: person.displayName,
+    bondLevel: person.bondLevel,
+    accounts: person.channelMappings.map((mapping) => ({
+      channel: mapping.channel,
+      channelUserId: mapping.channelUserId,
+      displayName: names[next++],
+    })),
+    ...activity[i],
+  }));
+}

--- a/packages/core/src/people/timeline-sources.ts
+++ b/packages/core/src/people/timeline-sources.ts
@@ -193,8 +193,8 @@ export function sentinelLogSource(db: DrizzleDb): TimelineSource {
 }
 
 /**
- * Every account a person is reachable at, with every address the channel folds
- * onto it.
+ * Every account each group of mappings is reachable at, with every address the
+ * channel folds onto it — one result per group, in the order given.
  *
  * Two mappings that name two addressings of one account collapse to one
  * account, so a person mapped under both a WhatsApp phone JID and its `@lid`
@@ -202,33 +202,75 @@ export function sentinelLogSource(db: DrizzleDb): TimelineSource {
  *
  * A channel with no account plane contributes the mapping's own address and
  * nothing else, which is all the channel can say about who it can reach.
+ *
+ * Positional and over every group at once, like `AccountNames.displayNames`
+ * next door: each channel's address book costs a full read, so one caller
+ * asking about a directory of people must not pay for one read per row.
  */
-export async function personTimelineAccounts(
+export async function timelineAccounts(
   deps: { whatsAppAccounts: TalkAccounts },
-  mappings: readonly { channel: string; channelUserId: string }[],
-): Promise<TimelineAccount[]> {
+  groups: readonly (readonly ChannelMapping[])[],
+): Promise<TimelineAccount[][]> {
+  const channels = new Set(groups.flatMap((group) => group.map((mapping) => mapping.channel)));
+  const books = await readAddressBooks(deps, channels);
+  return groups.map((group) => foldAccounts(books, group));
+}
+
+interface ChannelMapping {
+  channel: string;
+  channelUserId: string;
+}
+
+/** Every address a channel folds onto an account, grouped by the account —
+ *  the address map read the way the fold needs it, inverted once per request
+ *  rather than re-scanned per person.
+ *
+ *  Read only for the channels the mappings name, since a plane costs a full
+ *  address-book read. LinkedIn has a plane too but is deliberately absent: it
+ *  stores a member under its member id and nothing else, so folding it would
+ *  buy a whole mirror read and change no answer. It joins here when it starts
+ *  storing a second addressing. */
+async function readAddressBooks(
+  deps: { whatsAppAccounts: TalkAccounts },
+  channels: ReadonlySet<string>,
+): Promise<Map<string, AddressBook>> {
   const planes = new Map<string, TalkAccounts>([["whatsapp", deps.whatsAppAccounts]]);
-
-  const addressesByChannel = new Map<string, Map<string, string>>();
+  const books = new Map<string, AddressBook>();
   for (const [channel, accounts] of planes) {
-    // Reading a plane costs a full address-book read, so a person with no
-    // mapping on the channel never pays for one.
-    if (!mappings.some((mapping) => mapping.channel === channel)) continue;
-    addressesByChannel.set(channel, await accounts.listAddresses());
+    if (!channels.has(channel)) continue;
+    const addresses = await accounts.listAddresses();
+    const byAccount = new Map<string, string[]>();
+    for (const [address, accountId] of addresses) {
+      const folded = byAccount.get(accountId);
+      if (folded) folded.push(address);
+      else byAccount.set(accountId, [address]);
+    }
+    books.set(channel, { of: addresses, folded: byAccount });
   }
+  return books;
+}
 
+/** One channel's address map, and the same map read the other way round. */
+interface AddressBook {
+  /** Which account each address belongs to. */
+  of: Map<string, string>;
+  /** Every address of each account. */
+  folded: Map<string, string[]>;
+}
+
+function foldAccounts(
+  books: Map<string, AddressBook>,
+  mappings: readonly ChannelMapping[],
+): TimelineAccount[] {
   const byAccount = new Map<string, TimelineAccount>();
   for (const mapping of mappings) {
-    const addresses = addressesByChannel.get(mapping.channel);
-    const accountId = addresses?.get(mapping.channelUserId) ?? mapping.channelUserId;
+    const book = books.get(mapping.channel);
+    const accountId = book?.of.get(mapping.channelUserId) ?? mapping.channelUserId;
     const key = `${mapping.channel}\n${accountId}`;
     if (byAccount.has(key)) continue;
-    const folded = addresses
-      ? [...addresses].filter(([, id]) => id === accountId).map(([address]) => address)
-      : [];
     byAccount.set(key, {
       channel: mapping.channel,
-      addresses: [...new Set([mapping.channelUserId, ...folded])],
+      addresses: [...new Set([mapping.channelUserId, ...(book?.folded.get(accountId) ?? [])])],
     });
   }
   return [...byAccount.values()];

--- a/packages/core/src/people/timeline-sql.ts
+++ b/packages/core/src/people/timeline-sql.ts
@@ -3,9 +3,9 @@
 // once, and this module pages, orders and scopes them.
 
 import { sql, type SQL } from "drizzle-orm";
-import type { TimelineEntry } from "@rome/api-types/people";
+import { compareTimelineEntries, type TimelineEntry } from "@rome/api-types/people";
 import type { DrizzleDb } from "../db/index.js";
-import type { TimelineAccount, TimelineSource, TimelineRead } from "./timeline.js";
+import type { AccountDigest, TimelineAccount, TimelineSource, TimelineRead } from "./timeline.js";
 
 /**
  * A store's rows as timeline entries: a SELECT producing exactly the columns
@@ -55,6 +55,63 @@ export function sqlTimelineSource(options: {
       );
     },
 
+    async digest(accounts) {
+      const rows = view(accounts);
+      if (rows === null) return [];
+      // The head of each address's timeline and its length, from one pass over
+      // the rows. One named window rather than two inline ones: SQLite shares a
+      // partition pass only between windows that are spelled the same, and two
+      // spellings sort the whole scoped history twice.
+      //
+      // The frame is explicit because the ORDER BY inside the window would
+      // otherwise make `count(*)` a running total — the length of the history
+      // above each row rather than the length of the history.
+      //
+      // That ORDER BY is `read`'s, so the row this picks is the one `read`
+      // would put first. No cursor and no limit: this is the whole history
+      // summarized, not a page of it.
+      const summaries = (await db.all(sql`
+        SELECT source, address, at, outbound, ref, body, entries
+        FROM (
+          SELECT *, row_number() OVER w AS position, count(*) OVER w AS entries
+          FROM (${rows})
+          WINDOW w AS (
+            PARTITION BY source, address
+            ORDER BY at DESC, outbound DESC, source ASC, ref ASC
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+          )
+        )
+        WHERE position = 1
+      `)) as Array<Record<string, unknown>>;
+
+      const byAddress = new Map<string, { latest: TimelineEntry; messageCount: number }>();
+      for (const row of summaries) {
+        byAddress.set(addressKey(String(row.source), String(row.address)), {
+          latest: toEntry(row, options.body),
+          messageCount: Number(row.entries),
+        });
+      }
+
+      // An account is addressed several ways and each addressing grouped on its
+      // own above, so the account's summary is those groups folded: the newest
+      // head wins and the lengths add. Left unfolded, a WhatsApp contact whose
+      // history straddles a phone JID and a `@lid` JID would report whichever
+      // half the store listed first.
+      const digests: AccountDigest[] = [];
+      for (const account of accounts) {
+        const parts = account.addresses
+          .map((address) => byAddress.get(addressKey(account.channel, address)))
+          .filter((part) => part !== undefined);
+        if (parts.length === 0) continue;
+        digests.push({
+          account,
+          latest: parts.map((part) => part.latest).sort(compareTimelineEntries)[0],
+          messageCount: parts.reduce((total, part) => total + part.messageCount, 0),
+        });
+      }
+      return digests;
+    },
+
     async read(request: TimelineRead) {
       const rows = view(request.accounts);
       if (rows === null) return [];
@@ -65,21 +122,26 @@ export function sqlTimelineSource(options: {
         ORDER BY at DESC, outbound DESC, source ASC, ref ASC
         LIMIT ${Math.max(1, Math.floor(request.limit))}
       `)) as Array<Record<string, unknown>>;
-      return page.map((row) => {
-        const body = (row.body as string | null) ?? null;
-        return {
-          source: String(row.source),
-          timestamp: Number(row.at),
-          direction: Number(row.outbound) === 1 ? ("outbound" as const) : ("inbound" as const),
-          ref: String(row.ref),
-          body: options.body ? options.body(body) : body,
-        };
-      });
+      return page.map((row) => toEntry(row, options.body));
     },
   };
 }
 
 const addressKey = (channel: string, address: string) => `${channel}\n${address}`;
+
+function toEntry(
+  row: Record<string, unknown>,
+  body?: (raw: string | null) => string | null,
+): TimelineEntry {
+  const raw = (row.body as string | null) ?? null;
+  return {
+    source: String(row.source),
+    timestamp: Number(row.at),
+    direction: Number(row.outbound) === 1 ? "outbound" : "inbound",
+    ref: String(row.ref),
+    body: body ? body(raw) : raw,
+  };
+}
 
 /**
  * The rows that fall strictly after `cursor`, in the order the ORDER BY above

--- a/packages/core/src/people/timeline.test.ts
+++ b/packages/core/src/people/timeline.test.ts
@@ -6,6 +6,7 @@ import {
   type TimelineEntry,
 } from "@rome/api-types/people";
 import { readPersonTimeline, type TimelineAccount, type TimelineSource } from "./timeline.js";
+import { readPeopleActivity } from "./activity.js";
 
 // The merge above the stores: what a page is, how it resumes, and which store
 // owns an account. Every source here is a fake, so nothing below is about SQL —
@@ -38,6 +39,19 @@ function fakeSource(
     calls,
     async holds(accounts) {
       return accounts.filter((a) => a.addresses.some((address) => addressesHeld.has(address)));
+    },
+    async digest(accounts) {
+      return accounts.flatMap((a) => {
+        const entries = a.addresses.flatMap((address) => held[address] ?? []);
+        if (entries.length === 0) return [];
+        return [
+          {
+            account: a,
+            latest: [...entries].sort(compareTimelineEntries)[0],
+            messageCount: entries.length,
+          },
+        ];
+      });
     },
     async read(request) {
       calls.push(name);
@@ -155,5 +169,55 @@ describe("readPersonTimeline", () => {
   it("answers an empty page for a person with no accounts", async () => {
     const page = await readPersonTimeline([whatsapp, telegram], [], { limit: 10 });
     expect(page).toEqual({ entries: [], nextCursor: null });
+  });
+});
+
+// The same precedence, read as a summary instead of a page: what a directory
+// row shows for a person without opening their dossier.
+describe("readPeopleActivity", () => {
+  const waAccount = account("whatsapp", "wa-1");
+  const tgAccount = account("telegram", "tg-1");
+
+  it("summarizes each account from the first store that claims it", async () => {
+    // One exchange written down twice, as the real stores overlap. Counting
+    // both would report an inbox the dossier does not have.
+    const mirror = fakeSource("mirror", { "wa-1": [entry("whatsapp", 500, "mirrored")] });
+    const transcript = fakeSource("transcript", {
+      "wa-1": [entry("whatsapp", 500, "copy"), entry("whatsapp", 200, "older copy")],
+      "tg-1": [entry("telegram", 400, "typed")],
+    });
+
+    const [whatsapp, telegram] = await readPeopleActivity(
+      [mirror, transcript],
+      [[waAccount], [tgAccount]],
+    );
+    expect(whatsapp).toEqual({
+      messageCount: 1,
+      latest: { source: "whatsapp", timestamp: 500, preview: "mirrored@500" },
+    });
+    expect(telegram.messageCount).toBe(1);
+  });
+
+  it("folds a person's accounts into one history", async () => {
+    const store = fakeSource("store", {
+      "wa-1": [entry("whatsapp", 300, "wa:c"), entry("whatsapp", 100, "wa:a")],
+      "tg-1": [entry("telegram", 400, "tg:d")],
+    });
+
+    const [both] = await readPeopleActivity([store], [[waAccount, tgAccount]]);
+    expect(both).toEqual({
+      messageCount: 3,
+      // The head of the merged timeline, not of whichever account came first.
+      latest: { source: "telegram", timestamp: 400, preview: "tg:d@400" },
+    });
+  });
+
+  it("answers one activity per group, in the order given", async () => {
+    const store = fakeSource("store", { "tg-1": [entry("telegram", 400, "tg:d")] });
+    expect(await readPeopleActivity([store], [[waAccount], [], [tgAccount]])).toEqual([
+      { latest: null, messageCount: 0 },
+      { latest: null, messageCount: 0 },
+      { latest: { source: "telegram", timestamp: 400, preview: "tg:d@400" }, messageCount: 1 },
+    ]);
   });
 });

--- a/packages/core/src/people/timeline.ts
+++ b/packages/core/src/people/timeline.ts
@@ -33,20 +33,33 @@ export interface TimelineRead {
   limit: number;
 }
 
+/** One account's history as a store summarizes it — see
+ *  {@link TimelineSource.digest}. */
+export interface AccountDigest {
+  /** The element of the `accounts` the store was given, not a copy of it. */
+  account: TimelineAccount;
+  /** The newest entry, first in {@link compareTimelineEntries} order. */
+  latest: TimelineEntry;
+  /** Every entry the store holds for the account. */
+  messageCount: number;
+}
+
 /**
  * One message store, as a person's timeline reads it.
  *
  * Adding a store is one implementation of this interface listed alongside the
  * others; nothing above here knows how many there are or what they read.
  *
- * The two methods exist because the stores overlap rather than partition. One
- * inbound WhatsApp message is a `wa_messages` row, a `rome_agent_messages` row
- * on the channel session, and — when the sentinel triaged it — a `sentinel_log`
- * row as well. Merging all three renders one message three times, and the
- * copies carry different ids at different timestamps, so no after-the-fact
- * dedupe survives a page boundary. Instead each account's timeline comes from
- * exactly one store: {@link holds} is asked in order, and the first store that
- * holds an account owns it.
+ * The store answers which accounts it holds as well as what it holds for them,
+ * because the stores overlap rather than partition. One inbound WhatsApp
+ * message is a `wa_messages` row, a `rome_agent_messages` row on the channel
+ * session, and — when the sentinel triaged it — a `sentinel_log` row as well.
+ * Merging all three renders one message three times, and the copies carry
+ * different ids at different timestamps, so no after-the-fact dedupe survives
+ * a page boundary. Instead each account's timeline comes from exactly one
+ * store: the stores are asked in order, and the first one that holds an
+ * account owns it — for the page ({@link holds}, then {@link read}) and for
+ * the summary ({@link digest}) alike.
  */
 export interface TimelineSource {
   /** Stable, for tests and logs. Never {@link TimelineEntry.source}, which
@@ -57,6 +70,21 @@ export interface TimelineSource {
    *  the returned accounts are the caller's own; a store returns the elements
    *  it was given. */
   holds(accounts: readonly TimelineAccount[]): Promise<TimelineAccount[]>;
+
+  /**
+   * The same timeline {@link read} pages, summarized: the newest entry of each
+   * account, and how many entries it has in all.
+   *
+   * One read for a whole listing rather than one per person, and the newest
+   * entry is picked under {@link read}'s own ordering — so a directory row
+   * previews exactly the entry its dossier opens on, and its count is the
+   * length of exactly the history the dossier pages.
+   *
+   * Asked only about accounts {@link holds} has already given this store, so
+   * an account it holds nothing for is a person with no history rather than
+   * one whose history the next store down should have answered for.
+   */
+  digest(accounts: readonly TimelineAccount[]): Promise<AccountDigest[]>;
 
   /**
    * This store's newest entries for `accounts`, at most `limit` of them, every
@@ -112,9 +140,16 @@ export async function readPersonTimeline(
   };
 }
 
-/** Each store paired with the accounts it owns: the first store that holds an
- *  account takes it, and no later store is offered it. */
-async function assignAccounts(
+/**
+ * Each store paired with the accounts it owns: the first store that holds an
+ * account takes it, and no later store is offered it.
+ *
+ * The one place that rule is applied. Every read of a person's history — the
+ * page here, the summary in activity.ts — goes through this, because a summary
+ * that claimed accounts on its own terms could count an exchange the page
+ * attributes to a different store.
+ */
+export async function assignAccounts(
   sources: readonly TimelineSource[],
   accounts: readonly TimelineAccount[],
 ): Promise<Array<[TimelineSource, TimelineAccount[]]>> {


### PR DESCRIPTION
Closes #61.

## What this PR does

The People page has no backend. It reads `/api/identities` — a union contract that exists only in `@rome/api-types` and the dashboard's mock, with no core route behind it — and the writes underneath it speak the verb-style `/api/persons*` vocabulary. Nothing serves a person as the `/people` contract describes one: with the accounts they are reachable at, named as each platform names them, and what has happened across all of them.

This PR adds `GET /api/people` and `GET /api/people/:id`, and the `PersonResource` half of `@rome/api-types/people` they answer with. `GET /api/people/:id/messages` already landed in #72; this is the row the dossier hangs off.

## Design & Invariants

- **A row's activity is its own timeline, summarized.** `latest` and `messageCount` come from the same stores, claimed in the same order, as the page `GET /api/people/:id/messages` returns. So the line a row previews is the line its dossier opens on, and the number beside it counts what the dossier will show. A regression here is a preview and a dossier that disagree, which a reader has no way to reconcile — the failure `IdentityRow.latest` already warns about.

  This departs from the identity union's counting rule, which counts *records* — a WhatsApp reaction counts there, even though no timeline renders it. Alternative considered: keep that rule, reading counts from each mirror's `listActivity()`. Rejected — the union's rule is an artifact of what `listActivity()` happened to return, and a count that disagrees with the page it opens is worth less than one that matches it. The contract states the new rule explicitly.

- **Only a store can summarize itself.** The stores overlap rather than partition — one inbound WhatsApp message is a `wa_messages` row, a `rome_agent_messages` row and a `sentinel_log` row — so `TimelineSource` grew a `digest()` that answers the newest entry and the count for a batch of accounts. Pushing this above the seam would mean reading whole histories into memory to count them. One query per store serves the whole listing, so serializing one person and serializing every person cost the same.

- **Source precedence has exactly one home.** The page and the summary both claim accounts through `assignAccounts`. A summary that claimed on its own terms could count an exchange the page attributes to a different store.

- **Counts describe the whole `?q=` match, not the rows `?level=` returned.** The chips are how the guardian leaves the level they are on; a count over the returned rows reports zero for every chip but the selected one, and there is no way back.

- **`bondLevel` crosses the wire as stored, free text included.** The column holds levels off today's ladder ("colleague"); bucketing them is the reader's job, and rewriting one on the way out makes a person's own level unreadable.

- **The stranger sentinel is structure, not a person.** It is the row dismissed accounts are linked to. The listing excludes it and its id answers 404 — both decided once, in the serializer, so no route can serve it by forgetting to.

- **Ordering, search and the `?level=` parse are the identity stream's, widened rather than restated.** The two surfaces list the same rows, so a second definition is two answers to "who is at the top" — and, once this listing takes a cursor, a row skipped or repeated at every page boundary. `identityCursorOf` now takes the ordering tuple rather than a whole `IdentityRow`; `matchesQuery` and `parseFilterLevel` are the rules with the haystack and the ladder lifted out.

- **Serializing a person lives in `src/people/resource.ts`, not the route.** Every write on this surface answers with the person it changed — create, link, unlink, transfer, dismiss, merge — so a serializer living in one handler is a serializer the next five copy. That is how `routes/identities.ts` reached 480 lines.

Vocabulary is [`docs/concepts/identity.md`](../blob/main/docs/concepts/identity.md)'s; the account/link sweep of that doc is #70.

## Test plan

- [x] `pnpm typecheck` (full workspace)
- [x] `pnpm test:unit` (core: 348 files / 3992 tests; web + ui + rest all green)
- [x] `packages/core/src/api/routes/people.test.ts` — the listing, the accounts, the 404s, the stored bond level, counts under `?level=`, `?q=` by name and by phone number, and an invariant test asserting every row's `latest`/`messageCount` equals `latestDynamic` and the length of that person's own timeline
- [x] `packages/core/src/people/timeline.test.ts` — source precedence and the per-person fold, over fakes
- [x] `biome check` on the touched trees
- [ ] `pnpm dev:all` — docker is unreachable from this shell (`permission denied` on the socket), so the container smoke check did not run. CI covers it.

## Not in this PR

- Writes — create, link/unlink/transfer, dismiss/restore, merge (#62–#65).
- `GET /api/accounts` and its cursor, counts and silent-contact toggle (#60).
- Repointing the dashboard and the mock at these routes (#66–#68); mock mode still serves the legacy handlers.
- Retiring `/api/persons*` and `/api/identities` (#69) — both still serve, so nothing that reads them breaks.
- Digesting only the rows that survive `?q=`/`?level=`. Worth it if a filtered listing ever gets hot; today the unfiltered listing is the common call and saves nothing.
- Who owns an account when two people map two of its addressings. The union picks the lowest person id; this listing gives each of them the history. Worth pinning in the contract before merge and transfer have to reason about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)