### PR TITLE
feat(web): give instance links a social card

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -48,6 +48,40 @@
       }
     </style>
     <title>Rome</title>
+    <!-- Social card for links that leave the instance. `/share/:token` is a
+         login-free page built to be handed to people without accounts, and its
+         URL is the instance's own origin (ShareBar composes
+         `window.location.origin + share.url`) — so a shared chat pasted into a
+         chat app or a timeline is a link to `<slug>.romeos.cc`, which without
+         these renders as bare text.
+
+         Static, and identical on every instance: crawlers do not run the SPA, so
+         nothing React sets here would ever be seen, and per-chat titles would
+         have to be rendered server-side. The card carries Rome's own name and
+         nothing about the instance or its contents. The host is not repeated in
+         the title because every platform already renders it beside the card.
+
+         The image is the marketing site's, by absolute URL — instances have no
+         1200x630 asset of their own and copying one here would be a second
+         place to forget. It is datestamped, and rome-cloud renames it on every
+         swap so caches refetch, which makes this a link that a swap over there
+         breaks. A dead image costs the picture, not the card.
+
+         Each tag stays on ONE line even where that runs long. Rsbuild drops a
+         `<meta>` split across lines from the emitted HTML — the two description
+         tags vanished from dist/index.html that way, and nothing failed. Biome
+         ignores this file, so no formatter will rewrap them; a person might. -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Rome" />
+    <meta property="og:title" content="Rome OS - Enjoy your life with Rome" />
+    <meta property="og:description" content="Enjoy your life, work, business, and creativity with Rome OS, the private agentic operating system." />
+    <meta property="og:image" content="https://romeos.cc/public-og-20260825.jpg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Rome OS - Enjoy your life with Rome" />
+    <meta name="twitter:description" content="Enjoy your life, work, business, and creativity with Rome OS, the private agentic operating system." />
+    <meta name="twitter:image" content="https://romeos.cc/public-og-20260825.jpg" />
     <!-- Per-deployment browser config. Referenced unconditionally:
          the committed public/ copy is an empty stub for dev servers and host
          runs; the container-boot script overwrites it in the web root, which is


### PR DESCRIPTION
## What this PR does

A shared chat is a link to the instance's own origin — `ShareBar` composes `window.location.origin + share.url`, and `/share/:token` is a login-free page built to be handed to people without accounts. The SPA shell serving it carries PWA and theme metadata and no Open Graph tags at all, so every one of those links pastes into a chat app or a timeline as bare text.

## Design & Invariants

**Static, and identical on every instance.** Crawlers do not run the SPA, so anything React set would never be seen; a per-chat title would have to be rendered server-side for `/share/:token` specifically. The card names Rome and says nothing about the instance or its contents.

**The host is deliberately absent from the title.** Every platform renders it beside the card already, so `yunfan.romeos.cc` appears without being repeated.

**The image is the marketing site's, by absolute URL.** Instances have no 1200×630 asset, and copying one here would be a second place to forget. It is datestamped and rome-cloud renames it on each swap so caches refetch — which does make this a link that a swap over there breaks. A dead image costs the picture, not the card.

**Each tag stays on one line even where that runs long.** Rsbuild drops a `<meta>` split across lines from the emitted HTML: both description tags were written wrapped, both vanished from `dist/index.html`, and neither the build nor the suite failed. Biome ignores this file, so no formatter will rewrap them — a person might.

## Test plan

- [x] `pnpm --filter rome-web build`, then read `dist/index.html` — all eleven tags present, `<title>` intact.
- [x] `pnpm lint` — no errors (19 warnings, all pre-existing in `cdp-client`).
- [x] `pnpm --filter rome-web test` — 1091 passed.
- [ ] Paste a `/share/:token` link into a chat app after deploy.

Draft until that last item is done — the build check proves the tags ship, not that a card renders.

## Not in this PR

- **A per-chat card for `/share/:token`.** Crawlers need the title in the served HTML, so it has to come from the server rather than the SPA.
