### PR TITLE
fix(ui): keep the inline code tint inside its prose line

### DIFF
--- a/packages/ui/src/markdown.css
+++ b/packages/ui/src/markdown.css
@@ -33,7 +33,7 @@
 @source "../../../@streamdown/mermaid/dist/*.js";
 
 /* Dependency sources and authored docs still expose off-roster candidates.
-   Keep them out of host bundles. Restate inline code on Rome's smallest step. */
+   Keep them out of host bundles. Restate inline code on Rome's spacing scale. */
 @source not inline("py-0.5");
 @source not inline("p-1.5");
 @source not inline("px-1.5");
@@ -232,8 +232,13 @@
   @apply rounded-16;
 }
 
+/* Inline padding only. Padding on an inline box paints outside the line box
+   without growing it, and at 14px IBM Plex Mono's 1.3em content box already
+   fills 18.2px of a 20px prose line — a vertical step would spill the tint
+   over the lines above and below. The face carries that breathing room
+   itself: its ascent clears the caps by a third of an em. */
 [data-streamdown="inline-code"] {
-  @apply px-2 py-1;
+  @apply px-2;
 }
 
 [data-streamdown="code-block-actions"],


### PR DESCRIPTION
## What this PR does

Inline code painted a tint taller than the line it sat on. Mid-sentence, the block bulged above and below the words beside it; in a wrapped paragraph it lapped over the neighbouring lines.

Padding on an inline box paints outside the line box without growing it. Streamdown ships inline code at `text-sm`, and at 14px IBM Plex Mono's 1.3em content box already fills 18px of the 20px prose line — so the 4px vertical step had nowhere to go but over the lines above and below. Measured in the gallery: a 26px tint on a 20px line.

Dropping the step leaves an 18px tint that fits. The chip still reads as padded because the face carries that space itself: IBM Plex Mono's ascent clears its own cap height by about a third of an em.

## Design & Invariants

A tint bound to running prose never exceeds the line box it paints on. Vertical padding cannot hold that invariant on an inline box, so the box gets none; horizontal padding stays, since inline padding does grow the box it paints.

The alternative was to open the prose line-height until the padded chip fit. That trades a global rhythm token — one every heading, list, and paragraph reads — against one element, and 1.25 would have had to reach past 1.6 to clear the tint.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 36 files, 528 tests
- [x] Measured `/dev/gallery` in Chromium against the standard and compact Markdown specimens: tint 26px on a 20px line before, 18px inside the same 20px line after
- [x] Eyeballed both specimens in the same run — chips sit level with the prose, wrapped lines no longer overlap

## Not in this PR

- Inline code stays a fixed `0.875rem`, so it does not track its surroundings: undersized inside a heading, and the same size as the body text in compact prose. Sizing it in `em` is a typography call worth taking on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
