### PR TITLE
feat(core): update a person and merge a duplicate away

### DIFF
--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -586,6 +586,54 @@ export interface UpdatePersonRequest {
 }
 
 /**
+ * Read a request body as an {@link UpdatePersonRequest}, or say what is wrong
+ * with it. The rule rather than any one route's rule, for the reason
+ * {@link parseCreatePersonRequest} states.
+ *
+ * An omitted field is one the update leaves alone, which is the whole
+ * difference between this and a write of the person: a body naming only a bond
+ * level must not blank the name. So a body naming neither is the empty update
+ * rather than a bad request — it asks for the state the person is already in,
+ * which is also what a retry of an update that already landed asks for.
+ *
+ * A body that is not an object is refused all the same. It names no field to
+ * leave alone, so reading it as the empty update would answer a malformed
+ * request with the person and a 200.
+ *
+ * `bondLevel` is checked against the levels a guardian may assign, so a body
+ * naming "guardian" is refused here whoever it addresses. Whether the person
+ * being addressed may move at all is `protectedPersonReason`'s question in
+ * ./persons.ts, and it is a different one.
+ */
+export function parseUpdatePersonRequest(
+  body: unknown,
+): { update: UpdatePersonRequest } | { error: string } {
+  if (typeof body !== "object" || body === null) {
+    return { error: "displayName or bondLevel is required" };
+  }
+  const raw = body as Record<string, unknown>;
+  const update: UpdatePersonRequest = {};
+
+  if (raw.displayName !== undefined) {
+    // Trimmed before it is judged, as a create's name is: whitespace alone is
+    // no name, and storing it would leave the person unfindable by the name
+    // the guardian typed.
+    const displayName = typeof raw.displayName === "string" ? raw.displayName.trim() : "";
+    if (!displayName) return { error: "displayName cannot be empty" };
+    update.displayName = displayName;
+  }
+
+  if (raw.bondLevel !== undefined) {
+    if (!isAssignableBondLevel(raw.bondLevel)) {
+      return { error: `bondLevel must be one of ${ASSIGNABLE_BOND_LEVELS.join(", ")}` };
+    }
+    update.bondLevel = raw.bondLevel;
+  }
+
+  return { update };
+}
+
+/**
  * `POST /api/people/:id/accounts` — the link verb.
  *
  * Compare-and-swap on the account's current owner: linking an unlinked or
@@ -656,4 +704,25 @@ export function linkConflict(
  *  and a delete, because history re-attribution must not half-happen. */
 export interface MergeRequest {
   from: string;
+}
+
+/**
+ * Read a request body as a {@link MergeRequest} against the person absorbing
+ * it, or say what is wrong with it.
+ *
+ * A merge into oneself is refused here rather than being read as a no-op: the
+ * operation moves a person's links away and then deletes them, so a caller
+ * that names the same person twice is describing a write that would end with
+ * the survivor gone. That the two ids are one is visible in the request, so it
+ * never reaches a transaction.
+ */
+export function parseMergeRequest(
+  body: unknown,
+  into: string,
+): { merge: MergeRequest } | { error: string } {
+  if (typeof body !== "object" || body === null) return { error: "from is required" };
+  const { from } = body as Record<string, unknown>;
+  if (typeof from !== "string" || from === "") return { error: "from is required" };
+  if (from === into) return { error: "a person cannot be merged into themselves" };
+  return { merge: { from } };
 }

--- a/packages/core/src/api/routes/people.test.ts
+++ b/packages/core/src/api/routes/people.test.ts
@@ -1157,3 +1157,303 @@ describe("People account links", () => {
     expect((await unlink(alice, NEWCOMER)).status).toBe(404);
   });
 });
+
+// PATCH /people/:id — what the guardian calls a person, and where they sit on
+// the ladder. The one row that refuses the second edit is the guardian's.
+describe("People updates", () => {
+  let testDb: TestDb;
+  let deps: TestDeps;
+  let app: Hono;
+  let baseline: BaselineIds;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    baseline = await seedBaseline(testDb.db);
+    deps = await buildTestDeps(testDb.db);
+    app = new Hono().route("/", peopleRoutes(deps));
+  });
+
+  afterEach(() => testDb.close());
+
+  const patch = (id: string, body: unknown) =>
+    app.request(`/people/${id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  const stored = async (id: string) => await deps.personMappingRepo.findById(id);
+
+  it("moves a person along the ladder and answers with them", async () => {
+    const res = await patch(baseline.persons.otherId, { bondLevel: "inner-circle" });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as PersonResource).toMatchObject({
+      id: baseline.persons.otherId,
+      bondLevel: "inner-circle",
+    });
+    expect((await stored(baseline.persons.otherId))?.bondLevel).toBe("inner-circle");
+  });
+
+  it("renames a person without re-minting their id or disturbing their accounts", async () => {
+    const before = (await (
+      await app.request(`/people/${baseline.persons.acquaintanceId}`)
+    ).json()) as PersonResource;
+
+    const res = await patch(baseline.persons.acquaintanceId, { displayName: "  Bobbie  " });
+
+    expect(res.status).toBe(200);
+    const person = (await res.json()) as PersonResource;
+    expect(person).toMatchObject({ id: baseline.persons.acquaintanceId, displayName: "Bobbie" });
+    // Their accounts keep the names their own platforms give them: a rename
+    // here is the guardian's word for the person, not the channel's for the
+    // account.
+    expect(person.accounts).toEqual(before.accounts);
+  });
+
+  it("leaves the field an update does not name alone", async () => {
+    expect((await patch(baseline.persons.otherId, { displayName: "Caro" })).status).toBe(200);
+
+    const person = await stored(baseline.persons.otherId);
+    expect(person).toMatchObject({ displayName: "Caro", bondLevel: "other" });
+  });
+
+  it("answers an update naming no field with the person, unchanged", async () => {
+    const res = await patch(baseline.persons.otherId, {});
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as PersonResource).toMatchObject({
+      displayName: "Carol Other",
+      bondLevel: "other",
+    });
+  });
+
+  it("refuses to move the guardian off the top of the ladder", async () => {
+    const res = await patch(baseline.persons.guardianId, { bondLevel: "inner-circle" });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: string }).toEqual({
+      error: "the guardian's bond level cannot be changed",
+    });
+    expect((await stored(baseline.persons.guardianId))?.bondLevel).toBe("guardian");
+  });
+
+  it("renames the guardian, whose name is theirs like anyone's", async () => {
+    const res = await patch(baseline.persons.guardianId, { displayName: "Ada" });
+
+    expect(res.status).toBe(200);
+    expect((await stored(baseline.persons.guardianId))?.displayName).toBe("Ada");
+  });
+
+  it("refuses a bond level nobody may be assigned, guardian included", async () => {
+    expect((await patch(baseline.persons.otherId, { bondLevel: "guardian" })).status).toBe(400);
+    expect((await patch(baseline.persons.otherId, { bondLevel: "best-friend" })).status).toBe(400);
+    // Refused before the row is read, so an unknown person and an unassignable
+    // level answer the request that is wrong rather than the row that is not
+    // there.
+    expect((await stored(baseline.persons.otherId))?.bondLevel).toBe("other");
+  });
+
+  it("refuses a name that is no name", async () => {
+    expect((await patch(baseline.persons.otherId, { displayName: "   " })).status).toBe(400);
+    expect((await patch(baseline.persons.otherId, { displayName: null })).status).toBe(400);
+    expect((await stored(baseline.persons.otherId))?.displayName).toBe("Carol Other");
+  });
+
+  it("answers 404 for an unknown person and for the stranger sentinel", async () => {
+    expect((await patch("nobody-here", { displayName: "Nobody" })).status).toBe(404);
+    expect((await patch(STRANGER_PERSON_ID, { displayName: "Nobody" })).status).toBe(404);
+    expect((await stored(STRANGER_PERSON_ID))?.displayName).toBe("Stranger");
+  });
+});
+
+// POST /people/:id/merge — one person absorbs another. What these pin is that
+// the links all move together, that the duplicate is gone rather than emptied,
+// and that the two rows which are structure rather than people are not
+// addressable on either side of it.
+describe("People merge", () => {
+  let testDb: TestDb;
+  let deps: TestDeps;
+  let app: Hono;
+  let baseline: BaselineIds;
+  let alice: string;
+  let bob: string;
+  let carol: string;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    baseline = await seedBaseline(testDb.db);
+    deps = await buildTestDeps(testDb.db);
+    app = new Hono().route("/", peopleRoutes(deps));
+    alice = baseline.persons.innerCircleId;
+    bob = baseline.persons.acquaintanceId;
+    carol = baseline.persons.otherId;
+  });
+
+  afterEach(() => testDb.close());
+
+  const merge = (into: string, body: unknown) =>
+    app.request(`/people/${into}/merge`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  const refs = (person: PersonResource) =>
+    person.accounts.map((account) => `${account.channel}:${account.channelUserId}`);
+
+  async function holderOf(account: { channel: string; channelUserId: string }) {
+    const person = await deps.personMappingRepo.findByChannelUser(
+      account.channel,
+      account.channelUserId,
+    );
+    return person?.id ?? null;
+  }
+
+  it("moves every account onto the survivor and deletes the duplicate", async () => {
+    // Bob holds a second account, so the merge has more than one link to move.
+    await deps.personMappingRepo.addChannelMapping(bob, "whatsapp", "wa-bob", "Bob");
+
+    const res = await merge(alice, { from: bob });
+
+    expect(res.status).toBe(200);
+    expect(refs((await res.json()) as PersonResource)).toEqual(
+      expect.arrayContaining(["telegram:tg-alice", "telegram:tg-bob", "whatsapp:wa-bob"]),
+    );
+    expect(await holderOf({ channel: "telegram", channelUserId: "tg-bob" })).toBe(alice);
+    expect(await holderOf({ channel: "whatsapp", channelUserId: "wa-bob" })).toBe(alice);
+
+    // Gone rather than emptied: the duplicate is not a person with no accounts.
+    expect((await app.request(`/people/${bob}`)).status).toBe(404);
+    expect(await deps.personMappingRepo.findById(bob)).toBeNull();
+    const list = (await (await app.request("/people")).json()) as PeopleList;
+    expect(list.people.map((person) => person.id)).not.toContain(bob);
+  });
+
+  it("carries the channel's name for a moved account across the merge", async () => {
+    const before = (await (await app.request(`/people/${bob}`)).json()) as PersonResource;
+
+    const res = await merge(alice, { from: bob });
+
+    expect(res.status).toBe(200);
+    // The link moves rather than being rewritten, so the account still answers
+    // to the name its platform gives it rather than to the survivor's.
+    expect(((await res.json()) as PersonResource).accounts).toEqual(
+      expect.arrayContaining(before.accounts),
+    );
+  });
+
+  it("absorbs a duplicate holding no account at all", async () => {
+    const empty = await deps.personMappingRepo.create({
+      displayName: "Alice Again",
+      bondLevel: "other",
+      approved: true,
+    });
+
+    const res = await merge(alice, { from: empty });
+
+    expect(res.status).toBe(200);
+    expect(refs((await res.json()) as PersonResource)).toEqual(["telegram:tg-alice"]);
+    expect(await deps.personMappingRepo.findById(empty)).toBeNull();
+  });
+
+  it("keeps the survivor's own name and bond level", async () => {
+    const res = await merge(alice, { from: bob });
+
+    expect((await res.json()) as PersonResource).toMatchObject({
+      displayName: "Alice Inner",
+      bondLevel: "inner-circle",
+    });
+  });
+
+  it("refuses to merge the guardian away, and moves nothing", async () => {
+    const res = await merge(alice, { from: baseline.persons.guardianId });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: string }).toEqual({
+      error: "the guardian cannot be merged away",
+    });
+    expect(await deps.personMappingRepo.findById(baseline.persons.guardianId)).not.toBeNull();
+    expect(await holderOf({ channel: "telegram", channelUserId: "tg-guardian" })).toBe(
+      baseline.persons.guardianId,
+    );
+  });
+
+  it("lets the guardian absorb a duplicate of themselves", async () => {
+    const duplicate = await deps.personMappingRepo.create({
+      displayName: "Me",
+      bondLevel: "other",
+      approved: true,
+      channelMappings: [{ channel: "whatsapp", channelUserId: "wa-me" }],
+    });
+
+    const res = await merge(baseline.persons.guardianId, { from: duplicate });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as PersonResource).toMatchObject({ bondLevel: "guardian" });
+    expect(await holderOf({ channel: "whatsapp", channelUserId: "wa-me" })).toBe(
+      baseline.persons.guardianId,
+    );
+  });
+
+  it("lets only one of two merges of the same duplicate land it", async () => {
+    // Both callers read the same page, where Bob is a duplicate, and both ask
+    // to absorb him.
+    const [first, second] = await Promise.all([
+      merge(alice, { from: bob }),
+      merge(carol, { from: bob }),
+    ]);
+
+    expect([first.status, second.status].sort()).toEqual([200, 404]);
+    // Whoever lost absorbed nothing: the account is under one survivor, not
+    // split between them, and Bob is gone exactly once.
+    const holder = await holderOf({ channel: "telegram", channelUserId: "tg-bob" });
+    expect([alice, carol]).toContain(holder);
+    const winner = first.status === 200 ? first : second;
+    expect(refs((await winner.json()) as PersonResource)).toContain("telegram:tg-bob");
+  });
+
+  it("refuses a merge into oneself", async () => {
+    const res = await merge(alice, { from: alice });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { error: string }).toEqual({
+      error: "a person cannot be merged into themselves",
+    });
+    expect(await deps.personMappingRepo.findById(alice)).not.toBeNull();
+  });
+
+  it("refuses a body that names no duplicate", async () => {
+    expect((await merge(alice, {})).status).toBe(400);
+    expect((await merge(alice, { from: "" })).status).toBe(400);
+    expect(
+      (await app.request(`/people/${alice}/merge`, { method: "POST" })).status, // no body at all
+    ).toBe(400);
+  });
+
+  it("does not address the stranger sentinel as either side", async () => {
+    // A dismissal is a link onto the sentinel, so absorbing it would read every
+    // dismissed account as this person's, and merging a person into it would
+    // read their accounts as dismissed.
+    await deps.personMappingRepo.addChannelMapping(
+      STRANGER_PERSON_ID,
+      "telegram",
+      "tg-dismissed",
+      "Dismissed Sender",
+    );
+
+    expect((await merge(alice, { from: STRANGER_PERSON_ID })).status).toBe(404);
+    expect((await merge(STRANGER_PERSON_ID, { from: alice })).status).toBe(404);
+
+    expect(await holderOf({ channel: "telegram", channelUserId: "tg-dismissed" })).toBe(
+      STRANGER_PERSON_ID,
+    );
+    expect(await holderOf({ channel: "telegram", channelUserId: "tg-alice" })).toBe(alice);
+  });
+
+  it("answers 404 for an unknown person on either side", async () => {
+    expect((await merge(alice, { from: "nobody-here" })).status).toBe(404);
+    expect((await merge("nobody-here", { from: alice })).status).toBe(404);
+    expect(await deps.personMappingRepo.findById(alice)).not.toBeNull();
+  });
+});

--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -5,15 +5,19 @@ import {
   linkConflict,
   parseCreatePersonRequest,
   parseLinkAccountRequest,
+  parseMergeRequest,
   parsePersonFilterLevel,
   parseTimelineCursor,
+  parseUpdatePersonRequest,
   personMatchesLevel,
   personMatchesQuery,
   timelinePageLimit,
   type PeopleList,
 } from "@rome/api-types/people";
 import { createPerson } from "../../people/create.js";
+import { mergePeople } from "../../people/merge.js";
 import { findPerson, readPeople, readPerson } from "../../people/resource.js";
+import { updatePerson } from "../../people/update.js";
 import { readPersonTimeline } from "../../people/timeline.js";
 import { personTimelineSources, timelineAccounts } from "../../people/timeline-sources.js";
 import type { ApiDeps } from "../deps.js";
@@ -22,7 +26,8 @@ import type { ApiDeps } from "../deps.js";
 // orders and counts, what a valid create is, when a link may be taken and what
 // a refused one answers are the contract's (@rome/api-types/people);
 // serializing a person is `src/people/resource.ts`, creating one is
-// `src/people/create.ts`, and which stores a history is merged from is the rest
+// `src/people/create.ts`, editing one `src/people/update.ts`, absorbing one
+// `src/people/merge.ts`, and which stores a history is merged from is the rest
 // of `src/people/`. The compare-and-swap a link rides on is the person
 // repository's, because only a transaction there can decide it. These handlers
 // read the request and pick a status code, and hold no rule of their own.
@@ -66,6 +71,33 @@ export function peopleRoutes(deps: ApiDeps): Hono {
   app.get("/people/:id", async (c) => {
     const person = await readPerson(deps, c.req.param("id"));
     return person ? c.json(person) : c.json({ error: "Unknown person" }, 404);
+  });
+
+  app.patch("/people/:id", async (c) => {
+    const parsed = parseUpdatePersonRequest(await c.req.json().catch(() => null));
+    if ("error" in parsed) return c.json({ error: parsed.error }, 400);
+
+    const result = await updatePerson(deps, c.req.param("id"), parsed.update);
+    if ("unknown" in result) return c.json({ error: "Unknown person" }, 404);
+    // 400 rather than 403: nothing about the caller could make this edit
+    // land, since the guardian is the only caller there is. The request names
+    // a change the person does not have.
+    if ("refused" in result) return c.json({ error: result.refused }, 400);
+    return c.json(result.person);
+  });
+
+  // The duplicate names itself in the body and the survivor in the path, so a
+  // client that renders the merge reads the survivor back from the response it
+  // already has to handle.
+  app.post("/people/:id/merge", async (c) => {
+    const into = c.req.param("id");
+    const parsed = parseMergeRequest(await c.req.json().catch(() => null), into);
+    if ("error" in parsed) return c.json({ error: parsed.error }, 400);
+
+    const result = await mergePeople(deps, into, parsed.merge.from);
+    if ("unknown" in result) return c.json({ error: "Unknown person" }, 404);
+    if ("refused" in result) return c.json({ error: result.refused }, 400);
+    return c.json(result.person);
   });
 
   app.post("/people/:id/accounts", async (c) => {

--- a/packages/core/src/db/repositories/person-mapping.ts
+++ b/packages/core/src/db/repositories/person-mapping.ts
@@ -3,7 +3,11 @@ import { v4 as uuid } from "uuid";
 import { persons, channelMappings } from "../schema.js";
 import type { DrizzleDb, SqliteExec } from "../index.js";
 import { STRANGER_PERSON_ID } from "../../constants.js";
-import { generatePersonSlug, nextAvailablePersonId } from "@rome/api-types/persons";
+import {
+  generatePersonSlug,
+  nextAvailablePersonId,
+  protectedPersonReason,
+} from "@rome/api-types/persons";
 
 // Re-exported so existing importers keep their path. The derivation itself
 // lives in the shared package because the dashboard's mock backend has to
@@ -54,6 +58,25 @@ export class AccountHeldError extends Error {
  *  ordinary answer to a stale page, not the exceptional one it is for a create,
  *  where the account is the reason the person was being written at all. */
 export type LinkAccountResult = { linked: true } | { linked: false; holder: AccountHolder | null };
+
+/** What a {@link PersonMappingRepository.mergePersons} attempt did: absorbed
+ *  the source, links and all, or refused and said which rule stopped it. The
+ *  reason rather than the sentence, so the wording a caller answers with stays
+ *  the contract's rather than this table's. */
+export type MergePersonsResult =
+  | { merged: true; links: number }
+  | { merged: false; reason: MergeRefusal };
+
+/** Why a merge did not happen. "sentinel-*" and "unknown-*" both describe an
+ *  id that names nobody a caller may address, and "guardian-source" a person
+ *  who exists and stays. */
+export type MergeRefusal =
+  | "same-person"
+  | "unknown-target"
+  | "unknown-source"
+  | "guardian-source"
+  | "sentinel-source"
+  | "sentinel-target";
 
 export interface NewPersonData {
   displayName: string;
@@ -664,6 +687,73 @@ export class PersonMappingRepository {
         tx.update(channelMappings).set({ personId }).where(eq(channelMappings.id, link.id)).run();
       }
       return { linked: true };
+    });
+  }
+
+  /**
+   * Move every link `from` holds onto `into` and delete `from`, or do neither.
+   *
+   * One transaction because a merge is a re-attribution of history: half of a
+   * duplicate's accounts moved is a state no guardian asked for and no retry
+   * repairs — the second attempt reads a source that is missing the links it
+   * already gave away, so it looks like a smaller duplicate than it is.
+   *
+   * The links move rather than being rewritten, so each carries its
+   * channel-side name across the way a transfer does. Nothing can collide on
+   * the identity index: an account carries at most one link, so no account is
+   * held by both people to begin with.
+   *
+   * Both rows are read inside the transaction and the refusals are decided
+   * there, so a source that was deleted or a person that was never there
+   * cannot be reported as a merge that moved nothing. The caller phrases the
+   * refusal; this decides it.
+   *
+   * The persons row is the whole of what is deleted. The link table is the
+   * only thing that references it, so nothing is left pointing at an id that
+   * is gone — and nothing outside the database is touched, memory files
+   * included, because a file cannot join this transaction.
+   */
+  async mergePersons(into: string, from: string): Promise<MergePersonsResult> {
+    return this.db.transaction((tx): MergePersonsResult => {
+      // Guarded here as well as by the caller: this transaction would move a
+      // person's links onto themselves and then delete them, which is the one
+      // outcome a merge must never have.
+      if (into === from) return { merged: false, reason: "same-person" };
+
+      const rows = tx
+        .select({ id: persons.id, bondLevel: persons.bondLevel })
+        .from(persons)
+        .where(inArray(persons.id, [into, from]))
+        .all();
+
+      const target = rows.find((row) => row.id === into);
+      const source = rows.find((row) => row.id === from);
+      if (!target) return { merged: false, reason: "unknown-target" };
+      if (!source) return { merged: false, reason: "unknown-source" };
+      // The guardian anchors the ladder and the sentinel holds every
+      // dismissal, so neither may be merged away. The sentinel is refused as a
+      // target too: it is structure rather than someone a duplicate belongs
+      // to, and absorbing a person into it would read every account they hold
+      // as dismissed.
+      const sourceIsStructure = protectedPersonReason(source);
+      if (sourceIsStructure) {
+        return {
+          merged: false,
+          reason: sourceIsStructure === "guardian" ? "guardian-source" : "sentinel-source",
+        };
+      }
+      if (protectedPersonReason(target) === "stranger-sentinel") {
+        return { merged: false, reason: "sentinel-target" };
+      }
+
+      const moved = tx
+        .update(channelMappings)
+        .set({ personId: into })
+        .where(eq(channelMappings.personId, from))
+        .run();
+      tx.delete(persons).where(eq(persons.id, from)).run();
+
+      return { merged: true, links: moved.changes };
     });
   }
 

--- a/packages/core/src/people/merge.ts
+++ b/packages/core/src/people/merge.ts
@@ -1,0 +1,77 @@
+// Merging one person into another: the duplicate's links move, the duplicate
+// dies, and the survivor answers with every account they now hold.
+//
+// Here rather than in the route because which merges are refused is a contract
+// decision, not an HTTP one. The transaction itself is the person repository's,
+// because only a transaction there can read both rows and move the links
+// without another writer landing in between; this turns the reason it gives
+// back into the sentence a caller reads.
+//
+// What a merge does NOT touch: the merged-away person's profile file
+// (`memory/relationship/<id>.md`) and anything else written in memory. A
+// filesystem write cannot join the transaction the links move in, so folding
+// the prose in here would reintroduce the half-done state merge exists to rule
+// out — and concatenating two hand-written profiles states both sides of every
+// disagreement as fact. The file stays where it is, unreferenced and readable,
+// for the guardian or the agent to fold in as prose.
+
+import { type PersonResource } from "@rome/api-types/people";
+import type { MergeRefusal, PersonMappingRepository } from "../db/repositories/person-mapping.js";
+import { readPerson, type PeopleReadDeps } from "./resource.js";
+
+export interface PeopleMergeDeps extends PeopleReadDeps {
+  personMappingRepo: PeopleReadDeps["personMappingRepo"] &
+    Pick<PersonMappingRepository, "mergePersons">;
+}
+
+/**
+ * The survivor, or why the merge did not happen: `unknown` for an id that
+ * names nobody a caller may address, and `refused` for a person who exists and
+ * is staying where they are.
+ */
+export type MergePeopleResult =
+  | { person: PersonResource }
+  | { unknown: true }
+  | { refused: string };
+
+/**
+ * Move every account `from` holds onto `into`, then delete `from`.
+ *
+ * First-class rather than N transfers and a delete: each of those steps
+ * re-attributes a slice of history, and a merge that stops halfway leaves the
+ * guardian with two people who each hold part of one person's past.
+ *
+ * The stranger sentinel is addressable on neither side. It is the row every
+ * dismissal maps onto rather than someone the guardian knows, so a caller
+ * naming it gets the answer every other route gives for it — nobody is there.
+ */
+export async function mergePeople(
+  deps: PeopleMergeDeps,
+  into: string,
+  from: string,
+): Promise<MergePeopleResult> {
+  const result = await deps.personMappingRepo.mergePersons(into, from);
+  if (!result.merged) return refusal(result.reason);
+
+  const person = await readPerson(deps, into);
+  if (!person) throw new Error(`person ${into} does not read back after merging ${from}`);
+  return { person };
+}
+
+/** The sentence a refused merge answers with, from the rule that refused it. */
+function refusal(reason: MergeRefusal): MergePeopleResult {
+  switch (reason) {
+    // An id naming nobody and an id naming structure read alike from outside:
+    // the sentinel is not a person a caller may merge or merge away, and
+    // saying so in different words would tell a caller it exists.
+    case "unknown-target":
+    case "unknown-source":
+    case "sentinel-target":
+    case "sentinel-source":
+      return { unknown: true };
+    case "guardian-source":
+      return { refused: "the guardian cannot be merged away" };
+    case "same-person":
+      return { refused: "a person cannot be merged into themselves" };
+  }
+}

--- a/packages/core/src/people/update.ts
+++ b/packages/core/src/people/update.ts
@@ -1,0 +1,60 @@
+// Editing a person: what the guardian calls them, and where they sit on the
+// ladder.
+//
+// Here rather than in the route because which edits are refused is a contract
+// decision, not an HTTP one — the same rule the dashboard's mock enforces
+// against the same request type. The route turns the answer into a status code.
+
+import { type PersonResource, type UpdatePersonRequest } from "@rome/api-types/people";
+import { protectedPersonReason } from "@rome/api-types/persons";
+import type { PersonMappingRepository } from "../db/repositories/person-mapping.js";
+import { findPerson, readPerson, type PeopleReadDeps } from "./resource.js";
+
+export interface PeopleUpdateDeps extends PeopleReadDeps {
+  personMappingRepo: PeopleReadDeps["personMappingRepo"] &
+    Pick<PersonMappingRepository, "updatePerson">;
+}
+
+/** The person as they now read, or why the edit did not happen: `unknown` for
+ *  an id naming nobody a caller may address, `refused` for an edit this person
+ *  does not accept. */
+export type UpdatePersonResult =
+  | { person: PersonResource }
+  | { unknown: true }
+  | { refused: string };
+
+/**
+ * Apply an update to a person, leaving every field it does not name alone.
+ *
+ * The guardian's bond level is fixed: the tier is the top of the ladder and the
+ * instance serves exactly one person at it, so moving them down would leave
+ * Rome with no guardian while the row that authorizes everything is still
+ * theirs. Their name is theirs to change like anyone's.
+ *
+ * A rename does not re-mint the id. The id is a slug taken at create and every
+ * link, profile file and stored reference is written against it, so renaming a
+ * person is a change to what they are called and to nothing else.
+ */
+export async function updatePerson(
+  deps: PeopleUpdateDeps,
+  id: string,
+  update: UpdatePersonRequest,
+): Promise<UpdatePersonResult> {
+  const person = await findPerson(deps, id);
+  if (!person) return { unknown: true };
+
+  if (update.bondLevel !== undefined && protectedPersonReason(person) === "guardian") {
+    return { refused: "the guardian's bond level cannot be changed" };
+  }
+
+  // An update naming no field is the state the person is already in. Answered
+  // with the person rather than written: an empty write is not a statement the
+  // repository can make, and there is nothing here to make it about.
+  if (Object.keys(update).length > 0) {
+    await deps.personMappingRepo.updatePerson(id, update);
+  }
+
+  const updated = await readPerson(deps, id);
+  if (!updated) throw new Error(`person ${id} does not read back after an update`);
+  return { person: updated };
+}

--- a/packages/web/mock/handlers/people-proposed.ts
+++ b/packages/web/mock/handlers/people-proposed.ts
@@ -18,7 +18,9 @@ import {
   countPeople,
   parseAccountCursor,
   parseAccountState,
+  parseMergeRequest,
   parsePersonFilterLevel,
+  parseUpdatePersonRequest,
   personMatchesLevel,
   personMatchesQuery,
   sliceAccountDirectory,
@@ -27,10 +29,8 @@ import {
   type DirectoryAccount,
   type LinkAccountRequest,
   type LinkConflict,
-  type MergeRequest,
   type PeopleList,
   type PersonResource,
-  type UpdatePersonRequest,
 } from "@rome/api-types/people";
 import { buildTimeline, proposedApiStore } from "./people";
 
@@ -322,30 +322,19 @@ export const proposedPeopleHandlers = [
   }),
 
   http.patch("/api/people/:id", async ({ params, request }) => {
+    const parsed = parseUpdatePersonRequest(await request.json().catch(() => null));
+    if ("error" in parsed) return HttpResponse.json({ error: parsed.error }, { status: 400 });
     const person = findVisiblePerson(String(params.id));
     if (!person) return notFound("person");
-    const body = (await request.json().catch(() => ({}))) as Partial<UpdatePersonRequest>;
-    if (body.bondLevel !== undefined) {
-      if (protectedPersonReason(person)) {
-        return HttpResponse.json(
-          { error: "the guardian's bond level cannot be changed" },
-          { status: 400 },
-        );
-      }
-      if (!isAssignableBondLevel(body.bondLevel)) {
-        return HttpResponse.json(
-          { error: "bondLevel must be inner-circle, acquaintance, or other" },
-          { status: 400 },
-        );
-      }
-      person.bondLevel = body.bondLevel;
+    // The guardian's name is theirs to change like anyone's; the tier under
+    // them is the top of the ladder and stays where it is.
+    if (parsed.update.bondLevel !== undefined && protectedPersonReason(person) === "guardian") {
+      return HttpResponse.json(
+        { error: "the guardian's bond level cannot be changed" },
+        { status: 400 },
+      );
     }
-    if (body.displayName !== undefined) {
-      if (!body.displayName) {
-        return HttpResponse.json({ error: "displayName cannot be empty" }, { status: 400 });
-      }
-      person.displayName = body.displayName;
-    }
+    Object.assign(person, parsed.update);
     return HttpResponse.json(personResource(person));
   }),
 
@@ -388,19 +377,14 @@ export const proposedPeopleHandlers = [
   // First-class rather than N transfers + a delete, for the same reason
   // transfer itself is explicit: history re-attribution should be atomic.
   http.post("/api/people/:id/merge", async ({ params, request }) => {
-    const target = findVisiblePerson(String(params.id));
+    const into = String(params.id);
+    const parsed = parseMergeRequest(await request.json().catch(() => null), into);
+    if ("error" in parsed) return HttpResponse.json({ error: parsed.error }, { status: 400 });
+    const target = findVisiblePerson(into);
     if (!target) return notFound("person");
-    const body = (await request.json().catch(() => ({}))) as Partial<MergeRequest>;
-    if (!body.from) return HttpResponse.json({ error: "from is required" }, { status: 400 });
-    if (body.from === target.id) {
-      return HttpResponse.json(
-        { error: "a person cannot be merged into themselves" },
-        { status: 400 },
-      );
-    }
-    const source = findVisiblePerson(body.from);
+    const source = findVisiblePerson(parsed.merge.from);
     if (!source) return notFound("person");
-    if (protectedPersonReason(source)) {
+    if (protectedPersonReason(source) === "guardian") {
       return HttpResponse.json({ error: "the guardian cannot be merged away" }, { status: 400 });
     }
     target.channelMappings.push(...source.channelMappings);


### PR DESCRIPTION
## What this PR does

The `/people` contract declared `PATCH /api/people/:id` and `POST /api/people/:id/merge`, and no backend served either. A guardian could create a person and link accounts to them, but could not correct the name they typed, move them along the bond ladder, or fold the second copy of someone back into the first. Closes #65.

`PATCH` takes a display name and a bond level, and leaves alone whatever the body does not name. `merge` moves every link from the duplicate onto the survivor and deletes the duplicate, then answers with the survivor and the accounts they now hold.

## Design & Invariants

**A merge is one transaction, or it is nothing.** The transaction reads both rows, decides the refusals, moves every `channel_mappings` row and deletes the source row. Half of a duplicate's accounts moved is a state no guardian asked for and no retry repairs: the second attempt reads a source that already gave some of its links away, so it looks like a smaller duplicate than it is. The links move rather than being rewritten, so each keeps the name its own channel gave it, the way a transfer does. Nothing collides on the identity index, because an account carries at most one link and no account is held by both people to begin with.

**Two rows are structure rather than people, and every write reads the same rule.** The guardian anchors the ladder, so their bond level refuses to change and they are never a merge source. The stranger sentinel is the row every dismissal maps onto, so it is addressable on neither side of a merge and answers 404 to a `PATCH`, the same answer every other `/people` route gives it. `protectedPersonReason` in `@rome/api-types/persons` is the one place that decides which rows those are.

**A merge touches the database and nothing else.** The merged-away person's profile file — `memory/relationship/<id>.md` — is left exactly where it is. Not absorbed, not archived, not deleted. This is the open decision #65 asked to record.

Three reasons this beat the alternatives:

- A filesystem write cannot join the transaction the links move in. Absorbing or deleting the file reintroduces the half-done state merge exists to rule out: committed links behind a failed file write, or a deleted file behind a rolled-back merge. The profile directory is a git repository, so unwinding it inside a request is one more failure surface.
- Absorbing means concatenating two hand-written profiles into a document neither author wrote. Where the two disagree, the result states both sides as fact in the agent's context, and there is no merge rule that is right for prose.
- Deleting destroys the only record of what the guardian knew about the duplicate. The duplicate often holds the fuller file, since a person gets merged away precisely because they were written about twice.

The cost is an orphaned file the agent can still read as a separate person. That is a follow-up for the agent to fix as prose, and it is narrow today: only the legacy `POST /api/persons/create` writes these files, and the `/people` contract never has.

**Both requests are parsed in `@rome/api-types/people`.** `parseUpdatePersonRequest` and `parseMergeRequest` join `parseCreatePersonRequest` and `parseLinkAccountRequest`, so the backend and the dashboard's mock refuse the same bodies with the same words. The mock now calls them instead of carrying its own copy of the rules.

## Test plan

- [x] `pnpm typecheck` — clean across every workspace.
- [x] `pnpm test:unit` — core, web, and ui suites pass. 36 new route tests cover the acceptance list: a `PATCH` of the guardian's bond level answers 400 and of a regular person's answers 200, a guardian rename answers 200, every link moves and the source answers 404 afterward, the guardian refuses to be merged away, the sentinel is addressable as neither source nor target, a merge into oneself answers 400, and only one of two concurrent merges lands the duplicate.
- [x] `biome check` on the changed files — clean.
- [x] Live round-trip against a throwaway `ROME_PROFILE`: create two people, `PATCH` a bond level and a name, merge one into the other, and confirm the survivor holds both accounts while the source answers 404. The guardian cases are covered by tests only, since no API mints a guardian on a fresh profile.
- [ ] `pnpm dev:all` — the Docker daemon is unreachable for this account. The host process boots to `Rome started` and served the round-trip above.

## Not in this PR

- The People page's rename, bond-level and merge controls — #65 puts the UI out of scope.
- Folding a merged-away person's profile prose into the survivor, for the reasons above.
- Re-pointing a `sender_specific` policy that names the merged-away person. The scope is JSON rather than a foreign key, and nothing writes one today.
