### PR TITLE
feat(web): repoint the People page writes to the /people contract

### DIFF
--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -75,7 +75,10 @@
     "creating": "Creating…",
     "linkSubmit": "Link",
     "linking": "Linking…",
-    "markingStranger": "Marking…"
+    "markingStranger": "Marking…",
+    "restore": "Restore",
+    "restoring": "Restoring…",
+    "transfer": "Move it here"
   },
   "bulk": {
     "selected": "selected",
@@ -163,16 +166,21 @@
   },
   "createForm": {
     "nameLabel": "Name",
-    "bondLevelLabel": "Bond level",
-    "relationLabel": "Relation",
-    "relationPlaceholder": "How do you know them?"
+    "bondLevelLabel": "Bond level"
   },
   "linkForm": {
     "label": "Link to existing person",
     "selectPlaceholder": "Select a person…"
   },
+  "linkPicker": {
+    "heldBy": "now {{owner}}'s"
+  },
   "strangerConfirm": {
     "title": "Treat {{name}} as a stranger?",
-    "description": "Rome will treat messages from {{name}} as coming from a stranger, and they will no longer appear under {{section}}. You can't undo this from the dashboard."
+    "description": "Rome will treat messages from {{name}} as coming from a stranger, and they will no longer appear under {{section}}. You can restore them from the Stranger view."
+  },
+  "transfer": {
+    "title": "Move this account?",
+    "description": "{{account}} resolves to {{owner}} today. Moving it re-attributes every message on it, and {{owner}} keeps whatever else they hold."
   }
 }

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -75,7 +75,10 @@
     "creating": "创建中…",
     "linkSubmit": "关联",
     "linking": "关联中…",
-    "markingStranger": "标记中…"
+    "markingStranger": "标记中…",
+    "restore": "恢复",
+    "restoring": "恢复中…",
+    "transfer": "移到这里"
   },
   "bulk": {
     "selected": "已选择",
@@ -163,16 +166,21 @@
   },
   "createForm": {
     "nameLabel": "姓名",
-    "bondLevelLabel": "亲密度",
-    "relationLabel": "关系",
-    "relationPlaceholder": "你和他们是什么关系？"
+    "bondLevelLabel": "亲密度"
   },
   "linkForm": {
     "label": "关联到已有人物",
     "selectPlaceholder": "选择一位人物…"
   },
+  "linkPicker": {
+    "heldBy": "当前属于 {{owner}}"
+  },
   "strangerConfirm": {
     "title": "将 {{name}} 视为陌生人？",
-    "description": "Rome 会把来自 {{name}} 的消息当作陌生人发来的，并且他们将不再出现在“{{section}}”中。此操作无法在面板中撤销。"
+    "description": "Rome 将把来自 {{name}} 的消息视为陌生人发送，他们也不再出现在{{section}}中。你可以在“陌生人”视图中恢复。"
+  },
+  "transfer": {
+    "title": "移动这个账号？",
+    "description": "{{account}} 目前解析到 {{owner}}。移动后其上的所有消息都会重新归属，{{owner}} 仍保留其余账号。"
   }
 }

--- a/packages/web/src/pages/PeoplePage.test.tsx
+++ b/packages/web/src/pages/PeoplePage.test.tsx
@@ -281,7 +281,15 @@ function applyWrite(
  */
 function mockApi(
   world: { people?: PersonResource[]; accounts?: DirectoryAccount[] } = {},
-  options: { limit?: number; peopleFail?: boolean; accountsFail?: boolean; writes?: "fail" } = {},
+  options: {
+    limit?: number;
+    peopleFail?: boolean;
+    accountsFail?: boolean;
+    writes?: "fail";
+    /** Holds every transfer in flight until this resolves, so a test can act
+     *  while one is still running. */
+    holdTransfers?: Promise<void>;
+  } = {},
 ) {
   // Cloned rather than shared: the writes below mutate this world, and the
   // fixtures are module constants every other test reads.
@@ -308,9 +316,9 @@ function mockApi(
       ({ ok: status < 400, status, json: async () => payload }) as Response;
 
     if (method !== "GET") {
-      return options.writes === "fail"
-        ? json({ error: "write refused" }, 500)
-        : applyWrite(state, method, parsed.pathname, body ?? {}, json);
+      if (options.writes === "fail") return json({ error: "write refused" }, 500);
+      if (body?.transferFrom && options.holdTransfers) await options.holdTransfers;
+      return applyWrite(state, method, parsed.pathname, body ?? {}, json);
     }
 
     if (url.includes("/api/accounts")) {
@@ -740,6 +748,45 @@ describe("PeoplePage placement", () => {
       channelUserId: "6591234472@s.whatsapp.net",
       transferFrom: "mira",
     });
+  });
+
+  it("fires one transfer however many times the confirm is clicked", async () => {
+    const user = userEvent.setup();
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { calls, state } = mockApi(
+      { people: [FRIEND], accounts: [UNKNOWN_SENDER] },
+      { holdTransfers: held },
+    );
+    renderPage();
+
+    await user.click(chip(/^Unknown/));
+    await screen.findByText("Rachel Lim");
+    state.accounts[0]!.state = "linked";
+    state.accounts[0]!.personId = "mira";
+    state.accounts[0]!.personName = "Mira Chen";
+
+    await user.click(screen.getByRole("button", { name: "Link" }));
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: /Wei Chen/ }));
+    await user.click(screen.getByRole("button", { name: "Link" }));
+
+    const dialog = await screen.findByRole("dialog");
+    const confirm = within(dialog).getByRole("button", { name: "Move it here" });
+    await user.click(confirm);
+    await user.click(confirm);
+
+    // The dialog stays up until the write settles, so the confirm is still on
+    // screen while the first transfer is in flight. A second one would re-attribute
+    // the account's history again — and would arrive naming an owner the first
+    // has already replaced, so it refuses and reports a conflict against the
+    // person the guardian just moved it to.
+    expect(calls.filter((call) => call.body?.transferFrom)).toHaveLength(1);
+
+    release();
+    await waitFor(() => expect(state.accounts[0]!.personId).toBe("wei-chen"));
   });
 
   it("writes through no /persons route", async () => {

--- a/packages/web/src/pages/PeoplePage.test.tsx
+++ b/packages/web/src/pages/PeoplePage.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   countPeople,
+  linkConflict,
   parseAccountCursor,
   parseAccountState,
   parsePersonFilterLevel,
@@ -43,10 +44,22 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+/** Every field any of the contract's write bodies carries, so one shape reads
+ *  them all — the mock below dispatches on the path, not on the body. */
+interface WriteBody {
+  displayName?: string;
+  bondLevel?: string;
+  accounts?: { channel: string; channelUserId: string }[];
+  channel?: string;
+  channelUserId?: string;
+  transferFrom?: string;
+  from?: string;
+}
+
 interface FetchCall {
   url: string;
   method: string;
-  body: unknown;
+  body: WriteBody | undefined;
 }
 
 const NOW = Math.floor(Date.now() / 1000);
@@ -126,6 +139,140 @@ const LINKED_ACCOUNT: DirectoryAccount = {
   messageCount: 30,
 };
 
+/** The world both reads are served from, and every write applies to. */
+interface World {
+  people: PersonResource[];
+  accounts: DirectoryAccount[];
+  peopleFail: boolean;
+  accountsFail: boolean;
+}
+
+type Json = (payload: unknown, status?: number) => Response;
+
+interface AccountRef {
+  channel: string;
+  channelUserId: string;
+}
+
+function findAccount(world: World, ref: AccountRef) {
+  return world.accounts.find(
+    (account) => account.channel === ref.channel && account.channelUserId === ref.channelUserId,
+  );
+}
+
+/** Move an account under a person, on both sides of the join. */
+function attach(world: World, person: PersonResource, ref: AccountRef) {
+  const account = findAccount(world, ref);
+  if (!account) return;
+  const previous = account.personId && world.people.find((p) => p.id === account.personId);
+  if (previous) {
+    previous.accounts = previous.accounts.filter(
+      (held) => held.channel !== account.channel || held.channelUserId !== account.channelUserId,
+    );
+  }
+  account.state = "linked";
+  account.personId = person.id;
+  account.personName = person.displayName;
+  person.accounts = [
+    ...person.accounts,
+    {
+      channel: account.channel,
+      channelUserId: account.channelUserId,
+      displayName: account.displayName,
+    },
+  ];
+  person.messageCount += account.messageCount;
+  person.latest = account.latest ?? person.latest;
+}
+
+/**
+ * The write half of the contract, applied to the same world the reads serve.
+ *
+ * Every verb answers the row it changed and leaves the listing to be read
+ * again, which is what lets a test tell a page that settles by refetching from
+ * one that patched what it already had.
+ */
+function applyWrite(
+  world: World,
+  method: string,
+  path: string,
+  body: WriteBody,
+  json: Json,
+): Response {
+  const holder = (account: DirectoryAccount) => ({
+    id: account.personId ?? "",
+    displayName: account.personName ?? "",
+  });
+
+  const decision = /^\/api\/accounts\/([^/]+)\/(.+)\/(dismiss|restore)$/.exec(path);
+  if (decision) {
+    const [, channel, rawId, verb] = decision;
+    const account = findAccount(world, {
+      channel: decodeURIComponent(channel ?? ""),
+      channelUserId: decodeURIComponent(rawId ?? ""),
+    });
+    if (!account) return json({ error: "Unknown account" }, 404);
+    if (account.state === "linked") return json(linkConflict(account, holder(account)), 409);
+    account.state = verb === "dismiss" ? "dismissed" : "unlinked";
+    return json(account);
+  }
+
+  if (path === "/api/people" && method === "POST") {
+    const refs = body.accounts ?? [];
+    for (const ref of refs) {
+      const held = findAccount(world, ref);
+      if (held?.state === "linked") return json(linkConflict(ref, holder(held)), 409);
+    }
+    const person: PersonResource = {
+      id: (body.displayName ?? "").toLowerCase().replace(/\s+/g, "-"),
+      displayName: body.displayName ?? "",
+      bondLevel: body.bondLevel ?? "other",
+      accounts: [],
+      messageCount: 0,
+      latest: null,
+    };
+    world.people.push(person);
+    for (const ref of refs) attach(world, person, ref);
+    return json(person, 201);
+  }
+
+  const link = /^\/api\/people\/([^/]+)\/accounts$/.exec(path);
+  if (link && method === "POST") {
+    const person = world.people.find((p) => p.id === decodeURIComponent(link[1] ?? ""));
+    if (!person) return json({ error: "Unknown person" }, 404);
+    const ref = { channel: body.channel ?? "", channelUserId: body.channelUserId ?? "" };
+    const held = findAccount(world, ref);
+    // Compare-and-swap on the current owner: taking an account from another
+    // person needs `transferFrom` naming them exactly.
+    if (held?.state === "linked" && held.personId !== person.id) {
+      if (body.transferFrom !== held.personId) return json(linkConflict(ref, holder(held)), 409);
+    }
+    attach(world, person, ref);
+    return json(person);
+  }
+
+  const merge = /^\/api\/people\/([^/]+)\/merge$/.exec(path);
+  if (merge && method === "POST") {
+    const into = world.people.find((p) => p.id === decodeURIComponent(merge[1] ?? ""));
+    const from = world.people.find((p) => p.id === body.from);
+    if (!into || !from) return json({ error: "Unknown person" }, 404);
+    for (const ref of [...from.accounts]) attach(world, into, ref);
+    world.people = world.people.filter((p) => p.id !== from.id);
+    return json(into);
+  }
+
+  const one = /^\/api\/people\/([^/]+)$/.exec(path);
+  if (one && method === "PATCH") {
+    const person = world.people.find((p) => p.id === decodeURIComponent(one[1] ?? ""));
+    if (!person) return json({ error: "Unknown person" }, 404);
+    if (body.displayName !== undefined) person.displayName = body.displayName;
+    if (body.bondLevel !== undefined) person.bondLevel = body.bondLevel;
+    return json(person);
+  }
+
+  return json({ error: "Unknown route" }, 404);
+}
+
 /**
  * Serves both reads from mutable lists, through the same contract helpers the
  * routes are built on — so a fixture cannot drift from them on ordering,
@@ -136,9 +283,11 @@ function mockApi(
   world: { people?: PersonResource[]; accounts?: DirectoryAccount[] } = {},
   options: { limit?: number; peopleFail?: boolean; accountsFail?: boolean; writes?: "fail" } = {},
 ) {
-  const state = {
-    people: world.people ?? [],
-    accounts: world.accounts ?? [],
+  // Cloned rather than shared: the writes below mutate this world, and the
+  // fixtures are module constants every other test reads.
+  const state: World = {
+    people: (world.people ?? []).map((person) => ({ ...person, accounts: [...person.accounts] })),
+    accounts: (world.accounts ?? []).map((account) => ({ ...account })),
     peopleFail: options.peopleFail ?? false,
     accountsFail: options.accountsFail ?? false,
   };
@@ -149,16 +298,19 @@ function mockApi(
   ) => {
     const url = String(input);
     const method = (init?.method ?? "GET").toUpperCase();
-    const body = typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
+    const body = (typeof init?.body === "string" ? JSON.parse(init.body) : undefined) as
+      | WriteBody
+      | undefined;
     calls.push({ url, method, body });
-    const params = new URL(url, "http://localhost").searchParams;
-    const json = (payload: unknown, status = 200) =>
+    const parsed = new URL(url, "http://localhost");
+    const params = parsed.searchParams;
+    const json: Json = (payload: unknown, status = 200) =>
       ({ ok: status < 400, status, json: async () => payload }) as Response;
 
-    if (method === "POST") {
+    if (method !== "GET") {
       return options.writes === "fail"
         ? json({ error: "write refused" }, 500)
-        : json({ success: true, personId: "new-person" });
+        : applyWrite(state, method, parsed.pathname, body ?? {}, json);
     }
 
     if (url.includes("/api/accounts")) {
@@ -422,12 +574,12 @@ describe("PeoplePage directory", () => {
 });
 
 describe("PeoplePage placement", () => {
-  // The gestures that place an account are carried forward unchanged — they
-  // still post to the legacy `/api/persons/*` routes, and repointing them onto
-  // this contract is rome-os/rome#67. What the rebuild owes them is the row
-  // they hang off.
+  // The write half of the page, on the /people contract's verbs. What the union
+  // page called one "move" decomposes here: placing a sender is a create or a
+  // link, dismissing one is a decision about the account, and the ladder's
+  // dismissed end has a way back.
 
-  it("creates a person for a waiting sender, naming the account it came from", async () => {
+  it("places a waiting sender by creating the person and linking the account at once", async () => {
     const user = userEvent.setup();
     const { calls } = mockApi({ accounts: [UNKNOWN_SENDER] });
     renderPage();
@@ -437,22 +589,25 @@ describe("PeoplePage placement", () => {
     await user.click(screen.getByRole("button", { name: "Create" }));
     await user.click(screen.getByRole("button", { name: "Create profile" }));
 
-    await waitFor(() =>
-      expect(calls.some((c) => c.method === "POST" && c.url.includes("/api/persons/create"))).toBe(
-        true,
-      ),
-    );
-    expect(calls.find((c) => c.url.includes("/api/persons/create"))?.body).toMatchObject({
+    const create = await waitFor(() => {
+      const call = calls.find((c) => c.method === "POST" && c.url === "/api/people");
+      expect(call).toBeTruthy();
+      return call!;
+    });
+    // One request, not a create followed by a link: a person created for an
+    // account must never exist without it.
+    expect(create.body).toMatchObject({
       displayName: "Rachel Lim",
       bondLevel: "acquaintance",
-      channel: "whatsapp",
-      channelUserId: "6591234472@s.whatsapp.net",
+      accounts: [{ channel: "whatsapp", channelUserId: "6591234472@s.whatsapp.net" }],
     });
+    // The sender is placed, so it is no longer waiting on a decision.
+    await waitFor(() => expect(screen.queryByText("Rachel Lim")).toBeNull());
   });
 
   it("links a waiting sender onto a person the roster already holds", async () => {
     const user = userEvent.setup();
-    const { calls } = mockApi({ people: [GUARDIAN, FRIEND], accounts: [UNKNOWN_SENDER] });
+    const { calls, state } = mockApi({ people: [GUARDIAN, FRIEND], accounts: [UNKNOWN_SENDER] });
     renderPage();
 
     await user.click(chip(/^Unknown/));
@@ -462,16 +617,17 @@ describe("PeoplePage placement", () => {
     await user.click(await screen.findByRole("option", { name: /Wei Chen/ }));
     await user.click(screen.getByRole("button", { name: "Link" }));
 
-    await waitFor(() =>
-      expect(calls.some((c) => c.method === "POST" && c.url.includes("/api/persons/link"))).toBe(
-        true,
-      ),
-    );
-    expect(calls.find((c) => c.url.includes("/api/persons/link"))?.body).toMatchObject({
+    const link = await waitFor(() => {
+      const call = calls.find((c) => c.url === "/api/people/wei-chen/accounts");
+      expect(call).toBeTruthy();
+      return call!;
+    });
+    expect(link.method).toBe("POST");
+    expect(link.body).toEqual({
       channel: "whatsapp",
       channelUserId: "6591234472@s.whatsapp.net",
-      existingPersonId: "wei-chen",
     });
+    expect(state.accounts[0]!.personId).toBe("wei-chen");
   });
 
   it("confirms a dismissal before writing it, and says so when it fails", async () => {
@@ -483,18 +639,121 @@ describe("PeoplePage placement", () => {
     await screen.findByText("Rachel Lim");
     await user.click(screen.getByRole("button", { name: "Treat as stranger" }));
 
-    // A dismissal writes a mapping the dashboard cannot reverse, so nothing is
-    // posted until the confirmation is accepted.
+    // A dismissal changes how Rome answers this sender, so nothing is posted
+    // until the confirmation is accepted.
     const dialog = await screen.findByRole("dialog");
     expect(dialog.textContent).toContain("Rachel Lim");
-    expect(calls.some((c) => c.url.includes("mark-stranger"))).toBe(false);
+    expect(calls.some((c) => c.url.includes("/dismiss"))).toBe(false);
 
     await user.click(within(dialog).getByRole("button", { name: "Treat as stranger" }));
 
     // A write that didn't land leaves the account where it was, and says so —
     // closing the dialog silently would read as success.
     expect(await screen.findByRole("alert")).toBeTruthy();
-    expect(calls.some((c) => c.method === "POST" && c.url.includes("mark-stranger"))).toBe(true);
+    expect(calls.some((c) => c.method === "POST" && c.url.includes("/dismiss"))).toBe(true);
+  });
+
+  it("takes a dismissed sender out of Unknown, and the count that drops is the server's", async () => {
+    const user = userEvent.setup();
+    const { calls } = mockApi({ accounts: [UNKNOWN_SENDER, SILENT_CONTACT] });
+    renderPage();
+
+    await user.click(chip(/^Unknown/));
+    await screen.findByText("Rachel Lim");
+    await waitFor(() => expect(within(chip(/^Unknown/)).getByText("1")).toBeTruthy());
+
+    await user.click(screen.getByRole("button", { name: "Treat as stranger" }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Treat as stranger" }));
+
+    // The row leaves the view because the directory no longer serves it under
+    // `state=unlinked`, and the chip loses its number because the directory's
+    // own `counts` came back one lower. Neither is a patch of what was cached:
+    // the page holds nothing it could have patched.
+    await waitFor(() => expect(screen.queryByText("Rachel Lim")).toBeNull());
+    expect(within(chip(/^Unknown/)).queryByText(/^\d+$/)).toBeNull();
+    const dismiss = calls.find((c) => c.url.includes("/dismiss"))!;
+    // Named by the pair the contract says is the account's identity, so every
+    // address it answers to travels with it.
+    expect(dismiss.url).toBe("/api/accounts/whatsapp/6591234472%40s.whatsapp.net/dismiss");
+  });
+
+  it("restores a dismissed sender back onto the ladder", async () => {
+    const user = userEvent.setup();
+    const { calls } = mockApi({ accounts: [DISMISSED] });
+    renderPage();
+
+    await user.click(chip(/^Stranger/));
+    await screen.findByText("Crypto signals");
+    await user.click(screen.getByRole("button", { name: "Restore" }));
+
+    await waitFor(() =>
+      expect(
+        calls.some(
+          (c) =>
+            c.method === "POST" &&
+            c.url === "/api/accounts/whatsapp/447700900123%40s.whatsapp.net/restore",
+        ),
+      ).toBe(true),
+    );
+    // Dismissal is a state an account is in, not a merge into a sentinel, so
+    // the way back is the same account under the Unknown chip.
+    await waitFor(() => expect(screen.queryByText("Crypto signals")).toBeNull());
+    await user.click(chip(/^Unknown/));
+    expect(await screen.findByText("Crypto signals")).toBeTruthy();
+  });
+
+  it("offers a transfer only after naming who holds the account, and only on a second yes", async () => {
+    const user = userEvent.setup();
+    const { calls, state } = mockApi({ people: [FRIEND], accounts: [UNKNOWN_SENDER] });
+    renderPage();
+
+    await user.click(chip(/^Unknown/));
+    await screen.findByText("Rachel Lim");
+    // Somebody else claimed the account between the read and the click — the
+    // race the contract's compare-and-swap exists to catch.
+    state.accounts[0]!.state = "linked";
+    state.accounts[0]!.personId = "mira";
+    state.accounts[0]!.personName = "Mira Chen";
+
+    await user.click(screen.getByRole("button", { name: "Link" }));
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: /Wei Chen/ }));
+    await user.click(screen.getByRole("button", { name: "Link" }));
+
+    // The refusal names the owner rather than reporting a failed write.
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toContain("Mira Chen");
+    expect(calls.filter((c) => c.url.endsWith("/accounts") && c.body?.transferFrom)).toHaveLength(
+      0,
+    );
+
+    await user.click(within(dialog).getByRole("button", { name: "Move it here" }));
+
+    await waitFor(() => expect(state.accounts[0]!.personId).toBe("wei-chen"));
+    // A transfer re-attributes the account's whole history, so it never happens
+    // as the side effect of a retry: the second request is the one that names
+    // the person it is taken from.
+    expect(calls.filter((c) => c.url === "/api/people/wei-chen/accounts")).toHaveLength(2);
+    expect(calls.find((c) => c.body?.transferFrom)?.body).toEqual({
+      channel: "whatsapp",
+      channelUserId: "6591234472@s.whatsapp.net",
+      transferFrom: "mira",
+    });
+  });
+
+  it("writes through no /persons route", async () => {
+    const user = userEvent.setup();
+    const { calls } = mockApi({ people: [FRIEND], accounts: [UNKNOWN_SENDER] });
+    renderPage();
+
+    await user.click(chip(/^Unknown/));
+    await screen.findByText("Rachel Lim");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    await user.click(screen.getByRole("button", { name: "Create profile" }));
+
+    await waitFor(() => expect(calls.some((c) => c.url === "/api/people")).toBe(true));
+    expect(calls.filter((c) => c.url.includes("/api/persons"))).toEqual([]);
   });
 });
 

--- a/packages/web/src/pages/PeoplePage.tsx
+++ b/packages/web/src/pages/PeoplePage.tsx
@@ -7,10 +7,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { FilterChipGroup } from "@/components/ui/filter-chip-group";
 import { SegmentedControl } from "@/components/ui/segmented-control";
-import { useInvalidatePeople } from "@/hooks/use-people";
 import { PageShell, PageBody } from "@/shell/PageShell";
 import { DirectoryRow, StreamRow, levelLabelKey } from "./people/rows";
-import { UnknownEntry } from "./people/triage";
+import { DismissedEntry, UnknownEntry } from "./people/triage";
 import {
   directoryGroups,
   FILTER_ORDER,
@@ -41,7 +40,8 @@ import { LinkedInSection } from "./people/linkedin";
  *
  * Every number on screen is the server's. The directory pages, so a count taken
  * over the rows that happened to arrive would report no waiting senders as soon
- * as placed people filled page one.
+ * as placed people filled page one — and it is why a write settles by
+ * invalidating these reads rather than by editing what they returned.
  */
 
 /** The chips whose level the people read can be narrowed by: the levels a
@@ -62,10 +62,6 @@ export default function PeoplePage() {
   const { t } = useTranslation("people");
   const { t: tCommon } = useTranslation("common");
   const navigate = useNavigate();
-  // A placement changes who Rome knows, so the one shared people cache — the
-  // composer's mention list reads it — is invalidated alongside this page's own
-  // refetch rather than left to its own staleness window.
-  const invalidatePeople = useInvalidatePeople();
 
   const [view, setView] = useState<PeopleView>("latest");
   const [filter, setFilter] = useState<PeopleFilter>("all");
@@ -140,17 +136,16 @@ export default function PeoplePage() {
   const loading = roster.isPending;
   const loadError = roster.error ? roster.error.message : null;
 
-  const triage = (row: PeopleRow) => (
-    <UnknownEntry
-      key={row.id}
-      row={row}
-      people={linkTargets}
-      onSettled={() => {
-        void roster.refetch();
-        void invalidatePeople();
-      }}
-    />
-  );
+  // Both unplaced ends of the ladder render dense, with the gesture their
+  // position admits. A restore decides on the same evidence a placement does —
+  // what the sender actually sent — so it gets the same row rather than a
+  // roster line with a button on it.
+  const unplaced = (row: PeopleRow) =>
+    row.level === "stranger" ? (
+      <DismissedEntry key={row.id} row={row} />
+    ) : (
+      <UnknownEntry key={row.id} row={row} people={linkTargets} />
+    );
 
   return (
     <PageShell>
@@ -244,7 +239,7 @@ export default function PeoplePage() {
             rows={latest}
             searching={settled !== ""}
             onOpen={openRow}
-            renderUnknown={triage}
+            renderUnplaced={unplaced}
           />
         ) : (
           <DirectoryView
@@ -254,7 +249,7 @@ export default function PeoplePage() {
             silentTotal={roster.silentTotal}
             onToggleSilent={setShowSilent}
             onOpen={openRow}
-            renderUnknown={triage}
+            renderUnplaced={unplaced}
           />
         )}
 
@@ -288,12 +283,12 @@ function LatestView({
   rows,
   searching,
   onOpen,
-  renderUnknown,
+  renderUnplaced,
 }: {
   rows: PeopleRow[];
   searching: boolean;
   onOpen: (row: PeopleRow) => void;
-  renderUnknown: (row: PeopleRow) => React.ReactNode;
+  renderUnplaced: (row: PeopleRow) => React.ReactNode;
 }) {
   const { t } = useTranslation("people");
   if (rows.length === 0) {
@@ -321,14 +316,10 @@ function LatestView({
       </div>
       <div className="flex flex-col">
         {rows.map((row) =>
-          row.level === "unknown" ? (
-            renderUnknown(row)
+          row.kind === "account" ? (
+            renderUnplaced(row)
           ) : (
-            <StreamRow
-              key={row.id}
-              row={row}
-              onOpen={row.kind === "person" ? () => onOpen(row) : undefined}
-            />
+            <StreamRow key={row.id} row={row} onOpen={() => onOpen(row)} />
           ),
         )}
       </div>
@@ -343,7 +334,7 @@ function DirectoryView({
   silentTotal,
   onToggleSilent,
   onOpen,
-  renderUnknown,
+  renderUnplaced,
 }: {
   groups: { level: RowLevel; rows: PeopleRow[] }[];
   counts: Record<RowLevel, number>;
@@ -353,7 +344,7 @@ function DirectoryView({
   silentTotal: number;
   onToggleSilent: (value: boolean) => void;
   onOpen: (row: PeopleRow) => void;
-  renderUnknown: (row: PeopleRow) => React.ReactNode;
+  renderUnplaced: (row: PeopleRow) => React.ReactNode;
 }) {
   const { t } = useTranslation("people");
   if (groups.length === 0) {
@@ -406,14 +397,10 @@ function DirectoryView({
           </div>
           <div className="flex flex-col">
             {group.rows.map((row) =>
-              row.level === "unknown" ? (
-                renderUnknown(row)
+              row.kind === "account" ? (
+                renderUnplaced(row)
               ) : (
-                <DirectoryRow
-                  key={row.id}
-                  row={row}
-                  onOpen={row.kind === "person" ? () => onOpen(row) : undefined}
-                />
+                <DirectoryRow key={row.id} row={row} onOpen={() => onOpen(row)} />
               ),
             )}
           </div>

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -1,11 +1,17 @@
 // @vitest-environment jsdom
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { TimelineEntry } from "@rome/api-types/identities";
-import type { PersonResource } from "@rome/api-types/people";
+import {
+  countPeople,
+  linkConflict,
+  sliceAccountDirectory,
+  type DirectoryAccount,
+  type PersonResource,
+} from "@rome/api-types/people";
 import i18n from "@/i18n";
 import PersonDetailPage from "./PersonDetailPage";
 
@@ -73,9 +79,54 @@ const ENTRIES: TimelineEntry[] = [
   },
 ];
 
+/** A duplicate of the person, for the merge picker to land on. */
+const DUPLICATE: PersonResource = {
+  id: "wei-c",
+  displayName: "W. Chen",
+  bondLevel: "other",
+  accounts: [],
+  messageCount: 2,
+  latest: null,
+};
+
+const UNPLACED: DirectoryAccount = {
+  channel: "whatsapp",
+  channelUserId: "6591234472@s.whatsapp.net",
+  addresses: ["6591234472", "6591234472@s.whatsapp.net"],
+  displayName: "Rachel Lim",
+  state: "unlinked",
+  personId: null,
+  personName: null,
+  latest: { source: "whatsapp", timestamp: NOW - 7_200, preview: "Are you free Saturday?" },
+  messageCount: 12,
+};
+
+const HELD_BY_ANOTHER: DirectoryAccount = {
+  channel: "telegram",
+  channelUserId: "990014422",
+  addresses: ["990014422"],
+  displayName: "mira_c",
+  state: "linked",
+  personId: "mira",
+  personName: "Mira Chen",
+  latest: { source: "telegram", timestamp: NOW - 3_600, preview: "sent" },
+  messageCount: 4,
+};
+
+/** Whatever a write put on the wire, read back for assertions. */
+interface WriteBody {
+  displayName?: string;
+  bondLevel?: string;
+  channel?: string;
+  channelUserId?: string;
+  transferFrom?: string;
+  from?: string;
+}
+
 interface FetchCall {
   url: string;
   method: string;
+  body?: WriteBody;
 }
 
 function mockApi(
@@ -84,17 +135,54 @@ function mockApi(
     entries?: TimelineEntry[] | "fail";
     nextCursor?: string | null;
     older?: TimelineEntry[];
+    people?: PersonResource[];
+    accounts?: DirectoryAccount[];
+    writes?: "fail";
   } = {},
 ) {
   const calls: FetchCall[] = [];
+  const person = typeof options.person === "object" ? { ...options.person } : { ...PERSON };
   vi.spyOn(globalThis, "fetch").mockImplementation((async (
     input: RequestInfo | URL,
     init?: RequestInit,
   ) => {
     const url = String(input);
-    calls.push({ url, method: (init?.method ?? "GET").toUpperCase() });
-    const json = (body: unknown, status = 200) =>
-      ({ ok: status < 400, status, json: async () => body }) as Response;
+    const method = (init?.method ?? "GET").toUpperCase();
+    const body = (typeof init?.body === "string" ? JSON.parse(init.body) : undefined) as
+      | WriteBody
+      | undefined;
+    calls.push({ url, method, body });
+    const path = new URL(url, "http://localhost").pathname;
+    const json = (payload: unknown, status = 200) =>
+      ({ ok: status < 400, status, json: async () => payload }) as Response;
+
+    if (method !== "GET") {
+      if (options.writes === "fail") return json({ error: "write refused" }, 500);
+      if (path.endsWith("/accounts")) {
+        const held = (options.accounts ?? []).find(
+          (account) =>
+            account.channel === body?.channel && account.channelUserId === body?.channelUserId,
+        );
+        // Compare-and-swap on the current owner: taking an account from another
+        // person needs `transferFrom` naming them exactly.
+        if (held?.state === "linked" && body?.transferFrom !== held.personId) {
+          return json(
+            linkConflict(held, { id: held.personId ?? "", displayName: held.personName ?? "" }),
+            409,
+          );
+        }
+        return json(person);
+      }
+      if (path.endsWith("/merge")) {
+        const into = (options.people ?? []).find((p) => `/api/people/${p.id}/merge` === path);
+        return into ? json(into) : json({ error: "Unknown person" }, 404);
+      }
+      if (method === "PATCH") {
+        if (body?.bondLevel) person.bondLevel = body.bondLevel;
+        return json(person);
+      }
+      return json({ error: "Unknown route" }, 404);
+    }
 
     if (url.includes("/messages")) {
       if (options.entries === "fail") return json({ error: "timeline unavailable" }, 500);
@@ -105,10 +193,18 @@ function mockApi(
         nextCursor: options.nextCursor ?? null,
       });
     }
+    if (url.includes("/api/accounts")) {
+      return json(sliceAccountDirectory(options.accounts ?? []));
+    }
+    if (path === "/api/people") {
+      const listing = options.people ?? [];
+      return json({ people: listing, counts: countPeople(listing) });
+    }
     if (url.includes("/api/people/")) {
       if (options.person === "missing") return json({ error: "Unknown person" }, 404);
       if (options.person === "fail") return json({ error: "person store unavailable" }, 500);
-      return json(options.person ?? PERSON);
+      const merged = (options.people ?? []).find((p) => path === `/api/people/${p.id}`);
+      return json(merged ?? person);
     }
     return json({});
   }) as typeof fetch);
@@ -293,5 +389,113 @@ describe("PersonDetailPage", () => {
     await user.click(screen.getByRole("button", { name: "People" }));
 
     expect(await screen.findByText("people page")).toBeTruthy();
+  });
+});
+
+describe("PersonDetailPage management", () => {
+  // The write half of the dossier: the bond, the accounts that resolve here,
+  // and absorbing a duplicate. Every one of them is a /people verb.
+
+  it("changes the bond with a patch that names only the bond", async () => {
+    const user = userEvent.setup();
+    const calls = mockApi();
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("combobox", { name: "Bond" }));
+    await user.click(await screen.findByRole("option", { name: "Inner circle" }));
+
+    const patch = await waitFor(() => {
+      const call = calls.find((c) => c.method === "PATCH");
+      expect(call).toBeTruthy();
+      return call!;
+    });
+    expect(patch.url).toBe("/api/people/wei-chen");
+    // An omitted field is one the update leaves alone, so a bond change must
+    // not carry a name and blank it.
+    expect(patch.body).toEqual({ bondLevel: "inner-circle" });
+  });
+
+  it("links an account the directory holds onto this person", async () => {
+    const user = userEvent.setup();
+    const calls = mockApi({ accounts: [UNPLACED] });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("button", { name: "Link account…" }));
+    await user.click(await screen.findByRole("button", { name: /Rachel Lim/ }));
+
+    const link = await waitFor(() => {
+      const call = calls.find((c) => c.url === "/api/people/wei-chen/accounts");
+      expect(call).toBeTruthy();
+      return call!;
+    });
+    expect(link.method).toBe("POST");
+    // One call, and it names the account by the pair the contract says is its
+    // identity — every address it answers to travels with it.
+    expect(link.body).toEqual({
+      channel: "whatsapp",
+      channelUserId: "6591234472@s.whatsapp.net",
+    });
+  });
+
+  it("names who holds an account, and transfers it only on a second confirmation", async () => {
+    const user = userEvent.setup();
+    const calls = mockApi({ accounts: [HELD_BY_ANOTHER] });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("button", { name: "Link account…" }));
+    await user.click(await screen.findByRole("button", { name: /mira_c/ }));
+
+    // The refusal names the owner rather than reading as a failed write.
+    const confirm = await screen.findByRole("dialog", { name: "Move this account?" });
+    expect(confirm.textContent).toContain("Mira Chen");
+    expect(calls.filter((c) => c.body?.transferFrom)).toHaveLength(0);
+
+    await user.click(within(confirm).getByRole("button", { name: "Move it here" }));
+
+    // A transfer re-attributes the account's whole history, so it is a second
+    // request the guardian asked for by name.
+    await waitFor(() =>
+      expect(calls.find((c) => c.body?.transferFrom)?.body).toEqual({
+        channel: "telegram",
+        channelUserId: "990014422",
+        transferFrom: "mira",
+      }),
+    );
+  });
+
+  it("merges this person into the one picked, and lands on the survivor", async () => {
+    const user = userEvent.setup();
+    const calls = mockApi({ people: [DUPLICATE] });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("button", { name: "Merge into another person…" }));
+    await user.click(await screen.findByRole("button", { name: /W\. Chen/ }));
+
+    const merge = await waitFor(() => {
+      const call = calls.find((c) => c.url.endsWith("/merge"));
+      expect(call).toBeTruthy();
+      return call!;
+    });
+    // The survivor is named in the path and the duplicate in the body, so the
+    // page that had the duplicate open is the one that goes away.
+    expect(merge.url).toBe("/api/people/wei-c/merge");
+    expect(merge.body).toEqual({ from: "wei-chen" });
+    expect(await screen.findByRole("heading", { name: "W. Chen" })).toBeTruthy();
+  });
+
+  it("says a refused write failed rather than showing the change as saved", async () => {
+    const user = userEvent.setup();
+    mockApi({ writes: "fail" });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("combobox", { name: "Bond" }));
+    await user.click(await screen.findByRole("option", { name: "Inner circle" }));
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
   });
 });

--- a/packages/web/src/pages/PersonDetailPage.tsx
+++ b/packages/web/src/pages/PersonDetailPage.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft, CircleAlert } from "lucide-react";
-import { normalizeBondLevel, type TimelineEntry } from "@rome/api-types/identities";
+import type { TimelineEntry } from "@rome/api-types/identities";
 import { formatWhatsAppPhone } from "@rome/api-types/identities";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -10,7 +10,7 @@ import { PageShell, PageBody } from "@/shell/PageShell";
 import { Avatar } from "./people/avatar";
 import { ChannelPill } from "./people/channel-meta";
 import { clockTime, dayLabel, navigatorLocale, startOfDay } from "./people/format";
-import { levelLabelKey } from "./people/rows";
+import { PersonManagement } from "./people/manage";
 import { usePerson, usePersonTimeline } from "./people/use-roster";
 
 /**
@@ -21,16 +21,16 @@ import { usePerson, usePersonTimeline } from "./people/use-roster";
  * Timeline entries are generic, so a channel Rome learns about later shows up
  * here without a change to this page.
  *
- * A read. `GET /api/people/:id` and `GET /api/people/:id/messages` are the
- * whole page: one request for the person, one for the history across every
- * account they hold. Which stores that history is merged from is the server's
- * business, and a client that merged per-channel reads itself would have to
- * re-derive the ordering the cursor is written against — and would disagree
- * with it at every page boundary.
+ * Two reads own it. `GET /api/people/:id` and `GET /api/people/:id/messages`:
+ * one request for the person, one for the history across every account they
+ * hold. Which stores that history is merged from is the server's business, and
+ * a client that merged per-channel reads itself would have to re-derive the
+ * ordering the cursor is written against — and would disagree with it at every
+ * page boundary.
  *
  * The management gestures the design puts on this card — the bond select, Link
- * account…, Merge into… — are the write half of the surface and land with
- * rome-os/rome#67.
+ * account…, Merge into… — are `people/manage.tsx`, and each settles by
+ * invalidating those reads.
  */
 
 /**
@@ -101,8 +101,6 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
     );
   }
 
-  const level = normalizeBondLevel(person.bondLevel);
-
   return (
     <PageShell>
       <PageBody>
@@ -134,11 +132,13 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
               )}
             </div>
           </div>
-          {/* The stored bond, read: changing it is a write, and the writes move
-              onto this contract in rome-os/rome#67. */}
-          <p className="text-aux text-muted-foreground sm:text-right">
-            {t("detail.bond")}: {t(levelLabelKey(level))}
-          </p>
+          {/* A merge ends with this person gone, so the page that had them open
+              follows the account history to the survivor rather than sitting on
+              a route that now 404s. */}
+          <PersonManagement
+            person={person}
+            onMerged={(survivorId) => navigate(`/people/${encodeURIComponent(survivorId)}`)}
+          />
         </div>
 
         <section>

--- a/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
+++ b/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
@@ -33,8 +33,9 @@ import { DirectoryRow, StreamRow, UnknownRow, levelLabelKey } from "@/pages/peop
 // after the page stopped, which is the one thing a live note exists to prevent.
 //
 // What is written here is only what the page does not carry yet: the `⋯` menu
-// and the bulk bar, whose every item is a write, and the writes move onto the
-// /people contract in rome-os/rome#67.
+// and the bulk bar. The page's writes are on the /people contract, and those
+// two are the surfaces still ahead of it — a bulk gesture is N writes with one
+// confirmation, which the contract's verbs do not answer on their own.
 
 const NOW = Math.floor(Date.now() / 1000);
 const MINUTE = 60;
@@ -93,10 +94,12 @@ export function ChannelGlyphSet() {
  * The row menu the design gives every actionable row: a move to each level the
  * row is not already at, then merge.
  *
- * Written here rather than imported, because it is the one piece of the design
- * the page does not carry yet — every item is a write, and the writes move onto
- * the /people contract in rome-os/rome#67. When they land, this comes out and
- * the specimen renders the shipped menu.
+ * Written here rather than imported, because it is a piece of the design the
+ * page does not carry yet. The gestures behind it exist — a level on a person
+ * is `PATCH /api/people/:id`, and the unplaced ends of the ladder are the
+ * account's own verbs — but they reach the page from the row and the dossier
+ * rather than from one menu that enumerates targets. When a menu lands, this
+ * comes out and the specimen renders the shipped one.
  */
 function RowMenu({ row: subject }: { row: PeopleRow }) {
   const { t } = useTranslation("people");
@@ -333,8 +336,9 @@ export function DirectoryDemo() {
           ))}
         </div>
       ))}
-      {/* The bulk bar is the other half of #67: one choice applied to every
-          selected row, so its targets are the intersection across them. */}
+      {/* The bulk bar is still ahead: one choice applied to every selected
+          row, so its targets are the intersection across them — and N writes
+          behind one confirmation, which no single verb answers. */}
       {selected.length > 0 && (
         <div className="mt-2 flex items-center justify-between rounded-8 bg-primary/10 px-3 py-2">
           <span className="text-aux text-foreground">

--- a/packages/web/src/pages/dev/mdx/docs/people-page.mdx
+++ b/packages/web/src/pages/dev/mdx/docs/people-page.mdx
@@ -85,19 +85,24 @@ page. A row here exists to get you to a conversation.
 
 The Unknown chip keeps dense rows: channel pill, number or handle, message count,
 preview, and the `⋯` menu. The placement decision runs on that evidence, so all of it
-is on the row rather than a click away. A move updates the row in place and decrements
-the chip's count.
+is on the row rather than a click away. Placing a sender takes it off the view, and
+the chip's count drops because the next read says so.
 
 <Specimen title="Unknown rows">
   <UnknownDemo />
 </Specimen>
 
+Stranger keeps the same dense row and offers `Restore`. A restore is decided on the
+evidence a placement is decided on — what the sender actually sent — so it gets the
+row rather than a roster line with a button on it.
+
 <Invariant>
-  Unknown and Stranger are positions on one ladder. Placing a sender, promoting a
-  friend and dismissing spam are the same gesture — a **move** — so the row's `⋯` menu
-  is generated from its current level rather than written per group.
-  `moveTargetsFor(row)` is the only place that enumerates targets, and the row menu,
-  the bulk bar and the dossier select all read it.
+  Unknown and Stranger are positions on one ladder, and they are still not one
+  gesture. Placing a sender creates a person or links onto one; dismissing is a state
+  the *account* is in, so it names no target and its way back is `restore` rather than
+  a move off a sentinel. The union page generated a row's targets from its level
+  because one verb served them all — the contract has a verb per decision, and a row
+  asks for the one its position admits.
 </Invariant>
 
 ---
@@ -125,6 +130,12 @@ would otherwise have no way back on screen.
 `/people/:personId` is the dossier: identity card with bond select, linked accounts
 as neutral glyph + id pills, `Link account…` and `Merge into…`. The merged timeline
 grouped by day sits below it, and a sticky composer sits at the bottom.
+
+Both pickers offer more than what would succeed. `Link account…` lists the accounts
+another person already holds, because taking one back is a gesture the guardian has
+and the refusal is what makes it explicit. `Merge into…` names the survivor, so the
+person whose page is open is the one absorbed — which is why it ends on the survivor's
+page rather than on a route that now answers 404.
 
 <Specimen title="Dossier">
   <PersonPageDemo />
@@ -157,15 +168,30 @@ would be a second, contradictory color vocabulary on the same row.
 
 ## Writes
 
+Every gesture is a verb of the contract, and the union's single "move" decomposes into
+them: `POST /api/people` places a sender and links the account it came from in one
+request, `POST /api/people/:id/accounts` links onto somebody who already exists,
+`dismiss` and `restore` decide about an account, `POST /api/people/:id/merge` absorbs a
+duplicate, and `PATCH /api/people/:id` changes a bond.
+
 | Rule | Why |
 | --- | --- |
-| Settle by invalidation, never by patching cached rows | Where a row lands is the server's answer, and a hand-merged level disagrees the moment a move implies anything else |
-| A write holds its identities until the cache catches up | `planMove` reads a row's current id shape, so a second write against an identity the first is still reshaping plans from a shape that has already changed |
-| Placing or dismissing fans out over every channel the row stands for | A consolidated WhatsApp contact is one row under both its phone jid and its `@lid` jid, so acting on one would leave the rest to resurface as their own Unknown rows |
+| Settle by invalidation, never by patching cached rows | Where a row lands is the server's answer, and a client that edited its own copy is rendering a guess the next read contradicts — the chip counts are the clearest case, since they describe the whole roster and not the page in hand |
+| A write holds its rows until the refetch lands, not until the request returns | A gesture that reports itself done at the response leaves the row it acted on standing for as long as the read takes, which reads as a write that did nothing |
+| One call covers every address the row stands for | A WhatsApp contact answers to both its phone jid and its `@lid` jid; which of those are one account is the server's answer, given once in `addresses`, so the client names the account and the fold travels with it |
 
-The fan-out is best-effort past the first call: the first call **is** the move and has
-already committed, so a failed follow-up must not report a saved change as a failed
-one.
+The last one is what replaced a client-side fan-out. The union page acted per channel
+and made the follow-up calls best-effort, because the first call had already committed
+and a failed second one must not report a saved change as a failed one. There is no
+follow-up now: the account is one thing, and the write either landed on it or did not.
+
+<Invariant>
+  A transfer is asked for twice. Linking an account another person holds is refused
+  with a `409` naming the holder, and only a request carrying `transferFrom` — that
+  holder, by id — goes through. A transfer re-attributes the account's whole message
+  history, so it is never the side effect of a retry, and the page never re-points an
+  account silently the way the union page did.
+</Invariant>
 
 ---
 
@@ -177,3 +203,6 @@ one.
   from it.
 - Only WhatsApp can send. Other channels appear in the composer's select, disabled,
   until a send path exists.
+- The `⋯` row menu and the bulk bar are drawn in the specimens and not on the page. A
+  bulk gesture is N writes behind one confirmation, and the contract has no verb that
+  answers that — what a partial failure leaves behind has to be decided first.

--- a/packages/web/src/pages/people/legacy-api-shapes.ts
+++ b/packages/web/src/pages/people/legacy-api-shapes.ts
@@ -1,12 +1,12 @@
-// The shapes of the endpoints that predate `/api/identities`: the unmapped
-// queue, the curated persons list, and the WhatsApp address-book mirror. Core
-// still serves all three (this page reads `/api/persons` and writes through
-// it, and the mirror backs the chat drawer), so the dashboard's mock backend
-// still stands in for them and types its fixtures against these.
+// The shapes of the endpoints that predate the /people contract: the unmapped
+// queue, the curated persons list, and the two conversation mirrors. The People
+// page is off all but the LinkedIn mirror, whose threads are conversations
+// rather than accounts and reach no /accounts row. Core still serves the rest —
+// the WhatsApp mirror backs the chat drawer — so the dashboard's mock backend
+// stands in for them and types its fixtures against these.
 //
-// One definition, read by both the fetch site (`PeoplePage.tsx`) and the mock
-// that answers it — a second copy would let the two drift while both still
-// typecheck.
+// One definition, read by both the fetch site and the mock that answers it — a
+// second copy would let the two drift while both still typecheck.
 
 export interface UnknownSender {
   channel: string;

--- a/packages/web/src/pages/people/manage.tsx
+++ b/packages/web/src/pages/people/manage.tsx
@@ -1,0 +1,338 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  ASSIGNABLE_BOND_LEVELS,
+  formatWhatsAppPhone,
+  normalizeBondLevel,
+  type AssignableBondLevel,
+} from "@rome/api-types/identities";
+import {
+  accountRef,
+  personMatchesQuery,
+  type DirectoryAccount,
+  type LinkConflict,
+  type PersonResource,
+} from "@rome/api-types/people";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { usePeople } from "@/hooks/use-people";
+import { ChannelPill } from "./channel-meta";
+import { MutationError } from "./triage";
+import { levelLabelKey } from "./rows";
+import { TransferConfirm } from "./transfer";
+import { useAccountSearch } from "./use-roster";
+import { usePeopleWrites } from "./use-writes";
+
+// The dossier's management gestures: the bond, the accounts that resolve to
+// this person, and absorbing a duplicate. Three verbs of the /people contract
+// (`./writes.ts`), each settling the reads rather than editing them.
+//
+// The pickers offer more than what would succeed. An account another person
+// holds is offerable, because taking one back is a gesture the guardian has and
+// the contract answers the attempt with a conflict naming the holder — which is
+// the whole reason a transfer can be explicit rather than silent.
+
+/** The identifier a picker row is recognized by. */
+function handleOf(account: { channel: string; channelUserId: string }): string {
+  return account.channel === "whatsapp"
+    ? (formatWhatsAppPhone(account.channelUserId) ?? account.channelUserId)
+    : account.channelUserId;
+}
+
+/**
+ * The bond select, the two pickers, and whatever the last write said.
+ *
+ * The guardian's bond does not move — the contract refuses it — so their card
+ * reads the level rather than offering to change it.
+ */
+export function PersonManagement({
+  person,
+  onMerged,
+}: {
+  person: PersonResource;
+  /** Where to go once this person has been absorbed: they no longer exist. */
+  onMerged: (survivorId: string) => void;
+}) {
+  const { t } = useTranslation("people");
+  const writes = usePeopleWrites();
+  const level = normalizeBondLevel(person.bondLevel);
+  const [picker, setPicker] = useState<"link" | "merge" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [savingBond, setSavingBond] = useState(false);
+
+  async function handleBond(next: string) {
+    setSavingBond(true);
+    setError(null);
+    try {
+      const result = await writes.setBond(person.id, next as AssignableBondLevel);
+      if (!result.ok) setError("conflict" in result ? result.conflict.error : result.message);
+    } finally {
+      setSavingBond(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-stretch gap-2 sm:items-end">
+      {level === "guardian" ? (
+        <p className="text-aux text-muted-foreground sm:text-right">
+          {t("detail.bond")}: {t(levelLabelKey(level))}
+        </p>
+      ) : (
+        <Select value={level} disabled={savingBond} onValueChange={(next) => void handleBond(next)}>
+          <SelectTrigger aria-label={t("detail.bond")} className="w-full sm:w-48">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ASSIGNABLE_BOND_LEVELS.map((value) => (
+              <SelectItem key={value} value={value}>
+                {t(levelLabelKey(value))}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
+      {level !== "guardian" && (
+        <div className="flex flex-wrap gap-2 sm:justify-end">
+          <Button type="button" variant="outline" size="sm" onClick={() => setPicker("link")}>
+            {t("detail.linkAccount")}
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={() => setPicker("merge")}>
+            {t("actions.mergeInto")}
+          </Button>
+        </div>
+      )}
+
+      <MutationError message={error} />
+
+      {picker === "link" && <LinkAccountPicker person={person} onClose={() => setPicker(null)} />}
+      {picker === "merge" && (
+        <MergePicker person={person} onClose={() => setPicker(null)} onMerged={onMerged} />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Pick an account to resolve to this person.
+ *
+ * The search is the server's, because the directory is a synced address book
+ * rather than a curated listing: a filter over whichever page arrived would
+ * answer "no such account" for a contact the mirror holds.
+ */
+function LinkAccountPicker({ person, onClose }: { person: PersonResource; onClose: () => void }) {
+  const { t } = useTranslation("people");
+  const writes = usePeopleWrites();
+  const [search, setSearch] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [transfer, setTransfer] = useState<LinkConflict | null>(null);
+  const directory = useAccountSearch(search, { enabled: true });
+
+  const held = new Set(person.accounts.map((account) => accountRef(account)));
+  const candidates = (directory.data?.accounts ?? []).filter(
+    (account) => !held.has(accountRef(account)),
+  );
+
+  async function link(account: DirectoryAccount, transferFrom?: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await writes.link(person.id, account, transferFrom);
+      if (result.ok) {
+        setTransfer(null);
+        onClose();
+        return;
+      }
+      if ("conflict" in result && result.conflict.linkedPersonId) {
+        setTransfer(result.conflict);
+        return;
+      }
+      setTransfer(null);
+      setError("conflict" in result ? result.conflict.error : result.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <Dialog open onClose={onClose} size="md" ariaLabel={t("detail.linkAccount")}>
+        <DialogHeader onClose={onClose} closeLabel={t("actions.close")}>
+          <DialogTitle>{t("detail.linkAccount")}</DialogTitle>
+          <DialogDescription>{t("detail.linkDescription")}</DialogDescription>
+        </DialogHeader>
+        <DialogBody className="space-y-3">
+          <Input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label={t("search.label")}
+            placeholder={t("search.placeholder")}
+          />
+          {candidates.length === 0 ? (
+            <p className="py-6 text-center text-aux text-subtle-foreground">
+              {directory.isPending ? t("page.loading") : t("page.emptyForSearch")}
+            </p>
+          ) : (
+            <ul className="max-h-72 overflow-y-auto">
+              {candidates.map((account) => (
+                <li key={accountRef(account)}>
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void link(account)}
+                    className="flex w-full items-center gap-3 border-b border-border-subtle px-2 py-2 text-left last:border-b-0 hover:bg-surface"
+                  >
+                    <ChannelPill channel={account.channel} />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-ui text-foreground">
+                        {account.displayName}
+                      </span>
+                      <span className="block truncate text-aux text-muted-foreground">
+                        <span className="font-mono tabular-nums">{handleOf(account)}</span>
+                        {/* Whose it is right now, so picking one already held is
+                            a decision rather than a surprise. */}
+                        {account.personName &&
+                          ` · ${t("linkPicker.heldBy", { owner: account.personName })}`}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          <MutationError message={error} />
+        </DialogBody>
+      </Dialog>
+      {transfer && (
+        <TransferConfirm
+          conflict={transfer}
+          busy={busy}
+          onCancel={() => setTransfer(null)}
+          onConfirm={() => {
+            const account = candidates.find(
+              (candidate) =>
+                candidate.channel === transfer.channel &&
+                candidate.channelUserId === transfer.channelUserId,
+            );
+            if (account) void link(account, transfer.linkedPersonId ?? undefined);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * Pick the person this one is a duplicate of.
+ *
+ * This person is absorbed into the pick, so the page open when the merge lands
+ * is the one that goes away — the caller is handed the survivor to navigate to.
+ * The listing is curated and bounded, so the search runs over what it returned.
+ */
+function MergePicker({
+  person,
+  onClose,
+  onMerged,
+}: {
+  person: PersonResource;
+  onClose: () => void;
+  onMerged: (survivorId: string) => void;
+}) {
+  const { t } = useTranslation("people");
+  const writes = usePeopleWrites();
+  const people = usePeople();
+  const [search, setSearch] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const candidates = useMemo(
+    () =>
+      (people.data ?? []).filter(
+        (candidate) =>
+          candidate.id !== person.id &&
+          normalizeBondLevel(candidate.bondLevel) !== "guardian" &&
+          personMatchesQuery(candidate, search),
+      ),
+    [people.data, person.id, search],
+  );
+
+  async function merge(into: PersonResource) {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await writes.merge(into.id, person.id);
+      if (!result.ok) {
+        setError("conflict" in result ? result.conflict.error : result.message);
+        return;
+      }
+      onClose();
+      onMerged(into.id);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Dialog open onClose={onClose} size="md" ariaLabel={t("merge.title")}>
+      <DialogHeader onClose={onClose} closeLabel={t("actions.close")}>
+        <DialogTitle>{t("merge.title")}</DialogTitle>
+        <DialogDescription>{t("merge.description")}</DialogDescription>
+      </DialogHeader>
+      <DialogBody className="space-y-3">
+        <Input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label={t("merge.selectLabel")}
+          placeholder={t("merge.searchPlaceholder")}
+        />
+        {candidates.length === 0 ? (
+          <p className="py-6 text-center text-aux text-subtle-foreground">
+            {t("merge.noCandidates")}
+          </p>
+        ) : (
+          <ul className="max-h-72 overflow-y-auto">
+            {candidates.map((candidate) => (
+              <li key={candidate.id}>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => void merge(candidate)}
+                  className="flex w-full items-center gap-3 border-b border-border-subtle px-2 py-2 text-left last:border-b-0 hover:bg-surface"
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-ui text-foreground">
+                      {candidate.displayName}
+                    </span>
+                    <span className="block truncate text-aux text-muted-foreground">
+                      {t(levelLabelKey(normalizeBondLevel(candidate.bondLevel)))}
+                      {candidate.accounts.length > 0 &&
+                        ` · ${candidate.accounts.map(handleOf).join(", ")}`}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <MutationError message={error} />
+      </DialogBody>
+    </Dialog>
+  );
+}

--- a/packages/web/src/pages/people/manage.tsx
+++ b/packages/web/src/pages/people/manage.tsx
@@ -149,6 +149,10 @@ function LinkAccountPicker({ person, onClose }: { person: PersonResource; onClos
   );
 
   async function link(account: DirectoryAccount, transferFrom?: string) {
+    // The transfer confirm is disabled while `busy`, and this refuses re-entry
+    // besides: a disabled button depends on the render having flushed, and a
+    // second transfer would re-attribute the account's history all over again.
+    if (busy) return;
     setBusy(true);
     setError(null);
     try {

--- a/packages/web/src/pages/people/people-endpoint.test.ts
+++ b/packages/web/src/pages/people/people-endpoint.test.ts
@@ -1,0 +1,66 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { extname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// The People page reads and writes the /people contract, and nothing else. The
+// composer retired its own `/api/persons` read behind the same guard
+// (`components/chat/chat-people-endpoint.test.ts`); the page's writes were the
+// last thing keeping the legacy routes alive, so this pins their absence rather
+// than trusting a repointed call site not to come back.
+//
+// A path rather than a request: the union page fanned one gesture out over
+// several routes, so counting requests in a rendered test proves only that the
+// path the test walked stayed clean.
+
+const peopleRoot = fileURLToPath(new URL(".", import.meta.url));
+const pagesRoot = resolve(peopleRoot, "..");
+const webSrc = resolve(pagesRoot, "..");
+
+/** Every module the People surface is built from. */
+const PEOPLE_SURFACES = [
+  peopleRoot,
+  resolve(pagesRoot, "PeoplePage.tsx"),
+  resolve(pagesRoot, "PersonDetailPage.tsx"),
+];
+
+/** The LinkedIn mirror is not on this contract: its threads are conversations
+ *  rather than accounts, and it reads its own endpoints until a LinkedIn
+ *  account can be linked to a person. */
+const NOT_ON_THE_CONTRACT = ["linkedin.tsx", "legacy-api-shapes.ts"];
+
+function sourceFiles(path: string): string[] {
+  const entries = (() => {
+    try {
+      return readdirSync(path, { withFileTypes: true });
+    } catch {
+      return null;
+    }
+  })();
+  if (entries === null) {
+    const isSource = [".ts", ".tsx"].includes(extname(path)) && !path.includes(".test.");
+    return isSource && !NOT_ON_THE_CONTRACT.some((name) => path.endsWith(name)) ? [path] : [];
+  }
+  return entries.flatMap((entry) => sourceFiles(resolve(path, entry.name)));
+}
+
+describe("People surface endpoints", () => {
+  it("names no legacy /api/persons route", () => {
+    const offenders = PEOPLE_SURFACES.flatMap(sourceFiles).filter((path) =>
+      readFileSync(path, "utf8").includes("/api/persons"),
+    );
+
+    expect(offenders.map((path) => relative(webSrc, path)).sort()).toEqual([]);
+  });
+
+  it("names no identity union route either", () => {
+    // `/api/identities` was the union this rebuild replaced. It reads the same
+    // rows through one flattened noun, so a surface still on it would be a
+    // second answer to the same question.
+    const offenders = PEOPLE_SURFACES.flatMap(sourceFiles).filter((path) =>
+      readFileSync(path, "utf8").includes("/api/identities"),
+    );
+
+    expect(offenders.map((path) => relative(webSrc, path)).sort()).toEqual([]);
+  });
+});

--- a/packages/web/src/pages/people/rows.tsx
+++ b/packages/web/src/pages/people/rows.tsx
@@ -76,9 +76,9 @@ export function StreamRow({ row, onOpen }: { row: PeopleRow; onOpen?: () => void
  * evidence — which channel, which number, how much they have said — so all of
  * it is on the row rather than a click away.
  *
- * `actions` is whatever gesture the page offers for placing it. The gestures
- * themselves are the write half of this surface (rome-os/rome#67); the row only
- * says where they go.
+ * `actions` is whatever gesture the page offers for the position it is in:
+ * placing it, or taking a dismissal back. The gestures themselves are
+ * `people/triage.tsx`; the row only says where they go.
  */
 export function UnknownRow({ row, actions }: { row: PeopleRow; actions?: React.ReactNode }) {
   const { t } = useTranslation("people");
@@ -137,8 +137,8 @@ export function DirectoryRow({
   selected?: boolean;
   onOpen?: () => void;
   /** Given, the avatar becomes the selection control. Omitted — as the page
-   *  leaves it until the bulk bar lands (rome-os/rome#67) — the avatar is an
-   *  ornament and the row carries no selection state. */
+   *  leaves it until the bulk bar lands — the avatar is an ornament and the row
+   *  carries no selection state. */
   onToggleSelect?: () => void;
   actions?: React.ReactNode;
 }) {

--- a/packages/web/src/pages/people/transfer.tsx
+++ b/packages/web/src/pages/people/transfer.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from "react-i18next";
+import { formatWhatsAppPhone } from "@rome/api-types/identities";
+import type { LinkConflict } from "@rome/api-types/people";
+import { RomeConfirmDialog } from "@/components/rome-confirm-dialog";
+
+// The second half of a link that another person already holds.
+//
+// The union page re-pointed an account silently. The contract refuses instead,
+// and names the holder in the refusal, so the page can say whose account it is
+// about to take and take it only when asked again. A transfer re-attributes the
+// account's whole message history, which is why it is never the side effect of
+// a retry.
+
+/** The account as the guardian would recognize it, rather than as the channel
+ *  addresses it. */
+function accountLabel(conflict: LinkConflict): string {
+  if (conflict.channel !== "whatsapp") return conflict.channelUserId;
+  return formatWhatsAppPhone(conflict.channelUserId) ?? conflict.channelUserId;
+}
+
+/**
+ * Confirm taking an account from the person who holds it.
+ *
+ * Rendered only for a conflict that names a holder. One with `linkedPersonId`
+ * null says the caller's view of the owner is stale and the account is now held
+ * by nobody — there is no person to transfer from, so the caller shows the
+ * refusal and lets the guardian try again against a fresh read.
+ */
+export function TransferConfirm({
+  conflict,
+  busy,
+  onCancel,
+  onConfirm,
+}: {
+  conflict: LinkConflict;
+  /** True while the transfer is in flight, so the confirm cannot be fired twice. */
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const { t } = useTranslation("people");
+  return (
+    <RomeConfirmDialog
+      open
+      destructive
+      title={t("transfer.title")}
+      description={t("transfer.description", {
+        account: accountLabel(conflict),
+        owner: conflict.linkedPersonName ?? "",
+      })}
+      confirmLabel={t("actions.transfer")}
+      cancelLabel={t("actions.cancel")}
+      confirmDisabled={busy}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+    />
+  );
+}

--- a/packages/web/src/pages/people/triage.tsx
+++ b/packages/web/src/pages/people/triage.tsx
@@ -1,9 +1,12 @@
 import { useId, useState } from "react";
 import { useForm } from "@tanstack/react-form";
 import { useTranslation } from "react-i18next";
-import type { TFunction } from "i18next";
-import type { PersonResource } from "@rome/api-types/people";
-import { normalizeBondLevel } from "@rome/api-types/identities";
+import {
+  ASSIGNABLE_BOND_LEVELS,
+  normalizeBondLevel,
+  type AssignableBondLevel,
+} from "@rome/api-types/identities";
+import type { LinkConflict, PersonResource } from "@rome/api-types/people";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
@@ -18,18 +21,24 @@ import { RomeConfirmDialog } from "@/components/rome-confirm-dialog";
 import { cn } from "@/lib/utils";
 import { UnknownRow } from "./rows";
 import { levelLabelKey } from "./rows";
+import { TransferConfirm } from "./transfer";
+import { usePeopleWrites } from "./use-writes";
 import type { PeopleRow } from "./people-model";
 
-// Placing an account that nobody has decided about: create a person for it,
-// link it onto one that exists, or dismiss it.
+// Placing an account that nobody has decided about, and taking one back.
 //
-// These are the page's one set of write gestures, and they are carried forward
-// rather than rebuilt: they still post to the legacy `/api/persons/*` routes,
-// and repointing them onto the /people contract — where they become one "move"
-// along the ladder, from a row menu — is rome-os/rome#67. What this module owes
-// the rebuild is the row they hang off, which is the new one.
-
-const BOND_FORM_OPTIONS = ["inner-circle", "acquaintance", "other"] as const;
+// What the union page called one "move" is several verbs of the /people
+// contract (`./writes.ts`), because they are several different writes: placing
+// a sender creates a person or links onto one, dismissing it is a decision
+// about the account, and the dismissed end of the ladder has a way back.
+// Dismissal is a state an account is in rather than a merge into a sentinel, so
+// there is no target list to enumerate and nothing here has to know which moves
+// a row admits.
+//
+// A gesture names the account by the pair the contract says is its identity,
+// never by one of the addresses it answers to: the server folds a WhatsApp
+// contact's phone jid and `@lid` jid into one account, so one call already
+// covers every address the row stands for.
 
 /**
  * A submit label that swaps to a busy phrasing while the request is in flight.
@@ -53,37 +62,6 @@ export function BusyLabel({ idle, busy, isBusy }: { idle: string; busy: string; 
   );
 }
 
-/**
- * POST a person mutation and reduce whatever comes back to "it worked" or a
- * message worth showing. Never throws — the callers are event handlers, where
- * an unhandled rejection would leave the row silent.
- *
- * Only a 4xx body is treated as copy. These routes answer a rejected request
- * with an `{ error }` naming the missing field, which is exactly what the
- * guardian needs. A 5xx body carries the same shape but not the same meaning:
- * the API error handler serializes an unhandled exception as
- * `{ error: err.message }`, so trusting it would put a raw SQLite or repository
- * message on screen.
- */
-export async function postPersonMutation(
-  url: string,
-  body: unknown,
-  t: TFunction<"people">,
-): Promise<{ ok: true } | { ok: false; error: string }> {
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
-    body: JSON.stringify(body),
-  }).catch(() => null);
-
-  if (!res) return { ok: false, error: t("errors.network") };
-  if (res.ok) return { ok: true };
-  if (res.status >= 500) return { ok: false, error: t("errors.requestFailed") };
-  const payload = (await res.json().catch(() => null)) as { error?: string } | null;
-  return { ok: false, error: payload?.error || t("errors.requestFailed") };
-}
-
 /** Why the last write failed, sitting at the left end of a button row. */
 export function MutationError({ message }: { message: string | null }) {
   if (!message) return null;
@@ -104,19 +82,15 @@ function CreateProfileForm({
    *  likely to be created under, and never a linked person's. */
   defaultName: string;
   error: string | null;
-  onSubmit: (data: { displayName: string; bondLevel: string; relation: string }) => Promise<void>;
+  onSubmit: (data: { displayName: string; bondLevel: AssignableBondLevel }) => Promise<void>;
   onCancel: () => void;
 }) {
   const { t } = useTranslation("people");
   const uid = useId();
   const form = useForm({
-    defaultValues: { displayName: defaultName, bondLevel: "acquaintance", relation: "" },
+    defaultValues: { displayName: defaultName, bondLevel: "acquaintance" as AssignableBondLevel },
     onSubmit: async ({ value }) => {
-      await onSubmit({
-        displayName: value.displayName,
-        bondLevel: value.bondLevel,
-        relation: value.relation,
-      });
+      await onSubmit({ displayName: value.displayName, bondLevel: value.bondLevel });
     },
   });
 
@@ -150,12 +124,15 @@ function CreateProfileForm({
               <FieldLabel htmlFor={`${uid}-bond-level`}>
                 {t("createForm.bondLevelLabel")}
               </FieldLabel>
-              <Select value={field.state.value} onValueChange={field.handleChange}>
+              <Select
+                value={field.state.value}
+                onValueChange={(value) => field.handleChange(value as AssignableBondLevel)}
+              >
                 <SelectTrigger id={`${uid}-bond-level`} className="w-full">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {BOND_FORM_OPTIONS.map((value) => (
+                  {ASSIGNABLE_BOND_LEVELS.map((value) => (
                     <SelectItem key={value} value={value}>
                       {t(levelLabelKey(value))}
                     </SelectItem>
@@ -166,21 +143,6 @@ function CreateProfileForm({
           )}
         </form.Field>
       </div>
-      <form.Field name="relation">
-        {(field) => (
-          <Field>
-            <FieldLabel htmlFor={`${uid}-relation`}>{t("createForm.relationLabel")}</FieldLabel>
-            <Input
-              id={`${uid}-relation`}
-              type="text"
-              value={field.state.value}
-              onChange={(e) => field.handleChange(e.target.value)}
-              onBlur={field.handleBlur}
-              placeholder={t("createForm.relationPlaceholder")}
-            />
-          </Field>
-        )}
-      </form.Field>
       <form.Subscribe<{ isSubmitting: boolean; displayName: string }>
         selector={(s) => ({ isSubmitting: s.isSubmitting, displayName: s.values.displayName })}
       >
@@ -290,26 +252,29 @@ function LinkForm({
 /**
  * One unplaced account, with the gestures that place it.
  *
- * The row is the rebuild's; the gestures are the page's existing ones, which
- * still name an account by the pair (channel, channelUserId) the contract says
- * is its identity. A dismissal is confirmed first: it writes a permanent
- * mapping the dashboard cannot reverse.
+ * Nothing is handed back to a parent to refresh: every verb here settles by
+ * invalidating the reads and resolves once they have landed, so the row stands
+ * until the listing that no longer holds it has arrived.
  */
 export function UnknownEntry({
   row,
   people,
-  onSettled,
 }: {
   row: PeopleRow;
   /** The people a link can land on — the listing's own rows. */
   people: PersonResource[];
-  onSettled: () => void;
 }) {
   const { t } = useTranslation("people");
+  const writes = usePeopleWrites();
   const [action, setAction] = useState<"create" | "link" | null>(null);
   const [acting, setActing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [confirmingStranger, setConfirmingStranger] = useState(false);
+  const [confirmingDismiss, setConfirmingDismiss] = useState(false);
+  // A refused link, with the person it would be taken from. Held rather than
+  // acted on: the transfer is a second thing to ask for.
+  const [transfer, setTransfer] = useState<{ conflict: LinkConflict; personId: string } | null>(
+    null,
+  );
   const account = row.accounts[0];
   const name = row.displayName || account?.channelUserId || "";
 
@@ -319,66 +284,51 @@ export function UnknownEntry({
     setAction(next);
   }
 
-  async function handleCreate(data: { displayName: string; bondLevel: string; relation: string }) {
+  async function handleCreate(data: { displayName: string; bondLevel: AssignableBondLevel }) {
     if (!account) return;
     setError(null);
-    const res = await postPersonMutation(
-      "/api/persons/create",
-      { ...data, channel: account.channel, channelUserId: account.channelUserId },
-      t,
-    );
-    if (!res.ok) {
-      setError(res.error);
+    const result = await writes.place(account, data);
+    if (result.ok) {
+      setAction(null);
       return;
     }
-    setAction(null);
-    onSettled();
+    // A create cannot transfer — the contract has no `transferFrom` on it — so
+    // a held account is reported in the words the route refused in, and the
+    // guardian links onto the holder instead.
+    setError("conflict" in result ? result.conflict.error : result.message);
   }
 
-  async function handleLink(personId: string) {
+  async function handleLink(personId: string, transferFrom?: string) {
     if (!account) return;
     setError(null);
-    const res = await postPersonMutation(
-      "/api/persons/link",
-      {
-        channel: account.channel,
-        channelUserId: account.channelUserId,
-        existingPersonId: personId,
-        displayName: row.displayName,
-      },
-      t,
-    );
-    if (!res.ok) {
-      setError(res.error);
+    const result = await writes.link(personId, account, transferFrom);
+    if (result.ok) {
+      setTransfer(null);
+      setAction(null);
       return;
     }
-    setAction(null);
-    onSettled();
+    if ("conflict" in result && result.conflict.linkedPersonId) {
+      setTransfer({ conflict: result.conflict, personId });
+      return;
+    }
+    setTransfer(null);
+    setError("conflict" in result ? result.conflict.error : result.message);
   }
 
-  async function handleMarkStranger() {
+  async function handleDismiss() {
     if (!account) return;
     // The row's own trigger names the running operation, so the dialog steps out
     // of the way the moment the write starts rather than sitting there disabled
     // with nothing to say.
-    setConfirmingStranger(false);
+    setConfirmingDismiss(false);
     setActing(true);
     setError(null);
     try {
-      const res = await postPersonMutation(
-        "/api/persons/mark-stranger",
-        {
-          channel: account.channel,
-          channelUserId: account.channelUserId,
-          displayName: row.displayName,
-        },
-        t,
-      );
+      const result = await writes.dismiss(account);
       // A write that didn't land leaves the account exactly where it was. Say
       // so — closing the dialog silently reads as success, which is the
       // opposite of what this confirmation exists to do.
-      if (res.ok) onSettled();
-      else setError(res.error);
+      if (!result.ok) setError("conflict" in result ? result.conflict.error : result.message);
     } finally {
       setActing(false);
     }
@@ -412,7 +362,7 @@ export function UnknownEntry({
                 type="button"
                 variant="destructive"
                 size="sm"
-                onClick={() => setConfirmingStranger(true)}
+                onClick={() => setConfirmingDismiss(true)}
                 disabled={acting}
               >
                 <BusyLabel
@@ -446,13 +396,13 @@ export function UnknownEntry({
         <LinkForm
           people={people}
           error={error}
-          onSubmit={handleLink}
+          onSubmit={(personId) => handleLink(personId)}
           onCancel={() => openAction(null)}
         />
       )}
 
       <RomeConfirmDialog
-        open={confirmingStranger}
+        open={confirmingDismiss}
         destructive
         title={t("strangerConfirm.title", { name })}
         // A dismissal does not take the account off the directory — it moves it
@@ -466,9 +416,72 @@ export function UnknownEntry({
         // confirm and the button that carries it out promise the same thing.
         confirmLabel={t("actions.markStranger")}
         cancelLabel={t("actions.cancel")}
-        onCancel={() => setConfirmingStranger(false)}
-        onConfirm={() => void handleMarkStranger()}
+        onCancel={() => setConfirmingDismiss(false)}
+        onConfirm={() => void handleDismiss()}
       />
+
+      {transfer && (
+        <TransferConfirm
+          conflict={transfer.conflict}
+          busy={acting}
+          onCancel={() => setTransfer(null)}
+          onConfirm={() =>
+            void handleLink(transfer.personId, transfer.conflict.linkedPersonId ?? undefined)
+          }
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * An account the guardian dismissed, with the gesture that undoes it.
+ *
+ * The same dense row the Unknown view uses, because the decision runs on the
+ * same evidence: a restore is worth making on what the sender actually sent,
+ * not on a name in a roster. No confirmation — a restore only puts the account
+ * back where a decision is still owed.
+ */
+export function DismissedEntry({ row }: { row: PeopleRow }) {
+  const { t } = useTranslation("people");
+  const writes = usePeopleWrites();
+  const [acting, setActing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const account = row.accounts[0];
+
+  async function handleRestore() {
+    if (!account) return;
+    setActing(true);
+    setError(null);
+    try {
+      const result = await writes.restore(account);
+      if (!result.ok) setError("conflict" in result ? result.conflict.error : result.message);
+    } finally {
+      setActing(false);
+    }
+  }
+
+  return (
+    <div>
+      <UnknownRow
+        row={row}
+        actions={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={acting}
+            onClick={() => void handleRestore()}
+          >
+            <BusyLabel idle={t("actions.restore")} busy={t("actions.restoring")} isBusy={acting} />
+          </Button>
+        }
+      />
+      {error && (
+        <div className="flex justify-end px-2 pb-2">
+          <MutationError message={error} />
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/pages/people/triage.tsx
+++ b/packages/web/src/pages/people/triage.tsx
@@ -300,19 +300,31 @@ export function UnknownEntry({
 
   async function handleLink(personId: string, transferFrom?: string) {
     if (!account) return;
+    // The transfer confirm stays on screen until this settles — the write is
+    // what closes it — so the link has to hold the row busy rather than lean on
+    // the form's own submit state, which the confirm does not have. A second
+    // transfer would re-attribute the account's history again, and would arrive
+    // naming an owner the first one has already replaced: it refuses, and
+    // reports a conflict against the person the guardian just moved it to.
+    if (acting) return;
+    setActing(true);
     setError(null);
-    const result = await writes.link(personId, account, transferFrom);
-    if (result.ok) {
+    try {
+      const result = await writes.link(personId, account, transferFrom);
+      if (result.ok) {
+        setTransfer(null);
+        setAction(null);
+        return;
+      }
+      if ("conflict" in result && result.conflict.linkedPersonId) {
+        setTransfer({ conflict: result.conflict, personId });
+        return;
+      }
       setTransfer(null);
-      setAction(null);
-      return;
+      setError("conflict" in result ? result.conflict.error : result.message);
+    } finally {
+      setActing(false);
     }
-    if ("conflict" in result && result.conflict.linkedPersonId) {
-      setTransfer({ conflict: result.conflict, personId });
-      return;
-    }
-    setTransfer(null);
-    setError("conflict" in result ? result.conflict.error : result.message);
   }
 
   async function handleDismiss() {

--- a/packages/web/src/pages/people/use-roster.ts
+++ b/packages/web/src/pages/people/use-roster.ts
@@ -12,8 +12,8 @@ import { getApiErrorMessage } from "@/lib/api-error";
 import { fetchJson } from "@/lib/fetch-json";
 import { peopleRows, type PeopleRow } from "./people-model";
 
-// The People page's reads, and nothing else — the writes are still the legacy
-// `/api/persons/*` routes and move in rome-os/rome#67.
+// The People page's reads, and nothing else — the writes are `./writes.ts`,
+// and `./use-writes.ts` is what settles these queries after one lands.
 //
 // Named for the roster rather than for people: `@/hooks/use-people` is the one
 // shared people cache the composer's mention list reads, and these are this
@@ -30,9 +30,13 @@ import { peopleRows, type PeopleRow } from "./people-model";
 // happened to arrive would report no waiting senders whenever placed people
 // filled page one.
 
-const PEOPLE_KEY = "people";
-const ACCOUNTS_KEY = "accounts";
-const TIMELINE_KEY = "person-timeline";
+// The roots every query here is keyed under, exported so a write can invalidate
+// them by prefix rather than restating the variants each read is cached in —
+// which is what makes settling a write independent of how many chips, terms and
+// pages happen to be cached at the time.
+export const PEOPLE_KEY = "people";
+export const ACCOUNTS_KEY = "accounts";
+export const TIMELINE_KEY = "person-timeline";
 
 const ROSTER_POLL_MS = 30_000;
 
@@ -177,6 +181,34 @@ export function usePeopleRoster(params: PeopleRosterParams) {
 }
 
 export type PeopleRoster = ReturnType<typeof usePeopleRoster>;
+
+/**
+ * The accounts a picker can name, as the server answers the term typed.
+ *
+ * Every state, not only the unlinked ones. A picker that hid the accounts
+ * another person already holds would hide the one gesture that can take one
+ * back, and the contract answers that attempt with a conflict the caller
+ * surfaces rather than with a silent re-point.
+ *
+ * Server-side, because the directory is an address book rather than a curated
+ * listing: a filter over the page that happened to load would answer "no such
+ * account" for a contact the mirror holds.
+ */
+export function useAccountSearch(search: string, options: { enabled: boolean }) {
+  const { t } = useTranslation("people");
+  const fallback = t("errors.loadFailedFallback");
+  const term = useDebounced(search.trim(), SEARCH_DEBOUNCE_MS);
+  return useQuery<AccountDirectory>({
+    queryKey: [ACCOUNTS_KEY, "picker", term],
+    enabled: options.enabled,
+    placeholderData: keepPreviousData,
+    queryFn: ({ signal }) => {
+      const query = new URLSearchParams({ includeSilent: "true" });
+      if (term) query.set("q", term);
+      return fetchJson<AccountDirectory>(`/api/accounts?${query.toString()}`, { signal, fallback });
+    },
+  });
+}
 
 /**
  * One person by id — what lets the dossier open a person the roster has not

--- a/packages/web/src/pages/people/use-roster.ts
+++ b/packages/web/src/pages/people/use-roster.ts
@@ -246,14 +246,14 @@ export function usePerson(id: string | undefined) {
  * would have to re-derive the ordering the cursor is written against — and
  * would disagree with it at every page boundary.
  *
- * No interval. A dossier is a page for reading someone's history, and nothing
- * on it writes: the composer that would need its own line to converge is
- * rome-os/rome#67, and when it lands it can invalidate this query at the moment
- * of the send. What is left for a poll to catch is a message arriving while the
- * page sits open, which the client's `refetchOnWindowFocus` already catches at
- * the moment the reader looks back at it — and a refetch here re-reads every
- * page the reader has opened, so an interval charges the deepest reader the
- * most for the least.
+ * No interval. The dossier's writes converge on their own: `./use-writes.ts`
+ * invalidates this key the moment one lands, so a merge or a link shows its new
+ * history without waiting for a tick. The composer is the one write still to
+ * come, and it settles the same way. What is left for a poll to catch is a
+ * message arriving while the page sits open, which the client's
+ * `refetchOnWindowFocus` already catches at the moment the reader looks back at
+ * it — and a refetch here re-reads every page the reader has opened, so an
+ * interval charges the deepest reader the most for the least.
  */
 export function usePersonTimeline(id: string | undefined) {
   const { t } = useTranslation("people");

--- a/packages/web/src/pages/people/use-writes.ts
+++ b/packages/web/src/pages/people/use-writes.ts
@@ -10,7 +10,6 @@ import {
   linkAccount,
   mergePeople,
   restoreAccount,
-  unlinkAccount,
   updatePerson,
   type AccountRef,
   type WriteOutcome,
@@ -29,6 +28,11 @@ import {
 // gesture that reports itself done at the response leaves the row it acted on
 // standing for as long as the read takes, which reads as a write that did
 // nothing.
+//
+// One method per gesture the page has, which is fewer than the contract's verbs:
+// unlink is `./writes.ts`'s and stays there until a gesture asks for it. This
+// module is policy about settling, and there is nothing to settle for a write
+// nobody makes.
 
 export interface PeopleWrites {
   /** Create a person for an account nobody has placed, in one request. */
@@ -43,7 +47,6 @@ export interface PeopleWrites {
     account: AccountRef,
     transferFrom?: string,
   ): Promise<WriteOutcome<PersonResource>>;
-  unlink(personId: string, account: AccountRef): Promise<WriteOutcome<PersonResource>>;
   dismiss(account: AccountRef): Promise<WriteOutcome<DirectoryAccount>>;
   restore(account: AccountRef): Promise<WriteOutcome<DirectoryAccount>>;
   /** `into` absorbs `from`, and `from` is gone. */
@@ -91,7 +94,6 @@ export function usePeopleWrites(): PeopleWrites {
         settling(() =>
           linkAccount(personId, { ...ref(account), ...(transferFrom ? { transferFrom } : {}) }, t),
         ),
-      unlink: (personId, account) => settling(() => unlinkAccount(personId, ref(account), t)),
       dismiss: (account) => settling(() => dismissAccount(ref(account), t)),
       restore: (account) => settling(() => restoreAccount(ref(account), t)),
       merge: (into, from) => settling(() => mergePeople(into, from, t)),

--- a/packages/web/src/pages/people/use-writes.ts
+++ b/packages/web/src/pages/people/use-writes.ts
@@ -1,0 +1,101 @@
+import { useCallback, useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import type { AssignableBondLevel } from "@rome/api-types/identities";
+import type { DirectoryAccount, PersonResource } from "@rome/api-types/people";
+import { ACCOUNTS_KEY, PEOPLE_KEY, TIMELINE_KEY } from "./use-roster";
+import {
+  createPerson,
+  dismissAccount,
+  linkAccount,
+  mergePeople,
+  restoreAccount,
+  unlinkAccount,
+  updatePerson,
+  type AccountRef,
+  type WriteOutcome,
+} from "./writes";
+
+// Every write the People page makes, and how one settles.
+//
+// A write settles by invalidation, never by patching what is cached. The page
+// renders the server's rows and the server's counts, and a client that edited
+// either would be rendering its own guess of what the write did — which is
+// exactly the guess the contract's consolidation exists to remove, since one
+// gesture can move several addresses at once and re-derive a count the reader
+// then sees disagree with the next refetch.
+//
+// A verb resolves once that refetch has landed, not when the write returned. A
+// gesture that reports itself done at the response leaves the row it acted on
+// standing for as long as the read takes, which reads as a write that did
+// nothing.
+
+export interface PeopleWrites {
+  /** Create a person for an account nobody has placed, in one request. */
+  place(
+    account: AccountRef,
+    person: { displayName: string; bondLevel: AssignableBondLevel },
+  ): Promise<WriteOutcome<PersonResource>>;
+  /** Link an account onto a person. `transferFrom` names the person it is taken
+   *  from, which the contract requires when somebody else holds it. */
+  link(
+    personId: string,
+    account: AccountRef,
+    transferFrom?: string,
+  ): Promise<WriteOutcome<PersonResource>>;
+  unlink(personId: string, account: AccountRef): Promise<WriteOutcome<PersonResource>>;
+  dismiss(account: AccountRef): Promise<WriteOutcome<DirectoryAccount>>;
+  restore(account: AccountRef): Promise<WriteOutcome<DirectoryAccount>>;
+  /** `into` absorbs `from`, and `from` is gone. */
+  merge(into: string, from: string): Promise<WriteOutcome<PersonResource>>;
+  setBond(personId: string, bondLevel: AssignableBondLevel): Promise<WriteOutcome<PersonResource>>;
+}
+
+export function usePeopleWrites(): PeopleWrites {
+  const { t } = useTranslation("people");
+  const queryClient = useQueryClient();
+
+  // By prefix, so one call covers the roster's people query, the dossier's
+  // single-person read, the composer's shared mention cache and every cached
+  // chip, term and page of the directory. The three roots are the whole of what
+  // a people write can have changed.
+  const settle = useCallback(
+    () =>
+      Promise.all(
+        [PEOPLE_KEY, ACCOUNTS_KEY, TIMELINE_KEY].map((key) =>
+          queryClient.invalidateQueries({ queryKey: [key] }),
+        ),
+      ),
+    [queryClient],
+  );
+
+  return useMemo(() => {
+    const settling = async <T>(write: () => Promise<WriteOutcome<T>>) => {
+      const outcome = await write();
+      if (outcome.ok) await settle();
+      return outcome;
+    };
+
+    // Callers hand over whatever row they are holding — a directory account, a
+    // person's linked account — so the pair is projected here rather than
+    // spread, and a request never carries a field the verb has no place for.
+    const ref = (account: AccountRef): AccountRef => ({
+      channel: account.channel,
+      channelUserId: account.channelUserId,
+    });
+
+    return {
+      place: (account, person) =>
+        settling(() => createPerson({ ...person, accounts: [ref(account)] }, t)),
+      link: (personId, account, transferFrom) =>
+        settling(() =>
+          linkAccount(personId, { ...ref(account), ...(transferFrom ? { transferFrom } : {}) }, t),
+        ),
+      unlink: (personId, account) => settling(() => unlinkAccount(personId, ref(account), t)),
+      dismiss: (account) => settling(() => dismissAccount(ref(account), t)),
+      restore: (account) => settling(() => restoreAccount(ref(account), t)),
+      merge: (into, from) => settling(() => mergePeople(into, from, t)),
+      setBond: (personId, bondLevel) => settling(() => updatePerson(personId, { bondLevel }, t)),
+    };
+  }, [settle, t]);
+}

--- a/packages/web/src/pages/people/writes-against-mock.test.ts
+++ b/packages/web/src/pages/people/writes-against-mock.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { setupServer } from "msw/node";
+import type { TFunction } from "i18next";
+import i18n from "@/i18n";
+import { peopleHandlers } from "../../../mock/handlers/people";
+import { proposedPeopleHandlers } from "../../../mock/handlers/people-proposed";
+import {
+  createPerson,
+  dismissAccount,
+  linkAccount,
+  mergePeople,
+  restoreAccount,
+  unlinkAccount,
+  updatePerson,
+} from "./writes";
+
+// The page's own write functions against a backend that implements the /people
+// contract, rather than against a stub written from the same reading of it.
+//
+// `writes.test.ts` pins the request each verb sends. That leaves one thing it
+// cannot see: whether the request a route can answer is the request this client
+// builds. An account identifier is escaped into the path — a WhatsApp jid
+// carries an `@`, and channels are free to mint worse — so the escaping and the
+// decoding have to agree, and a test that asserts a URL string proves only that
+// the client is self-consistent.
+
+const server = setupServer(...proposedPeopleHandlers, ...peopleHandlers);
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+  server.listen({ onUnhandledRequest: "error" });
+});
+afterAll(() => server.close());
+
+const t = i18n.getFixedT("en", "people") as TFunction<"people">;
+
+// Fixtures from the mock store: an unlinked WhatsApp sender (whose jid is the
+// escaping case) and an unlinked Telegram one.
+const DEVIKA = { channel: "whatsapp", channelUserId: "447700900812@s.whatsapp.net" };
+const JULES = { channel: "telegram", channelUserId: "883104221" };
+
+describe("People writes, against the contract's own handlers", () => {
+  it("dismisses and restores an account whose identifier needs escaping", async () => {
+    const dismissed = await dismissAccount(DEVIKA, t);
+    expect(dismissed).toMatchObject({ ok: true, value: { state: "dismissed" } });
+
+    const restored = await restoreAccount(DEVIKA, t);
+    expect(restored).toMatchObject({ ok: true, value: { state: "unlinked" } });
+  });
+
+  it("creates a person and links the account it came from, in one request", async () => {
+    const created = await createPerson(
+      { displayName: "Devika Rao", bondLevel: "acquaintance", accounts: [DEVIKA] },
+      t,
+    );
+
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    expect(created.value.accounts).toContainEqual(expect.objectContaining(DEVIKA));
+
+    // And the same identifier addresses the account for the unlink that undoes
+    // it, through a route that takes it from the path rather than a body.
+    const unlinked = await unlinkAccount(created.value.id, DEVIKA, t);
+    expect(unlinked.ok).toBe(true);
+    if (!unlinked.ok) return;
+    expect(unlinked.value.accounts).toHaveLength(0);
+  });
+
+  it("refuses a link the contract holds, and takes it on the transfer", async () => {
+    const holder = await createPerson({ displayName: "Jules Holder", accounts: [JULES] }, t);
+    const taker = await createPerson({ displayName: "Jules Taker" }, t);
+    expect(holder.ok && taker.ok).toBe(true);
+    if (!holder.ok || !taker.ok) return;
+
+    const refused = await linkAccount(taker.value.id, JULES, t);
+    expect(refused.ok).toBe(false);
+    if (refused.ok || !("conflict" in refused)) throw new Error("expected a conflict");
+    // The refusal names the holder, which is the whole reason the page can
+    // offer a transfer by name instead of reporting a failed write.
+    expect(refused.conflict.linkedPersonId).toBe(holder.value.id);
+    expect(refused.conflict.linkedPersonName).toBe("Jules Holder");
+
+    const taken = await linkAccount(taker.value.id, { ...JULES, transferFrom: holder.value.id }, t);
+    expect(taken.ok).toBe(true);
+    if (!taken.ok) return;
+    expect(taken.value.accounts).toContainEqual(expect.objectContaining(JULES));
+  });
+
+  it("changes a bond and absorbs a duplicate", async () => {
+    const survivor = await createPerson({ displayName: "Mira Survivor" }, t);
+    const duplicate = await createPerson({ displayName: "Mira Duplicate" }, t);
+    expect(survivor.ok && duplicate.ok).toBe(true);
+    if (!survivor.ok || !duplicate.ok) return;
+
+    const patched = await updatePerson(survivor.value.id, { bondLevel: "inner-circle" }, t);
+    expect(patched).toMatchObject({ ok: true, value: { bondLevel: "inner-circle" } });
+
+    const merged = await mergePeople(survivor.value.id, duplicate.value.id, t);
+    expect(merged).toMatchObject({ ok: true, value: { id: survivor.value.id } });
+  });
+});

--- a/packages/web/src/pages/people/writes.test.ts
+++ b/packages/web/src/pages/people/writes.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { TFunction } from "i18next";
+import { linkConflict, type DirectoryAccount, type PersonResource } from "@rome/api-types/people";
+import i18n from "@/i18n";
+import {
+  createPerson,
+  dismissAccount,
+  linkAccount,
+  mergePeople,
+  restoreAccount,
+  unlinkAccount,
+  updatePerson,
+} from "./writes";
+
+// The People page's writes, at the wire. What is pinned here is the request each
+// gesture sends — verb, path, body — and what each answer becomes, because those
+// are the two halves the page is written against and neither is visible from a
+// rendered row.
+//
+// The contract's own `linkConflict` phrases the 409s, so a fixture cannot drift
+// from the wording a route refuses in.
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+const t = i18n.getFixedT("en", "people") as TFunction<"people">;
+
+const PERSON: PersonResource = {
+  id: "wei-chen",
+  displayName: "Wei Chen",
+  bondLevel: "acquaintance",
+  accounts: [],
+  messageCount: 0,
+  latest: null,
+};
+
+const ACCOUNT: DirectoryAccount = {
+  channel: "whatsapp",
+  channelUserId: "6591234472@s.whatsapp.net",
+  addresses: ["6591234472", "6591234472@s.whatsapp.net"],
+  displayName: "Rachel Lim",
+  state: "dismissed",
+  personId: null,
+  personName: null,
+  latest: null,
+  messageCount: 12,
+};
+
+const REF = { channel: "whatsapp", channelUserId: "6591234472@s.whatsapp.net" };
+
+interface Sent {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+/** Answers every request with one payload, and records what was sent. */
+function stubFetch(payload: unknown, status = 200) {
+  const sent: Sent[] = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation((async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
+    sent.push({
+      url: String(input),
+      method: (init?.method ?? "GET").toUpperCase(),
+      body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
+    });
+    return {
+      ok: status < 400,
+      status,
+      json: async () => payload,
+    } as Response;
+  }) as typeof fetch);
+  return sent;
+}
+
+describe("people writes — the request each verb sends", () => {
+  it("creates a person and links the account it came from, in one request", async () => {
+    const sent = stubFetch(PERSON, 201);
+
+    const result = await createPerson(
+      { displayName: "Rachel Lim", bondLevel: "acquaintance", accounts: [REF] },
+      t,
+    );
+
+    expect(result).toEqual({ ok: true, value: PERSON });
+    // Atomic create-and-link: one request, so a created person never exists
+    // without the account that was the reason to create them.
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ url: "/api/people", method: "POST" });
+    expect(sent[0]!.body).toEqual({
+      displayName: "Rachel Lim",
+      bondLevel: "acquaintance",
+      accounts: [REF],
+    });
+  });
+
+  it("links an account onto a person the roster already holds", async () => {
+    const sent = stubFetch(PERSON);
+
+    await linkAccount("wei-chen", REF, t);
+
+    expect(sent[0]).toMatchObject({ url: "/api/people/wei-chen/accounts", method: "POST" });
+    // No `transferFrom` when nobody holds it: the contract only asks for one
+    // when the link is a transfer.
+    expect(sent[0]!.body).toEqual(REF);
+  });
+
+  it("names the person a transfer takes the account from", async () => {
+    const sent = stubFetch(PERSON);
+
+    await linkAccount("wei-chen", { ...REF, transferFrom: "mira" }, t);
+
+    expect(sent[0]!.body).toEqual({ ...REF, transferFrom: "mira" });
+  });
+
+  it("unlinks by naming the account in the path, not in a body", async () => {
+    const sent = stubFetch(PERSON);
+
+    await unlinkAccount("wei-chen", REF, t);
+
+    expect(sent[0]).toMatchObject({
+      method: "DELETE",
+      url: "/api/people/wei-chen/accounts/whatsapp/6591234472%40s.whatsapp.net",
+    });
+  });
+
+  it("dismisses and restores the same account at the same address", async () => {
+    const dismissed = stubFetch(ACCOUNT);
+    await dismissAccount(REF, t);
+    expect(dismissed[0]).toMatchObject({
+      method: "POST",
+      url: "/api/accounts/whatsapp/6591234472%40s.whatsapp.net/dismiss",
+    });
+
+    vi.restoreAllMocks();
+    const restored = stubFetch({ ...ACCOUNT, state: "unlinked" });
+    await restoreAccount(REF, t);
+    expect(restored[0]).toMatchObject({
+      method: "POST",
+      url: "/api/accounts/whatsapp/6591234472%40s.whatsapp.net/restore",
+    });
+  });
+
+  it("leaves an identifier's own separators in the path", async () => {
+    const sent = stubFetch(ACCOUNT);
+
+    await dismissAccount({ channel: "matrix", channelUserId: "room/42" }, t);
+
+    // The route takes the rest of the path before the verb, separators
+    // included — a channel mints its own addresses, and a percent-escaped "/"
+    // would be a segment the route never sees.
+    expect(sent[0]!.url).toBe("/api/accounts/matrix/room/42/dismiss");
+  });
+
+  it("merges the duplicate named in the body into the survivor named in the path", async () => {
+    const sent = stubFetch(PERSON);
+
+    await mergePeople("wei-chen", "wei-chen-duplicate", t);
+
+    expect(sent[0]).toMatchObject({ url: "/api/people/wei-chen/merge", method: "POST" });
+    expect(sent[0]!.body).toEqual({ from: "wei-chen-duplicate" });
+  });
+
+  it("changes a bond with a patch that names only the bond", async () => {
+    const sent = stubFetch({ ...PERSON, bondLevel: "inner-circle" });
+
+    await updatePerson("wei-chen", { bondLevel: "inner-circle" }, t);
+
+    expect(sent[0]).toMatchObject({ url: "/api/people/wei-chen", method: "PATCH" });
+    // An omitted field is one the update leaves alone, so a bond change must
+    // not carry a name and blank it.
+    expect(sent[0]!.body).toEqual({ bondLevel: "inner-circle" });
+  });
+});
+
+describe("people writes — what an answer becomes", () => {
+  it("hands back a refused link as the conflict it is, owner included", async () => {
+    const conflict = linkConflict(REF, { id: "mira", displayName: "Mira Chen" });
+    stubFetch(conflict, 409);
+
+    const result = await linkAccount("wei-chen", REF, t);
+
+    // Not an error string: the page has to name the owner and offer a transfer,
+    // and a message it would have to parse is not a person's id.
+    expect(result).toEqual({ ok: false, conflict });
+  });
+
+  it("reads a conflict on a create the same way", async () => {
+    const conflict = linkConflict(REF, { id: "mira", displayName: "Mira Chen" });
+    stubFetch(conflict, 409);
+
+    const result = await createPerson({ displayName: "Rachel Lim", accounts: [REF] }, t);
+
+    expect(result).toEqual({ ok: false, conflict });
+  });
+
+  it("shows a rejected request in the words the route refused it with", async () => {
+    stubFetch({ error: "displayName is required" }, 400);
+
+    const result = await createPerson({ displayName: " " }, t);
+
+    expect(result).toEqual({ ok: false, message: "displayName is required" });
+  });
+
+  it("never puts a server fault on screen in its own words", async () => {
+    stubFetch({ error: "SQLITE_BUSY: database is locked" }, 500);
+
+    const result = await mergePeople("wei-chen", "duplicate", t);
+
+    // A 5xx body carries the same shape as a 4xx one and not the same meaning:
+    // the API error handler serializes an unhandled exception into it.
+    expect(result).toEqual({ ok: false, message: t("errors.requestFailed") });
+  });
+
+  it("says the server was unreachable rather than throwing at a click handler", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
+    const result = await dismissAccount(REF, t);
+
+    expect(result).toEqual({ ok: false, message: t("errors.network") });
+  });
+});

--- a/packages/web/src/pages/people/writes.ts
+++ b/packages/web/src/pages/people/writes.ts
@@ -1,0 +1,175 @@
+import type { TFunction } from "i18next";
+import type {
+  CreatePersonRequest,
+  DirectoryAccount,
+  LinkAccountRequest,
+  LinkConflict,
+  PersonResource,
+  UpdatePersonRequest,
+} from "@rome/api-types/people";
+
+// The People page's writes, at the wire: one function per verb of the /people
+// contract (@rome/api-types/people), and no view logic. What each verb means,
+// when it refuses and what a refusal carries are the contract's; this module
+// only names the route and reduces the answer to something a click handler can
+// render.
+//
+// An account is named by the pair the contract says is its identity, never by
+// one of the addresses it answers to. The server folds a WhatsApp contact's
+// phone jid and `@lid` jid into one account and reports both in `addresses`, so
+// a gesture on a row already covers every address it stands for — the reason
+// none of these takes a list.
+
+/** An account, named the way every verb here names one. */
+export interface AccountRef {
+  channel: string;
+  channelUserId: string;
+}
+
+/**
+ * What a write answers.
+ *
+ * A conflict is its own outcome rather than an error string: the caller has to
+ * name the person who holds the account and offer an explicit transfer, and a
+ * sentence it would have to parse is not a person's id.
+ */
+export type WriteOutcome<T> =
+  | { ok: true; value: T }
+  | { ok: false; conflict: LinkConflict }
+  | { ok: false; message: string };
+
+function isLinkConflict(payload: unknown): payload is LinkConflict {
+  if (typeof payload !== "object" || payload === null) return false;
+  const body = payload as Record<string, unknown>;
+  return typeof body.channel === "string" && typeof body.channelUserId === "string";
+}
+
+/**
+ * The path an account occupies, escaped, with its own separators left in place.
+ *
+ * The routes take the rest of the path as the identifier: a channel mints its
+ * own addresses and channels are open — a Rome App brings one — so nothing
+ * promises they avoid "/", and a percent-escaped one would name a segment the
+ * route never sees.
+ */
+function accountPath(account: AccountRef): string {
+  const identifier = account.channelUserId.split("/").map(encodeURIComponent).join("/");
+  return `${encodeURIComponent(account.channel)}/${identifier}`;
+}
+
+/**
+ * Send one write and reduce whatever comes back. Never throws — every caller is
+ * an event handler, where an unhandled rejection leaves the gesture silent.
+ *
+ * Only a 4xx body is treated as copy. These routes answer a rejected request
+ * with an `{ error }` naming what is wrong with it, which is what the guardian
+ * needs. A 5xx body carries the same shape and not the same meaning: the API
+ * error handler serializes an unhandled exception as `{ error: err.message }`,
+ * so trusting it would put a raw SQLite or repository message on screen.
+ */
+async function send<T>(
+  url: string,
+  init: { method: string; json?: unknown },
+  t: TFunction<"people">,
+): Promise<WriteOutcome<T>> {
+  const response = await fetch(url, {
+    method: init.method,
+    credentials: "include",
+    cache: "no-store",
+    ...(init.json === undefined
+      ? {}
+      : { headers: { "Content-Type": "application/json" }, body: JSON.stringify(init.json) }),
+  }).catch(() => null);
+
+  if (!response) return { ok: false, message: t("errors.network") };
+  const payload: unknown = await response.json().catch(() => null);
+  if (response.ok) return { ok: true, value: payload as T };
+  if (response.status === 409 && isLinkConflict(payload)) return { ok: false, conflict: payload };
+  if (response.status >= 500) return { ok: false, message: t("errors.requestFailed") };
+  const error = (payload as { error?: unknown } | null)?.error;
+  return {
+    ok: false,
+    message: typeof error === "string" && error !== "" ? error : t("errors.requestFailed"),
+  };
+}
+
+/** `POST /api/people`. Both-or-neither: a create naming an account somebody
+ *  holds refuses whole, so a person never exists without the account that was
+ *  the reason to create them. */
+export function createPerson(
+  request: CreatePersonRequest,
+  t: TFunction<"people">,
+): Promise<WriteOutcome<PersonResource>> {
+  return send("/api/people", { method: "POST", json: request }, t);
+}
+
+/** `POST /api/people/:id/accounts`. `transferFrom` names the person the account
+ *  is taken from, and is what makes a transfer something the guardian asked
+ *  for rather than the side effect of a retry. */
+export function linkAccount(
+  personId: string,
+  request: LinkAccountRequest,
+  t: TFunction<"people">,
+): Promise<WriteOutcome<PersonResource>> {
+  return send(
+    `/api/people/${encodeURIComponent(personId)}/accounts`,
+    { method: "POST", json: request },
+    t,
+  );
+}
+
+/** `DELETE /api/people/:id/accounts/:channel/:channelUserId`. */
+export function unlinkAccount(
+  personId: string,
+  account: AccountRef,
+  t: TFunction<"people">,
+): Promise<WriteOutcome<PersonResource>> {
+  return send(
+    `/api/people/${encodeURIComponent(personId)}/accounts/${accountPath(account)}`,
+    { method: "DELETE" },
+    t,
+  );
+}
+
+/** `POST /api/accounts/:channel/:channelUserId/dismiss`. Dismissal is a state
+ *  the account is in, not a merge into a sentinel, so {@link restoreAccount} is
+ *  the whole way back. */
+export function dismissAccount(
+  account: AccountRef,
+  t: TFunction<"people">,
+): Promise<WriteOutcome<DirectoryAccount>> {
+  return send(`/api/accounts/${accountPath(account)}/dismiss`, { method: "POST" }, t);
+}
+
+/** `POST /api/accounts/:channel/:channelUserId/restore`. */
+export function restoreAccount(
+  account: AccountRef,
+  t: TFunction<"people">,
+): Promise<WriteOutcome<DirectoryAccount>> {
+  return send(`/api/accounts/${accountPath(account)}/restore`, { method: "POST" }, t);
+}
+
+/** `POST /api/people/:id/merge`. The survivor is named in the path and the
+ *  duplicate in the body: every link transfers atomically, then the duplicate
+ *  is gone. */
+export function mergePeople(
+  into: string,
+  from: string,
+  t: TFunction<"people">,
+): Promise<WriteOutcome<PersonResource>> {
+  return send(
+    `/api/people/${encodeURIComponent(into)}/merge`,
+    { method: "POST", json: { from } },
+    t,
+  );
+}
+
+/** `PATCH /api/people/:id`. An omitted field is one the update leaves alone, so
+ *  a bond change carries the bond and nothing else. */
+export function updatePerson(
+  personId: string,
+  update: UpdatePersonRequest,
+  t: TFunction<"people">,
+): Promise<WriteOutcome<PersonResource>> {
+  return send(`/api/people/${encodeURIComponent(personId)}`, { method: "PATCH", json: update }, t);
+}

--- a/packages/web/src/pages/people/writes.ts
+++ b/packages/web/src/pages/people/writes.ts
@@ -118,7 +118,14 @@ export function linkAccount(
   );
 }
 
-/** `DELETE /api/people/:id/accounts/:channel/:channelUserId`. */
+/**
+ * `DELETE /api/people/:id/accounts/:channel/:channelUserId`.
+ *
+ * No gesture calls this yet — the row menu that would is still ahead. It sits
+ * here because this module is the contract's verbs and a wire missing one reads
+ * as a verb that does not exist; `./use-writes.ts` carries only the gestures the
+ * page has.
+ */
 export function unlinkAccount(
   personId: string,
   account: AccountRef,


### PR DESCRIPTION
## What this PR does

The People page read the new contract and still wrote the old one. Every gesture posted to `/api/persons/*`, where placing a sender, promoting a friend and dismissing spam were one **move** over a flattened union of persons and unmapped senders. That single verb could not say who already held an account, so taking one re-pointed it silently; it addressed a channel rather than an account, so a consolidated WhatsApp contact needed a client-side fan-out over every jid it answered to; and it had no inverse, so a dismissal was a one-way door.

Each gesture is now the verb it actually is:

| Gesture | Verb |
| --- | --- |
| Place an unknown sender | `POST /api/people` — create and link, atomically |
| Place onto someone who exists | `POST /api/people/:id/accounts` |
| Dismiss / restore | `POST /api/accounts/:channel/:channelUserId/{dismiss,restore}` |
| Take an account another person holds | link with `transferFrom` |
| Merge a duplicate away | `POST /api/people/:id/merge` |
| Change a bond | `PATCH /api/people/:id` |

The dismissed end of the ladder gains the gesture it never had. Dismissal is a state the account is in rather than a merge into a sentinel, so `Restore` is the whole way back — and the Stranger view keeps the dense row, because a restore is decided on the same evidence a placement is.

The dossier stops being read-only: the bond select, `Link account…` and `Merge into…` are live. Both pickers offer more than would succeed. The link picker lists accounts another person holds, because taking one back is a gesture the guardian has; the merge picker names the *survivor*, so the person whose page is open is the one absorbed, and the page follows the history to the survivor rather than sitting on a route that now 404s.

## Design & Invariants

- **Settle by invalidation, never by patching cached rows.** Where a row lands is the server's answer. The chip counts make it plainest: they describe the whole roster and not the page in hand, so a client that decremented its own copy would be rendering a guess the next read contradicts.
- **A write holds its rows until the refetch lands, not until the request returns.** `usePeopleWrites` awaits the invalidation before resolving, so the invariant is structural rather than repeated at each call site. A gesture that reported itself done at the response would leave the row it acted on standing for as long as the read takes — which reads as a write that did nothing.
- **One call covers every address a row stands for.** A WhatsApp contact answers to both its phone jid and its `@lid` jid; which of those are one account is the server's answer, given once in `addresses`. The source PR's best-effort fan-out is gone: there is no follow-up call to fail, so nothing has to decide what a half-committed move left behind.
- **A transfer is asked for twice.** A link over a held account is refused with a `409` naming the holder, and only a request carrying `transferFrom` goes through. A transfer re-attributes the account's whole message history, so it is never the side effect of a retry. This is new UI — the union page had no conflict to surface.
- **`moveTargetsFor` and `canMoveToStranger` do not port.** They existed because one verb served every position on the ladder. The contract has a verb per decision, so a row asks for the one its position admits and nothing enumerates targets.

Layering: `people/writes.ts` is the wire (one function per verb, no React, never throws), `people/use-writes.ts` is the settle policy, and the components hold only what a gesture looks like.

## Test plan

- [x] `pnpm test` in `packages/web` — 155 files, 1157 tests green.
- [x] `writes.test.ts` (new) pins the request each verb sends and what each answer becomes: paths, bodies, the 409 → conflict reduction, and that a 5xx body never reaches the screen in its own words.
- [x] `writes-against-mock.test.ts` (new) runs the page's own write functions against the contract's MSW handlers, so the escaping this client does and the decoding a route does have to agree — a URL assertion alone only proves the client is self-consistent.
- [x] `PeoplePage.test.tsx` — the mock now applies writes to the same world the reads are served from, through the contract's `linkConflict`/`sliceAccountDirectory`. Covers place, link, dismiss, restore, and the conflict-then-transfer race; the dismissal test asserts the row leaves **and** the chip's number drops out of the directory's own `counts`.
- [x] `PersonDetailPage.test.tsx` — bond patch carries only the bond, link from the picker, conflict naming the owner then transfer on the second yes, merge landing on the survivor.
- [x] `people-endpoint.test.ts` (new) — a static guard, in the shape of the composer's: no People module names `/api/persons` or `/api/identities`. A request count in a rendered test proves only that the path the test walked stayed clean.
- [x] `pnpm typecheck` and `biome check` clean; `pnpm build` produces the bundle.
- [ ] Manual pass in the browser (`pnpm start:web:mock`) — the agent browser was not reachable in this environment.

## Not in this PR

- **The read views** (#66 / #81), now on `main` — this branch is rebased onto them, so the diff is the write half alone.
- **The `⋯` row menu and the bulk bar.** Drawn in the design note's specimens, not on the page. A bulk gesture is N writes behind one confirmation and no verb answers that — what a partial failure leaves behind has to be decided first.
- **The composer send path**, which stays per-channel, as in the source PR.
- **The mock's dismiss/restore routes take a single path segment** where core takes the rest of the path. No fixture identifier contains a `/`, so mock mode and core agree today.

Closes rome-os/rome#67
