### PR TITLE
feat(web): host MDX design docs under /dev

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@mdx-js/loader": "^3.1.1",
-    "@mdx-js/mdx": "^3.1.1",
     "@playwright/test": "1.62.1",
     "@rsbuild/core": "^2.0.7",
     "@rsbuild/plugin-react": "^2.0.0",
@@ -68,6 +67,7 @@
     "@tailwindcss/postcss": "^4.1.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/mdx": "^2.0.14",
     "@types/node": "^25.2.3",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -59,6 +59,8 @@
     "zustand": "^5.0.2"
   },
   "devDependencies": {
+    "@mdx-js/loader": "^3.1.1",
+    "@mdx-js/mdx": "^3.1.1",
     "@playwright/test": "1.62.1",
     "@rsbuild/core": "^2.0.7",
     "@rsbuild/plugin-react": "^2.0.0",
@@ -71,6 +73,7 @@
     "@types/react-dom": "^19.1.0",
     "jsdom": "^29.1.1",
     "msw": "^2.15.0",
+    "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.9.3",
     "vite": "^6.0.7"

--- a/packages/web/rsbuild.config.ts
+++ b/packages/web/rsbuild.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, loadEnv } from "@rsbuild/core";
 import { pluginReact } from "@rsbuild/plugin-react";
 import { pluginSvgr } from "@rsbuild/plugin-svgr";
+import remarkGfm from "remark-gfm";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 
@@ -51,6 +52,25 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": srcDir,
+    },
+  },
+  // MDX design docs (src/pages/dev/mdx/docs/*.mdx) compile to React components
+  // so a design note can render the real primitives it is describing. The
+  // loader emits plain JS against the automatic JSX runtime, so nothing
+  // downstream has to transform it. Dev-only surface: the docs are reachable
+  // from /dev, which drops out of production builds.
+  tools: {
+    rspack: {
+      module: {
+        rules: [
+          {
+            test: /\.mdx$/,
+            // remark-gfm buys the table syntax a design doc needs for its
+            // rule/reason columns; plain MDX would render the pipes as text.
+            use: [{ loader: "@mdx-js/loader", options: { remarkPlugins: [remarkGfm] } }],
+          },
+        ],
+      },
     },
   },
   source: {

--- a/packages/web/src/env.d.ts
+++ b/packages/web/src/env.d.ts
@@ -14,15 +14,3 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
-
-// MDX design docs, compiled by @mdx-js/loader (see rsbuild.config.ts). The
-// default export is a React component; `components` overrides which element
-// each Markdown construct renders as.
-declare module "*.mdx" {
-  import type { ComponentType, ReactNode } from "react";
-  const MDXComponent: ComponentType<{
-    components?: Record<string, ComponentType<Record<string, unknown>>>;
-    children?: ReactNode;
-  }>;
-  export default MDXComponent;
-}

--- a/packages/web/src/env.d.ts
+++ b/packages/web/src/env.d.ts
@@ -14,3 +14,15 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// MDX design docs, compiled by @mdx-js/loader (see rsbuild.config.ts). The
+// default export is a React component; `components` overrides which element
+// each Markdown construct renders as.
+declare module "*.mdx" {
+  import type { ComponentType, ReactNode } from "react";
+  const MDXComponent: ComponentType<{
+    components?: Record<string, ComponentType<Record<string, unknown>>>;
+    children?: ReactNode;
+  }>;
+  export default MDXComponent;
+}

--- a/packages/web/src/pages/dev/dev-routes.ts
+++ b/packages/web/src/pages/dev/dev-routes.ts
@@ -63,6 +63,13 @@ export const DEV_ROUTES: DevRoute[] = import.meta.env.DEV
         Component: lazy(() => import("./ChatBlocksPage")),
       },
       {
+        path: "/dev/mdx",
+        title: "Design docs (MDX)",
+        description:
+          "MDX design notes that render live components — prose and the specimen it describes in one file, against the real tokens and primitives.",
+        Component: lazy(() => import("./mdx/MdxDocsPage")),
+      },
+      {
         path: "/dev/login",
         title: "Login page",
         description:

--- a/packages/web/src/pages/dev/mdx/MdxDocsPage.tsx
+++ b/packages/web/src/pages/dev/mdx/MdxDocsPage.tsx
@@ -1,0 +1,57 @@
+import { Suspense } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { cn } from "@/lib/utils";
+import { MDX_DOCS } from "./docs";
+import { mdxComponents } from "./mdx-components";
+
+// /dev/mdx — the MDX design-doc host. The doc list is a sidebar and the
+// selection rides in `?doc=`, so a doc is a shareable URL without a nested
+// route: one DEV_ROUTES entry covers the whole surface.
+
+export default function MdxDocsPage() {
+  const [params, setParams] = useSearchParams();
+  const slug = params.get("doc") ?? MDX_DOCS[0]?.slug;
+  const active = MDX_DOCS.find((doc) => doc.slug === slug);
+
+  return (
+    <div className="flex min-h-screen bg-background">
+      <nav className="w-64 shrink-0 border-r border-border bg-surface">
+        <div className="border-b border-border px-4 py-4">
+          <Link to="/dev" className="text-badge text-muted-foreground hover:text-foreground">
+            ← Dev pages
+          </Link>
+          <h1 className="mt-2 text-section text-foreground">Design docs</h1>
+        </div>
+        <ul className="p-2">
+          {MDX_DOCS.map((doc) => (
+            <li key={doc.slug}>
+              <button
+                type="button"
+                onClick={() => setParams({ doc: doc.slug })}
+                className={cn(
+                  "w-full rounded-8 px-3 py-2 text-left transition-colors",
+                  doc.slug === slug ? "bg-surface-muted" : "hover:bg-surface-hover",
+                )}
+              >
+                <span className="block text-ui text-foreground">{doc.title}</span>
+                <span className="mt-1 block text-aux text-muted-foreground">{doc.summary}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <main className="min-w-0 flex-1">
+        <div className="mx-auto max-w-3xl px-8 py-10">
+          {active ? (
+            <Suspense fallback={<p className="text-body text-muted-foreground">Loading…</p>}>
+              <active.Doc components={mdxComponents} />
+            </Suspense>
+          ) : (
+            <p className="text-body text-muted-foreground">No doc named “{slug}”.</p>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/packages/web/src/pages/dev/mdx/docs.ts
+++ b/packages/web/src/pages/dev/mdx/docs.ts
@@ -1,4 +1,5 @@
 import { lazy, type ComponentType, type LazyExoticComponent } from "react";
+import type { MDXProps } from "mdx/types";
 
 // The MDX design docs, and the only place a new one is registered.
 //
@@ -16,7 +17,7 @@ export type MdxDoc = {
   title: string;
   /** One line shown in the doc list. */
   summary: string;
-  Doc: LazyExoticComponent<ComponentType<{ components?: Record<string, unknown> }>>;
+  Doc: LazyExoticComponent<ComponentType<MDXProps>>;
 };
 
 export const MDX_DOCS: MdxDoc[] = [
@@ -25,6 +26,6 @@ export const MDX_DOCS: MdxDoc[] = [
     title: "People page",
     summary:
       "The stream / directory / person-page rebuild: row shapes, the bond ladder, and channels as glyphs.",
-    Doc: lazy(() => import("./docs/people-page.mdx")) as MdxDoc["Doc"],
+    Doc: lazy(() => import("./docs/people-page.mdx")),
   },
 ];

--- a/packages/web/src/pages/dev/mdx/docs.ts
+++ b/packages/web/src/pages/dev/mdx/docs.ts
@@ -1,0 +1,30 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from "react";
+
+// The MDX design docs, and the only place a new one is registered.
+//
+// MDX is the format because a design note can render the thing it describes:
+// the prose and the live component sit in one file, against the real tokens
+// and the real primitives, so "what it should look like" and "what it looks
+// like" cannot drift apart the way a screenshot in a Markdown file does.
+//
+// Dev-only, like everything under /dev — this module is reached from
+// DEV_ROUTES, which is the empty array in production builds.
+
+export type MdxDoc = {
+  /** URL slug, e.g. `?doc=people-page`. */
+  slug: string;
+  title: string;
+  /** One line shown in the doc list. */
+  summary: string;
+  Doc: LazyExoticComponent<ComponentType<{ components?: Record<string, unknown> }>>;
+};
+
+export const MDX_DOCS: MdxDoc[] = [
+  {
+    slug: "people-page",
+    title: "People page",
+    summary:
+      "The stream / directory / person-page rebuild: row shapes, the bond ladder, and channels as glyphs.",
+    Doc: lazy(() => import("./docs/people-page.mdx")) as MdxDoc["Doc"],
+  },
+];

--- a/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
+++ b/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
@@ -1,0 +1,608 @@
+import { useState } from "react";
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { FilterChipGroup } from "@/components/ui/filter-chip-group";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+// Live specimens for the People-page design note (people-page.mdx).
+//
+// These are stand-ins, not the shipping components: they carry the design's
+// row shapes and glyph vocabulary against literal fixtures, with no data
+// fetching, no i18n and no write path. The note is a design document, so it
+// has to render on its own — wiring it to the real page's hooks would make it
+// a second copy of the page instead of a description of it.
+
+/* ---------------------------------------------------------------- channels */
+
+// Channels are monochrome glyphs, never colors. Status hues stay reserved for
+// status semantics, and a channel a Rome App contributes gets the generic
+// glyph rather than an undefined palette slot.
+
+function WhatsAppGlyph({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M12.04 2C6.58 2 2.13 6.45 2.13 11.91c0 1.75.46 3.45 1.32 4.95L2 22l5.25-1.38a9.9 9.9 0 0 0 4.79 1.22h.01c5.46 0 9.91-4.45 9.91-9.91 0-2.65-1.03-5.14-2.9-7.01A9.82 9.82 0 0 0 12.04 2Zm0 1.67c2.2 0 4.27.86 5.83 2.42a8.2 8.2 0 0 1 2.41 5.82c0 4.54-3.7 8.24-8.25 8.24a8.23 8.23 0 0 1-4.2-1.15l-.3-.18-3.12.82.83-3.04-.2-.31a8.2 8.2 0 0 1-1.26-4.38c0-4.54 3.7-8.24 8.26-8.24Zm-3.1 4.2c-.15 0-.4.06-.6.28-.21.22-.8.78-.8 1.9 0 1.11.82 2.19.93 2.34.12.15 1.6 2.44 3.87 3.42.54.23.96.37 1.29.48.54.17 1.03.15 1.42.09.44-.07 1.34-.55 1.53-1.08.19-.53.19-.98.13-1.08-.06-.09-.21-.15-.44-.26-.22-.12-1.34-.66-1.55-.74-.2-.07-.36-.11-.51.12-.15.22-.58.73-.71.88-.13.15-.26.17-.49.06-.22-.12-.94-.35-1.8-1.11-.66-.6-1.11-1.32-1.24-1.55-.13-.22-.02-.34.1-.46.1-.1.22-.26.33-.4.11-.14.15-.23.22-.38.08-.15.04-.28-.02-.4-.06-.11-.5-1.24-.7-1.7-.18-.44-.37-.38-.51-.39l-.44-.01Z" />
+    </svg>
+  );
+}
+
+function TelegramGlyph({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M21.6 4.1 2.9 11.3c-.9.34-.9.9-.16 1.13l4.8 1.5 1.85 5.68c.22.6.4.83.83.83.42 0 .6-.19.83-.42l2.28-2.22 4.74 3.5c.87.48 1.5.23 1.72-.8l3.1-14.6c.31-1.27-.49-1.84-1.29-1.48v-.32ZM7.9 13.6l10.28-6.48c.5-.3.97-.14.59.2l-8.8 7.95-.35 3.7-1.72-5.37Z" />
+    </svg>
+  );
+}
+
+function DiscordGlyph({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M19.3 5.36A16.8 16.8 0 0 0 15.1 4l-.2.4a15.7 15.7 0 0 1 3.7 1.2 12.9 12.9 0 0 0-11.2 0A15.6 15.6 0 0 1 11.1 4.4L10.9 4a16.8 16.8 0 0 0-4.2 1.36C4 9.4 3.3 13.35 3.65 17.24A16.9 16.9 0 0 0 8.8 20a12.6 12.6 0 0 0 1.1-1.8 11 11 0 0 1-1.73-.84l.42-.33a12 12 0 0 0 10.82 0l.43.33c-.55.33-1.13.61-1.74.84A12.5 12.5 0 0 0 19.2 20a16.8 16.8 0 0 0 5.15-2.76v-.01c.42-4.5-.7-8.42-2.9-11.87ZM9.4 14.86c-1.02 0-1.86-.94-1.86-2.1 0-1.15.82-2.1 1.86-2.1s1.88.95 1.86 2.1c0 1.16-.82 2.1-1.86 2.1Zm5.2 0c-1.02 0-1.86-.94-1.86-2.1 0-1.15.82-2.1 1.86-2.1s1.87.95 1.85 2.1c0 1.16-.81 2.1-1.85 2.1Z" />
+    </svg>
+  );
+}
+
+function WebchatGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M3 12h18" />
+      <path d="M12 3a14 14 0 0 1 3.6 9A14 14 0 0 1 12 21a14 14 0 0 1-3.6-9A14 14 0 0 1 12 3Z" />
+    </svg>
+  );
+}
+
+function AppGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="3" width="7" height="7" rx="1.5" />
+      <rect x="14" y="3" width="7" height="7" rx="1.5" />
+      <rect x="3" y="14" width="7" height="7" rx="1.5" />
+      <rect x="14" y="14" width="7" height="7" rx="1.5" />
+    </svg>
+  );
+}
+
+export type Channel = "whatsapp" | "telegram" | "discord" | "webchat" | "app";
+
+export const CHANNEL_META: Record<Channel, { label: string; Glyph: typeof WhatsAppGlyph }> = {
+  whatsapp: { label: "WhatsApp", Glyph: WhatsAppGlyph },
+  telegram: { label: "Telegram", Glyph: TelegramGlyph },
+  discord: { label: "Discord", Glyph: DiscordGlyph },
+  webchat: { label: "Web chat", Glyph: WebchatGlyph },
+  app: { label: "Rome App", Glyph: AppGlyph },
+};
+
+export function ChannelGlyph({ channel, className }: { channel: Channel; className?: string }) {
+  const { Glyph } = CHANNEL_META[channel];
+  return <Glyph className={cn("size-4", className)} />;
+}
+
+export function ChannelPill({ channel }: { channel: Channel }) {
+  const { label } = CHANNEL_META[channel];
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-border-subtle px-2 py-1 text-badge text-muted-foreground">
+      <ChannelGlyph channel={channel} className="size-3" />
+      {label}
+    </span>
+  );
+}
+
+/** Every glyph the page can draw, side by side, at muted foreground. */
+export function ChannelGlyphSet() {
+  return (
+    <div className="flex flex-wrap items-center gap-4 rounded-12 border border-border bg-surface p-4">
+      {(Object.keys(CHANNEL_META) as Channel[]).map((channel) => (
+        <span key={channel} className="flex items-center gap-2 text-aux text-muted-foreground">
+          <ChannelGlyph channel={channel} />
+          {CHANNEL_META[channel].label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ pieces */
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+const AVATAR_TONE = "bg-surface-muted text-muted-foreground";
+const GUARDIAN_TONE = "bg-foreground text-background";
+
+export function Avatar({ name, tone = AVATAR_TONE }: { name: string; tone?: string }) {
+  return (
+    <div
+      className={cn("flex size-8 shrink-0 items-center justify-center rounded-full text-aux", tone)}
+      aria-hidden="true"
+    >
+      {initials(name)}
+    </div>
+  );
+}
+
+export type Level = "unknown" | "guardian" | "inner-circle" | "acquaintance" | "other" | "stranger";
+
+const LEVEL_LABEL: Record<Level, string> = {
+  unknown: "Unknown",
+  guardian: "Guardian",
+  "inner-circle": "Inner circle",
+  acquaintance: "Acquaintance",
+  other: "Other",
+  stranger: "Stranger",
+};
+
+export type Row = {
+  id: string;
+  name: string;
+  level: Level;
+  channel: Channel;
+  handle?: string;
+  preview?: string;
+  ago?: string;
+  messageCount?: number;
+  neverMessaged?: boolean;
+};
+
+/** The one row menu: every level the row is not already at, then merge. */
+function RowMenu({ row }: { row: Row }) {
+  const targets = (Object.keys(LEVEL_LABEL) as Level[]).filter(
+    (level) => level !== row.level && level !== "guardian" && level !== "unknown",
+  );
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="ghost" size="sm" aria-label={`Actions for ${row.name}`}>
+          <MoreHorizontal aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Move to</DropdownMenuLabel>
+        {targets.map((level) => (
+          <DropdownMenuItem key={level} variant={level === "stranger" ? "destructive" : "default"}>
+            {LEVEL_LABEL[level]}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>Merge into…</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+const ROW_BASE =
+  "grid w-full items-center gap-3 border-b border-border-subtle px-2 py-2 text-left last:border-b-0";
+
+function Frame({ children, label }: { children: React.ReactNode; label?: string }) {
+  return (
+    <div className="overflow-hidden rounded-12 border border-border bg-background">
+      {label && (
+        <div className="border-b border-border-subtle bg-surface px-3 py-1 text-badge text-subtle-foreground">
+          {label}
+        </div>
+      )}
+      <div className="p-2">{children}</div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ stream */
+
+const STREAM: Row[] = [
+  {
+    id: "1",
+    name: "Mira Okafor",
+    level: "inner-circle",
+    channel: "whatsapp",
+    preview: "landed, heading to the hotel now",
+    ago: "4m ago",
+  },
+  {
+    id: "2",
+    name: "Dan Levy",
+    level: "acquaintance",
+    channel: "telegram",
+    preview: "sent over the revised deck",
+    ago: "22m ago",
+  },
+  {
+    id: "3",
+    name: "+1 415 555 0142",
+    level: "unknown",
+    channel: "whatsapp",
+    preview: "Hi — is this the right number for Rome?",
+    ago: "1h ago",
+  },
+  {
+    id: "4",
+    name: "build-bot",
+    level: "other",
+    channel: "app",
+    preview: "nightly finished: 1117 passed",
+    ago: "3h ago",
+  },
+  { id: "5", name: "Priya Raman", level: "inner-circle", channel: "discord", ago: "6h ago" },
+];
+
+/** One row per identity, newest first, carrying only what routing needs. */
+export function StreamDemo() {
+  return (
+    <Frame label="Latest">
+      {STREAM.map((row) => (
+        <button
+          key={row.id}
+          type="button"
+          className={cn(ROW_BASE, "grid-cols-[2rem_minmax(0,1fr)_auto] hover:bg-surface")}
+        >
+          <Avatar name={row.name} />
+          <span className="grid min-w-0 gap-1 sm:grid-cols-[minmax(7rem,1fr)_minmax(0,1.8fr)] sm:items-center sm:gap-3">
+            <span className="truncate text-ui text-foreground">{row.name}</span>
+            <span className="flex min-w-0 items-center gap-2 text-aux text-muted-foreground">
+              <span className="text-subtle-foreground" title={CHANNEL_META[row.channel].label}>
+                <ChannelGlyph channel={row.channel} />
+              </span>
+              {row.preview ? (
+                <span className="truncate">{row.preview}</span>
+              ) : (
+                <span className="truncate text-subtle-foreground italic">No preview</span>
+              )}
+            </span>
+          </span>
+          <span className="justify-self-end font-mono text-badge tabular-nums text-subtle-foreground">
+            {row.ago}
+          </span>
+        </button>
+      ))}
+    </Frame>
+  );
+}
+
+/* ----------------------------------------------------------------- unknown */
+
+const UNKNOWN: Row[] = [
+  {
+    id: "u1",
+    name: "+1 415 555 0142",
+    level: "unknown",
+    channel: "whatsapp",
+    handle: "+1 415 555 0142",
+    messageCount: 3,
+    preview: "Hi — is this the right number for Rome?",
+    ago: "1h ago",
+  },
+  {
+    id: "u2",
+    name: "@quietstorm",
+    level: "unknown",
+    channel: "telegram",
+    handle: "@quietstorm",
+    messageCount: 1,
+    preview: "hey, saw your talk",
+    ago: "2d ago",
+  },
+  {
+    id: "u3",
+    name: "+44 7700 900321",
+    level: "unknown",
+    channel: "whatsapp",
+    handle: "+44 7700 900321",
+    messageCount: 12,
+    preview: "CLAIM YOUR PRIZE NOW",
+    ago: "5d ago",
+  },
+];
+
+/** The Unknown chip's row: dense, because the placement decision runs on the
+ *  evidence — which channel, which number, how much they have said. */
+export function UnknownDemo() {
+  return (
+    <Frame label="Unknown">
+      {UNKNOWN.map((row) => (
+        <div
+          key={row.id}
+          className={cn(
+            ROW_BASE,
+            "cursor-pointer grid-cols-[2rem_minmax(0,1fr)_auto] hover:bg-surface sm:grid-cols-[2rem_minmax(10rem,1.1fr)_minmax(0,1.6fr)_auto]",
+          )}
+        >
+          <Avatar name={row.name} />
+          <span className="min-w-0 text-left">
+            <span className="flex min-w-0 flex-wrap items-center gap-2">
+              <span className="truncate text-ui text-foreground">{row.name}</span>
+              <ChannelPill channel={row.channel} />
+            </span>
+            <span className="block truncate text-aux text-muted-foreground">
+              <span className="font-mono tabular-nums">{row.handle}</span>
+              {" · "}
+              <span className="tabular-nums">{row.messageCount} messages</span>
+            </span>
+          </span>
+          <span className="hidden min-w-0 text-left text-aux text-muted-foreground sm:block">
+            <span className="block truncate">{row.preview}</span>
+          </span>
+          <span className="flex items-center justify-end gap-1">
+            <span className="font-mono text-badge tabular-nums text-subtle-foreground">
+              {row.ago}
+            </span>
+            <RowMenu row={row} />
+          </span>
+        </div>
+      ))}
+    </Frame>
+  );
+}
+
+/* --------------------------------------------------------------- directory */
+
+const DIRECTORY: { level: Level; total: number; rows: Row[] }[] = [
+  {
+    level: "guardian",
+    total: 1,
+    rows: [{ id: "g", name: "Fan Zhang", level: "guardian", channel: "webchat", handle: "You" }],
+  },
+  {
+    level: "inner-circle",
+    total: 2,
+    rows: [
+      {
+        id: "d1",
+        name: "Mira Okafor",
+        level: "inner-circle",
+        channel: "whatsapp",
+        handle: "+1 206 555 0113",
+      },
+      {
+        id: "d2",
+        name: "Priya Raman",
+        level: "inner-circle",
+        channel: "discord",
+        handle: "@priya",
+      },
+    ],
+  },
+  {
+    level: "acquaintance",
+    total: 2,
+    rows: [
+      { id: "d3", name: "Dan Levy", level: "acquaintance", channel: "telegram", handle: "@danl" },
+      {
+        id: "d4",
+        name: "Ana Ruiz",
+        level: "acquaintance",
+        channel: "whatsapp",
+        neverMessaged: true,
+      },
+    ],
+  },
+];
+
+/** The management view: everyone grouped by bond with live totals, three
+ *  columns, no channel badges. Clicking the avatar selects. */
+export function DirectoryDemo() {
+  const [selected, setSelected] = useState<string[]>([]);
+  return (
+    <Frame label="Directory">
+      {DIRECTORY.map((group) => (
+        <div key={group.level} className="mb-2 last:mb-0">
+          <div className="flex items-baseline gap-2 px-2 py-1">
+            <span className="text-ui text-foreground">{LEVEL_LABEL[group.level]}</span>
+            <span className="font-mono text-badge tabular-nums text-subtle-foreground">
+              {group.total}
+            </span>
+          </div>
+          {group.rows.map((row) => {
+            const fixed = row.level === "guardian";
+            const isSelected = selected.includes(row.id);
+            return (
+              <div
+                key={row.id}
+                className={cn(
+                  ROW_BASE,
+                  "grid-cols-[2rem_minmax(0,1fr)_auto]",
+                  fixed ? "cursor-default" : "hover:bg-surface",
+                  isSelected && "bg-primary/10 hover:bg-primary/15",
+                )}
+              >
+                {fixed ? (
+                  <Avatar name={row.name} tone={GUARDIAN_TONE} />
+                ) : (
+                  <button
+                    type="button"
+                    aria-pressed={isSelected}
+                    aria-label={`Select ${row.name}`}
+                    onClick={() =>
+                      setSelected((prev) =>
+                        prev.includes(row.id)
+                          ? prev.filter((id) => id !== row.id)
+                          : [...prev, row.id],
+                      )
+                    }
+                    className="rounded-full outline-none focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-ring"
+                  >
+                    <Avatar name={row.name} />
+                  </button>
+                )}
+                <span className="min-w-0 text-left">
+                  <span className="block truncate text-ui text-foreground">{row.name}</span>
+                  <span className="block truncate text-aux text-muted-foreground">
+                    {row.neverMessaged ? (
+                      <span className="italic">No activity yet</span>
+                    ) : (
+                      <span className="font-mono tabular-nums">{row.handle}</span>
+                    )}
+                  </span>
+                </span>
+                <span className="flex items-center justify-end">
+                  {!fixed && <RowMenu row={row} />}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      ))}
+      {selected.length > 0 && (
+        <div className="mt-2 flex items-center justify-between rounded-8 bg-primary/10 px-3 py-2">
+          <span className="text-aux text-foreground">{selected.length} selected</span>
+          <span className="flex gap-2">
+            <Button size="sm" variant="secondary">
+              Move to…
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => setSelected([])}>
+              Clear
+            </Button>
+          </span>
+        </div>
+      )}
+    </Frame>
+  );
+}
+
+/* ----------------------------------------------------------- view switcher */
+
+/** The two one-of-N controls: the kit's radiogroups, not styled buttons. */
+export function ViewSwitcherDemo() {
+  const [view, setView] = useState("latest");
+  const [chip, setChip] = useState("all");
+  return (
+    <div className="flex flex-col gap-3 rounded-12 border border-border bg-surface p-4">
+      <SegmentedControl
+        aria-label="People view"
+        size="sm"
+        value={view}
+        onValueChange={setView}
+        options={[
+          { value: "latest", label: "Latest" },
+          { value: "directory", label: "Directory" },
+        ]}
+      />
+      <FilterChipGroup
+        aria-label="Filter people"
+        value={chip}
+        onValueChange={setChip}
+        options={[
+          { value: "all", label: "All" },
+          { value: "unknown", label: "Unknown", count: 6 },
+          { value: "inner-circle", label: "Inner circle" },
+          { value: "acquaintance", label: "Acquaintance" },
+          { value: "other", label: "Other" },
+          { value: "stranger", label: "Stranger" },
+        ]}
+      />
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------ person page */
+
+/** The dossier: identity card with bond select and linked-account pills, the
+ *  merged timeline grouped by day, a sticky composer. */
+export function PersonPageDemo() {
+  return (
+    <Frame label="/people/:identityId">
+      <div className="flex flex-col gap-4 p-2">
+        <div className="flex items-start gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-surface-muted text-aux text-muted-foreground">
+            MO
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-title text-foreground">Mira Okafor</div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center gap-2 rounded-full border border-border-subtle px-2 py-1 font-mono text-badge text-muted-foreground">
+                <ChannelGlyph channel="whatsapp" className="size-3" />
+                +1 206 555 0113
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full border border-border-subtle px-2 py-1 font-mono text-badge text-muted-foreground">
+                <ChannelGlyph channel="telegram" className="size-3" />
+                @mira
+              </span>
+              <Button size="sm" variant="ghost">
+                Link account…
+              </Button>
+              <Button size="sm" variant="ghost">
+                Merge into…
+              </Button>
+            </div>
+          </div>
+          <Select defaultValue="inner-circle">
+            <SelectTrigger size="sm" className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(["inner-circle", "acquaintance", "other", "stranger"] as Level[]).map((level) => (
+                <SelectItem key={level} value={level}>
+                  {LEVEL_LABEL[level]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex flex-col gap-3 border-t border-border-subtle pt-3">
+          <div className="text-center text-badge text-subtle-foreground">Today</div>
+          {[
+            { from: "Mira", text: "landed, heading to the hotel now", at: "09:14", out: false },
+            { from: "You", text: "perfect — dinner at 7?", at: "09:16", out: true },
+            { from: "Mira", text: "yes, book it", at: "09:31", out: false },
+          ].map((msg) => (
+            <div key={msg.at} className="flex gap-2 text-body">
+              <span className="w-12 shrink-0 font-mono text-badge tabular-nums text-subtle-foreground">
+                {msg.at}
+              </span>
+              <span className="min-w-0">
+                {msg.out && <span className="text-muted-foreground">You: </span>}
+                <span className="text-foreground">{msg.text}</span>
+              </span>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-2 border-t border-border-subtle pt-3">
+          <input
+            readOnly
+            placeholder="Message Mira…"
+            className="h-9 flex-1 rounded-8 border border-border bg-background px-3 text-ui text-foreground placeholder:text-subtle-foreground"
+          />
+          <Button size="sm">Send</Button>
+        </div>
+      </div>
+    </Frame>
+  );
+}

--- a/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
+++ b/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { MoreHorizontal } from "lucide-react";
+import { Avatar as KitAvatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -113,12 +115,14 @@ export function ChannelGlyph({ channel, className }: { channel: Channel; classNa
 }
 
 export function ChannelPill({ channel }: { channel: Channel }) {
-  const { label } = CHANNEL_META[channel];
+  const { label, Glyph } = CHANNEL_META[channel];
+  // The glyph goes in bare: Badge sizes an `<svg>` that carries no `size-*` of
+  // its own, and a size written here would opt out of that rule.
   return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-border-subtle px-2 py-1 text-badge text-muted-foreground">
-      <ChannelGlyph channel={channel} className="size-3" />
+    <Badge variant="outline" className="text-muted-foreground">
+      <Glyph />
       {label}
-    </span>
+    </Badge>
   );
 }
 
@@ -148,14 +152,24 @@ function initials(name: string): string {
 const AVATAR_TONE = "bg-surface-muted text-muted-foreground";
 const GUARDIAN_TONE = "bg-foreground text-background";
 
-export function Avatar({ name, tone = AVATAR_TONE }: { name: string; tone?: string }) {
+/**
+ * The page's avatar: initials on a neutral tone, never an image. It is the kit's
+ * Avatar with only a fallback child, so the roster inherits the kit's ring and
+ * size steps and a tone is the one thing a caller sets.
+ */
+export function Avatar({
+  name,
+  tone = AVATAR_TONE,
+  size = "default",
+}: {
+  name: string;
+  tone?: string;
+  size?: "default" | "lg";
+}) {
   return (
-    <div
-      className={cn("flex size-8 shrink-0 items-center justify-center rounded-full text-aux", tone)}
-      aria-hidden="true"
-    >
-      {initials(name)}
-    </div>
+    <KitAvatar size={size} aria-hidden="true">
+      <AvatarFallback className={cn("text-aux", tone)}>{initials(name)}</AvatarFallback>
+    </KitAvatar>
   );
 }
 
@@ -539,20 +553,18 @@ export function PersonPageDemo() {
     <Frame label="/people/:identityId">
       <div className="flex flex-col gap-4 p-2">
         <div className="flex items-start gap-3">
-          <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-surface-muted text-aux text-muted-foreground">
-            MO
-          </div>
+          <Avatar name="Mira Okafor" size="lg" />
           <div className="min-w-0 flex-1">
             <div className="text-title text-foreground">Mira Okafor</div>
             <div className="mt-2 flex flex-wrap items-center gap-2">
-              <span className="inline-flex items-center gap-2 rounded-full border border-border-subtle px-2 py-1 font-mono text-badge text-muted-foreground">
-                <ChannelGlyph channel="whatsapp" className="size-3" />
+              <Badge variant="outline" className="font-mono text-muted-foreground">
+                <CHANNEL_META.whatsapp.Glyph />
                 +1 206 555 0113
-              </span>
-              <span className="inline-flex items-center gap-2 rounded-full border border-border-subtle px-2 py-1 font-mono text-badge text-muted-foreground">
-                <ChannelGlyph channel="telegram" className="size-3" />
+              </Badge>
+              <Badge variant="outline" className="font-mono text-muted-foreground">
+                <CHANNEL_META.telegram.Glyph />
                 @mira
-              </span>
+              </Badge>
               <Button size="sm" variant="ghost">
                 Link account…
               </Button>

--- a/packages/web/src/pages/dev/mdx/docs/people-page.mdx
+++ b/packages/web/src/pages/dev/mdx/docs/people-page.mdx
@@ -1,0 +1,165 @@
+import {
+  ChannelGlyphSet,
+  DirectoryDemo,
+  PersonPageDemo,
+  StreamDemo,
+  UnknownDemo,
+  ViewSwitcherDemo,
+} from "./people-demo";
+
+# People, rebuilt
+
+The People page read three endpoints and rendered three sections — curated persons,
+unmapped senders, the WhatsApp address book. The same human could sit in more than
+one, each with its own row shape and its own controls, and no section could say
+where a person stood relative to another.
+
+Even flattened into one list, a roster answers the wrong question. People open this
+page to find out **who has something new**, and a roster shows everyone at once with
+management controls on every row.
+
+This note is the design in three surfaces: a stream, a directory, and a person page.
+Every specimen below is live — the same primitives, tokens, and focus rules the page
+ships with, so switching the theme re-renders the design rather than a picture of it.
+
+> Source of truth for the visual design: PR
+> [#2393](https://github.com/amantru/rome-internal/pull/2393) and its interactive
+> mockup, version `monochrome-channel-glyphs`.
+
+---
+
+## Two views, one control set
+
+**Latest** is the default. **Directory** is the management view. They are a
+`SegmentedControl`, and the bond filter below it is a `FilterChipGroup` — both the
+kit's radiogroups, because Radix supplies the roving focus and arrow-key movement
+that `role="radio"` on a plain button promises and does not have.
+
+<Specimen title="View switcher + filter chips">
+  <ViewSwitcherDemo />
+</Specimen>
+
+`All` means the **placed** people: it holds back both unplaced ends of the ladder, so
+Unknown and Stranger are each entered on purpose. The Unknown chip carries a count
+when senders are waiting.
+
+<Invariant>
+  Every number on screen is the server's. Chips read `counts`, directory headings read
+  `totals`, and neither is derived from the rows that happened to load — the union is
+  paged, so a count taken over page one would report no waiting senders whenever
+  placed people fill it. The two numbers answer different questions and are meant to
+  disagree.
+</Invariant>
+
+---
+
+## Latest — the stream
+
+One row per identity, newest first, carrying only what routing needs: neutral avatar,
+name, monochrome source glyph, one line of preview, relative time.
+
+<Specimen title="Stream rows">
+  <StreamDemo />
+</Specimen>
+
+No management controls on a stream row. Bond and linked accounts live on the person
+page. A row here exists to get you to a conversation.
+
+---
+
+## Unknown — the placement view
+
+The Unknown chip keeps dense rows: channel pill, number or handle, message count,
+preview, and the `⋯` menu. The placement decision runs on that evidence, so all of it
+is on the row rather than a click away. A move updates the row in place and decrements
+the chip's count.
+
+<Specimen title="Unknown rows">
+  <UnknownDemo />
+</Specimen>
+
+<Invariant>
+  Unknown and Stranger are positions on one ladder. Placing a sender, promoting a
+  friend and dismissing spam are the same gesture — a **move** — so the row's `⋯` menu
+  is generated from its current level rather than written per group.
+  `moveTargetsFor(row)` is the only place that enumerates targets, and the row menu,
+  the bulk bar and the dossier select all read it.
+</Invariant>
+
+---
+
+## Directory — the roster
+
+Everyone grouped by bond with live counts, three columns (avatar, name plus
+identifier, `⋯`), no channel badges. Click a row to open the person, and click the
+avatar to select. A selection raises the bulk bar, whose choices are the **intersection**
+across the selection, since one choice applies to every row in it.
+
+<Specimen title="Directory groups, selection, bulk bar">
+  <DirectoryDemo />
+</Specimen>
+
+The guardian row is fixed: not moved, not merged, not selected. Never-messaged
+contacts sit behind a toggle in the Unknown group — which is why the Unknown heading
+survives an empty group, since an address book with no waiting senders in front of it
+would otherwise have no way back on screen.
+
+---
+
+## The person page
+
+`/people/:identityId` is the dossier: identity card with bond select, linked accounts
+as neutral glyph + id pills, `Link account…` and `Merge into…`. The merged timeline
+grouped by day sits below it, and a sticky composer sits at the bottom.
+
+<Specimen title="Dossier">
+  <PersonPageDemo />
+</Specimen>
+
+Day grouping is a calendar comparison, not an elapsed-time one — the day either side
+of a DST change is 23 or 25 hours long, so "yesterday" is a calendar step. The year
+appears in a label only once it disambiguates.
+
+---
+
+## Channels are glyphs, never colors
+
+`CHANNEL_META` ships an icon per channel, drawn in `currentColor` at muted foreground.
+
+<Specimen title="Channel glyphs">
+  <ChannelGlyphSet />
+</Specimen>
+
+<Invariant>
+  Status hues stay reserved for status semantics, and there are more channels than a
+  palette has room for. A channel contributed by a Rome App gets the generic glyph
+  rather than an undefined color.
+</Invariant>
+
+Avatars are neutral everywhere for the same reason — tinting an avatar by channel
+would be a second, contradictory color vocabulary on the same row.
+
+---
+
+## Writes
+
+| Rule | Why |
+| --- | --- |
+| Settle by invalidation, never by patching cached rows | Where a row lands is the server's answer, and a hand-merged level disagrees the moment a move implies anything else |
+| A write holds its identities until the cache catches up | `planMove` reads a row's current id shape, so a second write against an identity the first is still reshaping plans from a shape that has already changed |
+| Placing or dismissing fans out over every channel the row stands for | A consolidated WhatsApp contact is one row under both its phone jid and its `@lid` jid, so acting on one would leave the rest to resurface as their own Unknown rows |
+
+The fan-out is best-effort past the first call: the first call **is** the move and has
+already committed, so a failed follow-up must not report a saved change as a failed
+one.
+
+---
+
+## Open questions
+
+- Directory filters apply after pagination, so a level with a nonzero total can render
+  short. The real fix is paging each group independently.
+- The chip rail stays lit while a search is active, though the search has taken over
+  from it.
+- Only WhatsApp can send. Other channels appear in the composer's select, disabled,
+  until a send path exists.

--- a/packages/web/src/pages/dev/mdx/docs/people-page.mdx
+++ b/packages/web/src/pages/dev/mdx/docs/people-page.mdx
@@ -26,6 +26,12 @@ ships with, so switching the theme re-renders the design rather than a picture o
 > [#2393](https://github.com/amantru/rome-internal/pull/2393) and its interactive
 > mockup, version `monochrome-channel-glyphs`.
 
+The specimens stand in for #2393's row components, which this repo does not carry
+yet. They hold the row shapes and the glyph set against literal fixtures. In one
+place they diverge from what ships: an avatar here is the kit's `Avatar` with a
+fallback child, where #2393 rolls its own. Both draw the same initials on the same
+neutral tone, and the kit's adds a hairline ring.
+
 ---
 
 ## Two views, one control set

--- a/packages/web/src/pages/dev/mdx/mdx-components.tsx
+++ b/packages/web/src/pages/dev/mdx/mdx-components.tsx
@@ -1,0 +1,160 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+// How a design doc's Markdown renders. MDX hands every Markdown construct to
+// the component named here, so prose picks up the same typography roles and
+// semantic colors as the product it is describing — a doc and the UI it
+// documents are read in one theme, not two.
+
+function H1(props: ComponentPropsWithoutRef<"h1">) {
+  return <h1 className="mt-10 mb-3 text-display text-foreground first:mt-0" {...props} />;
+}
+
+function H2(props: ComponentPropsWithoutRef<"h2">) {
+  return (
+    <h2
+      className="mt-10 mb-3 border-b border-border-subtle pb-2 text-title text-foreground"
+      {...props}
+    />
+  );
+}
+
+function H3(props: ComponentPropsWithoutRef<"h3">) {
+  return <h3 className="mt-6 mb-2 text-section text-foreground" {...props} />;
+}
+
+function P(props: ComponentPropsWithoutRef<"p">) {
+  return <p className="my-3 text-body text-muted-foreground" {...props} />;
+}
+
+function Ul(props: ComponentPropsWithoutRef<"ul">) {
+  return <ul className="my-3 list-disc pl-6 text-body text-muted-foreground" {...props} />;
+}
+
+function Ol(props: ComponentPropsWithoutRef<"ol">) {
+  return <ol className="my-3 list-decimal pl-6 text-body text-muted-foreground" {...props} />;
+}
+
+function Li(props: ComponentPropsWithoutRef<"li">) {
+  return <li className="my-1" {...props} />;
+}
+
+function Strong(props: ComponentPropsWithoutRef<"strong">) {
+  return <strong className="font-medium text-foreground" {...props} />;
+}
+
+function A(props: ComponentPropsWithoutRef<"a">) {
+  return (
+    <a
+      className="text-primary underline underline-offset-2"
+      target="_blank"
+      rel="noreferrer"
+      {...props}
+    />
+  );
+}
+
+function Code({ className, ...props }: ComponentPropsWithoutRef<"code">) {
+  return (
+    <code
+      className={cn(
+        "rounded-4 bg-surface-muted px-2 py-1 font-mono text-aux text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function Pre(props: ComponentPropsWithoutRef<"pre">) {
+  return (
+    <pre
+      className="my-4 overflow-x-auto rounded-12 border border-border bg-surface p-4 font-mono text-aux text-foreground [&_code]:bg-transparent [&_code]:p-0"
+      {...props}
+    />
+  );
+}
+
+function Blockquote(props: ComponentPropsWithoutRef<"blockquote">) {
+  return (
+    <blockquote
+      className="my-4 border-l-2 border-border-strong pl-4 text-body text-muted-foreground italic"
+      {...props}
+    />
+  );
+}
+
+function Hr() {
+  return <hr className="my-8 border-border-subtle" />;
+}
+
+function Table(props: ComponentPropsWithoutRef<"table">) {
+  return (
+    <div className="my-4 overflow-x-auto rounded-12 border border-border">
+      <table className="w-full text-ui" {...props} />
+    </div>
+  );
+}
+
+function Th(props: ComponentPropsWithoutRef<"th">) {
+  return (
+    <th
+      className="border-b border-border-subtle bg-surface px-3 py-2 text-left text-badge text-foreground"
+      {...props}
+    />
+  );
+}
+
+function Td(props: ComponentPropsWithoutRef<"td">) {
+  return (
+    <td className="border-b border-border-subtle px-3 py-2 text-muted-foreground" {...props} />
+  );
+}
+
+/**
+ * A rendered specimen: the live component, with the design claim it is there
+ * to demonstrate underneath it. Available to every doc without an import.
+ */
+export function Specimen({ title, children }: { title?: string; children: ReactNode }) {
+  return (
+    <figure className="my-6">
+      {title && (
+        <figcaption className="mb-2 text-badge text-subtle-foreground uppercase">
+          {title}
+        </figcaption>
+      )}
+      {children}
+    </figure>
+  );
+}
+
+/** A design invariant called out of the prose — the rule a reviewer checks. */
+export function Invariant({ children }: { children: ReactNode }) {
+  return (
+    <aside className="my-4 rounded-12 border border-border-strong bg-surface p-4">
+      <div className="mb-1 text-badge text-subtle-foreground uppercase">Invariant</div>
+      <div className="text-body text-foreground">{children}</div>
+    </aside>
+  );
+}
+
+export const mdxComponents = {
+  h1: H1,
+  h2: H2,
+  h3: H3,
+  p: P,
+  ul: Ul,
+  ol: Ol,
+  li: Li,
+  strong: Strong,
+  a: A,
+  code: Code,
+  pre: Pre,
+  blockquote: Blockquote,
+  hr: Hr,
+  table: Table,
+  th: Th,
+  td: Td,
+  Specimen,
+  Invariant,
+} as const;

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -14,7 +14,7 @@
     "jsx": "react-jsx",
     "incremental": true,
     "useDefineForClassFields": true,
-    "types": ["@rsbuild/core/types"],
+    "types": ["@rsbuild/core/types", "mdx"],
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,10 +146,10 @@ importers:
         version: link:../ui
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0))(@rspack/core@2.0.1(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.3(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0))(@rspack/core@2.0.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21))
       '@rslib/core':
         specifier: ^0.21.3
-        version: 0.21.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0)(typescript@5.9.3)
+        version: 0.21.3(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0)(typescript@5.9.3)
       '@tailwindcss/postcss':
         specifier: ^4.1.0
         version: 4.1.18
@@ -186,7 +186,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: ^2.0.0
-        version: 2.0.1(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21)
+        version: 2.0.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
@@ -496,10 +496,10 @@ importers:
     devDependencies:
       '@rsbuild/core':
         specifier: ^2.0.9
-        version: 2.0.9(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0)
+        version: 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0)
       '@rsbuild/plugin-react':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.9(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0))(@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))
+        version: 2.0.1(@rsbuild/core@2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0))(@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23))
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -542,7 +542,7 @@ importers:
     dependencies:
       '@statsig/statsig-node-core':
         specifier: ^0.19.6
-        version: 0.19.6(encoding@0.1.13)
+        version: 0.19.6(encoding@0.1.13)(supports-color@8.1.1)
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -570,7 +570,7 @@ importers:
         version: 2.2.0(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))
       expo:
         specifier: ~57.0.16
-        version: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+        version: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       expo-application:
         specifier: ~57.0.2
         version: 57.0.2(expo@57.0.16)
@@ -853,6 +853,12 @@ importers:
         specifier: ^5.0.2
         version: 5.0.14(@types/react@19.2.15)(immer@11.1.15)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     devDependencies:
+      '@mdx-js/loader':
+        specifier: ^3.1.1
+        version: 3.1.1
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
       '@playwright/test':
         specifier: 1.62.1
         version: 1.62.1
@@ -889,6 +895,9 @@ importers:
       msw:
         specifier: ^2.15.0
         version: 2.15.0(@types/node@25.2.3)(typescript@5.9.3)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwindcss:
         specifier: ^4.1.0
         version: 4.2.2
@@ -3219,6 +3228,17 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@mdx-js/loader@3.1.1':
+    resolution: {integrity: sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==}
+    peerDependencies:
+      webpack: '>=5'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+
+  '@mdx-js/mdx@3.1.1':
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
@@ -6267,6 +6287,9 @@ packages:
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
+  '@types/mdx@2.0.14':
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
   '@types/memcached@2.2.10':
     resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
 
@@ -6480,6 +6503,11 @@ packages:
     peerDependencies:
       acorn: ^8
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -6606,6 +6634,10 @@ packages:
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
+
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
 
   async-exit-hook@2.0.1:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
@@ -7017,6 +7049,9 @@ packages:
     peerDependencies:
       react: 19.2.6
       react-dom: 19.2.6
+
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -7826,6 +7861,12 @@ packages:
     resolution: {integrity: sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==}
     engines: {node: '>=0.12'}
 
+  esast-util-from-estree@2.0.0:
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
+
+  esast-util-from-js@2.0.1:
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -7873,8 +7914,23 @@ packages:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
 
+  estree-util-attach-comments@3.0.0:
+    resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
+
+  estree-util-build-jsx@3.0.1:
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
+
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-scope@1.0.1:
+    resolution: {integrity: sha512-B0np3dcdxqILX5e9nEi5/Fr4K7gL4oYFVPV1zRa2e9wRCbQoZZNWOZFYyoInvXUPJXBXjss+QXlWLJChDEHDkA==}
+
+  estree-util-to-js@2.0.0:
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -8412,6 +8468,9 @@ packages:
 
   hast-util-sanitize@5.0.2:
     resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
+  hast-util-to-estree@3.1.3:
+    resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
 
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
@@ -9220,6 +9279,10 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  markdown-extensions@2.0.0:
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
+    engines: {node: '>=16'}
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -9281,6 +9344,9 @@ packages:
 
   mdast-util-mdx-jsx@3.2.0:
     resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
 
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
@@ -9481,11 +9547,29 @@ packages:
   micromark-extension-math@3.1.0:
     resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
 
   micromark-factory-label@2.0.1:
     resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
 
   micromark-factory-space@2.0.1:
     resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
@@ -9516,6 +9600,9 @@ packages:
 
   micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
 
   micromark-util-html-tag-name@2.0.1:
     resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
@@ -10491,6 +10578,20 @@ packages:
       react-dom: 19.2.6
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  recma-build-jsx@1.0.0:
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
+
+  recma-jsx@1.0.1:
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  recma-parse@1.0.0:
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
+
+  recma-stringify@1.0.0:
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -10538,6 +10639,9 @@ packages:
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
 
+  rehype-recma@1.0.0:
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
   rehype-sanitize@6.0.0:
     resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
@@ -10546,6 +10650,9 @@ packages:
 
   remark-math@6.0.0:
     resolution: {integrity: sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -10913,6 +11020,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -11395,6 +11506,9 @@ packages:
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
@@ -12057,7 +12171,7 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.0(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -12115,7 +12229,7 @@ snapshots:
 
   '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
@@ -12128,14 +12242,14 @@ snapshots:
 
   '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       debug: 4.4.3(supports-color@8.1.1)
@@ -12171,7 +12285,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
@@ -12180,7 +12294,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7
@@ -12195,7 +12309,7 @@ snapshots:
 
   '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-wrap-function': 7.29.7
       '@babel/traverse': 7.29.7
@@ -12204,7 +12318,7 @@ snapshots:
 
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/traverse': 7.29.7
@@ -12253,7 +12367,7 @@ snapshots:
 
   '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.0)
@@ -12262,52 +12376,52 @@ snapshots:
 
   '@babel/plugin-proposal-export-default-from@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-export-default-from@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.0)
       '@babel/traverse': 7.29.7
@@ -12316,7 +12430,7 @@ snapshots:
 
   '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.0)
@@ -12325,12 +12439,12 @@ snapshots:
 
   '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
@@ -12338,7 +12452,7 @@ snapshots:
 
   '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
@@ -12346,7 +12460,7 @@ snapshots:
 
   '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-globals': 7.29.7
@@ -12358,7 +12472,7 @@ snapshots:
 
   '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
@@ -12366,18 +12480,18 @@ snapshots:
 
   '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.0)
 
   '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
@@ -12385,12 +12499,12 @@ snapshots:
 
   '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
@@ -12398,18 +12512,18 @@ snapshots:
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0)
@@ -12420,12 +12534,12 @@ snapshots:
 
   '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
@@ -12433,12 +12547,12 @@ snapshots:
 
   '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
@@ -12446,7 +12560,7 @@ snapshots:
 
   '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
@@ -12455,19 +12569,19 @@ snapshots:
 
   '@babel/plugin-transform-react-display-name@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-development@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
@@ -12478,16 +12592,16 @@ snapshots:
 
   '@babel/plugin-transform-react-pure-annotations@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.0)':
+  '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.0)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)(supports-color@8.1.1)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
@@ -12496,7 +12610,7 @@ snapshots:
 
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
@@ -12507,13 +12621,13 @@ snapshots:
 
   '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/preset-typescript@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.0)
@@ -13119,7 +13233,7 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@expo/cli@57.0.18(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-constants@57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)))(expo-font@57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)':
+  '@expo/cli@57.0.18(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-constants@57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)))(expo-font@57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 57.0.9(typescript@6.0.3)
@@ -13127,23 +13241,23 @@ snapshots:
       '@expo/devcert': 1.2.1
       '@expo/env': 2.4.2
       '@expo/image-utils': 0.11.5(typescript@6.0.3)
-      '@expo/inline-modules': 0.1.6(typescript@6.0.3)
+      '@expo/inline-modules': 0.1.6(supports-color@8.1.1)(typescript@6.0.3)
       '@expo/json-file': 11.0.1
       '@expo/log-box': 57.0.3(@expo/dom-webview@57.0.1)(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)
       '@expo/metro': 56.0.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@expo/metro-config': 57.0.10(bufferutil@4.1.0)(expo@57.0.16)(typescript@6.0.3)(utf-8-validate@5.0.10)
-      '@expo/metro-file-map': 57.0.2
+      '@expo/metro-file-map': 57.0.2(supports-color@8.1.1)
       '@expo/osascript': 2.7.1
       '@expo/package-manager': 1.13.1
       '@expo/plist': 0.8.1
-      '@expo/prebuild-config': 57.0.14(typescript@6.0.3)
+      '@expo/prebuild-config': 57.0.14(supports-color@8.1.1)(typescript@6.0.3)
       '@expo/require-utils': 57.0.5(typescript@6.0.3)
-      '@expo/router-server': 57.0.7(expo-constants@57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)))(expo-font@57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(expo-server@57.0.3)(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react@19.2.3)
+      '@expo/router-server': 57.0.7(expo-constants@57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)))(expo-font@57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(expo-server@57.0.3)(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react@19.2.3)(supports-color@8.1.1)
       '@expo/schema-utils': 57.0.2
       '@expo/spawn-async': 1.8.0
       '@expo/ws-tunnel': 2.0.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@expo/xcpretty': 4.4.4
-      '@react-native/dev-middleware': 0.86.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@react-native/dev-middleware': 0.86.2(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)
       accepts: 1.3.8
       agent-cli-detector: 0.1.6
       arg: 5.0.2
@@ -13155,7 +13269,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3(supports-color@8.1.1)
       dnssd-advertise: 1.1.6
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       expo-server: 57.0.3
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -13200,7 +13314,7 @@ snapshots:
     dependencies:
       node-forge: 1.4.0
 
-  '@expo/config-plugins@57.0.8(typescript@6.0.3)':
+  '@expo/config-plugins@57.0.8(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@expo/config-types': 57.0.2
       '@expo/json-file': 11.0.1
@@ -13242,7 +13356,7 @@ snapshots:
 
   '@expo/config@57.0.8(typescript@6.0.3)':
     dependencies:
-      '@expo/config-plugins': 57.0.8(typescript@6.0.3)
+      '@expo/config-plugins': 57.0.8(supports-color@8.1.1)(typescript@6.0.3)
       '@expo/config-types': 57.0.2
       '@expo/json-file': 11.0.1
       '@expo/require-utils': 57.0.4(typescript@6.0.3)
@@ -13288,7 +13402,7 @@ snapshots:
 
   '@expo/dom-webview@57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)':
     dependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)
 
@@ -13302,7 +13416,7 @@ snapshots:
 
   '@expo/expo-modules-macros-plugin@0.6.1': {}
 
-  '@expo/fingerprint@0.20.10':
+  '@expo/fingerprint@0.20.10(supports-color@8.1.1)':
     dependencies:
       '@expo/env': 2.4.2
       '@expo/spawn-async': 1.8.0
@@ -13331,9 +13445,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/inline-modules@0.1.6(typescript@6.0.3)':
+  '@expo/inline-modules@0.1.6(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
-      '@expo/config-plugins': 57.0.8(typescript@6.0.3)
+      '@expo/config-plugins': 57.0.8(supports-color@8.1.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -13355,7 +13469,7 @@ snapshots:
     dependencies:
       '@expo/dom-webview': 57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)
       anser: 1.4.10
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)
       stacktrace-parser: 0.1.11
@@ -13363,7 +13477,7 @@ snapshots:
   '@expo/metro-config@57.0.10(bufferutil@4.1.0)(expo@57.0.16)(typescript@6.0.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@expo/config': 57.0.9(typescript@6.0.3)
       '@expo/env': 2.4.2
@@ -13386,14 +13500,14 @@ snapshots:
       postcss: 8.5.15
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
 
-  '@expo/metro-file-map@57.0.2':
+  '@expo/metro-file-map@57.0.2(supports-color@8.1.1)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       fb-watchman: 2.0.2
@@ -13444,7 +13558,7 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
-  '@expo/prebuild-config@57.0.14(typescript@6.0.3)':
+  '@expo/prebuild-config@57.0.14(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@expo/config': 57.0.9(typescript@6.0.3)
       '@expo/config-plugins': 57.0.9(typescript@6.0.3)
@@ -13463,7 +13577,7 @@ snapshots:
   '@expo/require-utils@57.0.4(typescript@6.0.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
     optionalDependencies:
       typescript: 6.0.3
@@ -13473,17 +13587,17 @@ snapshots:
   '@expo/require-utils@57.0.5(typescript@6.0.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/router-server@57.0.7(expo-constants@57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)))(expo-font@57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(expo-server@57.0.3)(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react@19.2.3)':
+  '@expo/router-server@57.0.7(expo-constants@57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)))(expo-font@57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(expo-server@57.0.3)(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react@19.2.3)(supports-color@8.1.1)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       expo-constants: 57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))
       expo-font: 57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)
       expo-server: 57.0.3
@@ -13505,13 +13619,13 @@ snapshots:
 
   '@expo/ui@57.0.13(@babel/core@7.29.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)':
     dependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)
       sf-symbols-typescript: 2.2.0
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.3))(react@19.2.3)
     optionalDependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       react-dom: 19.2.6(react@19.2.3)
     transitivePeerDependencies:
       - '@types/react'
@@ -13908,6 +14022,43 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mdx-js/loader@3.1.1':
+    dependencies:
+      '@mdx-js/mdx': 3.1.1
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mdx-js/mdx@3.1.1':
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdx': 2.0.14
+      acorn: 8.15.0
+      collapse-white-space: 2.1.0
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-util-scope: 1.0.1
+      estree-walker: 3.0.3
+      hast-util-to-jsx-runtime: 2.3.6
+      markdown-extensions: 2.0.0
+      recma-build-jsx: 1.0.0
+      recma-jsx: 1.0.1(acorn@8.15.0)
+      recma-stringify: 1.0.0
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      source-map: 0.7.6
+      unified: 11.0.5
+      unist-util-position-from-estree: 2.0.0
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@mermaid-js/parser@1.1.1':
     dependencies:
       '@chevrotain/types': 11.1.2
@@ -14007,7 +14158,7 @@ snapshots:
     dependencies:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       lru-cache: 10.4.3
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -16186,7 +16337,7 @@ snapshots:
 
   '@react-native/codegen@0.86.2(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/parser': 7.29.7
       hermes-parser: 0.36.0
       invariant: 2.2.4
@@ -16196,7 +16347,7 @@ snapshots:
 
   '@react-native/community-cli-plugin@0.86.2(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)':
     dependencies:
-      '@react-native/dev-middleware': 0.86.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@react-native/dev-middleware': 0.86.2(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)
       debug: 4.4.3(supports-color@8.1.1)
       invariant: 2.2.4
       metro: 0.84.4(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)
@@ -16210,7 +16361,7 @@ snapshots:
 
   '@react-native/debugger-frontend@0.86.2': {}
 
-  '@react-native/debugger-shell@0.86.2':
+  '@react-native/debugger-shell@0.86.2(supports-color@8.1.1)':
     dependencies:
       cross-spawn: 7.0.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -16218,11 +16369,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/dev-middleware@0.86.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+  '@react-native/dev-middleware@0.86.2(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10)':
     dependencies:
       '@isaacs/ttlcache': 1.4.1
       '@react-native/debugger-frontend': 0.86.2
-      '@react-native/debugger-shell': 0.86.2
+      '@react-native/debugger-shell': 0.86.2(supports-color@8.1.1)
       chrome-launcher: 0.15.2
       chromium-edge-launcher: 0.3.0
       connect: 3.7.0
@@ -16339,9 +16490,9 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
-  '@rsbuild/core@2.0.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0)':
+  '@rsbuild/core@2.0.3(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0)':
     dependencies:
-      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
       '@swc/helpers': 0.5.21
     optionalDependencies:
       core-js: 3.46.0
@@ -16357,21 +16508,21 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/core@2.0.9(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0)':
+  '@rsbuild/core@2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0)':
     dependencies:
-      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23)
+      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     optionalDependencies:
       core-js: 3.46.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0))(@rspack/core@2.0.1(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21))':
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.3(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0))(@rspack/core@2.0.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.1(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0)
+      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -16393,19 +16544,19 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.9(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0))(@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0))(@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0)
+      '@rsbuild/core': 2.0.9(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
   '@rsbuild/plugin-svgr@2.0.2(@rsbuild/core@2.0.7(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0))(@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21))(typescript@5.9.3)':
     dependencies:
       '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.0.7(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0))(@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21))
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
       deepmerge: 4.3.1
@@ -16417,10 +16568,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rslib/core@0.21.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0)(typescript@5.9.3)':
+  '@rslib/core@0.21.3(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0)(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0)
-      rsbuild-plugin-dts: 0.21.3(@rsbuild/core@2.0.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0))(typescript@5.9.3)
+      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0)
+      rsbuild-plugin-dts: 0.21.3(@rsbuild/core@2.0.3(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0))(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -16569,7 +16720,7 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.0.5
       '@rspack/binding-win32-x64-msvc': 2.0.5
 
-  '@rspack/core@2.0.1(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21)':
+  '@rspack/core@2.0.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)':
     dependencies:
       '@rspack/binding': 2.0.1
     optionalDependencies:
@@ -16591,18 +16742,18 @@ snapshots:
       '@swc/helpers': 0.5.21
     optional: true
 
-  '@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23)':
+  '@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.0.5
     optionalDependencies:
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0(encoding@0.1.13))
       '@swc/helpers': 0.5.23
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.1(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.21)
 
   '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21))(react-refresh@0.18.0)':
     dependencies:
@@ -16610,11 +16761,11 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.21)
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23)
+      '@rspack/core': 2.0.5(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   '@rspack/resolver-binding-darwin-arm64@0.4.0':
     optional: true
@@ -16751,10 +16902,10 @@ snapshots:
   '@statsig/statsig-node-core-win32-x64-msvc@0.19.6':
     optional: true
 
-  '@statsig/statsig-node-core@0.19.6(encoding@0.1.13)':
+  '@statsig/statsig-node-core@0.19.6(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:
       '@octokit/core': 6.1.6
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
       '@statsig/statsig-node-core-darwin-arm64': 0.19.6
@@ -16791,39 +16942,39 @@ snapshots:
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
       '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
       '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
@@ -16833,9 +16984,9 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
 
-  '@svgr/core@8.1.0(typescript@5.9.3)':
+  '@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
@@ -16851,9 +17002,9 @@ snapshots:
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -16861,7 +17012,7 @@ snapshots:
 
   '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       deepmerge: 4.3.1
       svgo: 3.3.3
@@ -17325,6 +17476,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/mdx@2.0.14': {}
+
   '@types/memcached@2.2.10':
     dependencies:
       '@types/node': 25.9.1
@@ -17586,6 +17739,10 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
   acorn@8.15.0: {}
 
   agent-base@7.1.4: {}
@@ -17724,6 +17881,8 @@ snapshots:
   astral-regex@2.0.0:
     optional: true
 
+  astring@1.9.0: {}
+
   async-exit-hook@2.0.1: {}
 
   async-limiter@1.0.1: {}
@@ -17756,27 +17915,27 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0)(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17800,7 +17959,7 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
 
-  babel-preset-expo@57.0.8(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo-widgets@57.0.12)(expo@57.0.16)(react-refresh@0.14.2):
+  babel-preset-expo@57.0.8(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo-widgets@57.0.12)(expo@57.0.16)(react-refresh@0.14.2)(supports-color@8.1.1):
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/helper-module-imports': 7.29.7
@@ -17834,7 +17993,7 @@ snapshots:
       '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx-development': 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-transform-react-pure-annotations': 7.29.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.0)(supports-color@8.1.1)
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.0)
@@ -17847,7 +18006,7 @@ snapshots:
       react-refresh: 0.14.2
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       expo-widgets: 57.0.12(@babel/core@7.29.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)
     transitivePeerDependencies:
       - '@babel/core'
@@ -18023,7 +18182,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       js-yaml: 4.1.1
       sanitize-filename: 1.6.3
       source-map-support: 0.5.21
@@ -18263,6 +18422,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  collapse-white-space@2.1.0: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -19068,6 +19229,20 @@ snapshots:
       d: 1.0.2
       ext: 1.7.0
 
+  esast-util-from-estree@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      unist-util-position-from-estree: 2.0.0
+
+  esast-util-from-js@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.15.0
+      esast-util-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
   esbuild-register@3.6.0(esbuild@0.25.12)(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -19177,7 +19352,34 @@ snapshots:
       event-emitter: 0.3.5
       type: 2.7.3
 
+  estree-util-attach-comments@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  estree-util-build-jsx@3.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-walker: 3.0.3
+
   estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-scope@1.0.1:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+
+  estree-util-to-js@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      astring: 1.9.0
+      source-map: 0.7.6
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
 
   estree-walker@3.0.3:
     dependencies:
@@ -19206,12 +19408,12 @@ snapshots:
 
   expo-application@57.0.2(expo@57.0.16):
     dependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
 
   expo-asset@57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.11.5(typescript@6.0.3)
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       expo-constants: 57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)
@@ -19222,39 +19424,39 @@ snapshots:
   expo-constants@57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)):
     dependencies:
       '@expo/env': 2.4.2
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       react-native: 0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - supports-color
 
   expo-crypto@57.0.2(expo@57.0.16):
     dependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
 
   expo-device@57.0.1(expo@57.0.16):
     dependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       ua-parser-js: 0.7.41
 
   expo-file-system@57.0.5(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)):
     dependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       react-native: 0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)
 
   expo-font@57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       fontfaceobserver: 2.3.0
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)
 
   expo-haptics@57.0.1(expo@57.0.16):
     dependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
 
   expo-keep-awake@57.0.1(expo@57.0.16)(react@19.2.3):
     dependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       react: 19.2.3
 
   expo-modules-autolinking@57.0.11(typescript@6.0.3):
@@ -19284,7 +19486,7 @@ snapshots:
       '@expo/image-utils': 0.11.5(typescript@6.0.3)
       abort-controller: 3.0.0
       badgin: 1.2.3
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       expo-application: 57.0.2(expo@57.0.16)
       expo-constants: 57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))
       react: 19.2.3
@@ -19295,20 +19497,20 @@ snapshots:
 
   expo-secure-store@57.0.1(expo@57.0.16):
     dependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
 
   expo-server@57.0.3: {}
 
   expo-web-browser@57.0.2(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)):
     dependencies:
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       react-native: 0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)
 
   expo-widgets@57.0.12(@babel/core@7.29.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3):
     dependencies:
       '@expo/plist': 0.8.1
       '@expo/ui': 57.0.13(@babel/core@7.29.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)
-      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      expo: 57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       react: 19.2.3
       react-native: 0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -19318,20 +19520,20 @@ snapshots:
       - react-dom
       - react-native-worklets
 
-  expo@57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10):
+  expo@57.0.16(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-widgets@57.0.12)(react-dom@19.2.6(react@19.2.3))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 57.0.18(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-constants@57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)))(expo-font@57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      '@expo/cli': 57.0.18(@expo/dom-webview@57.0.1)(bufferutil@4.1.0)(expo-constants@57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10)))(expo-font@57.0.1(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3))(expo@57.0.16)(react-dom@19.2.6(react@19.2.3))(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(supports-color@8.1.1)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@expo/config': 57.0.9(typescript@6.0.3)
       '@expo/config-plugins': 57.0.9(typescript@6.0.3)
       '@expo/devtools': 57.0.1(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)
-      '@expo/fingerprint': 0.20.10
+      '@expo/fingerprint': 0.20.10(supports-color@8.1.1)
       '@expo/local-build-cache-provider': 57.0.7(typescript@6.0.3)
       '@expo/log-box': 57.0.3(@expo/dom-webview@57.0.1)(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)
       '@expo/metro': 56.0.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@expo/metro-config': 57.0.10(bufferutil@4.1.0)(expo@57.0.16)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@ungap/structured-clone': 1.3.0
-      babel-preset-expo: 57.0.8(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo-widgets@57.0.12)(expo@57.0.16)(react-refresh@0.14.2)
+      babel-preset-expo: 57.0.8(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo-widgets@57.0.12)(expo@57.0.16)(react-refresh@0.14.2)(supports-color@8.1.1)
       expo-asset: 57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))(react@19.2.3)(typescript@6.0.3)
       expo-constants: 57.0.14(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))
       expo-file-system: 57.0.5(expo@57.0.16)(react-native@0.86.2(@babel/core@7.29.0)(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)(utf-8-validate@5.0.10))
@@ -19648,7 +19850,7 @@ snapshots:
   gaxios@6.7.1(encoding@0.1.13):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-stream: 2.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       uuid: 9.0.1
@@ -19882,6 +20084,27 @@ snapshots:
       '@ungap/structured-clone': 1.3.0
       unist-util-position: 5.0.0
 
+  hast-util-to-estree@3.1.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-attach-comments: 3.0.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      zwitch: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -20047,7 +20270,7 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -20697,6 +20920,8 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  markdown-extensions@2.0.0: {}
+
   markdown-table@3.0.4: {}
 
   marked@14.0.0: {}
@@ -20835,6 +21060,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -20929,7 +21164,7 @@ snapshots:
 
   metro-babel-transformer@0.84.4:
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       flow-enums-runtime: 0.0.6
       hermes-parser: 0.35.0
       metro-cache-key: 0.84.4
@@ -20939,7 +21174,7 @@ snapshots:
 
   metro-babel-transformer@0.84.5:
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       flow-enums-runtime: 0.0.6
       hermes-parser: 0.35.0
       metro-cache-key: 0.84.5
@@ -20959,7 +21194,7 @@ snapshots:
     dependencies:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       metro-core: 0.84.4
     transitivePeerDependencies:
       - supports-color
@@ -20968,7 +21203,7 @@ snapshots:
     dependencies:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       metro-core: 0.84.5
     transitivePeerDependencies:
       - supports-color
@@ -21123,7 +21358,7 @@ snapshots:
 
   metro-transform-plugins@0.84.4:
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.7
@@ -21134,7 +21369,7 @@ snapshots:
 
   metro-transform-plugins@0.84.5:
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.7
@@ -21145,7 +21380,7 @@ snapshots:
 
   metro-transform-worker@0.84.4(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
@@ -21165,7 +21400,7 @@ snapshots:
 
   metro-transform-worker@0.84.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
@@ -21186,7 +21421,7 @@ snapshots:
   metro@0.84.4(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10):
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -21232,7 +21467,7 @@ snapshots:
   metro@0.84.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -21361,6 +21596,57 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-factory-destination@2.0.1:
     dependencies:
       micromark-util-character: 2.1.1
@@ -21373,6 +21659,18 @@ snapshots:
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
 
   micromark-factory-space@2.0.1:
     dependencies:
@@ -21425,6 +21723,16 @@ snapshots:
       micromark-util-symbol: 2.0.1
 
   micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
 
   micromark-util-html-tag-name@2.0.1: {}
 
@@ -21733,7 +22041,7 @@ snapshots:
 
   node-edge-tts@1.2.10(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -22570,6 +22878,35 @@ snapshots:
       - '@types/react'
       - redux
 
+  recma-build-jsx@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-util-build-jsx: 3.0.1
+      vfile: 6.0.3
+
+  recma-jsx@1.0.1(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      estree-util-to-js: 2.0.0
+      recma-parse: 1.0.0
+      recma-stringify: 1.0.0
+      unified: 11.0.5
+
+  recma-parse@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      esast-util-from-js: 2.0.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  recma-stringify@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-util-to-js: 2.0.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -22629,6 +22966,14 @@ snapshots:
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
+  rehype-recma@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      hast-util-to-estree: 3.1.3
+    transitivePeerDependencies:
+      - supports-color
+
   rehype-sanitize@6.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -22651,6 +22996,13 @@ snapshots:
       mdast-util-math: 3.0.0
       micromark-extension-math: 3.1.0
       unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -22844,10 +23196,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  rsbuild-plugin-dts@0.21.3(@rsbuild/core@2.0.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0))(typescript@5.9.3):
+  rsbuild-plugin-dts@0.21.3(@rsbuild/core@2.0.3(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0))(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0)
+      '@rsbuild/core': 2.0.3(@module-federation/runtime-tools@2.5.0)(core-js@3.46.0)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -23137,6 +23489,8 @@ snapshots:
   source-map@0.5.7: {}
 
   source-map@0.6.1: {}
+
+  source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
 
@@ -23622,6 +23976,10 @@ snapshots:
       unist-util-is: 6.0.1
 
   unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
     dependencies:
       '@types/unist': 3.0.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,9 +856,6 @@ importers:
       '@mdx-js/loader':
         specifier: ^3.1.1
         version: 3.1.1
-      '@mdx-js/mdx':
-        specifier: ^3.1.1
-        version: 3.1.1
       '@playwright/test':
         specifier: 1.62.1
         version: 1.62.1
@@ -880,6 +877,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/mdx':
+        specifier: ^2.0.14
+        version: 2.0.14
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3


### PR DESCRIPTION
## What this PR does

A UI design has no home in this repo between the mockup and the merged page. A design note is Markdown with a screenshot, and the screenshot is stale the moment a token moves. Review of a redesign therefore runs against an artifact nobody can theme, focus, or tab through, and the note and the page it describes drift apart with nothing reporting it.

`/dev/mdx` hosts MDX design docs. MDX compiles to React, so a note renders the primitives it describes: the prose and the live specimen sit in one file, against the real tokens, the real focus rules, and the real kit. Switching the theme re-renders the design rather than a picture of it.

Three pieces:

- `@mdx-js/loader` and `remark-gfm` in an rspack rule, plus a `declare module "*.mdx"`.
- `src/pages/dev/mdx/` — the doc registry, the page shell, and the Markdown-to-token mapping.
- One `DEV_ROUTES` entry.

The first doc is the People page rebuild from [#2393](https://github.com/amantru/rome-internal/pull/2393): the stream, the Unknown placement view, the Directory, and the person page, with six live specimens.

## Design & Invariants

**A specimen renders the kit, never a copy of it.** The doc's controls are `SegmentedControl`, `FilterChipGroup`, `Button`, `DropdownMenu`, `Select`, `Avatar`, and `Badge` — the same primitives the page ships with. A specimen that reimplemented a control would report its own appearance rather than the system's, which is the failure a screenshot already has. One divergence is deliberate and written into the doc: the avatar is the kit's with a fallback child, where #2393 rolls its own. Both draw the same initials on the same neutral tone, and whether #2393 should reach for the kit is a question for that PR.

**Markdown reads the typography roles and the semantic tokens.** `mdx-components.tsx` maps every Markdown construct onto `text-display`, `text-title`, `text-body`, and the color tokens, so a doc and the UI it documents are read in one theme. A doc that reached past the semantic indirection would render in the theme its author was looking at and break in every other one.

**The surface drops out of production with the rest of `/dev`.** The route is one `DEV_ROUTES` entry, and every dynamic import behind it is constructed inside the `import.meta.env.DEV` branch. Production emits no chunk for the docs, the specimens, or the MDX runtime.

**Adding a doc is one registry entry.** `docs.ts` is the single source of truth for slug, title, summary, and the lazy import. The registry is hand-written rather than discovered from the directory, so a doc carries a summary and an intentional slug.

**The selection rides in `?doc=`.** A doc is a shareable URL without a nested route, which keeps the whole surface inside the flat `DEV_ROUTES` shape.

**The People specimens are stand-ins, and the module says so.** #2393's `rows.tsx` and `channel-meta.tsx` are not in this repo. They read `react-i18next` keys from that PR's rewritten `people.json` and types from its additions to `@rome/api-types/identities`, so importing them means landing part of an unmerged PR. `people-demo.tsx` reproduces the row shapes and the glyph set against literal fixtures instead. Once #2393 lands, the MDX imports the real components and the demo module is deleted whole.

## Test plan

- [x] `pnpm --filter rome-web typecheck`
- [x] `pnpm --filter rome-web test` — 1104 pass across 146 files
- [x] `pnpm test:ui:tokens` — 22 pass. The gate caught nine off-roster utilities in the first draft, all now on the spacing and radius rosters
- [x] `biome check` clean on every touched path
- [x] `/dev/mdx` in Chromium against `rsbuild dev`: six specimens and the GFM table render, no console errors. The chip rail and view switcher answer arrow keys, the row menus open, and the directory avatars raise the bulk bar
- [ ] Not exercised in dark mode or a non-default theme

## Not in this PR

- No tests over the MDX surface — the docs are dev-only and carry no product behavior.
- No entry under `docs/`. The format earns a written home once a second doc lands.
- Docs are registered by hand rather than discovered from the directory, so an `.mdx` file alone does not appear.
- The People specimens do not import #2393's components. Reason above.
- No code-block highlighting. The doc's code is inline spans and one fenced block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

