### PR TITLE
test(web): hold inline tints inside their line box

### DIFF
--- a/packages/web/e2e/layout-invariants.self.spec.ts
+++ b/packages/web/e2e/layout-invariants.self.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "@playwright/test";
-import { collectButtonViolations, collectRowHeightViolations } from "./layout-invariants.js";
+import {
+  collectButtonViolations,
+  collectInlineTintViolations,
+  collectRowHeightViolations,
+} from "./layout-invariants.js";
 
 /**
  * Fixture tests for the `row-height-uniformity` and `sibling-uniformity`
@@ -161,6 +165,68 @@ for (const { name, html, flagged } of SIBLING_CASES) {
 
     const all = await page.evaluate(collectButtonViolations);
     const violations = all.filter((v) => v.invariant === "sibling-uniformity");
+    const report = violations.map((v) => `  [${v.invariant}] ${v.element}\n    ${v.detail}`);
+
+    expect(violations.length, `expected ${flagged ? 1 : 0} violation:\n${report.join("\n")}`).toBe(
+      flagged ? 1 : 0,
+    );
+  });
+}
+
+/**
+ * Fixtures for the `inline-tint-fits-line-box` collector.
+ *
+ * Geometry is declared in px and the tint is a plain fill, so no case depends
+ * on a webfont or a design token — the only thing under test is whether the
+ * collector reads the relationship between a painted inline box and the line
+ * rhythm around it.
+ */
+const prose = (line: number, chip: string) =>
+  `<p style="margin:0;font-size:16px;line-height:${line}px">Backoff doubles per attempt, capped at ${chip}.</p>`;
+
+const tint = (style: string) =>
+  `<code style="background:#eee;font-size:14px;${style}">t_max</code>`;
+
+const TINT_CASES: { name: string; html: string; flagged: boolean }[] = [
+  {
+    name: "an inline chip whose vertical padding outgrows the line",
+    html: prose(20, tint("padding:4px 8px")),
+    flagged: true,
+  },
+  {
+    name: "an inline chip inside the line",
+    html: prose(20, tint("padding:0 8px")),
+    flagged: false,
+  },
+  {
+    // Padding on an inline-block does grow the line box, so the box the
+    // collector would flag is one the line has already made room for.
+    name: "an inline-block chip with the same padding",
+    html: prose(20, tint("display:inline-block;padding:4px 8px")),
+    flagged: false,
+  },
+  {
+    // A block that leaves line-height `normal` states no rhythm, so there is
+    // nothing to hold the tint to.
+    name: "a chip in a block with no declared rhythm",
+    html: `<p style="margin:0;font-size:16px;line-height:normal">capped at ${tint("padding:4px 8px")}.</p>`,
+    flagged: false,
+  },
+  {
+    // The tint is the trigger, not the padding: an unfilled inline box paints
+    // nothing to spill.
+    name: "a padded inline box with no fill",
+    html: prose(20, `<code style="font-size:14px;padding:4px 8px">t_max</code>`),
+    flagged: false,
+  },
+];
+
+for (const { name, html, flagged } of TINT_CASES) {
+  test(`inline-tint-fits-line-box ${flagged ? "flags" : "ignores"}: ${name}`, async ({ page }) => {
+    await page.setContent(`<body style="margin:0">${html}</body>`);
+    await page.evaluate(() => document.fonts.ready);
+
+    const violations = await page.evaluate(collectInlineTintViolations);
     const report = violations.map((v) => `  [${v.invariant}] ${v.element}\n    ${v.detail}`);
 
     expect(violations.length, `expected ${flagged ? 1 : 0} violation:\n${report.join("\n")}`).toBe(

--- a/packages/web/e2e/layout-invariants.ts
+++ b/packages/web/e2e/layout-invariants.ts
@@ -267,3 +267,79 @@ export function collectRowHeightViolations(): Violation[] {
 
   return violations;
 }
+
+/**
+ * Serialized into the page. Sweeps every visible inline element that paints a
+ * background — an inline code chip, a `<mark>`, a `<kbd>` beside body text —
+ * and applies:
+ *
+ * - `inline-tint-fits-line-box`: the painted box is no taller than the line
+ *   rhythm of the block it sits in.
+ *
+ * Padding on an inline box paints outside the line box without growing it, so
+ * a tint taller than the rhythm has nowhere to go but over the lines above and
+ * below. On a wrapped paragraph it laps its neighbours; on a single line it
+ * bulges past the words beside it. Neither is visible to a test that reads the
+ * declaration — the overflow only exists once the font's own metrics land
+ * inside a concrete line box, which is to say only in a browser.
+ *
+ * The reference is the block's own computed line-height rather than any pixel
+ * value, so retuning a prose scale moves both sides together. A block that
+ * leaves line-height `normal` declares no rhythm to measure against and is
+ * skipped.
+ *
+ * Inline-block and inline-flex are out of scope on purpose: their padding does
+ * grow the line box, so the same geometry is no defect there.
+ */
+export function collectInlineTintViolations(): Violation[] {
+  const violations: Violation[] = [];
+
+  const describe = (el: Element): string => {
+    const hook = el.getAttribute("data-streamdown");
+    const text = (el.textContent ?? "").trim().slice(0, 40);
+    return `${el.tagName.toLowerCase()}${hook ? `[data-streamdown=${hook}]` : ""} "${text}"`;
+  };
+
+  const paintsBackground = (cs: CSSStyleDeclaration): boolean => {
+    const bg = cs.backgroundColor;
+    if (!bg || bg === "transparent") return false;
+    // rgba(...) with a zero alpha is the computed form of no fill.
+    const alpha = bg.match(/^rgba?\([^)]*,\s*([\d.]+)\)$/);
+    return alpha ? Number.parseFloat(alpha[1]) > 0 : true;
+  };
+
+  for (const el of document.body.querySelectorAll("*")) {
+    const cs = getComputedStyle(el);
+    if (cs.display !== "inline") continue;
+    if (!paintsBackground(cs)) continue;
+
+    const rect = el.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) continue;
+    if (cs.visibility === "hidden") continue;
+
+    // The block that owns the rhythm: the nearest ancestor laying out lines.
+    let block = el.parentElement;
+    while (block && getComputedStyle(block).display === "inline") {
+      block = block.parentElement;
+    }
+    if (!block) continue;
+
+    const rhythm = Number.parseFloat(getComputedStyle(block).lineHeight);
+    if (!Number.isFinite(rhythm)) continue;
+
+    // Half a pixel of slack: a line-height carried as a ratio lands on a
+    // fraction, and the painted box is snapped to device pixels.
+    if (rect.height > rhythm + 0.5) {
+      violations.push({
+        invariant: "inline-tint-fits-line-box",
+        element: describe(el),
+        detail:
+          `painted box is ${rect.height.toFixed(1)}px tall in a ${rhythm.toFixed(1)}px line ` +
+          `(padding ${cs.paddingTop} / ${cs.paddingBottom}); the overflow paints over the ` +
+          `lines above and below`,
+      });
+    }
+  }
+
+  return violations;
+}

--- a/packages/web/e2e/markdown-inline-tint.spec.ts
+++ b/packages/web/e2e/markdown-inline-tint.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+import { collectInlineTintViolations } from "./layout-invariants.js";
+
+/**
+ * Markdown prose keeps its inline tints inside the line they sit on.
+ *
+ * `/dev/gallery` renders the Markdown specimens at both token bindings —
+ * standard and compact — with inline code mid-sentence, alone in a list item,
+ * and on a wrapped line. Those are the shapes an overflowing tint shows up in,
+ * and the kit's own unit tests can see none of them: jsdom lays out no text,
+ * so every rect there is 0x0 and a chip painting over its neighbours measures
+ * the same as one that fits.
+ *
+ * The route sweep in `layout-invariants.spec.ts` leaves `/dev/gallery` out
+ * until its intermittent control-geometry violation is diagnosed. This spec
+ * measures inline tints only, so that diagnosis does not gate it.
+ */
+
+test("inline tints on the gallery fit their line box", async ({ page }) => {
+  await page.goto("/dev/gallery");
+  // A cold rsbuild dev server compiles the route's chunk on demand.
+  await expect(page.locator('[data-streamdown="inline-code"]').first()).toBeVisible({
+    timeout: 30_000,
+  });
+  // Prose geometry is font metrics: measuring before the webfont swaps in
+  // reads the fallback's box.
+  await page.evaluate(() => document.fonts.ready);
+
+  const violations = await page.evaluate(collectInlineTintViolations);
+  const report = violations.map((v) => `  [${v.invariant}] ${v.element}\n    ${v.detail}`).join("\n");
+
+  expect(violations, `inline tint violations on /dev/gallery:\n${report}`).toEqual([]);
+});


### PR DESCRIPTION
## What this PR does

#84 fixed an inline code chip that painted a 26px tint on a 20px prose line. Nothing in the suite could have caught it. `packages/ui/src/markdown.test.tsx` asserts the chip renders with its `data-streamdown` hook, and that was true the whole time the bug existed — jsdom lays out no text, so every rect there is 0x0 and a tint painting over its neighbours measures exactly like one that fits. The defect lives between the CSS and the font metrics: `px-2 py-1` reads fine, and is only wrong once IBM Plex Mono's 1.3em box meets a 20px line.

This adds the invariant the fix restored, to the one suite that can see it:

> An inline box that paints a background is no taller than the line rhythm of the block it sits in.

Padding on an inline box paints outside the line box without growing it, so a tint over the rhythm has nowhere to go but onto the neighbouring lines. Three pieces, following the shape the suite already uses for control geometry: the collector in `layout-invariants.ts`, fixtures in `layout-invariants.self.spec.ts` pinning what it flags and what it stays silent on, and a spec over the gallery's Markdown specimens.

## Design & Invariants

The reference is the block's own computed `line-height`, never a pixel value, so retuning a prose scale moves both sides of the comparison together. A block that leaves line-height `normal` declares no rhythm and is skipped rather than guessed at.

Inline-block and inline-flex are out of scope, and that is the substantive carve-out: their padding *does* grow the line box, so identical geometry is no defect there. A fixture pins it, because a collector that flagged every padded inline-block chip in the dashboard would be reverted rather than fixed.

The trigger is the fill, not the padding — an unpadded inline box paints nothing to spill, and a padded one with no background spills nothing visible. Also fixtured.

The rule generalizes past code chips by construction: it sweeps any inline element that paints, so a `<mark>`, a `<kbd>`, or the next chip dropped into prose is covered without another spec.

`/dev/gallery` is deliberately absent from `ROUTES` in `layout-invariants.spec.ts` until its intermittent control-geometry violation is diagnosed. This spec measures inline tints only and never touches a control, so it does not wait on that.

## Test plan

- [x] `playwright test markdown-inline-tint layout-invariants.self` — 21 passed, including the 5 new fixtures
- [x] Red on the defect: restored `py-1` in `markdown.css` and re-ran. The spec fails on all 5 chips across both token bindings, reporting `painted box is 26.0px tall in a 20.0px line (padding 4px / 4px)`
- [x] Green on `main` as merged
- [ ] CI `layout-invariants`, which runs the whole `test:layout` suite in the pinned Playwright image — the run here used a local Chromium, since Playwright's own build does not launch on NixOS

## Not in this PR

- The gallery's intermittent control-geometry violation, which still keeps the route out of the multi-route sweep.
- A positional check. The collector measures height, not offset, so a tint the right size riding high on its line still passes. That failure mode is hypothetical — the fix measured 2px above and 4px below, no vertical bias — and a threshold for it would have to be invented rather than derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
