### PR TITLE
refactor(web): drop text-ui where DropdownMenuItem already sets it

### DIFF
--- a/packages/web/src/shell/AppGrid.tsx
+++ b/packages/web/src/shell/AppGrid.tsx
@@ -492,7 +492,6 @@ export function AppGrid({ headerControlsHost, collapsed, onSearch }: AppGridProp
       </DropdownMenuTrigger>
       <DropdownMenuContent side="bottom" align="end">
         <DropdownMenuItem
-          className="text-ui"
           onSelect={() => {
             // Freeze which apps are "new" before persisting "seen", so the
             // badges survive the acknowledgement for this edit session.

--- a/packages/web/src/shell/ProfileMenu.tsx
+++ b/packages/web/src/shell/ProfileMenu.tsx
@@ -94,17 +94,16 @@ export function ProfileMenu() {
               <DropdownMenuSeparator />
             </>
           ) : null}
-          <DropdownMenuItem className="text-ui" onSelect={() => navigate("/settings")}>
+          <DropdownMenuItem onSelect={() => navigate("/settings")}>
             <Settings aria-hidden />
             {t("nav.settings")}
           </DropdownMenuItem>
-          <DropdownMenuItem className="text-ui" onSelect={() => setFeedbackOpen(true)}>
+          <DropdownMenuItem onSelect={() => setFeedbackOpen(true)}>
             <MessageSquarePlus aria-hidden />
             {t("feedback.open")}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
-            className="text-ui"
             variant="destructive"
             disabled={signingOut}
             onSelect={(event) => {

--- a/packages/web/src/shell/RecentChats.tsx
+++ b/packages/web/src/shell/RecentChats.tsx
@@ -537,7 +537,7 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
                 setOpenMenuId(null);
               }}
             >
-              <DropdownMenuItem className="text-ui" aria-keyshortcuts="P" onSelect={togglePin}>
+              <DropdownMenuItem aria-keyshortcuts="P" onSelect={togglePin}>
                 {session.pinnedAt ? (
                   <PinOff className="h-3.5 w-3.5 shrink-0" aria-hidden />
                 ) : (
@@ -546,34 +546,25 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
                 {session.pinnedAt ? t("recentChats.unpinChat") : t("recentChats.pinChat")}
                 <DropdownMenuShortcut aria-hidden>P</DropdownMenuShortcut>
               </DropdownMenuItem>
-              <DropdownMenuItem className="text-ui" aria-keyshortcuts="R" onSelect={beginRename}>
+              <DropdownMenuItem aria-keyshortcuts="R" onSelect={beginRename}>
                 <Pencil className="h-3.5 w-3.5 shrink-0" aria-hidden />
                 {t("recentChats.rename")}
                 <DropdownMenuShortcut aria-hidden>R</DropdownMenuShortcut>
               </DropdownMenuItem>
               {session.archived ? (
-                <DropdownMenuItem
-                  className="text-ui"
-                  aria-keyshortcuts="A"
-                  onSelect={toggleArchive}
-                >
+                <DropdownMenuItem aria-keyshortcuts="A" onSelect={toggleArchive}>
                   <ArchiveRestore className="h-3.5 w-3.5 shrink-0" aria-hidden />
                   {t("recentChats.unarchive")}
                   <DropdownMenuShortcut aria-hidden>A</DropdownMenuShortcut>
                 </DropdownMenuItem>
               ) : (
-                <DropdownMenuItem
-                  className="text-ui"
-                  aria-keyshortcuts="A"
-                  onSelect={toggleArchive}
-                >
+                <DropdownMenuItem aria-keyshortcuts="A" onSelect={toggleArchive}>
                   <Archive className="h-3.5 w-3.5 shrink-0" aria-hidden />
                   {t("recentChats.archive")}
                   <DropdownMenuShortcut aria-hidden>A</DropdownMenuShortcut>
                 </DropdownMenuItem>
               )}
               <DropdownMenuItem
-                className="text-ui"
                 variant="destructive"
                 onSelect={() => setPendingDeleteId(session.id)}
               >
@@ -655,10 +646,7 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent side="bottom" align="end">
-                  <DropdownMenuItem
-                    className="text-ui"
-                    onSelect={() => togglePinnedProject(projectPath)}
-                  >
+                  <DropdownMenuItem onSelect={() => togglePinnedProject(projectPath)}>
                     {pinned ? (
                       <PinOff className="h-3.5 w-3.5 shrink-0" aria-hidden />
                     ) : (


### PR DESCRIPTION
## What this PR does

`DropdownMenuItem` sets `text-ui` in every size variant, so ten call sites across the shell pass the kit a token it already applies. The redundancy invites the reader to look for a difference that does not exist, and it hides which classes at a call site carry real intent.

At each of the ten sites `text-ui` is the only class, so the `className` prop goes away entirely.

## Design & Invariants

`DropdownMenuItem` owns its type token. A caller reaches for `className` to say something the kit has not already decided, and a class that matches the default says nothing.

The component composes through `cn`, which merges with tailwind-merge. An override that names the token the base already carries resolves to that same token, so removing it changes the rendered class set only in ordering:

- before: `… px-2 py-1 [&_svg…]:size-4 text-ui`
- after: `… px-2 py-1 text-ui [&_svg…]:size-4`

Computed type metrics stay identical at `font-size=14px`, `line-height=20px`, `weight=400`, `letter-spacing=normal`. A regression here is any change to rendered text.

`DropdownMenuLabel` and `DropdownMenuShortcut` carry `text-aux` by design. Their call sites state a different token than the kit default, so this PR leaves them alone.

Biome reflows five JSX tags in `RecentChats.tsx` onto one line, because dropping the prop brings them under the 100-column limit. That accounts for the line count in that file.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 559 files, 5908 tests, exit 0. Covers the `check-utility-tokens` guard and the keyboard-shortcut tests that #45 added to `RecentChats.test.tsx`.
- [x] Opened the profile menu and a recent-chats row menu in the browser under `pnpm start:web:mock`, captured each with and without the change. Both screenshots are byte-identical.
- [ ] `pnpm dev:all` and `Rome started` in `docker logs`. The daemon is unreachable from the authoring machine, which is not in the `docker` group, and no `sudo` is available to change that.

## Not in this PR

- `RecentChats.tsx:718` and `:740` restate the same default as `className={selected ? "text-ui text-foreground" : "text-ui text-foreground/85"}`. Each carries a second class, so the fix edits the token list rather than removing the prop.

This branch sits on top of #45, which adds a letter-key shortcut to each chat row action. The rebase keeps that behavior whole and removes only the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
