### PR TITLE
feat(core): move an account between people with an explicit transfer

### DIFF
--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -1,18 +1,18 @@
 // The People surface's contract, in two nouns — a person, and the accounts
 // they are reachable at:
 //
-//   GET /api/people              -> PeopleList (curated people only)
-//   GET /api/people/:id          -> PersonResource
-//   GET /api/people/:id/messages -> TimelinePage
-//   GET /api/accounts            -> AccountDirectory
-//
-// The write half. `POST /api/people` is served. The rest are request types
-// that lead, with the backend following (issues #63–#65):
-//
-//   POST   /api/people               -> PersonResource (201) | LinkConflict (409)
-//   PATCH  /api/people/:id           -> PersonResource
-//   POST   /api/people/:id/accounts  -> PersonResource | LinkConflict (409)
+//   GET    /api/people              -> PeopleList (curated people only)
+//   GET    /api/people/:id          -> PersonResource
+//   GET    /api/people/:id/messages -> TimelinePage
+//   GET    /api/accounts            -> AccountDirectory
+//   POST   /api/people              -> PersonResource (201) | LinkConflict (409)
+//   POST   /api/people/:id/accounts -> PersonResource | LinkConflict (409)
 //   DELETE /api/people/:id/accounts/:channel/:channelUserId -> PersonResource
+//
+// The rest are request types that lead, with the backend following (issues
+// #64, #65):
+//
+//   PATCH  /api/people/:id           -> PersonResource
 //   POST   /api/people/:id/merge     -> PersonResource
 //   POST   /api/accounts/:channel/:channelUserId/dismiss  -> DirectoryAccount
 //   POST   /api/accounts/:channel/:channelUserId/restore  -> DirectoryAccount
@@ -20,6 +20,8 @@
 // The vocabulary is docs/concepts/identity.md's. Rome never mints an account:
 // an account is platform-owned, named by the pair (channel, channelUserId),
 // and the only identity fact Rome contributes is which person it belongs to.
+// So the writes here move a link between people; none of them creates or
+// destroys the account under it.
 //
 // The timeline's entry shape, its ordering and its cursor are the identity
 // union's, and they are re-exported rather than restated. The surfaces page
@@ -600,29 +602,52 @@ export interface LinkAccountRequest {
   transferFrom?: string;
 }
 
-/** The 409 body for a refused link or dismissal: names the current owner so
- *  the caller can render the conflict and offer an explicit transfer. Never
- *  the stranger sentinel — a dismissal-held account never conflicts. */
+/**
+ * The request a body carries, or null when it is not one — a channel
+ * {@link accountRef} cannot name and an empty identifier name no account, and
+ * an empty `transferFrom` is a caller that meant to name an owner.
+ */
+export function parseLinkAccountRequest(body: unknown): LinkAccountRequest | null {
+  if (typeof body !== "object" || body === null) return null;
+  const { channel, channelUserId, transferFrom } = body as Record<string, unknown>;
+  if (typeof channel !== "string" || !isChannelIdentifier(channel)) return null;
+  if (typeof channelUserId !== "string" || channelUserId === "") return null;
+  if (transferFrom === undefined) return { channel, channelUserId };
+  if (typeof transferFrom !== "string" || transferFrom === "") return null;
+  return { channel, channelUserId, transferFrom };
+}
+
+/**
+ * The 409 body for a refused link or dismissal: names the current owner so the
+ * caller can render the conflict and offer an explicit transfer. Never the
+ * stranger sentinel — a dismissal-held account never conflicts.
+ *
+ * The owner is null in one case: a `transferFrom` naming someone who does not
+ * hold the account, where the account is now held by nobody. The caller's view
+ * of the owner is stale either way, and this is the answer that says so.
+ */
 export interface LinkConflict {
   error: string;
   channel: string;
   channelUserId: string;
-  linkedPersonId: string;
-  linkedPersonName: string;
+  linkedPersonId: string | null;
+  linkedPersonName: string | null;
 }
 
 /** Phrase a {@link LinkConflict}, wording included, so every route and the
  *  mock refuse in the same words. */
 export function linkConflict(
   account: { channel: string; channelUserId: string },
-  holder: { id: string; displayName: string },
+  holder: { id: string; displayName: string } | null,
 ): LinkConflict {
   return {
-    error: `${account.channel}:${account.channelUserId} is already linked to ${holder.displayName}`,
+    error: holder
+      ? `${account.channel}:${account.channelUserId} is already linked to ${holder.displayName}`
+      : `${account.channel}:${account.channelUserId} is linked to nobody`,
     channel: account.channel,
     channelUserId: account.channelUserId,
-    linkedPersonId: holder.id,
-    linkedPersonName: holder.displayName,
+    linkedPersonId: holder?.id ?? null,
+    linkedPersonName: holder?.displayName ?? null,
   };
 }
 

--- a/packages/core/src/api/routes/people.test.ts
+++ b/packages/core/src/api/routes/people.test.ts
@@ -1136,6 +1136,18 @@ describe("People account links", () => {
     expect(await holderOf(ALICES)).toBeNull();
   });
 
+  it("unlinks an account whose identifier carries the path separator", async () => {
+    // A channel mints its own addresses, so nothing promises they avoid "/".
+    const SLASHED = { channel: "slack", channelUserId: "T0ABCDEF/U0123456" };
+    expect((await link(alice, SLASHED)).status).toBe(200);
+
+    const res = await unlink(alice, SLASHED);
+
+    expect(res.status).toBe(200);
+    expect(refs((await res.json()) as PersonResource)).toEqual(["telegram:tg-alice"]);
+    expect(await holderOf(SLASHED)).toBeNull();
+  });
+
   it("answers 404 when the person does not hold the account", async () => {
     // Held by someone else, so unlinking it here would be a way to reach into
     // their accounts.

--- a/packages/core/src/api/routes/people.test.ts
+++ b/packages/core/src/api/routes/people.test.ts
@@ -941,3 +941,207 @@ describe("People create API", () => {
     return (await res.json()) as PeopleList;
   }
 });
+
+// POST/DELETE /people/:id/accounts — the link verb, and the compare-and-swap
+// that decides who an account's whole history belongs to. These tests pin what
+// a caller working from a stale page is told, and that being told it leaves
+// the stored link exactly where it was.
+
+describe("People account links", () => {
+  const NEWCOMER = { channel: "telegram", channelUserId: "tg-newcomer" };
+  const DISMISSED = { channel: "telegram", channelUserId: "tg-dismissed" };
+  const BOBS = { channel: "telegram", channelUserId: "tg-bob" };
+  const ALICES = { channel: "telegram", channelUserId: "tg-alice" };
+
+  let testDb: TestDb;
+  let deps: TestDeps;
+  let app: Hono;
+  let baseline: BaselineIds;
+  let alice: string;
+  let bob: string;
+  let carol: string;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    baseline = await seedBaseline(testDb.db);
+    deps = await buildTestDeps(testDb.db);
+    app = new Hono().route("/", peopleRoutes(deps));
+    alice = baseline.persons.innerCircleId;
+    bob = baseline.persons.acquaintanceId;
+    carol = baseline.persons.otherId;
+
+    // An account the guardian set aside: stored as a link onto the sentinel,
+    // which is a dismissal rather than a person holding it.
+    await deps.personMappingRepo.addChannelMapping(
+      STRANGER_PERSON_ID,
+      DISMISSED.channel,
+      DISMISSED.channelUserId,
+      "Dismissed Sender",
+    );
+  });
+
+  afterEach(() => testDb.close());
+
+  const link = (personId: string, body: unknown) =>
+    app.request(`/people/${personId}/accounts`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  const unlink = (personId: string, account: { channel: string; channelUserId: string }) =>
+    app.request(`/people/${personId}/accounts/${account.channel}/${account.channelUserId}`, {
+      method: "DELETE",
+    });
+
+  const refs = (person: PersonResource) =>
+    person.accounts.map((account) => `${account.channel}:${account.channelUserId}`);
+
+  async function accountsOf(id: string): Promise<string[]> {
+    const res = await app.request(`/people/${id}`);
+    expect(res.status).toBe(200);
+    return refs((await res.json()) as PersonResource);
+  }
+
+  /** Who the stored link says holds an account, or null when nothing does. */
+  async function holderOf(account: { channel: string; channelUserId: string }) {
+    const person = await deps.personMappingRepo.findByChannelUser(
+      account.channel,
+      account.channelUserId,
+    );
+    return person?.id ?? null;
+  }
+
+  it("takes an account nobody holds, and answers the person holding it now", async () => {
+    const res = await link(alice, NEWCOMER);
+
+    expect(res.status).toBe(200);
+    const person = (await res.json()) as PersonResource;
+    expect(person.id).toBe(alice);
+    expect(refs(person)).toEqual(expect.arrayContaining(["telegram:tg-newcomer"]));
+    expect(await holderOf(NEWCOMER)).toBe(alice);
+  });
+
+  it("takes a dismissed account without being told to", async () => {
+    // A dismissal is a link onto the sentinel, not a person's claim, so naming
+    // the sender takes it back with no transfer to declare.
+    const res = await link(alice, DISMISSED);
+
+    expect(res.status).toBe(200);
+    expect(await holderOf(DISMISSED)).toBe(alice);
+  });
+
+  it("refuses an account another person holds, and names them", async () => {
+    const res = await link(alice, BOBS);
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      channel: "telegram",
+      channelUserId: "tg-bob",
+      linkedPersonId: bob,
+      linkedPersonName: "Bob Acquaintance",
+    });
+    expect(await holderOf(BOBS)).toBe(bob);
+    expect(await accountsOf(alice)).toEqual(["telegram:tg-alice"]);
+  });
+
+  it("moves an account when transferFrom names the person holding it", async () => {
+    const res = await link(alice, { ...BOBS, transferFrom: bob });
+
+    expect(res.status).toBe(200);
+    expect(refs((await res.json()) as PersonResource)).toEqual(
+      expect.arrayContaining(["telegram:tg-alice", "telegram:tg-bob"]),
+    );
+    expect(await accountsOf(bob)).toEqual([]);
+  });
+
+  it("refuses a stale transferFrom and moves nothing", async () => {
+    const wrongOwner = await link(alice, { ...BOBS, transferFrom: carol });
+
+    expect(wrongOwner.status).toBe(409);
+    expect(await wrongOwner.json()).toMatchObject({ linkedPersonId: bob });
+    expect(await holderOf(BOBS)).toBe(bob);
+
+    // The same staleness the other way round: the caller names an owner for an
+    // account that has none, so their view is wrong and the swap fails.
+    const noOwner = await link(alice, { ...NEWCOMER, transferFrom: bob });
+
+    expect(noOwner.status).toBe(409);
+    expect(await noOwner.json()).toMatchObject({ linkedPersonId: null, linkedPersonName: null });
+    expect(await holderOf(NEWCOMER)).toBeNull();
+  });
+
+  it("never names the sentinel as an account's holder", async () => {
+    const res = await link(alice, { ...DISMISSED, transferFrom: bob });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body).toMatchObject({ linkedPersonId: null, linkedPersonName: null });
+    expect(JSON.stringify(body)).not.toContain(STRANGER_PERSON_ID);
+    expect(await holderOf(DISMISSED)).toBe(STRANGER_PERSON_ID);
+  });
+
+  it("answers a re-link to the same person without disturbing their accounts", async () => {
+    const plain = await link(alice, ALICES);
+    expect(plain.status).toBe(200);
+    expect(refs((await plain.json()) as PersonResource)).toEqual(["telegram:tg-alice"]);
+
+    // A retry that carries the owner it read is naming this person, which is
+    // the same request answered twice rather than a transfer.
+    const withTransfer = await link(alice, { ...ALICES, transferFrom: alice });
+    expect(withTransfer.status).toBe(200);
+    expect(await accountsOf(alice)).toEqual(["telegram:tg-alice"]);
+  });
+
+  it("lets only one of two conflicting transfers land the account", async () => {
+    // Both callers read the same page, where Bob holds the account, and both
+    // ask to take it from him.
+    const [first, second] = await Promise.all([
+      link(alice, { ...BOBS, transferFrom: bob }),
+      link(carol, { ...BOBS, transferFrom: bob }),
+    ]);
+
+    expect([first.status, second.status].sort()).toEqual([200, 409]);
+    const holder = await holderOf(BOBS);
+    expect([alice, carol]).toContain(holder);
+    expect(await accountsOf(bob)).toEqual([]);
+    // The loser is told who holds it now, so its next attempt can be the
+    // explicit transfer from whoever won.
+    const refused = first.status === 409 ? first : second;
+    expect(await refused.json()).toMatchObject({ linkedPersonId: holder });
+  });
+
+  it("refuses a body that names no account", async () => {
+    expect((await link(alice, {})).status).toBe(400);
+    expect((await link(alice, { channel: "telegram" })).status).toBe(400);
+    expect((await link(alice, { ...BOBS, transferFrom: "" })).status).toBe(400);
+    expect(await accountsOf(alice)).toEqual(["telegram:tg-alice"]);
+  });
+
+  it("answers 404 for an unknown person and for the stranger sentinel", async () => {
+    expect((await link("nobody-here", NEWCOMER)).status).toBe(404);
+    expect((await link(STRANGER_PERSON_ID, NEWCOMER)).status).toBe(404);
+    expect((await unlink("nobody-here", ALICES)).status).toBe(404);
+    expect((await unlink(STRANGER_PERSON_ID, DISMISSED)).status).toBe(404);
+    expect(await holderOf(DISMISSED)).toBe(STRANGER_PERSON_ID);
+  });
+
+  it("unlinks only the account named", async () => {
+    expect((await link(alice, NEWCOMER)).status).toBe(200);
+
+    const res = await unlink(alice, ALICES);
+
+    expect(res.status).toBe(200);
+    expect(refs((await res.json()) as PersonResource)).toEqual(["telegram:tg-newcomer"]);
+    expect(await holderOf(ALICES)).toBeNull();
+  });
+
+  it("answers 404 when the person does not hold the account", async () => {
+    // Held by someone else, so unlinking it here would be a way to reach into
+    // their accounts.
+    expect((await unlink(alice, BOBS)).status).toBe(404);
+    expect(await holderOf(BOBS)).toBe(bob);
+
+    expect((await unlink(alice, NEWCOMER)).status).toBe(404);
+  });
+});

--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -1,8 +1,10 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import {
   comparePeople,
   countPeople,
+  linkConflict,
   parseCreatePersonRequest,
+  parseLinkAccountRequest,
   parsePersonFilterLevel,
   parseTimelineCursor,
   personMatchesLevel,
@@ -17,10 +19,12 @@ import { personTimelineSources, timelineAccounts } from "../../people/timeline-s
 import type { ApiDeps } from "../deps.js";
 
 // The People surface. What a person and their accounts are, how the listing
-// orders and counts, what a valid create is and what a refused link answers
-// are the contract's (@rome/api-types/people); serializing a person is
-// `src/people/resource.ts`, creating one is `src/people/create.ts`, and which
-// stores a history is merged from is the rest of `src/people/`. These handlers
+// orders and counts, what a valid create is, when a link may be taken and what
+// a refused one answers are the contract's (@rome/api-types/people);
+// serializing a person is `src/people/resource.ts`, creating one is
+// `src/people/create.ts`, and which stores a history is merged from is the rest
+// of `src/people/`. The compare-and-swap a link rides on is the person
+// repository's, because only a transaction there can decide it. These handlers
 // read the request and pick a status code, and hold no rule of their own.
 
 export function peopleRoutes(deps: ApiDeps): Hono {
@@ -64,6 +68,48 @@ export function peopleRoutes(deps: ApiDeps): Hono {
     return person ? c.json(person) : c.json({ error: "Unknown person" }, 404);
   });
 
+  app.post("/people/:id/accounts", async (c) => {
+    const person = await findPerson(deps, c.req.param("id"));
+    if (!person) return c.json({ error: "Unknown person" }, 404);
+
+    const request = parseLinkAccountRequest(await c.req.json().catch(() => null));
+    if (!request) return c.json({ error: "channel and channelUserId are required" }, 400);
+
+    const result = await deps.personMappingRepo.linkAccount({
+      personId: person.id,
+      channel: request.channel,
+      channelUserId: request.channelUserId,
+      transferFrom: request.transferFrom,
+    });
+    if (!result.linked) {
+      const { holder } = result;
+      return c.json(
+        linkConflict(request, holder && { id: holder.personId, displayName: holder.personName }),
+        409,
+      );
+    }
+
+    return respondWithPerson(deps, c, person.id);
+  });
+
+  app.delete("/people/:id/accounts/:channel/:channelUserId", async (c) => {
+    const person = await findPerson(deps, c.req.param("id"));
+    if (!person) return c.json({ error: "Unknown person" }, 404);
+
+    // A link this person does not hold is one this route cannot drop, whoever
+    // else holds it: unlinking is not a way to reach into another person's
+    // accounts, and reporting success would tell the caller their view was
+    // right when it was stale.
+    const unlinked = await deps.personMappingRepo.unlinkAccount(
+      person.id,
+      c.req.param("channel"),
+      c.req.param("channelUserId"),
+    );
+    if (!unlinked) return c.json({ error: "Unknown account" }, 404);
+
+    return respondWithPerson(deps, c, person.id);
+  });
+
   app.get("/people/:id/messages", async (c) => {
     const person = await findPerson(deps, c.req.param("id"));
     if (!person) return c.json({ error: "Unknown person" }, 404);
@@ -91,4 +137,12 @@ export function peopleRoutes(deps: ApiDeps): Hono {
   });
 
   return app;
+}
+
+/** The person a write just changed, read back through the same serializer the
+ *  reads answer with, so a client can render the outcome without a second
+ *  request. */
+async function respondWithPerson(deps: ApiDeps, c: Context, id: string) {
+  const person = await readPerson(deps, id);
+  return person ? c.json(person) : c.json({ error: "Unknown person" }, 404);
 }

--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -92,7 +92,12 @@ export function peopleRoutes(deps: ApiDeps): Hono {
     return respondWithPerson(deps, c, person.id);
   });
 
-  app.delete("/people/:id/accounts/:channel/:channelUserId", async (c) => {
+  // The identifier takes the rest of the path, separators included. A channel
+  // mints its own addresses and channels are open — a Rome App brings one — so
+  // there is no format to promise they avoid "/", and a plain segment would
+  // answer 404 for an account that exists rather than unlinking it. The channel
+  // name above stays one segment, which `accountRef` already requires of it.
+  app.delete("/people/:id/accounts/:channel/:channelUserId{.+}", async (c) => {
     const person = await findPerson(deps, c.req.param("id"));
     if (!person) return c.json({ error: "Unknown person" }, 404);
 

--- a/packages/core/src/db/repositories/person-mapping.test.ts
+++ b/packages/core/src/db/repositories/person-mapping.test.ts
@@ -18,6 +18,18 @@ describe("PersonMappingRepository", () => {
     testDb.close();
   });
 
+  /** What marking a sender as a stranger does: file the identity under the
+   *  sentinel rather than deleting it. */
+  async function dismiss(channel: string, channelUserId: string, displayName?: string) {
+    if (!(await repo.findById(STRANGER_PERSON_ID))) {
+      await repo.createWithId(STRANGER_PERSON_ID, {
+        displayName: "Stranger",
+        bondLevel: "other",
+      });
+    }
+    await repo.addChannelMapping(STRANGER_PERSON_ID, channel, channelUserId, displayName);
+  }
+
   it("findAllWithMappings() reads every person and their identities at once", async () => {
     // One statement, so an identity moving between two people mid-read cannot
     // land under both of them — which is the identity union's whole premise.
@@ -445,19 +457,134 @@ describe("PersonMappingRepository", () => {
     });
   });
 
-  describe("create() claiming channel identities", () => {
-    /** What marking a sender as a stranger does: file the identity under the
-     *  sentinel rather than deleting it. */
-    async function dismiss(channel: string, channelUserId: string, displayName?: string) {
-      if (!(await repo.findById(STRANGER_PERSON_ID))) {
-        await repo.createWithId(STRANGER_PERSON_ID, {
-          displayName: "Stranger",
-          bondLevel: "other",
-        });
-      }
-      await repo.addChannelMapping(STRANGER_PERSON_ID, channel, channelUserId, displayName);
-    }
+  describe("linkAccount() compare-and-swap", () => {
+    it("takes an account nobody holds, and names it only from the channel", async () => {
+      const person = await repo.create({ displayName: "Alice", bondLevel: "other" });
 
+      expect(
+        await repo.linkAccount({ personId: person, channel: "telegram", channelUserId: "tg-new" }),
+      ).toEqual({ linked: true });
+
+      const rows = await testDb.db
+        .select()
+        .from(channelMappings)
+        .where(eq(channelMappings.channelUserId, "tg-new"));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].personId).toBe(person);
+      // A link names an account; what to call it is the provider directory's
+      // answer at read time, so a claim invents no name.
+      expect(rows[0].displayName).toBeNull();
+    });
+
+    it("refuses an account a real person holds, and writes nothing", async () => {
+      const holder = await repo.create({ displayName: "Holder", bondLevel: "other" });
+      const claimant = await repo.create({ displayName: "Claimant", bondLevel: "other" });
+      await repo.addChannelMapping(holder, "telegram", "tg-held", "Held");
+
+      const result = await repo.linkAccount({
+        personId: claimant,
+        channel: "telegram",
+        channelUserId: "tg-held",
+      });
+
+      expect(result).toEqual({
+        linked: false,
+        holder: {
+          channel: "telegram",
+          channelUserId: "tg-held",
+          personId: holder,
+          personName: "Holder",
+        },
+      });
+      const rows = await testDb.db
+        .select()
+        .from(channelMappings)
+        .where(eq(channelMappings.channelUserId, "tg-held"));
+      expect(rows.map((row) => row.personId)).toEqual([holder]);
+    });
+
+    it("reclaims an account that was only dismissed, and keeps its name", async () => {
+      const person = await repo.create({ displayName: "Alice", bondLevel: "other" });
+      await dismiss("telegram", "tg-set-aside", "Sender");
+
+      expect(
+        await repo.linkAccount({
+          personId: person,
+          channel: "telegram",
+          channelUserId: "tg-set-aside",
+        }),
+      ).toEqual({ linked: true });
+
+      // The row moves rather than being replaced, so the name the channel put
+      // on it survives the reclaim.
+      const rows = await testDb.db
+        .select()
+        .from(channelMappings)
+        .where(eq(channelMappings.channelUserId, "tg-set-aside"));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].personId).toBe(person);
+      expect(rows[0].displayName).toBe("Sender");
+    });
+
+    it("lets only the first of two callers working from one view take the account", async () => {
+      const holder = await repo.create({ displayName: "Holder", bondLevel: "other" });
+      const first = await repo.create({ displayName: "First", bondLevel: "other" });
+      const second = await repo.create({ displayName: "Second", bondLevel: "other" });
+      await repo.addChannelMapping(holder, "telegram", "tg-contested");
+
+      // Both read the same page, so both name the same owner to swap out. The
+      // check and the move are one transaction, so the second reads an owner
+      // that is no longer the one it expects instead of overwriting a transfer
+      // it never saw.
+      const won = await repo.linkAccount({
+        personId: first,
+        channel: "telegram",
+        channelUserId: "tg-contested",
+        transferFrom: holder,
+      });
+      const lost = await repo.linkAccount({
+        personId: second,
+        channel: "telegram",
+        channelUserId: "tg-contested",
+        transferFrom: holder,
+      });
+
+      expect(won).toEqual({ linked: true });
+      expect(lost).toEqual({
+        linked: false,
+        holder: {
+          channel: "telegram",
+          channelUserId: "tg-contested",
+          personId: first,
+          personName: "First",
+        },
+      });
+      const rows = await testDb.db
+        .select()
+        .from(channelMappings)
+        .where(eq(channelMappings.channelUserId, "tg-contested"));
+      expect(rows.map((row) => row.personId)).toEqual([first]);
+    });
+
+    it("unlinkAccount() drops one link and leaves the person's others", async () => {
+      const person = await repo.create({ displayName: "Alice", bondLevel: "other" });
+      await repo.addChannelMapping(person, "telegram", "tg-one");
+      await repo.addChannelMapping(person, "whatsapp", "wa-one");
+
+      expect(await repo.unlinkAccount(person, "telegram", "tg-one")).toBe(true);
+      // A link nobody holds, and one held by somebody else, are both nothing
+      // for this person to drop.
+      expect(await repo.unlinkAccount(person, "telegram", "tg-one")).toBe(false);
+
+      const rows = await testDb.db
+        .select()
+        .from(channelMappings)
+        .where(eq(channelMappings.personId, person));
+      expect(rows.map((row) => row.channelUserId)).toEqual(["wa-one"]);
+    });
+  });
+
+  describe("create() claiming channel identities", () => {
     it("reclaims an identity that was only dismissed onto the stranger sentinel", async () => {
       await dismiss("whatsapp", "+15551234", "Bob");
 

--- a/packages/core/src/db/repositories/person-mapping.ts
+++ b/packages/core/src/db/repositories/person-mapping.ts
@@ -46,6 +46,15 @@ export class AccountHeldError extends Error {
   }
 }
 
+/** What a {@link PersonMappingRepository.linkAccount} attempt did: took the
+ *  account, or refused it and named whoever holds it — null where nobody does,
+ *  which is what a stale `transferFrom` runs into.
+ *
+ *  A result rather than an {@link AccountHeldError}: a refused link is the
+ *  ordinary answer to a stale page, not the exceptional one it is for a create,
+ *  where the account is the reason the person was being written at all. */
+export type LinkAccountResult = { linked: true } | { linked: false; holder: AccountHolder | null };
+
 export interface NewPersonData {
   displayName: string;
   bondLevel: "guardian" | "inner-circle" | "acquaintance" | "other";
@@ -563,13 +572,91 @@ export class PersonMappingRepository {
       .run();
   }
 
-  async reassignChannelMapping(channel: string, channelUserId: string, newPersonId: string) {
-    await this.db
-      .update(channelMappings)
-      .set({ personId: newPersonId })
+  /**
+   * Link an account to a person, if it is still where the caller last saw it.
+   *
+   * `transferFrom` is the owner the caller is taking the account from, and it
+   * has to hold the account at the moment of the write. Omitted, the caller is
+   * claiming an account they believe nobody holds — an unlinked one, one only
+   * dismissed onto the sentinel, or one this person already holds, which is the
+   * same request arriving twice. Every other case refuses and names the holder.
+   *
+   * The read and the move are one transaction, so of two callers working from
+   * the same page exactly one lands the account: the loser's expected owner is
+   * no longer the owner by the time its own transaction reads, and it is
+   * refused rather than overwriting a transfer it never saw.
+   */
+  async linkAccount(params: {
+    personId: string;
+    channel: string;
+    channelUserId: string;
+    transferFrom?: string | null;
+  }): Promise<LinkAccountResult> {
+    const { personId, channel, channelUserId } = params;
+    const expected = params.transferFrom ?? null;
+
+    return this.db.transaction((tx): LinkAccountResult => {
+      const link = tx
+        .select({
+          id: channelMappings.id,
+          personId: channelMappings.personId,
+          personName: persons.displayName,
+        })
+        .from(channelMappings)
+        .innerJoin(persons, eq(persons.id, channelMappings.personId))
+        .where(
+          and(
+            eq(channelMappings.channel, channel),
+            eq(channelMappings.channelUserId, channelUserId),
+          ),
+        )
+        .get();
+
+      // A dismissal is a link onto the sentinel rather than a placement, so it
+      // holds the account against nobody: naming its sender takes it back, on
+      // the same terms as {@link resolveClaims}.
+      const holder: AccountHolder | null =
+        link && link.personId !== STRANGER_PERSON_ID
+          ? { channel, channelUserId, personId: link.personId, personName: link.personName }
+          : null;
+
+      const swapped =
+        expected === null
+          ? holder === null || holder.personId === personId
+          : holder?.personId === expected;
+      if (!swapped) return { linked: false, holder };
+
+      if (link == null) {
+        // The channel's name for the account is not this caller's to supply —
+        // a link names an account, and what to call it comes from the provider
+        // directory at read time.
+        tx.insert(channelMappings)
+          .values({ id: uuid(), personId, channel, channelUserId, displayName: null })
+          .run();
+      } else if (link.personId !== personId) {
+        // The row moves rather than being replaced, so the channel-side name it
+        // carries survives a transfer the way it survives a reclaim.
+        tx.update(channelMappings).set({ personId }).where(eq(channelMappings.id, link.id)).run();
+      }
+      return { linked: true };
+    });
+  }
+
+  /** Drop one person's link to an account, leaving the account itself and
+   *  every other link they hold alone. Reports whether the link was theirs to
+   *  drop, which is the only way a caller can tell an unlink from a no-op. */
+  async unlinkAccount(personId: string, channel: string, channelUserId: string): Promise<boolean> {
+    const result = this.db
+      .delete(channelMappings)
       .where(
-        and(eq(channelMappings.channel, channel), eq(channelMappings.channelUserId, channelUserId)),
-      );
+        and(
+          eq(channelMappings.personId, personId),
+          eq(channelMappings.channel, channel),
+          eq(channelMappings.channelUserId, channelUserId),
+        ),
+      )
+      .run();
+    return result.changes > 0;
   }
 }
 


### PR DESCRIPTION
## What this PR does

The People surface can read a person and the accounts they are linked to, but nothing on it can change a link. Placing an account is still the verb-style `POST /api/persons/link`, whose write re-points whatever it finds: two guardians working from the same page, or one retrying a request that already landed, take the account from each other with neither of them told.

This PR adds `POST /api/people/:id/accounts` and `DELETE /api/people/:id/accounts/:channel/:channelUserId`, and the link half of `@rome/api-types/people` they speak. Closes #63.

## Design & Invariants

- **A link changes hands only by compare-and-swap.** Claiming an account nobody holds needs nothing declared, and re-linking one this person already holds is the same request answered twice. Taking an account from another person requires `transferFrom` naming that person exactly; anything else answers 409 with the holder actually found. A link decides who every message an account ever sent belongs to, so a transfer re-attributes a whole history — it is a thing the guardian says, never the side effect of a retry against a page that moved.
- **The check and the move are one transaction**, in the person repository, so of two callers holding the same stale view exactly one lands the account: the loser's expected owner is no longer the owner by the time its own transaction reads. A route that read the owner and then wrote would let both of them win, and the second would silently undo a transfer it never saw.
- **A dismissal holds an account against nobody.** It is a link onto the stranger sentinel rather than a person's claim, so naming the sender takes the account back with no transfer to declare. No refusal ever names the sentinel — a caller handed that id would render a row no write may touch. It is the rule `accountPresentation` states for the directory and `create()` already claims identities by, extended rather than restated.
- **Rome never creates or destroys an account**, per [`docs/concepts/identity.md`](docs/concepts/identity.md) — both verbs move the link under it and nothing else. Unlinking drops one link and leaves the person's others alone, and a link the person does not hold is not theirs to drop: 404 rather than a way to reach into another person's accounts.
- **A link carries no name.** A claim writes a null channel-side name and a transfer moves the row, so what to call an account stays the provider directory's answer at read time and survives changing hands.
- The request parse and the conflict body read an account's identity through `accountRef`, so what may name a channel is the directory's answer here too, and a conflict renders the account as the same token a directory row keys on.
- Alternative considered: an unconditional re-point (what `POST /api/persons/link` does today) with a read-before-write guard in the route. Rejected — the guard is not the write, so the race it is there for passes straight through it.

## Test plan

- [x] `pnpm typecheck` (full workspace)
- [x] `pnpm test:unit` — 4022 core tests, including 12 new route tests (`src/api/routes/people.test.ts`) and 5 new repository tests (`src/db/repositories/person-mapping.test.ts`)
- [x] Two conflicting transfers issued together: exactly one answers 200, the other 409 naming the winner, and the stored link is the winner's
- [x] `biome check` on the changed files (devShell biome)
- [ ] `pnpm dev:all` — no docker socket in this environment; the routes are exercised through Hono in the unit suite

## Not in this PR

- Dismiss and restore on accounts — #64, riding the same link machinery.
- Merge — #65, which is N transfers plus a delete made atomic.
- Retiring `POST /api/persons/link` and `POST /api/persons/mark-stranger` — #69, after the dashboard repoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)