### PR TITLE
feat(core): create people atomically

### DIFF
--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -6,10 +6,10 @@
 //   GET /api/people/:id/messages -> TimelinePage
 //   GET /api/accounts            -> AccountDirectory
 //
-// The write half — no core route serves these yet; the request types lead and
-// the backend follows (issues #62–#65):
+// The write half. `POST /api/people` is served. The rest are request types
+// that lead, with the backend following (issues #63–#65):
 //
-//   POST   /api/people               -> PersonResource (201; atomic create-and-link)
+//   POST   /api/people               -> PersonResource (201) | LinkConflict (409)
 //   PATCH  /api/people/:id           -> PersonResource
 //   POST   /api/people/:id/accounts  -> PersonResource | LinkConflict (409)
 //   DELETE /api/people/:id/accounts/:channel/:channelUserId -> PersonResource
@@ -29,9 +29,11 @@
 // disagree about.
 
 import {
+  ASSIGNABLE_BOND_LEVELS,
   compareIdentityCursors,
   encodeIdentityCursor,
   identityCursorOf,
+  isAssignableBondLevel,
   isChannelIdentifier,
   matchesQuery,
   normalizeBondLevel,
@@ -58,6 +60,11 @@ export {
   // column is free text — older rows carry levels off today's ladder — so
   // every reader has to bucket them the same way.
   normalizeBondLevel,
+  // The levels a guardian may place a person at. Guardian is not one of them:
+  // the instance serves exactly one, and the ladder's other two positions —
+  // unknown and stranger — are read off the links rather than stored.
+  ASSIGNABLE_BOND_LEVELS,
+  type AssignableBondLevel,
   type IdentityDynamic,
   type TimelineEntry,
   type TimelinePage,
@@ -524,6 +531,52 @@ export interface CreatePersonRequest {
   accounts?: { channel: string; channelUserId: string }[];
 }
 
+/** A create request with its defaults applied: what the write is given. */
+export type NewPerson = Required<CreatePersonRequest>;
+
+/**
+ * Read a request body as a {@link NewPerson}, or say what is wrong with it.
+ *
+ * The rule rather than any one route's rule, so the backend and the dashboard's
+ * mock refuse the same bodies with the same words — the page renders the
+ * `error` string, so the wording is part of what a client is written against.
+ *
+ * A name is trimmed before it is judged, and whitespace alone is no name: it
+ * slugs to nothing, so accepting it would mint a person whose id is a uuid the
+ * guardian never sees a reason for.
+ */
+export function parseCreatePersonRequest(body: unknown): { person: NewPerson } | { error: string } {
+  if (typeof body !== "object" || body === null) return { error: "displayName is required" };
+  const raw = body as Record<string, unknown>;
+
+  const displayName = typeof raw.displayName === "string" ? raw.displayName.trim() : "";
+  if (!displayName) return { error: "displayName is required" };
+
+  if (raw.bondLevel !== undefined && !isAssignableBondLevel(raw.bondLevel)) {
+    return { error: `bondLevel must be one of ${ASSIGNABLE_BOND_LEVELS.join(", ")}` };
+  }
+
+  if (raw.accounts !== undefined && !Array.isArray(raw.accounts)) {
+    return { error: "accounts must be an array of { channel, channelUserId }" };
+  }
+  // Keyed rather than pushed: naming one account twice asks for the state
+  // naming it once produces, and the link table holds one row per account, so
+  // the repeat would abort the write over a request that was never ambiguous.
+  const accounts = new Map<string, NewPerson["accounts"][number]>();
+  for (const entry of (raw.accounts ?? []) as unknown[]) {
+    const account = entry as Partial<NewPerson["accounts"][number]> | null;
+    if (!account?.channel || !account.channelUserId) {
+      return { error: "each account needs a channel and a channelUserId" };
+    }
+    const ref = { channel: account.channel, channelUserId: account.channelUserId };
+    accounts.set(`${ref.channel}\n${ref.channelUserId}`, ref);
+  }
+
+  return {
+    person: { displayName, bondLevel: raw.bondLevel ?? "other", accounts: [...accounts.values()] },
+  };
+}
+
 /** `PATCH /api/people/:id`. The guardian's bond level refuses to change. */
 export interface UpdatePersonRequest {
   displayName?: string;
@@ -556,6 +609,21 @@ export interface LinkConflict {
   channelUserId: string;
   linkedPersonId: string;
   linkedPersonName: string;
+}
+
+/** Phrase a {@link LinkConflict}, wording included, so every route and the
+ *  mock refuse in the same words. */
+export function linkConflict(
+  account: { channel: string; channelUserId: string },
+  holder: { id: string; displayName: string },
+): LinkConflict {
+  return {
+    error: `${account.channel}:${account.channelUserId} is already linked to ${holder.displayName}`,
+    channel: account.channel,
+    channelUserId: account.channelUserId,
+    linkedPersonId: holder.id,
+    linkedPersonName: holder.displayName,
+  };
 }
 
 /** `POST /api/people/:id/merge` — :id absorbs `from`: every link transfers

--- a/packages/api-types/src/persons.ts
+++ b/packages/api-types/src/persons.ts
@@ -68,11 +68,17 @@ export function generatePersonSlug(displayName: string): string {
 /**
  * The id to mint for `base` given the ids already taken that could collide with
  * it — `base` itself, and anything of the form `base-<n>`. Returns `base` when
- * it is free, otherwise `base-<n>` one past the highest numeric suffix in use.
+ * it is free, otherwise `base-<n>`.
  *
- * One past the highest, not the first free slot: reusing the id of a person who
- * has been deleted would silently re-point their old profile file and any
- * channel mapping that outlived them at whoever is created next.
+ * The suffix numbers the person among everyone sharing the name, and `base` is
+ * the first of them: the second Ada Lovelace is `ada-lovelace-2`, the third
+ * `ada-lovelace-3`. So the id a guardian reads on the People page counts the
+ * way they would count, and no id claims to be the first of a name that
+ * already has one.
+ *
+ * One past the highest suffix in use, not the first free slot: reusing the id
+ * of a person who has been deleted would silently re-point their old profile
+ * file and any channel mapping that outlived them at whoever is created next.
  *
  * Callers may pass ids that cannot collide; they are ignored. Passing only a
  * pre-filtered set is therefore an optimization, never a correctness condition.
@@ -81,7 +87,7 @@ export function nextAvailablePersonId(base: string, taken: Iterable<string>): st
   const takenIds = [...taken];
   if (!takenIds.includes(base)) return base;
 
-  let suffix = 1;
+  let suffix = 2;
   for (const id of takenIds) {
     if (!id.startsWith(`${base}-`)) continue;
     const num = Number.parseInt(id.slice(base.length + 1), 10);

--- a/packages/core/src/api/routes/people.test.ts
+++ b/packages/core/src/api/routes/people.test.ts
@@ -755,3 +755,189 @@ describe("People API", () => {
     return (await res.json()) as TimelinePage;
   }
 });
+
+// POST /people — the guardian names someone, and says which accounts are
+// theirs. Both halves land or neither does, so most of these tests check what
+// is in the database after a refusal rather than only the status code.
+
+describe("People create API", () => {
+  const ALICE_JID = "15550002222@s.whatsapp.net";
+  const BOB_JID = "15550003333@s.whatsapp.net";
+
+  let testDb: TestDb;
+  let deps: TestDeps;
+  let app: Hono;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    await seedBaseline(testDb.db);
+    deps = await buildTestDeps(testDb.db);
+    app = new Hono().route("/", peopleRoutes(deps));
+
+    await deps.whatsAppStoreRepo.upsertContacts([
+      { jid: ALICE_JID, phoneNumber: "15550002222", name: "Alice Marsh" },
+      { jid: BOB_JID, phoneNumber: "15550003333", name: "Bob Reyes" },
+    ]);
+  });
+
+  afterEach(() => testDb.close());
+
+  it("creates the person and both links, named as each platform names them", async () => {
+    const res = await create({
+      displayName: "Bob Reyes",
+      bondLevel: "inner-circle",
+      accounts: [
+        { channel: "whatsapp", channelUserId: BOB_JID },
+        { channel: "telegram", channelUserId: "tg-bob-reyes" },
+      ],
+    });
+
+    expect(res.status).toBe(201);
+    const person = (await res.json()) as PersonResource;
+    expect(person.id).toBe("bob-reyes");
+    expect(person.bondLevel).toBe("inner-circle");
+    expect(person.accounts).toEqual([
+      { channel: "whatsapp", channelUserId: BOB_JID, displayName: "Bob Reyes" },
+      // No mirror answers for telegram, so the address is the only name there
+      // is — the person's own name never stands in for it.
+      { channel: "telegram", channelUserId: "tg-bob-reyes", displayName: "tg-bob-reyes" },
+    ]);
+
+    // The response is a read of what was written, not a copy of the request.
+    expect(await fetchPerson("bob-reyes")).toEqual(person);
+    const { people } = await fetchList();
+    expect(people.map((p) => p.id)).toContain("bob-reyes");
+  });
+
+  it("places a person at 'other' when the request names no bond level", async () => {
+    const res = await create({ displayName: "Unranked" });
+    expect(res.status).toBe(201);
+    expect(((await res.json()) as PersonResource).bondLevel).toBe("other");
+  });
+
+  it("refuses the whole request over one held account, and writes nothing", async () => {
+    const alice = await deps.personMappingRepo.create({
+      displayName: "Alice Marsh",
+      bondLevel: "inner-circle",
+      approved: true,
+      channelMappings: [{ channel: "whatsapp", channelUserId: ALICE_JID }],
+    });
+
+    const res = await create({
+      displayName: "Bob Reyes",
+      accounts: [
+        { channel: "telegram", channelUserId: "tg-bob-reyes" },
+        { channel: "whatsapp", channelUserId: ALICE_JID },
+      ],
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: expect.stringContaining("Alice Marsh"),
+      channel: "whatsapp",
+      channelUserId: ALICE_JID,
+      linkedPersonId: alice,
+      linkedPersonName: "Alice Marsh",
+    });
+
+    // Neither half of the request survived: no person, and the account that
+    // was free before the call is still free.
+    expect((await fetchPeopleRes("bob-reyes")).status).toBe(404);
+    expect(await deps.personMappingRepo.findByChannelUser("telegram", "tg-bob-reyes")).toBeNull();
+    expect((await deps.personMappingRepo.findByChannelUser("whatsapp", ALICE_JID))?.id).toBe(alice);
+  });
+
+  it("links an account that only a dismissal held", async () => {
+    await deps.personMappingRepo.addChannelMapping(
+      STRANGER_PERSON_ID,
+      "whatsapp",
+      BOB_JID,
+      "Bob Reyes",
+    );
+
+    const res = await create({
+      displayName: "Bob Reyes",
+      accounts: [{ channel: "whatsapp", channelUserId: BOB_JID }],
+    });
+
+    expect(res.status).toBe(201);
+    expect((await deps.personMappingRepo.findByChannelUser("whatsapp", BOB_JID))?.id).toBe(
+      "bob-reyes",
+    );
+    const sentinel = await deps.personMappingRepo.findById(STRANGER_PERSON_ID);
+    expect(sentinel!.channelMappings).toHaveLength(0);
+  });
+
+  it("numbers people who share a name, counting the first as one", async () => {
+    const ids: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const res = await create({ displayName: "Ada Lovelace" });
+      expect(res.status).toBe(201);
+      ids.push(((await res.json()) as PersonResource).id);
+    }
+    expect(ids).toEqual(["ada-lovelace", "ada-lovelace-2", "ada-lovelace-3"]);
+  });
+
+  it("links an account once when the request names it twice", async () => {
+    const res = await create({
+      displayName: "Bob Reyes",
+      accounts: [
+        { channel: "whatsapp", channelUserId: BOB_JID },
+        { channel: "whatsapp", channelUserId: BOB_JID },
+      ],
+    });
+
+    expect(res.status).toBe(201);
+    expect(((await res.json()) as PersonResource).accounts).toHaveLength(1);
+  });
+
+  it("answers 400 with an error body for a request nobody can act on", async () => {
+    for (const body of [
+      {},
+      { displayName: "   " },
+      { displayName: "Bob", bondLevel: "guardian" },
+      { displayName: "Bob", bondLevel: "colleague" },
+      { displayName: "Bob", accounts: [{ channel: "whatsapp" }] },
+      { displayName: "Bob", accounts: "whatsapp" },
+    ]) {
+      const res = await create(body);
+      expect(res.status, JSON.stringify(body)).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toBeTruthy();
+    }
+
+    // A body that is not JSON at all reads as a request with no name in it.
+    const malformed = await app.request("/people", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+    expect(malformed.status).toBe(400);
+
+    // None of the above left a row behind.
+    expect((await fetchList()).people.map((person) => person.displayName)).not.toContain("Bob");
+  });
+
+  function create(body: unknown) {
+    return app.request("/people", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  function fetchPeopleRes(id: string) {
+    return app.request(`/people/${id}`);
+  }
+
+  async function fetchPerson(id: string): Promise<PersonResource> {
+    const res = await fetchPeopleRes(id);
+    expect(res.status).toBe(200);
+    return (await res.json()) as PersonResource;
+  }
+
+  async function fetchList(): Promise<PeopleList> {
+    const res = await app.request("/people");
+    expect(res.status).toBe(200);
+    return (await res.json()) as PeopleList;
+  }
+});

--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import {
   comparePeople,
   countPeople,
+  parseCreatePersonRequest,
   parsePersonFilterLevel,
   parseTimelineCursor,
   personMatchesLevel,
@@ -9,16 +10,18 @@ import {
   timelinePageLimit,
   type PeopleList,
 } from "@rome/api-types/people";
+import { createPerson } from "../../people/create.js";
 import { findPerson, readPeople, readPerson } from "../../people/resource.js";
 import { readPersonTimeline } from "../../people/timeline.js";
 import { personTimelineSources, timelineAccounts } from "../../people/timeline-sources.js";
 import type { ApiDeps } from "../deps.js";
 
-// The People surface's reads. What a person and their accounts are, how the
-// listing orders and counts, and what a page of history is are the contract's
-// (@rome/api-types/people); serializing a person is `src/people/resource.ts`;
-// which stores a history is merged from is the rest of `src/people/`. These
-// handlers parse query parameters and hold no rule of their own.
+// The People surface. What a person and their accounts are, how the listing
+// orders and counts, what a valid create is and what a refused link answers
+// are the contract's (@rome/api-types/people); serializing a person is
+// `src/people/resource.ts`, creating one is `src/people/create.ts`, and which
+// stores a history is merged from is the rest of `src/people/`. These handlers
+// read the request and pick a status code, and hold no rule of their own.
 
 export function peopleRoutes(deps: ApiDeps): Hono {
   const app = new Hono();
@@ -43,6 +46,17 @@ export function peopleRoutes(deps: ApiDeps): Hono {
         .sort(comparePeople),
       counts: countPeople(matching),
     } satisfies PeopleList);
+  });
+
+  app.post("/people", async (c) => {
+    const parsed = parseCreatePersonRequest(await c.req.json().catch(() => null));
+    if ("error" in parsed) return c.json({ error: parsed.error }, 400);
+
+    const created = await createPerson(deps, parsed.person);
+    // 409 rather than 400: the body is well formed and the guardian may well
+    // have meant it. A held account is a fact about Rome's state, which a
+    // transfer can change, rather than a mistake in the request.
+    return "conflict" in created ? c.json(created.conflict, 409) : c.json(created.person, 201);
   });
 
   app.get("/people/:id", async (c) => {

--- a/packages/core/src/db/repositories/person-mapping.test.ts
+++ b/packages/core/src/db/repositories/person-mapping.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTestDb, type TestDb } from "../../test/helpers.js";
-import { PersonMappingRepository } from "./person-mapping.js";
+import { AccountHeldError, PersonMappingRepository } from "./person-mapping.js";
 import { eq } from "drizzle-orm";
 import { persons, channelMappings } from "../schema.js";
 import { STRANGER_PERSON_ID } from "../../constants.js";
@@ -504,6 +504,38 @@ describe("PersonMappingRepository", () => {
       ).rejects.toThrow(/already belongs to person "alice"/);
 
       expect((await repo.findByChannelUser("whatsapp", "+15551234"))?.id).toBe(alice);
+    });
+
+    it("names the person holding the identity it refused", async () => {
+      const alice = await repo.create({
+        displayName: "Alice Marsh",
+        bondLevel: "inner-circle",
+        channelMappings: [{ channel: "whatsapp", channelUserId: "+15551234" }],
+      });
+
+      // The holder's own name, not the channel-side one the mapping carries: a
+      // caller reporting the conflict has to say whose account it is, and the
+      // guardian knows the person by the name they gave them.
+      const refused = await repo
+        .create({
+          displayName: "Bob",
+          bondLevel: "inner-circle",
+          channelMappings: [
+            { channel: "telegram", channelUserId: "tg-bob" },
+            { channel: "whatsapp", channelUserId: "+15551234" },
+          ],
+        })
+        .catch((err: unknown) => err);
+
+      expect(refused).toBeInstanceOf(AccountHeldError);
+      expect((refused as AccountHeldError).holder).toEqual({
+        channel: "whatsapp",
+        channelUserId: "+15551234",
+        personId: alice,
+        personName: "Alice Marsh",
+      });
+      // The unheld identity in the same request is still unheld.
+      expect(await repo.findByChannelUser("telegram", "tg-bob")).toBeNull();
     });
 
     it("leaves no half-made person behind when a claim is refused", async () => {

--- a/packages/core/src/db/repositories/person-mapping.ts
+++ b/packages/core/src/db/repositories/person-mapping.ts
@@ -18,6 +18,34 @@ interface ChannelClaim {
   displayName: string | null;
 }
 
+/** An account a person already holds, and the person holding it. */
+export interface AccountHolder {
+  channel: string;
+  channelUserId: string;
+  personId: string;
+  personName: string;
+}
+
+/**
+ * Thrown when a write would take an account a real person already holds.
+ *
+ * Carries the holder rather than only reporting that there is one: every
+ * caller has to name them, because the guardian decides whether to move the
+ * account and cannot decide without knowing whose it is.
+ *
+ * A dismissed account has no holder. Dismissal files an account under the
+ * stranger sentinel, which is structure rather than a person, so naming its
+ * sender releases it with nothing to refuse.
+ */
+export class AccountHeldError extends Error {
+  constructor(readonly holder: AccountHolder) {
+    super(
+      `Channel identity ${holder.channel}:${holder.channelUserId} already belongs to person "${holder.personId}"`,
+    );
+    this.name = "AccountHeldError";
+  }
+}
+
 export interface NewPersonData {
   displayName: string;
   bondLevel: "guardian" | "inner-circle" | "acquaintance" | "other";
@@ -204,11 +232,15 @@ export class PersonMappingRepository {
    *
    * An identity filed under the stranger sentinel is a dismissal rather than a
    * placement, so naming its sender releases it. An identity a real person
-   * holds stays held: this refuses instead of stealing it, because creating a
-   * person is not a re-point. The refusal is a rollback, not a partial write —
-   * a person committed without their identity would be unreachable and
-   * permanent, since {@link findByName} would then reject every retry as a
-   * duplicate of the wreckage.
+   * holds stays held: this throws {@link AccountHeldError} instead of stealing
+   * it, because creating a person is not a re-point. The refusal is a
+   * rollback, not a partial write — a person committed without their identity
+   * would be unreachable and permanent, since {@link findByName} would then
+   * reject every retry as a duplicate of the wreckage.
+   *
+   * Whatever the caller names, all of it or none of it: the identities are
+   * settled together before the transaction opens, so one held identity in a
+   * list of five leaves the other four where they were.
    */
   async create(data: {
     displayName: string;
@@ -243,9 +275,12 @@ export class PersonMappingRepository {
     for (const mapping of mappings) {
       const held = await this.findChannelMapping(mapping.channel, mapping.channelUserId);
       if (held && held.personId !== STRANGER_PERSON_ID) {
-        throw new Error(
-          `Channel identity ${mapping.channel}:${mapping.channelUserId} already belongs to person "${held.personId}"`,
-        );
+        throw new AccountHeldError({
+          channel: mapping.channel,
+          channelUserId: mapping.channelUserId,
+          personId: held.personId,
+          personName: held.personName,
+        });
       }
       claims.push({
         channel: mapping.channel,
@@ -267,15 +302,19 @@ export class PersonMappingRepository {
       .run();
   }
 
-  /** The row holding a channel identity, or null when nobody holds it. */
+  /** The row holding a channel identity and the name of the person holding it,
+   *  or null when nobody holds it. The join loses nothing — every mapping
+   *  references a person row. */
   private async findChannelMapping(channel: string, channelUserId: string) {
     const rows = await this.db
-      .select()
+      .select({ mapping: channelMappings, personName: persons.displayName })
       .from(channelMappings)
+      .innerJoin(persons, eq(channelMappings.personId, persons.id))
       .where(
         and(eq(channelMappings.channel, channel), eq(channelMappings.channelUserId, channelUserId)),
       );
-    return rows[0] ?? null;
+    const row = rows[0];
+    return row ? { ...row.mapping, personName: row.personName } : null;
   }
 
   /** Write helper for {@link createWithId}, taking an executor (see

--- a/packages/core/src/people/create.ts
+++ b/packages/core/src/people/create.ts
@@ -1,0 +1,68 @@
+// Creating a person, with the accounts the guardian says are theirs.
+//
+// Here rather than in the route because the outcome is a contract decision,
+// not an HTTP one: either the person exists with every account named, or
+// nothing was written and one of those accounts belongs to someone else. The
+// route turns that answer into a status code and holds no rule of its own.
+
+import {
+  linkConflict,
+  type LinkConflict,
+  type NewPerson,
+  type PersonResource,
+} from "@rome/api-types/people";
+import {
+  AccountHeldError,
+  type PersonMappingRepository,
+} from "../db/repositories/person-mapping.js";
+import { readPerson, type PeopleReadDeps } from "./resource.js";
+
+export interface PeopleWriteDeps extends PeopleReadDeps {
+  personMappingRepo: PeopleReadDeps["personMappingRepo"] & Pick<PersonMappingRepository, "create">;
+}
+
+/** The person that now exists, or the account that stopped them existing. */
+export type CreatePersonResult = { person: PersonResource } | { conflict: LinkConflict };
+
+/**
+ * Create a person and link every account named, or write nothing at all.
+ *
+ * Both-or-neither because the halves are worthless apart. A person with none
+ * of their accounts is unreachable — no inbound message resolves to them —
+ * and their name is now taken, so the retry that would repair them reads as a
+ * duplicate instead. An account linked to a person who was never committed is
+ * a link to nobody.
+ *
+ * A dismissed account links silently. Dismissal files an account under the
+ * stranger sentinel, so a guardian naming its sender is telling Rome who that
+ * sender is, which is the answer dismissal declined to give rather than one it
+ * contradicts.
+ */
+export async function createPerson(
+  deps: PeopleWriteDeps,
+  request: NewPerson,
+): Promise<CreatePersonResult> {
+  let id: string;
+  try {
+    id = await deps.personMappingRepo.create({
+      displayName: request.displayName,
+      bondLevel: request.bondLevel,
+      // The guardian typed this person in, so there is nobody left to approve
+      // them — the same standing every person the dashboard creates has.
+      approved: true,
+      channelMappings: request.accounts,
+    });
+  } catch (err) {
+    if (err instanceof AccountHeldError) {
+      const { holder } = err;
+      return {
+        conflict: linkConflict(holder, { id: holder.personId, displayName: holder.personName }),
+      };
+    }
+    throw err;
+  }
+
+  const person = await readPerson(deps, id);
+  if (!person) throw new Error(`created person ${id} does not read back`);
+  return { person };
+}


### PR DESCRIPTION
Closes #62. This was stacked on #74 and #57, both since merged, so the diff is against `main`.

## What this PR does

The People surface can read a person but cannot make one. What the dashboard has is `POST /api/persons/create`: it takes exactly one account, requires it, and answers `{ success, personId }` rather than the person it made. A guardian who knows someone on WhatsApp and on Telegram has to create them once and then repair them, and there is no repair verb.

`POST /api/people` is one request that names the person and every account that is theirs. Either all of it lands, or none of it does and the response names whoever holds the account that stopped it.

## Design & Invariants

**Both-or-neither, because the halves are worthless apart.** A person with none of their accounts is unreachable — no inbound message resolves to them — and their name is now taken, so the retry that would repair them reads as a duplicate rather than a repair. An account linked to a person who was never committed is a link to nobody. So the repository settles every account before its transaction opens: one held account in a list of five leaves the other four where they were, and the person is never written. A rival claim landing between that check and the write collides on the identity's unique index, which rolls the whole transaction back rather than letting half of it through.

**A refusal names the holder.** `AccountHeldError` carries the person and the account rather than only reporting that there is a conflict. Every caller has to name them: the guardian decides whether to move the account, and cannot decide without knowing whose it is. The alternative — parsing the holder back out of an error message — is a contract nothing enforces, and #63 has to make the same refusal from the link verb.

**A dismissed account has no holder.** Dismissal files an account under the stranger sentinel, which is structure rather than a person. A guardian naming its sender is giving the answer dismissal declined to give, not contradicting one, so the link happens silently and the sentinel's id reaches no response.

**409, not 400.** The body is well formed and the guardian may well have meant it. A held account is a fact about Rome's state that a transfer can change, rather than a mistake in the request.

**What a valid create is lives in the contract, wording included.** #57 landed `CreatePersonRequest` and `LinkConflict` as the shapes. What it did not land is the rule that decides whether a body is one, or the wording of a refusal — and the page renders the `error` string, so that wording is part of what a client is written against. `parseCreatePersonRequest` and `linkConflict` are those two, next to the types they serve. `parseCreatePersonRequest` also applies the defaults, so the write is handed a request with no optional field left to interpret.

**Naming one account twice is not an error.** It asks for the state naming it once produces. The link table holds one row per account, so passing the repeat through would abort a write over a request that was never ambiguous.

**The slug suffix counts the person among everyone sharing the name**, and the bare slug is the first of them — the second Ada Lovelace is `ada-lovelace-2`. Still one past the highest suffix in use rather than the first free slot, so a deleted person's id is never handed to whoever is created next.

**Creating lives in `src/people/create.ts`, not the route.** The outcome is a contract decision — the person exists with every account, or nothing was written — and the route only turns that into a status code. The four writes still to come (#63–#65) answer with the same person the same way.

Vocabulary is [`docs/concepts/identity.md`](../blob/main/docs/concepts/identity.md)'s. The account/link sweep of that doc is #70.

## Test plan

- [x] `pnpm typecheck` (full workspace)
- [x] `pnpm test:unit` — core 4,013 / web 1,092 / ui 528, all green
- [x] `packages/core/src/api/routes/people.test.ts` — a create with two accounts landing both links named as each platform names them, the default bond level, a 409 that names the holder while leaving both the person and the other account unwritten, a dismissal-held account linking and emptying the sentinel, three people sharing a name numbering 1/2/3, a repeated account linking once, and six 400 bodies plus malformed JSON leaving no row behind
- [x] `packages/core/src/db/repositories/person-mapping.test.ts` — the refusal carries the holder's own name, not the channel-side one, and the unheld account in the same request stays unheld
- [x] `biome check` on every changed file
- [ ] `pnpm dev:all` — the Docker socket is not reachable from this environment

## Not in this PR

- The standalone link, unlink and transfer verbs — #63. `linkConflict` and `AccountHeldError` are the pieces they share with this route.
- Dismiss and restore — #64.
- `PATCH /api/people/:id` and merge — #65.
- The profile markdown file `POST /api/persons/create` writes. A person created here carries no `profilePath`, which is the state every person the system app creates is already in, and the message handler has a branch for it. #69 retires the old route and owns moving the profile write.
- Answering 409 rather than 500 when a rival claim wins the race between the check and the write. Nothing is written either way. #63 needs the transactional compare-and-swap that would also close this.
- Repointing the dashboard and the mock at this route — #66–#68. `mock/handlers/people-proposed.ts` carries its own local `linkConflict` and `AccountRef`, which is the drift `parseCreatePersonRequest` and `linkConflict` exist to end. Retiring them belongs with the PR that wires the mock to the real route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

