### PR TITLE
fix(desktop): sudo the nerdctl load in build-local-image

### DIFF
--- a/packages/desktop/scripts/build-local-image.sh
+++ b/packages/desktop/scripts/build-local-image.sh
@@ -27,6 +27,11 @@ docker build --platform "linux/$(uname -m | sed s/x86_64/amd64/)" \
   --build-arg "ROME_BUILD_SHA=$BUILD_SHA" \
   --build-arg "ROME_BUILD_TIME=$BUILD_TIME" \
   -t "$TAG" "$REPO_ROOT"
-docker save "$TAG" | "$LIMACTL" shell --workdir=/ rome nerdctl --namespace=rome load
+# `sudo`, because containerd in the guest runs as root under OpenRC. Without it
+# nerdctl takes the rootless path, looks for a socket under $XDG_RUNTIME_DIR
+# that is never there, and exits with "rootless containerd not running?" — after
+# the image has already built, so the failure costs a full rebuild to retry.
+# Every nerdctl call the app itself makes is sudo'd (runtime/providers/lima.ts).
+docker save "$TAG" | "$LIMACTL" shell --workdir=/ rome sudo nerdctl --namespace=rome load
 
 ROME_DESKTOP_IMAGE="$TAG" pnpm dev --filter=rome-desktop


### PR DESCRIPTION
## What this PR does

`pnpm --filter rome-desktop image:local` builds the image, then dies loading it into the guest:

```
rootless containerd not running? ... XDG_RUNTIME_DIR is not set
```

containerd runs as root there under OpenRC, so an unsudo'd `nerdctl` takes the rootless path and looks for a socket that is never present.

Two things make it worse than a one-word typo. It fails *after* the build, so a retry costs a full image build. And the error names a fix — `containerd-rootless-setuptool.sh install` — that would be the wrong thing to do to this guest.

## Design & Invariants

**The app is the reference, and it already agrees.** Every `nerdctl` call in `runtime/providers/lima.ts` is sudo'd. This line was the sole exception, which is what makes it a script bug rather than an environment one.

## Test plan

- [x] `bash -n` — clean.
- [x] Ran the corrected command by hand against the same guest: `Loaded image: rome-local:dev`, and the app then recreated its container onto that image (`Rome container config differs (image or env changed); recreating from scratch`).
- [x] A full `image:local` run start to finish.

Draft until that last item — the fixed line is verified, the script around it end-to-end is not.
