### PR TITLE
feat: add app keys for guardian-entered app credentials

### DIFF
--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -16,6 +16,7 @@
     "./sessions": "./src/sessions.ts",
     "./anthropic-compatible-providers": "./src/anthropic-compatible-providers.ts",
     "./anthropic-compatible-env": "./src/anthropic-compatible-env.ts",
+    "./app-keys": "./src/app-keys.ts",
     "./apps-runtime": "./src/apps-runtime.ts",
     "./discord-broker": "./src/discord-broker.ts",
     "./favors": "./src/favors.ts",

--- a/packages/api-types/src/app-keys.ts
+++ b/packages/api-types/src/app-keys.ts
@@ -1,0 +1,96 @@
+// App keys — guardian-entered named values injected into the Rome process
+// environment for apps to read. Shared contract between core's routes, the
+// dashboard, and mock mode. Name validation lives here rather than in core so
+// the mock rejects exactly the names the server rejects.
+
+/** The value-free wire shape. Values never travel: the API returns names and
+ * labels only, and `overridden` says a real environment variable is shadowing
+ * the stored value (operator env always wins). */
+export interface AppKeyDto {
+  name: string;
+  label: string;
+  /** ISO-8601 timestamp of the last write. */
+  updatedAt: string;
+  overridden: boolean;
+}
+
+export interface AppKeysListResponse {
+  keys: AppKeyDto[];
+}
+
+export const APP_KEY_MAX_NAME_LENGTH = 64;
+export const APP_KEY_MAX_LABEL_LENGTH = 120;
+export const APP_KEY_MAX_VALUE_LENGTH = 32768;
+
+const NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
+// An app key lands in `process.env`, so a name that collides with platform
+// configuration could reroute the database, the API ports, or an upstream
+// credential. Config env names are only expressed as inline `env.X` reads in
+// core's `config.ts` (`envToRawConfig`) — there is no enumerable schema to
+// check against — so this list carries every prefix family the platform
+// consumes plus the ambient OS names a child process relies on.
+const RESERVED_PREFIXES = [
+  "ROME_",
+  "NODE_",
+  "NPM_",
+  "PNPM_",
+  "PANTHEON_",
+  "INTERNAL_API_",
+  "RELAY_",
+  "STATSIG_",
+  "FEATURE_GATE_",
+  "OTEL_",
+  "SQLITE_",
+  "POSTGRES_",
+  "DATABASE_",
+  "WEB_",
+  "LINKEDIN_",
+  "SENTINEL_",
+  "ANTHROPIC_",
+  "DOCKERHUB_",
+  "CLICKHOUSE_",
+  "AWS_",
+  "SSH_",
+  "NEXT_",
+];
+
+const RESERVED_NAMES = new Set([
+  "PATH",
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "SHELL",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "PWD",
+  "LANG",
+  "LC_ALL",
+  "TZ",
+  "TERM",
+  "HOSTNAME",
+  "EDITOR",
+  "CI",
+  "LOG_LEVEL",
+  "UPDATES_DOMAIN",
+]);
+
+/** Returns a human-readable rejection reason, or null when the name is usable. */
+export function appKeyNameError(name: string): string | null {
+  if (name.length === 0) return "Name is required.";
+  if (name.length > APP_KEY_MAX_NAME_LENGTH) {
+    return `Name must be at most ${APP_KEY_MAX_NAME_LENGTH} characters.`;
+  }
+  if (!NAME_PATTERN.test(name)) {
+    return "Name must use only uppercase letters, digits, and underscores, and start with a letter.";
+  }
+  if (RESERVED_NAMES.has(name)) {
+    return `${name} is reserved by Rome. Pick a different name.`;
+  }
+  const prefix = RESERVED_PREFIXES.find((p) => name.startsWith(p));
+  if (prefix) {
+    return `Names starting with ${prefix} are reserved by Rome. Pick a different name.`;
+  }
+  return null;
+}

--- a/packages/app-runtime-sdk/src/index.ts
+++ b/packages/app-runtime-sdk/src/index.ts
@@ -1453,6 +1453,11 @@ export interface TalkRouter {
 export interface ChannelMessageHook {
   register(): Promise<void>;
   registerConnection(connectionId: string, service: string): void;
+  /** Detach every subscription `register`/`registerConnection` took out, so
+   * the host can swap in a replacement instance (e.g. after an app-keys
+   * environment change) without double-handling inbound messages. A hook
+   * without this method cannot be hot-swapped and stays live until restart. */
+  unregister?(): void;
 }
 
 export interface ActionRunContext {

--- a/packages/core/drizzle.system.config.ts
+++ b/packages/core/drizzle.system.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     "sentinel_log",
     "approvals",
     "settings",
+    "app_keys",
     "policies",
     "guardian_auth",
     "provider_accounts",

--- a/packages/core/drizzle/system/0060_serious_adam_destine.sql
+++ b/packages/core/drizzle/system/0060_serious_adam_destine.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `app_keys` (
+	`name` text PRIMARY KEY NOT NULL,
+	`label` text NOT NULL,
+	`value` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);

--- a/packages/core/drizzle/system/meta/0060_snapshot.json
+++ b/packages/core/drizzle/system/meta/0060_snapshot.json
@@ -1,0 +1,3082 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "878b427b-06bb-4f40-8b38-c6780bb59129",
+  "prevId": "835eed13-830c-44af-83ba-df19347bcb60",
+  "tables": {
+    "action_executions": {
+      "name": "action_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initiator": {
+          "name": "initiator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_keys": {
+      "name": "app_keys",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "approvals": {
+      "name": "approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_state": {
+          "name": "execution_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_error": {
+          "name": "execution_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_mappings": {
+      "name": "channel_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_channel_mappings_identity": {
+          "name": "idx_channel_mappings_identity",
+          "columns": [
+            "channel",
+            "channel_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_mappings_person_id_persons_id_fk": {
+          "name": "channel_mappings_person_id_persons_id_fk",
+          "tableFrom": "channel_mappings",
+          "tableTo": "persons",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connection_grants": {
+      "name": "connection_grants",
+      "columns": {
+        "custody": {
+          "name": "custody",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential": {
+          "name": "credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conferred_at": {
+          "name": "conferred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_at": {
+          "name": "degraded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_reason": {
+          "name": "degraded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connection_grants_custody_name_pk": {
+          "columns": [
+            "custody",
+            "name"
+          ],
+          "name": "connection_grants_custody_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connections": {
+      "name": "connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connections_service_unique": {
+          "name": "connections_service_unique",
+          "columns": [
+            "service"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tzid": {
+          "name": "tzid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_time": {
+          "name": "local_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rrule": {
+          "name": "rrule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "execution_journal": {
+      "name": "execution_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_hash": {
+          "name": "args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expected_action_name": {
+          "name": "expected_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expected_args_hash": {
+          "name": "expected_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_action_name": {
+          "name": "actual_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_args_hash": {
+          "name": "actual_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ej_root_execution_id": {
+          "name": "idx_ej_root_execution_id",
+          "columns": [
+            "root_execution_id"
+          ],
+          "isUnique": false
+        },
+        "idx_ej_created_at": {
+          "name": "idx_ej_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardian_auth": {
+      "name": "guardian_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guardian_auth_user_id_unique": {
+          "name": "guardian_auth_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_messages": {
+      "name": "linkedin_messages",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_profile_url": {
+          "name": "sender_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_headline": {
+          "name": "sender_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_is_self": {
+          "name": "sender_is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_messages_thread_sent": {
+          "name": "idx_linkedin_messages_thread_sent",
+          "columns": [
+            "thread_id",
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_messages_thread_id_message_id_pk": {
+          "columns": [
+            "thread_id",
+            "message_id"
+          ],
+          "name": "linkedin_messages_thread_id_message_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_participants": {
+      "name": "linkedin_participants",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_self": {
+          "name": "is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_thread_participants": {
+      "name": "linkedin_thread_participants",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_thread_participants_participant": {
+          "name": "idx_linkedin_thread_participants_participant",
+          "columns": [
+            "participant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_thread_participants_thread_id_participant_id_pk": {
+          "columns": [
+            "thread_id",
+            "participant_id"
+          ],
+          "name": "linkedin_thread_participants_thread_id_participant_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_threads": {
+      "name": "linkedin_threads",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_url": {
+          "name": "thread_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_name": {
+          "name": "person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_name": {
+          "name": "conversation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread": {
+          "name": "unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "counterparty_type": {
+          "name": "counterparty_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "participants_last_read_at": {
+          "name": "participants_last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_pending_attempts": {
+      "name": "oauth_pending_attempts",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_origin": {
+          "name": "callback_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_pending_attempts_expires_at": {
+          "name": "idx_oauth_pending_attempts_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persons": {
+      "name": "persons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bond_level": {
+          "name": "bond_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_path": {
+          "name": "profile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_value": {
+          "name": "scope_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sync_links": {
+      "name": "project_sync_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_type": {
+          "name": "project_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_extra": {
+          "name": "project_link_extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sync_links_project_path_unique": {
+          "name": "project_sync_links_project_path_unique",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_accounts": {
+      "name": "provider_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "provider_accounts_provider_unique": {
+          "name": "provider_accounts_provider_unique",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_messages": {
+      "name": "rome_agent_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_platform_message_id": {
+          "name": "reply_to_platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_injected_turn_id": {
+          "name": "context_injected_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_messages_session_id": {
+          "name": "idx_rome_agent_messages_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_turn_id": {
+          "name": "idx_rome_agent_messages_turn_id",
+          "columns": [
+            "turn_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_role_created_at": {
+          "name": "idx_rome_agent_messages_role_created_at",
+          "columns": [
+            "role",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_platform_message": {
+          "name": "idx_rome_agent_messages_platform_message",
+          "columns": [
+            "session_id",
+            "platform_message_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_agent_messages\".\"platform_message_id\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_trace_blocks": {
+      "name": "rome_agent_trace_blocks",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_trace_blocks_session_id": {
+          "name": "idx_rome_agent_trace_blocks_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_trace_blocks_terminal_message": {
+          "name": "idx_rome_agent_trace_blocks_terminal_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') IN ('result', 'error')"
+        },
+        "idx_rome_agent_trace_blocks_turn_end_message": {
+          "name": "idx_rome_agent_trace_blocks_turn_end_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') = 'turn_end'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rome_agent_trace_blocks_message_id_seq_pk": {
+          "columns": [
+            "message_id",
+            "seq"
+          ],
+          "name": "rome_agent_trace_blocks_message_id_seq_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_sessions": {
+      "name": "rome_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "large_model_selection": {
+          "name": "large_model_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webchat'"
+        },
+        "source_channel": {
+          "name": "source_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_name": {
+          "name": "source_thread_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_type": {
+          "name": "source_thread_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_settings": {
+          "name": "channel_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_turn_id": {
+          "name": "parent_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handoff_spec": {
+          "name": "handoff_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_activity_at": {
+          "name": "last_seen_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_sessions_project_path": {
+          "name": "idx_rome_sessions_project_path",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_sidebar_activity": {
+          "name": "idx_rome_sessions_sidebar_activity",
+          "columns": [
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_project_activity": {
+          "name": "idx_rome_sessions_project_activity",
+          "columns": [
+            "project_path",
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_channel": {
+          "name": "idx_rome_sessions_source_channel",
+          "columns": [
+            "source_channel"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_thread": {
+          "name": "idx_rome_sessions_source_thread",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_channel_address": {
+          "name": "idx_rome_sessions_channel_address",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_sessions\".\"type\" = 'channel' AND \"rome_sessions\".\"source_channel\" IS NOT NULL AND \"rome_sessions\".\"source_thread_id\" IS NOT NULL"
+        },
+        "idx_rome_sessions_parent_session": {
+          "name": "idx_rome_sessions_parent_session",
+          "columns": [
+            "parent_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routine_runs": {
+      "name": "routine_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_routine_runs_routine_id": {
+          "name": "idx_routine_runs_routine_id",
+          "columns": [
+            "routine_id"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_fired_at": {
+          "name": "idx_routine_runs_fired_at",
+          "columns": [
+            "fired_at"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_status": {
+          "name": "idx_routine_runs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "routine_runs_routine_id_routines_id_fk": {
+          "name": "routine_runs_routine_id_routines_id_fk",
+          "tableFrom": "routine_runs",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routines": {
+      "name": "routines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed_by": {
+          "name": "managed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "routines_key_unique": {
+          "name": "routines_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sentinel_log": {
+      "name": "sentinel_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_turn_checkpoints": {
+      "name": "session_turn_checkpoints",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_turn_checkpoints_session_id_sessions_id_fk": {
+          "name": "session_turn_checkpoints_session_id_sessions_id_fk",
+          "tableFrom": "session_turn_checkpoints",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_turn_checkpoints_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "session_turn_checkpoints_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_thread_key": {
+          "name": "channel_thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shared_chats": {
+      "name": "shared_chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_shared_chats_session_id": {
+          "name": "idx_shared_chats_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_chats": {
+      "name": "wa_chats",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_contacts": {
+      "name": "wa_contacts",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify": {
+          "name": "notify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "img_url": {
+          "name": "img_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_messages": {
+      "name": "wa_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_jid": {
+          "name": "chat_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_jid": {
+          "name": "sender_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_me": {
+          "name": "from_me",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_media": {
+          "name": "has_media",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "push_name": {
+          "name": "push_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reacts_to_id": {
+          "name": "reacts_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_chat_ts": {
+          "name": "idx_wa_messages_chat_ts",
+          "columns": [
+            "chat_jid",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wa_messages_chat_jid_id_pk": {
+          "columns": [
+            "chat_jid",
+            "id"
+          ],
+          "name": "wa_messages_chat_jid_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_projects": {
+      "name": "webchat_projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webchat_projects_path_unique": {
+          "name": "webchat_projects_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_turn_feedback": {
+      "name": "webchat_turn_feedback",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webchat_turn_feedback_session_id": {
+          "name": "idx_webchat_turn_feedback_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webchat_turn_feedback_session_id_rome_sessions_id_fk": {
+          "name": "webchat_turn_feedback_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_turn_feedback",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webchat_turn_feedback_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "webchat_turn_feedback_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_workspace_layouts": {
+      "name": "webchat_workspace_layouts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webchat_workspace_layouts_session_id_rome_sessions_id_fk": {
+          "name": "webchat_workspace_layouts_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_workspace_layouts",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_invocations": {
+      "name": "webhook_invocations",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_url": {
+          "name": "callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_status": {
+          "name": "callback_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_attempted_at": {
+          "name": "callback_attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_delivered_at": {
+          "name": "callback_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_response_status": {
+          "name": "callback_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_error": {
+          "name": "callback_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webhook_invocations_created_at": {
+          "name": "idx_webhook_invocations_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_webhook_invocations_action_name": {
+          "name": "idx_webhook_invocations_action_name",
+          "columns": [
+            "action_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/system/meta/_journal.json
+++ b/packages/core/drizzle/system/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1787564333900,
       "tag": "0059_cool_quasar",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "6",
+      "when": 1787866308438,
+      "tag": "0060_serious_adam_destine",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/actions/app-actions-wiring.ts
+++ b/packages/core/src/actions/app-actions-wiring.ts
@@ -65,6 +65,7 @@ export function createNoopChannelMessageHook(): ChannelMessageHook {
   return {
     async register() {},
     registerConnection() {},
+    unregister() {},
   };
 }
 
@@ -270,4 +271,42 @@ export async function createChannelMessageHookFromCatalog(
   throw new Error(
     `Hook "${hookRef.publicName}" must export createHook(deps) from ${hookRef.absolutePath}`,
   );
+}
+
+/**
+ * Rebuilds the live channel-message hook from the catalog — the app-keys
+ * refresh path. The hook is instantiated once at boot and retained by
+ * subscription closures, so recreating it is the only way a module-scope env
+ * capture in its module graph follows a key change. The swap is
+ * double-dispatch-safe: the old instance detaches before the new one
+ * registers, and a hook without `unregister()` is left in place (stale but
+ * single) rather than doubled. If the fresh instance fails to register, the
+ * previous one is re-registered so inbound messages keep flowing; the error
+ * propagates for the caller to report.
+ */
+export function createChannelMessageHookReloader(options: {
+  catalog: AppCatalog;
+  deps: unknown;
+  getCurrent: () => ChannelMessageHook;
+  setCurrent: (hook: ChannelMessageHook) => void;
+  onSkip?: (reason: string) => void;
+}): () => Promise<void> {
+  return async () => {
+    const previous = options.getCurrent();
+    if (typeof previous.unregister !== "function") {
+      options.onSkip?.("channel-message hook has no unregister(); keeping the current instance");
+      return;
+    }
+    const reloaded = await createChannelMessageHookFromCatalog(options.catalog, options.deps);
+    if (!reloaded) return;
+    previous.unregister();
+    options.setCurrent(reloaded);
+    try {
+      await reloaded.register();
+    } catch (err) {
+      options.setCurrent(previous);
+      await previous.register();
+      throw err;
+    }
+  };
 }

--- a/packages/core/src/actions/channel-message-reload.test.ts
+++ b/packages/core/src/actions/channel-message-reload.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createChannelMessageHookReloader,
+  createNoopChannelMessageHook,
+} from "./app-actions-wiring.js";
+import { bumpModuleEnvEpoch } from "./module-loader.js";
+import type { AppCatalog } from "../apps/catalog.js";
+import type { ChannelMessageHook } from "../hooks/types.js";
+
+const TEST_KEY = "CHANNEL_MESSAGE_RELOAD_PROBE";
+
+type ProbeHook = ChannelMessageHook & { secret: string; registered: boolean };
+
+function catalogWithHookDir(dir: string): AppCatalog {
+  return {
+    listArtifacts: (kind: string) =>
+      kind === "hook"
+        ? [{ publicName: "channel-message", absolutePath: dir, ownerId: "inbox" }]
+        : [],
+  } as unknown as AppCatalog;
+}
+
+describe("createChannelMessageHookReloader", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    delete process.env[TEST_KEY];
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  async function writeHookModule(body: string): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "channel-message-reload-"));
+    tempDirs.push(dir);
+    await writeFile(join(dir, "index.js"), body, "utf-8");
+    return dir;
+  }
+
+  it("recreates the hook so a module-scope env capture follows save and delete", async () => {
+    const dir = await writeHookModule(`
+const captured = process.env.${TEST_KEY} ?? "unset";
+export function createHook() {
+  return {
+    secret: captured,
+    registered: false,
+    async register() { this.registered = true; },
+    registerConnection() {},
+    unregister() {},
+  };
+}
+`);
+
+    // Boot failed for want of the key: the live hook is the noop placeholder.
+    let current: ChannelMessageHook = createNoopChannelMessageHook();
+    const reload = createChannelMessageHookReloader({
+      catalog: catalogWithHookDir(dir),
+      deps: {},
+      getCurrent: () => current,
+      setCurrent: (hook) => {
+        current = hook;
+      },
+    });
+
+    // Save: the key goes live, the refresh recreates the hook against it.
+    process.env[TEST_KEY] = "v1";
+    bumpModuleEnvEpoch();
+    await reload();
+    expect((current as ProbeHook).secret).toBe("v1");
+    expect((current as ProbeHook).registered).toBe(true);
+
+    // Delete: the recreated hook no longer sees the removed value.
+    delete process.env[TEST_KEY];
+    bumpModuleEnvEpoch();
+    await reload();
+    expect((current as ProbeHook).secret).toBe("unset");
+  });
+
+  it("keeps a hook without unregister() in place rather than double-registering", async () => {
+    const dir = await writeHookModule(`
+export function createHook() {
+  return { async register() {}, registerConnection() {} };
+}
+`);
+    const previous = {
+      async register() {},
+      registerConnection() {},
+    } as ChannelMessageHook;
+    let current: ChannelMessageHook = previous;
+    const onSkip = vi.fn();
+    const reload = createChannelMessageHookReloader({
+      catalog: catalogWithHookDir(dir),
+      deps: {},
+      getCurrent: () => current,
+      setCurrent: (hook) => {
+        current = hook;
+      },
+      onSkip,
+    });
+
+    await reload();
+    expect(current).toBe(previous);
+    expect(onSkip).toHaveBeenCalledOnce();
+  });
+
+  it("restores and re-registers the previous hook when the fresh one fails to register", async () => {
+    const dir = await writeHookModule(`
+export function createHook() {
+  return {
+    async register() { throw new Error("register exploded"); },
+    registerConnection() {},
+    unregister() {},
+  };
+}
+`);
+    const previous = {
+      register: vi.fn(async () => {}),
+      registerConnection: vi.fn(),
+      unregister: vi.fn(),
+    };
+    let current: ChannelMessageHook = previous;
+    const reload = createChannelMessageHookReloader({
+      catalog: catalogWithHookDir(dir),
+      deps: {},
+      getCurrent: () => current,
+      setCurrent: (hook) => {
+        current = hook;
+      },
+    });
+
+    await expect(reload()).rejects.toThrow("register exploded");
+    expect(current).toBe(previous);
+    expect(previous.unregister).toHaveBeenCalledOnce();
+    expect(previous.register).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/actions/module-loader.test.ts
+++ b/packages/core/src/actions/module-loader.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// These tests spawn a real Node process (with tsx, the same loader the dev
+// stack and forked action workers run under). Vitest cannot host them: its
+// module runner executes `import(url)` through vite-node, which resolves the
+// module graph itself and never consults Node's resolve hooks — the very
+// mechanism under test.
+describe("importModuleWithCacheBuster env epoch (native ESM)", () => {
+  const TEST_KEY = "MODULE_LOADER_EPOCH_PROBE";
+
+  it("re-evaluates the relative-import graph only after an epoch bump", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "module-loader-epoch-"));
+    try {
+      // The env read lives in an imported helper, not the entry: the resolve
+      // hook must propagate the entry's cache salt onto the relative import
+      // or the helper stays cached across epochs.
+      await writeFile(
+        join(dir, "config.js"),
+        `export const captured = process.env.${TEST_KEY} ?? "unset";\n`,
+        "utf-8",
+      );
+      await writeFile(join(dir, "entry.js"), `export { captured } from "./config.js";\n`, "utf-8");
+
+      const loaderUrl = pathToFileURL(
+        resolve(dirname(fileURLToPath(import.meta.url)), "module-loader.ts"),
+      ).href;
+      const probePath = join(dir, "probe.mjs");
+      await writeFile(
+        probePath,
+        `
+import { bumpModuleEnvEpoch, importModuleWithCacheBuster } from ${JSON.stringify(loaderUrl)};
+
+const entry = process.argv[2];
+const before = await importModuleWithCacheBuster(entry);
+process.env.${TEST_KEY} = "v1";
+const withoutBump = await importModuleWithCacheBuster(entry);
+bumpModuleEnvEpoch();
+const after = await importModuleWithCacheBuster(entry);
+console.log(JSON.stringify({
+  before: before.captured,
+  withoutBump: withoutBump.captured,
+  after: after.captured,
+}));
+`,
+        "utf-8",
+      );
+
+      // Run under tsx — both the `source` container mode and the forked action
+      // workers in dev use it, and it is the loader that normalizes queries
+      // away without the short-circuit hook. (Plain node, the `compiled` mode,
+      // exercises the same hooks minus the tsx chain.)
+      const coreRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", probePath, join(dir, "entry.js")],
+        { cwd: coreRoot },
+      );
+      const lines = stdout.trim().split("\n");
+      expect(JSON.parse(lines[lines.length - 1])).toEqual({
+        before: "unset",
+        withoutBump: "unset",
+        after: "v1",
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/packages/core/src/actions/module-loader.ts
+++ b/packages/core/src/actions/module-loader.ts
@@ -58,9 +58,21 @@ export async function resolveModuleEntryPath(baseDir: string, entry?: string): P
   return result.path;
 }
 
+// App modules can read process.env at module scope, and the file-identity
+// buster below cannot see an environment change. Bumping this epoch salts the
+// cache key so every subsequent import re-evaluates module scope against the
+// current environment (app keys do this on save/delete). Each bump strands the
+// previously imported instances in the ESM cache — the same cost as an app
+// upgrade changing mtime — bounded by how often a guardian edits keys.
+let envEpoch = 0;
+
+export function bumpModuleEnvEpoch(): void {
+  envEpoch++;
+}
+
 export async function importModuleWithCacheBuster(path: string): Promise<Record<string, unknown>> {
   const fileStat = await stat(path);
-  const cacheBuster = `${Math.trunc(fileStat.mtimeMs)}-${fileStat.size}`;
+  const cacheBuster = `${Math.trunc(fileStat.mtimeMs)}-${fileStat.size}-e${envEpoch}`;
   const url = `${pathToFileURL(path).href}?v=${cacheBuster}`;
   return await import(url);
 }

--- a/packages/core/src/actions/module-loader.ts
+++ b/packages/core/src/actions/module-loader.ts
@@ -1,8 +1,68 @@
+import { readFileSync } from "node:fs";
 import { realpath, stat } from "node:fs/promises";
+import { registerHooks } from "node:module";
 import { isAbsolute, relative, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { ResolverFactory } from "@rspack/resolver";
 import type { Action, ActionConfig } from "./types.js";
+
+// Node's ESM resolver drops the query string when a module resolves its own
+// static imports, so the ?v= cache-buster on an entry URL re-evaluates only
+// the entry file: a helper it imports keeps its unsalted URL and stays cached
+// with whatever it captured at module scope. These hooks give the entry's
+// whole own-file graph one identity per (file stats, env epoch):
+//
+// - resolve: short-circuits already-salted file URLs before any other loader
+//   sees them (tsx — the `source` container mode — otherwise normalizes the
+//   query away, collapsing every epoch onto one cached instance), and
+//   propagates the parent's salt onto relative imports.
+// - load: serves salted URLs from disk itself, because downstream loaders
+//   fail on file URLs that carry a query.
+//
+// Only compiled `.js`/`.mjs` files are salted: TypeScript app sources need
+// tsx's transform pipeline, which the bypass would skip — source-mode
+// workspace apps keep their existing repack-or-restart reload story. Bare
+// specifiers stay untouched on purpose: node_modules must resolve to the one
+// shared instance per process.
+const SALT_QUERY = /\?v=[^&]*$/;
+
+function isSaltableUrl(url: string): boolean {
+  const path = url.split("?")[0];
+  return path.endsWith(".js") || path.endsWith(".mjs");
+}
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith("file:") && SALT_QUERY.test(specifier) && isSaltableUrl(specifier)) {
+      return { url: specifier, format: "module", shortCircuit: true };
+    }
+    const result = nextResolve(specifier, context);
+    if (
+      (specifier.startsWith("./") || specifier.startsWith("../")) &&
+      context.parentURL !== undefined &&
+      SALT_QUERY.test(context.parentURL) &&
+      result.url.startsWith("file:") &&
+      !result.url.includes("?") &&
+      isSaltableUrl(result.url)
+    ) {
+      const salt = new URL(context.parentURL).searchParams.get("v");
+      if (salt) return { url: `${result.url}?v=${salt}`, format: "module", shortCircuit: true };
+    }
+    return result;
+  },
+  load(url, context, nextLoad) {
+    if (url.startsWith("file:") && SALT_QUERY.test(url) && isSaltableUrl(url)) {
+      const cleanUrl = new URL(url);
+      cleanUrl.search = "";
+      return {
+        format: "module",
+        source: readFileSync(fileURLToPath(cleanUrl)),
+        shortCircuit: true,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});
 
 // Apps written in TypeScript declare `entry: ./index.ts` against their `src/`
 // layout; `rome build` emits `.js` into `dist/` and copies the YAML unchanged.

--- a/packages/core/src/api/deps.ts
+++ b/packages/core/src/api/deps.ts
@@ -24,6 +24,8 @@ import type { ActionRegistryImpl } from "../actions/registry.js";
 import type { AgentLoader } from "../core/agent-loader.js";
 import type { SkillCatalog } from "../core/skill-catalog.js";
 import type { SettingsRepository } from "../db/repositories/settings.js";
+import type { AppKeysRepository } from "../db/repositories/app-keys.js";
+import type { AppKeyInjector } from "../app-keys/injector.js";
 import type { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
 import type { ActionExecutionsRepository } from "../db/repositories/action-executions.js";
 import type { SessionManager } from "../core/session-manager.js";
@@ -116,6 +118,8 @@ export interface ApiDeps {
   /** Override for `~/.rome/<profile>/apps/` (tests inject tmpdir). */
   appsRoot?: string;
   settingsRepo: SettingsRepository;
+  appKeysRepo: AppKeysRepository;
+  appKeyInjector: AppKeyInjector;
   appRuntimeRepositories: AppRuntimeRepositories;
   sentinelLogRepo: SentinelLogRepository;
   actionExecutionsRepo: ActionExecutionsRepository;

--- a/packages/core/src/api/deps.ts
+++ b/packages/core/src/api/deps.ts
@@ -120,6 +120,10 @@ export interface ApiDeps {
   settingsRepo: SettingsRepository;
   appKeysRepo: AppKeysRepository;
   appKeyInjector: AppKeyInjector;
+  /** Makes an app-keys environment change reach already-running app code:
+   * salts the module-import cache, recycles warm action workers, and reloads
+   * the hook chains. See `refreshAppRuntimeEnv` in `src/index.ts`. */
+  refreshAppRuntime: () => Promise<void>;
   appRuntimeRepositories: AppRuntimeRepositories;
   sentinelLogRepo: SentinelLogRepository;
   actionExecutionsRepo: ActionExecutionsRepository;

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -25,6 +25,7 @@ import { appApiDashboardRoutes, appApiPublicRoutes } from "./routes/app-api.js";
 import { webhookRoutes } from "./routes/webhooks.js";
 import { createWebchatRuntime, type WebchatRuntime } from "./routes/webchat.js";
 import { settingsRoutes } from "./routes/settings.js";
+import { appKeysRoutes } from "./routes/app-keys.js";
 import { uptimeRoutes } from "./routes/uptime.js";
 import { buildInfoRoutes } from "./routes/build-info.js";
 import { diagnosisRoutes } from "./routes/diagnosis.js";
@@ -147,6 +148,7 @@ export function buildApp(
   api.route("/", conversationSettingsRoutes(deps));
   api.route("/", approvalsRoutes(deps));
   api.route("/", settingsRoutes(deps));
+  api.route("/", appKeysRoutes(deps));
   api.route("/", routinesRoutes(deps));
   api.route("/", eventCatalogRoutes(deps));
   api.route("/", personsRoutes(deps));

--- a/packages/core/src/api/routes/app-keys.test.ts
+++ b/packages/core/src/api/routes/app-keys.test.ts
@@ -128,6 +128,7 @@ describe("appKeysRoutes", () => {
       },
     );
     deps.actionEngine = engine;
+    deps.refreshAppRuntime = () => engine.restartWorkerWarmPool();
     // The engine snapshots the real process.env at fork time, so the injector
     // must write there for the test to observe propagation.
     deps.appKeyInjector = new AppKeyInjector();
@@ -155,20 +156,28 @@ describe("appKeysRoutes", () => {
     }
   });
 
-  it("does not recycle workers for a rejected or shadowed save", async () => {
-    const restart = vi.spyOn(deps.actionEngine, "restartWorkerWarmPool");
+  it("refreshes the app runtime only when the environment changed", async () => {
+    const refresh = vi.spyOn(deps, "refreshAppRuntime");
 
     const rejected = await put("lowercase", { value: "v" });
     expect(rejected.status).toBe(400);
-    expect(restart).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
 
-    // A shadowed save changes nothing in the environment, so no recycle.
+    const saved = await put("MY_KEY", { value: "v1" });
+    expect(saved.status).toBe(200);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    const removed = await app.request("/app-keys/MY_KEY", { method: "DELETE" });
+    expect(removed.status).toBe(200);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    // A shadowed save changes nothing in the environment, so no refresh.
     const env: NodeJS.ProcessEnv = { TAKEN_KEY: "from-operator" };
     deps.appKeyInjector = new AppKeyInjector(env);
     app = new Hono().route("/", appKeysRoutes(deps));
     const shadowed = await put("TAKEN_KEY", { value: "from-dashboard" });
     expect(await shadowed.json()).toEqual({ ok: true, overridden: true });
-    expect(restart).not.toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalledTimes(2);
   });
 
   it("deletes a key and 404s on an unknown one", async () => {

--- a/packages/core/src/api/routes/app-keys.test.ts
+++ b/packages/core/src/api/routes/app-keys.test.ts
@@ -1,7 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
+import { EventEmitter } from "node:events";
+import type { ChildProcess, ForkOptions } from "node:child_process";
 import { buildTestDeps, createTestDb, type TestDb, type TestDeps } from "../../test/helpers.js";
 import { AppKeyInjector } from "../../app-keys/injector.js";
+import { ActionEngine } from "../../actions/engine.js";
+import { ActionRegistryImpl } from "../../actions/registry.js";
 import { appKeysRoutes } from "./app-keys.js";
 
 describe("appKeysRoutes", () => {
@@ -77,6 +81,94 @@ describe("appKeysRoutes", () => {
       keys: Array<{ overridden: boolean }>;
     };
     expect(list.keys[0].overridden).toBe(true);
+  });
+
+  it("recycles the warm action-worker pool so new workers fork with the current env", async () => {
+    // Warm workers snapshot process.env at fork time and are reused, so a
+    // saved or deleted key must retire the pool to reach action code. This
+    // drives the real pool through the fork seam and asserts each generation's
+    // captured env.
+    const TEST_KEY = "APP_KEYS_WORKER_REFRESH_PROBE";
+
+    class FakeWorkerChild extends EventEmitter {
+      pid = 4242;
+      connected = true;
+      exitCode: number | null = null;
+      send(message: unknown, cb?: (err: Error | null) => void): boolean {
+        cb?.(null);
+        if ((message as { type?: unknown }).type === "shutdown") {
+          this.connected = false;
+          this.exitCode = 0;
+          queueMicrotask(() => this.emit("exit", 0, null));
+        }
+        return true;
+      }
+      kill(): boolean {
+        return true;
+      }
+    }
+
+    const forkedEnvs: Array<NodeJS.ProcessEnv | undefined> = [];
+    const children: FakeWorkerChild[] = [];
+    const engine = new ActionEngine(
+      new ActionRegistryImpl([]),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        processRole: "main",
+        workerWarmPoolSize: 1,
+        actionWorkerFork: (_entryPath: string, options: ForkOptions) => {
+          forkedEnvs.push(options.env);
+          const child = new FakeWorkerChild();
+          children.push(child);
+          return child as unknown as ChildProcess;
+        },
+      },
+    );
+    deps.actionEngine = engine;
+    // The engine snapshots the real process.env at fork time, so the injector
+    // must write there for the test to observe propagation.
+    deps.appKeyInjector = new AppKeyInjector();
+    app = new Hono().route("/", appKeysRoutes(deps));
+
+    try {
+      engine.startWorkerWarmPool();
+      expect(children).toHaveLength(1);
+      children[0].emit("message", { type: "ready" });
+      expect(forkedEnvs[0]?.[TEST_KEY]).toBeUndefined();
+
+      const saved = await put(TEST_KEY, { value: "v1" });
+      expect(saved.status).toBe(200);
+      expect(children).toHaveLength(2);
+      expect(forkedEnvs[1]?.[TEST_KEY]).toBe("v1");
+      children[1].emit("message", { type: "ready" });
+
+      const del = await app.request(`/app-keys/${TEST_KEY}`, { method: "DELETE" });
+      expect(del.status).toBe(200);
+      expect(children).toHaveLength(3);
+      expect(forkedEnvs[2]?.[TEST_KEY]).toBeUndefined();
+    } finally {
+      await engine.stopWorkerWarmPool();
+      delete process.env[TEST_KEY];
+    }
+  });
+
+  it("does not recycle workers for a rejected or shadowed save", async () => {
+    const restart = vi.spyOn(deps.actionEngine, "restartWorkerWarmPool");
+
+    const rejected = await put("lowercase", { value: "v" });
+    expect(rejected.status).toBe(400);
+    expect(restart).not.toHaveBeenCalled();
+
+    // A shadowed save changes nothing in the environment, so no recycle.
+    const env: NodeJS.ProcessEnv = { TAKEN_KEY: "from-operator" };
+    deps.appKeyInjector = new AppKeyInjector(env);
+    app = new Hono().route("/", appKeysRoutes(deps));
+    const shadowed = await put("TAKEN_KEY", { value: "from-dashboard" });
+    expect(await shadowed.json()).toEqual({ ok: true, overridden: true });
+    expect(restart).not.toHaveBeenCalled();
   });
 
   it("deletes a key and 404s on an unknown one", async () => {

--- a/packages/core/src/api/routes/app-keys.test.ts
+++ b/packages/core/src/api/routes/app-keys.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { buildTestDeps, createTestDb, type TestDb, type TestDeps } from "../../test/helpers.js";
+import { AppKeyInjector } from "../../app-keys/injector.js";
+import { appKeysRoutes } from "./app-keys.js";
+
+describe("appKeysRoutes", () => {
+  let testDb: TestDb;
+  let deps: TestDeps;
+  let app: Hono;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    deps = await buildTestDeps(testDb.db);
+    app = new Hono().route("/", appKeysRoutes(deps));
+  });
+
+  afterEach(() => {
+    testDb.close();
+  });
+
+  const put = (name: string, body: unknown) =>
+    app.request(`/app-keys/${name}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  it("stores a key, injects it, and lists it without the value", async () => {
+    const res = await put("MY_DB_PASSWORD", { label: "Shop DB password", value: "hunter2" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, overridden: false });
+
+    const list = await app.request("/app-keys");
+    expect(list.status).toBe(200);
+    const payload = (await list.json()) as {
+      keys: Array<{ name: string; label: string; overridden: boolean; updatedAt: string }>;
+    };
+    expect(payload.keys).toHaveLength(1);
+    expect(payload.keys[0].name).toBe("MY_DB_PASSWORD");
+    expect(payload.keys[0].label).toBe("Shop DB password");
+    expect(payload.keys[0].overridden).toBe(false);
+    expect(JSON.stringify(payload)).not.toContain("hunter2");
+  });
+
+  it("rejects reserved and malformed names", async () => {
+    for (const name of ["ROME_PROFILE", "PATH", "lowercase"]) {
+      const res = await put(name, { value: "v" });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("rejects a missing value", async () => {
+    const res = await put("MY_KEY", { label: "no value" });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toMatch(/Value is required/);
+  });
+
+  it("defaults the label to the name", async () => {
+    await put("MY_KEY", { value: "v" });
+    const payload = (await (await app.request("/app-keys")).json()) as {
+      keys: Array<{ label: string }>;
+    };
+    expect(payload.keys[0].label).toBe("MY_KEY");
+  });
+
+  it("reports overridden when the process environment already owns the name", async () => {
+    const env: NodeJS.ProcessEnv = { TAKEN_KEY: "from-operator" };
+    deps.appKeyInjector = new AppKeyInjector(env);
+    app = new Hono().route("/", appKeysRoutes(deps));
+
+    const res = await put("TAKEN_KEY", { value: "from-dashboard" });
+    expect(await res.json()).toEqual({ ok: true, overridden: true });
+    expect(env.TAKEN_KEY).toBe("from-operator");
+
+    const list = (await (await app.request("/app-keys")).json()) as {
+      keys: Array<{ overridden: boolean }>;
+    };
+    expect(list.keys[0].overridden).toBe(true);
+  });
+
+  it("deletes a key and 404s on an unknown one", async () => {
+    await put("MY_KEY", { value: "v" });
+    const del = await app.request("/app-keys/MY_KEY", { method: "DELETE" });
+    expect(del.status).toBe(200);
+    expect(
+      ((await (await app.request("/app-keys")).json()) as { keys: unknown[] }).keys,
+    ).toHaveLength(0);
+
+    const missing = await app.request("/app-keys/MY_KEY", { method: "DELETE" });
+    expect(missing.status).toBe(404);
+  });
+});

--- a/packages/core/src/api/routes/app-keys.ts
+++ b/packages/core/src/api/routes/app-keys.ts
@@ -1,0 +1,69 @@
+import { Hono } from "hono";
+import type { ApiDeps } from "../deps.js";
+import {
+  APP_KEY_MAX_LABEL_LENGTH,
+  APP_KEY_MAX_VALUE_LENGTH,
+  appKeyNameError,
+} from "@rome/api-types/app-keys";
+
+// App keys are guardian-entered secrets injected into process.env for apps to
+// read. The read surface never returns values — only names, labels, and
+// whether a real environment variable is shadowing the stored value. Replacing
+// a value means retyping it; there is no read-back.
+export function appKeysRoutes(deps: ApiDeps): Hono {
+  const app = new Hono();
+
+  app.get("/app-keys", async (c) => {
+    const rows = await deps.appKeysRepo.list();
+    return c.json({
+      keys: rows.map((row) => ({
+        name: row.name,
+        label: row.label,
+        updatedAt: row.updatedAt.toISOString(),
+        overridden: deps.appKeyInjector.isOverridden(row.name),
+      })),
+    });
+  });
+
+  app.put("/app-keys/:name", async (c) => {
+    const name = c.req.param("name");
+    const nameError = appKeyNameError(name);
+    if (nameError) return c.json({ error: nameError }, 400);
+
+    const body = await c.req
+      .json<{ label?: unknown; value?: unknown }>()
+      .catch(() => ({}) as { label?: unknown; value?: unknown });
+
+    if (typeof body.value !== "string" || body.value.length === 0) {
+      return c.json({ error: "Value is required." }, 400);
+    }
+    if (body.value.length > APP_KEY_MAX_VALUE_LENGTH) {
+      return c.json(
+        { error: `Value must be at most ${APP_KEY_MAX_VALUE_LENGTH} characters.` },
+        400,
+      );
+    }
+    const label = typeof body.label === "string" && body.label.trim() ? body.label.trim() : name;
+    if (label.length > APP_KEY_MAX_LABEL_LENGTH) {
+      return c.json(
+        { error: `Label must be at most ${APP_KEY_MAX_LABEL_LENGTH} characters.` },
+        400,
+      );
+    }
+
+    await deps.appKeysRepo.upsert({ name, label, value: body.value });
+    const live = deps.appKeyInjector.apply(name, body.value);
+    return c.json({ ok: true, overridden: !live });
+  });
+
+  app.delete("/app-keys/:name", async (c) => {
+    const name = c.req.param("name");
+    const existing = await deps.appKeysRepo.get(name);
+    if (!existing) return c.json({ error: "Unknown app key." }, 404);
+    await deps.appKeysRepo.delete(name);
+    deps.appKeyInjector.remove(name);
+    return c.json({ ok: true });
+  });
+
+  return app;
+}

--- a/packages/core/src/api/routes/app-keys.ts
+++ b/packages/core/src/api/routes/app-keys.ts
@@ -53,10 +53,11 @@ export function appKeysRoutes(deps: ApiDeps): Hono {
 
     await deps.appKeysRepo.upsert({ name, label, value: body.value });
     const live = deps.appKeyInjector.apply(name, body.value);
-    // Warm action workers were forked with an env snapshot and are reused, so
-    // a changed value never reaches them on its own. Recycle the pool whenever
-    // the environment actually changed (an overridden save changes nothing).
-    if (live) await deps.actionEngine.restartWorkerWarmPool();
+    // Running app code captured the old environment: warm workers hold a
+    // fork-time snapshot, and cached main-process modules (API handlers,
+    // hooks) may have read env at module scope. Refresh them whenever the
+    // environment actually changed (an overridden save changes nothing).
+    if (live) await deps.refreshAppRuntime();
     return c.json({ ok: true, overridden: !live });
   });
 
@@ -65,9 +66,9 @@ export function appKeysRoutes(deps: ApiDeps): Hono {
     const existing = await deps.appKeysRepo.get(name);
     if (!existing) return c.json({ error: "Unknown app key." }, 404);
     await deps.appKeysRepo.delete(name);
-    // Same env-snapshot staleness as the save path: without a recycle, a warm
-    // worker keeps serving the deleted secret for up to its remaining reuses.
-    if (deps.appKeyInjector.remove(name)) await deps.actionEngine.restartWorkerWarmPool();
+    // Same staleness as the save path: without a refresh, running app code
+    // keeps serving the deleted secret until Rome restarts.
+    if (deps.appKeyInjector.remove(name)) await deps.refreshAppRuntime();
     return c.json({ ok: true });
   });
 

--- a/packages/core/src/api/routes/app-keys.ts
+++ b/packages/core/src/api/routes/app-keys.ts
@@ -53,6 +53,10 @@ export function appKeysRoutes(deps: ApiDeps): Hono {
 
     await deps.appKeysRepo.upsert({ name, label, value: body.value });
     const live = deps.appKeyInjector.apply(name, body.value);
+    // Warm action workers were forked with an env snapshot and are reused, so
+    // a changed value never reaches them on its own. Recycle the pool whenever
+    // the environment actually changed (an overridden save changes nothing).
+    if (live) await deps.actionEngine.restartWorkerWarmPool();
     return c.json({ ok: true, overridden: !live });
   });
 
@@ -61,7 +65,9 @@ export function appKeysRoutes(deps: ApiDeps): Hono {
     const existing = await deps.appKeysRepo.get(name);
     if (!existing) return c.json({ error: "Unknown app key." }, 404);
     await deps.appKeysRepo.delete(name);
-    deps.appKeyInjector.remove(name);
+    // Same env-snapshot staleness as the save path: without a recycle, a warm
+    // worker keeps serving the deleted secret for up to its remaining reuses.
+    if (deps.appKeyInjector.remove(name)) await deps.actionEngine.restartWorkerWarmPool();
     return c.json({ ok: true });
   });
 

--- a/packages/core/src/app-keys/injector.test.ts
+++ b/packages/core/src/app-keys/injector.test.ts
@@ -26,12 +26,13 @@ describe("AppKeyInjector", () => {
     expect(env.MY_KEY).toBe("v2");
   });
 
-  it("removes only what it injected", () => {
+  it("removes only what it injected, and reports whether the env changed", () => {
     const env: NodeJS.ProcessEnv = { OPERATOR_KEY: "keep" };
     const injector = new AppKeyInjector(env);
     injector.apply("MY_KEY", "secret");
-    injector.remove("MY_KEY");
-    injector.remove("OPERATOR_KEY");
+    expect(injector.remove("MY_KEY")).toBe(true);
+    expect(injector.remove("MY_KEY")).toBe(false);
+    expect(injector.remove("OPERATOR_KEY")).toBe(false);
     expect(env.MY_KEY).toBeUndefined();
     expect(env.OPERATOR_KEY).toBe("keep");
   });

--- a/packages/core/src/app-keys/injector.test.ts
+++ b/packages/core/src/app-keys/injector.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { AppKeyInjector } from "./injector.js";
+
+describe("AppKeyInjector", () => {
+  it("injects into an empty slot and reports it live", () => {
+    const env: NodeJS.ProcessEnv = {};
+    const injector = new AppKeyInjector(env);
+    expect(injector.apply("MY_KEY", "secret")).toBe(true);
+    expect(env.MY_KEY).toBe("secret");
+    expect(injector.isOverridden("MY_KEY")).toBe(false);
+  });
+
+  it("never overwrites a pre-existing environment value", () => {
+    const env: NodeJS.ProcessEnv = { MY_KEY: "from-operator" };
+    const injector = new AppKeyInjector(env);
+    expect(injector.apply("MY_KEY", "from-dashboard")).toBe(false);
+    expect(env.MY_KEY).toBe("from-operator");
+    expect(injector.isOverridden("MY_KEY")).toBe(true);
+  });
+
+  it("updates a value it injected itself", () => {
+    const env: NodeJS.ProcessEnv = {};
+    const injector = new AppKeyInjector(env);
+    injector.apply("MY_KEY", "v1");
+    expect(injector.apply("MY_KEY", "v2")).toBe(true);
+    expect(env.MY_KEY).toBe("v2");
+  });
+
+  it("removes only what it injected", () => {
+    const env: NodeJS.ProcessEnv = { OPERATOR_KEY: "keep" };
+    const injector = new AppKeyInjector(env);
+    injector.apply("MY_KEY", "secret");
+    injector.remove("MY_KEY");
+    injector.remove("OPERATOR_KEY");
+    expect(env.MY_KEY).toBeUndefined();
+    expect(env.OPERATOR_KEY).toBe("keep");
+  });
+
+  it("clears the overridden flag when the key is removed", () => {
+    const env: NodeJS.ProcessEnv = { MY_KEY: "from-operator" };
+    const injector = new AppKeyInjector(env);
+    injector.apply("MY_KEY", "from-dashboard");
+    expect(injector.isOverridden("MY_KEY")).toBe(true);
+    injector.remove("MY_KEY");
+    expect(injector.isOverridden("MY_KEY")).toBe(false);
+    expect(env.MY_KEY).toBe("from-operator");
+  });
+});

--- a/packages/core/src/app-keys/injector.ts
+++ b/packages/core/src/app-keys/injector.ts
@@ -34,13 +34,14 @@ export class AppKeyInjector {
     return true;
   }
 
-  /** Removes a stored key from the environment, only if this injector set it. */
-  remove(name: string): void {
-    if (this.injected.has(name)) {
-      delete this.env[name];
-      this.injected.delete(name);
-    }
+  /** Removes a stored key from the environment, only if this injector set it.
+   * Returns true when the environment actually changed. */
+  remove(name: string): boolean {
     this.overridden.delete(name);
+    if (!this.injected.has(name)) return false;
+    delete this.env[name];
+    this.injected.delete(name);
+    return true;
   }
 
   isOverridden(name: string): boolean {

--- a/packages/core/src/app-keys/injector.ts
+++ b/packages/core/src/app-keys/injector.ts
@@ -1,0 +1,49 @@
+import { createLogger } from "../logger.js";
+
+const logger = createLogger("app-keys");
+
+/**
+ * Owns the stored-key slice of `process.env`. Two invariants:
+ *
+ * - The real process environment always wins. A name that already had a value
+ *   before injection is never overwritten — operator config (env files, CI,
+ *   container env) cannot be shadowed from the dashboard. Such keys are
+ *   reported as overridden instead of silently going live.
+ * - Only names this injector set are ever deleted or scrubbed. It tracks its
+ *   own writes, so removing a stored key can never unset an operator-set var
+ *   that happens to share the name.
+ */
+export class AppKeyInjector {
+  private injected = new Set<string>();
+  private overridden = new Set<string>();
+
+  constructor(private env: NodeJS.ProcessEnv = process.env) {}
+
+  /** Applies a stored key. Returns true when the value went live, false when a
+   * pre-existing environment value kept precedence. */
+  apply(name: string, value: string): boolean {
+    if (!this.injected.has(name) && this.env[name] !== undefined) {
+      this.overridden.add(name);
+      logger.warn(
+        `App key ${name} is overridden by the process environment; the stored value is not live`,
+      );
+      return false;
+    }
+    this.env[name] = value;
+    this.injected.add(name);
+    return true;
+  }
+
+  /** Removes a stored key from the environment, only if this injector set it. */
+  remove(name: string): void {
+    if (this.injected.has(name)) {
+      delete this.env[name];
+      this.injected.delete(name);
+    }
+    this.overridden.delete(name);
+  }
+
+  isOverridden(name: string): boolean {
+    return this.overridden.has(name);
+  }
+}

--- a/packages/core/src/app-keys/reserved.test.ts
+++ b/packages/core/src/app-keys/reserved.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { appKeyNameError } from "@rome/api-types/app-keys";
+
+describe("appKeyNameError", () => {
+  it("accepts well-formed names", () => {
+    expect(appKeyNameError("TAELOR_DB_PASSWORD")).toBeNull();
+    expect(appKeyNameError("MY_API_KEY")).toBeNull();
+    expect(appKeyNameError("X")).toBeNull();
+    expect(appKeyNameError("A1_B2")).toBeNull();
+  });
+
+  it("rejects malformed names", () => {
+    expect(appKeyNameError("")).toMatch(/required/);
+    expect(appKeyNameError("lowercase")).toMatch(/uppercase/);
+    expect(appKeyNameError("1STARTS_WITH_DIGIT")).toMatch(/start with a letter/);
+    expect(appKeyNameError("HAS-DASH")).toMatch(/uppercase/);
+    expect(appKeyNameError("HAS SPACE")).toMatch(/uppercase/);
+    expect(appKeyNameError("A".repeat(65))).toMatch(/at most 64/);
+  });
+
+  it("rejects platform-reserved names and prefixes", () => {
+    expect(appKeyNameError("PATH")).toMatch(/reserved/);
+    expect(appKeyNameError("HOME")).toMatch(/reserved/);
+    expect(appKeyNameError("ROME_PROFILE")).toMatch(/reserved/);
+    expect(appKeyNameError("ANTHROPIC_API_KEY")).toMatch(/reserved/);
+    expect(appKeyNameError("DATABASE_TYPE")).toMatch(/reserved/);
+    expect(appKeyNameError("INTERNAL_API_PORT")).toMatch(/reserved/);
+    expect(appKeyNameError("NODE_OPTIONS")).toMatch(/reserved/);
+    expect(appKeyNameError("STATSIG_SERVER_SECRET_KEY")).toMatch(/reserved/);
+  });
+
+  it("allows names that merely share letters with a reserved prefix", () => {
+    // WEBHOOK_ is not WEB_ + separator; ROMEO_ is not ROME_.
+    expect(appKeyNameError("WEBHOOK_SECRET")).toBeNull();
+    expect(appKeyNameError("ROMEO_KEY")).toBeNull();
+  });
+});

--- a/packages/core/src/apps/context.test.ts
+++ b/packages/core/src/apps/context.test.ts
@@ -21,6 +21,7 @@ import {
   getCurrentActionContext,
 } from "@rome-os/app-runtime";
 import { registerAppActions, registerLazyAppActions } from "../actions/app-actions-wiring.js";
+import { bumpModuleEnvEpoch } from "../actions/module-loader.js";
 import type { SettingsRepository } from "../db/repositories/settings.js";
 import type { WebChatRepository } from "../db/repositories/webchat.js";
 import type { FavorActionRequestView, FavorService } from "../favors/types.js";
@@ -173,6 +174,51 @@ export function createApiHandler(ctx) {
       { surface: "action", appId: "shared-context-app", repositories },
       { surface: "api", appId: "shared-context-app", repositories },
     ]);
+  });
+
+  it("re-evaluates module-scope env reads after an app-keys refresh", async () => {
+    // An API module that captures env at module scope stays cached across
+    // dispatches — the import cache key is file identity, so an env change
+    // alone never reaches it. The app-keys refresh bumps the module env epoch;
+    // this pins both halves: stale without the bump, fresh after it.
+    const TEST_KEY = "APP_KEYS_MODULE_SCOPE_PROBE";
+    const apiEntryPath = join(await tempDir(), "index.js");
+    await writeFile(
+      apiEntryPath,
+      `
+const CAPTURED = process.env.${TEST_KEY} ?? "unset";
+export function createApiHandler() {
+  return { handle: async () => new Response(CAPTURED) };
+}
+`,
+      "utf-8",
+    );
+
+    const app = resolvedApp("env-probe-app", { apiEntryPath });
+    const dispatcher = new AppApiDispatcher(catalogFor(app), {
+      db: {} as RomeAppRuntimeServices["db"],
+      actionEngine: {} as ActionEngine,
+      repositories: createRepositories(),
+    });
+    const request = {
+      method: "GET",
+      path: ["probe"],
+      headers: {},
+      query: new URLSearchParams(),
+      caller: { kind: "anonymous" } as const,
+    };
+
+    try {
+      expect(await (await dispatcher.dispatch(app.appId, request)).text()).toBe("unset");
+
+      process.env[TEST_KEY] = "v1";
+      expect(await (await dispatcher.dispatch(app.appId, request)).text()).toBe("unset");
+
+      bumpModuleEnvEpoch();
+      expect(await (await dispatcher.dispatch(app.appId, request)).text()).toBe("v1");
+    } finally {
+      delete process.env[TEST_KEY];
+    }
   });
 
   it("can register app action stubs without importing the implementation until execution", async () => {

--- a/packages/core/src/db/repositories/app-keys.test.ts
+++ b/packages/core/src/db/repositories/app-keys.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestDb, type TestDb } from "../../test/helpers.js";
+import { AppKeysRepository } from "./app-keys.js";
+
+describe("AppKeysRepository", () => {
+  let testDb: TestDb;
+  let repo: AppKeysRepository;
+
+  beforeEach(() => {
+    testDb = createTestDb();
+    repo = new AppKeysRepository(testDb.db);
+  });
+
+  afterEach(() => {
+    testDb.close();
+  });
+
+  it("upserts and reads back a key", async () => {
+    await repo.upsert({ name: "MY_KEY", label: "My key", value: "secret" });
+    const row = await repo.get("MY_KEY");
+    expect(row?.label).toBe("My key");
+    expect(row?.value).toBe("secret");
+  });
+
+  it("replaces label and value on conflict", async () => {
+    await repo.upsert({ name: "MY_KEY", label: "Old", value: "v1" });
+    await repo.upsert({ name: "MY_KEY", label: "New", value: "v2" });
+    const row = await repo.get("MY_KEY");
+    expect(row?.label).toBe("New");
+    expect(row?.value).toBe("v2");
+    expect(await repo.list()).toHaveLength(1);
+  });
+
+  it("lists summaries without values, sorted by name", async () => {
+    await repo.upsert({ name: "B_KEY", label: "b", value: "vb" });
+    await repo.upsert({ name: "A_KEY", label: "a", value: "va" });
+    const summaries = await repo.list();
+    expect(summaries.map((s) => s.name)).toEqual(["A_KEY", "B_KEY"]);
+    for (const summary of summaries) {
+      expect(summary).not.toHaveProperty("value");
+    }
+  });
+
+  it("deletes a key", async () => {
+    await repo.upsert({ name: "MY_KEY", label: "My key", value: "secret" });
+    await repo.delete("MY_KEY");
+    expect(await repo.get("MY_KEY")).toBeNull();
+    expect(await repo.list()).toHaveLength(0);
+  });
+});

--- a/packages/core/src/db/repositories/app-keys.ts
+++ b/packages/core/src/db/repositories/app-keys.ts
@@ -1,0 +1,64 @@
+import { eq } from "drizzle-orm";
+import { appKeys } from "../schema.js";
+import type { DrizzleDb } from "../index.js";
+
+export interface AppKeyRow {
+  name: string;
+  label: string;
+  value: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** The value-free projection the API returns. The secret only leaves this
+ * repository through `listWithValues`, whose sole consumer is the boot/save
+ * injector. */
+export interface AppKeySummary {
+  name: string;
+  label: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class AppKeysRepository {
+  constructor(private db: DrizzleDb) {}
+
+  async list(): Promise<AppKeySummary[]> {
+    const rows = await this.db
+      .select({
+        name: appKeys.name,
+        label: appKeys.label,
+        createdAt: appKeys.createdAt,
+        updatedAt: appKeys.updatedAt,
+      })
+      .from(appKeys);
+    return rows.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async listWithValues(): Promise<AppKeyRow[]> {
+    return await this.db.select().from(appKeys);
+  }
+
+  async get(name: string): Promise<AppKeyRow | null> {
+    const rows = await this.db.select().from(appKeys).where(eq(appKeys.name, name));
+    return rows[0] ?? null;
+  }
+
+  // One atomic upsert rather than a read-then-branch: two concurrent writers to
+  // the same name would both observe an empty read and race into a duplicate
+  // insert on the `app_keys.name` primary key.
+  async upsert(input: { name: string; label: string; value: string }): Promise<void> {
+    const now = new Date();
+    await this.db
+      .insert(appKeys)
+      .values({ ...input, createdAt: now, updatedAt: now })
+      .onConflictDoUpdate({
+        target: appKeys.name,
+        set: { label: input.label, value: input.value, updatedAt: now },
+      });
+  }
+
+  async delete(name: string): Promise<void> {
+    await this.db.delete(appKeys).where(eq(appKeys.name, name));
+  }
+}

--- a/packages/core/src/db/schema/system.ts
+++ b/packages/core/src/db/schema/system.ts
@@ -313,6 +313,18 @@ export const settings = sqliteTable("settings", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });
 
+// Guardian-entered named values ("App keys" in Settings → Connections) injected
+// into process.env at boot so any installed app can read them. `name` is the
+// env var name apps read; `label` is the guardian's human description. Values
+// never leave the server through the API — the read surface returns names only.
+export const appKeys = sqliteTable("app_keys", {
+  name: text("name").primaryKey(),
+  label: text("label").notNull(),
+  value: text("value").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
 export const policies = sqliteTable("policies", {
   id: text("id").primaryKey(),
   scopeType: text("scope_type").notNull(),

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -1,4 +1,9 @@
 export interface ChannelMessageHook {
   register(): Promise<void>;
   registerConnection(connectionId: string, service: string): void;
+  /** Detach every subscription `register`/`registerConnection` took out, so
+   * the host can swap in a replacement instance (e.g. after an app-keys
+   * environment change) without double-handling inbound messages. A hook
+   * without this method cannot be hot-swapped and stays live until restart. */
+  unregister?(): void;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,8 @@ import { createAccountNames } from "./channels/account-names.js";
 import { SentinelLogRepository } from "./db/repositories/sentinel-log.js";
 import { ApprovalsRepository } from "./db/repositories/approvals.js";
 import { SettingsRepository } from "./db/repositories/settings.js";
+import { AppKeysRepository } from "./db/repositories/app-keys.js";
+import { AppKeyInjector } from "./app-keys/injector.js";
 import { PoliciesRepository } from "./db/repositories/policies.js";
 import { WebChatRepository } from "./db/repositories/webchat.js";
 import { ActionExecutionsRepository } from "./db/repositories/action-executions.js";
@@ -248,6 +250,15 @@ async function main() {
     log.info("Seeded instance token from environment into database");
   }
   await hydrateInstanceToken(settingsRepo);
+
+  // App keys: guardian-entered values go live in process.env before any app
+  // code, action worker, or route can read them. Operator-set env always wins;
+  // the injector records those as overridden instead of clobbering.
+  const appKeysRepo = new AppKeysRepository(db);
+  const appKeyInjector = new AppKeyInjector();
+  for (const row of await appKeysRepo.listWithValues()) {
+    appKeyInjector.apply(row.name, row.value);
+  }
 
   const policiesRepo = new PoliciesRepository(db);
   const webchatRepo = new WebChatRepository(db);
@@ -1176,6 +1187,8 @@ async function main() {
       skillCatalog,
       db,
       settingsRepo,
+      appKeysRepo,
+      appKeyInjector,
       appRuntimeRepositories,
       sentinelLogRepo,
       actionExecutionsRepo,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -137,6 +137,7 @@ import {
   createAppActionsSubscriber,
   createNoopChannelMessageHook,
   createChannelMessageHookFromCatalog,
+  createChannelMessageHookReloader,
   registerAppActions,
 } from "./actions/app-actions-wiring.js";
 import type { ChannelMessageHook } from "./hooks/types.js";
@@ -1004,6 +1005,23 @@ async function main() {
   connectionRegistry.onUnlocked("talk", (connection) => {
     messageHook.registerConnection(connection.id, connection.service);
   });
+  // App-keys refreshes recreate this hook: it is instantiated once and held by
+  // the subscription closures above, so an env value captured in its module
+  // graph would otherwise outlive the key edit. The let-binding is the single
+  // handle — the onUnlocked callback reads it at call time, so a swap re-routes
+  // future unlocks, and register() on the fresh instance re-subscribes the
+  // already-unlocked connections via talkRouter.list().
+  const reloadChannelMessageHook = messageHandlerRegistered
+    ? createChannelMessageHookReloader({
+        catalog: appCatalog,
+        deps: { actionEngine, talkRouter, conversationSettings },
+        getCurrent: () => messageHook,
+        setCurrent: (hook) => {
+          messageHook = hook;
+        },
+        onSkip: (reason) => log.warn(reason),
+      })
+    : null;
 
   // Fold the legacy providerAccounts rows into the grant ledger
   // BEFORE load(), so rehydration re-materializes each provider grant exactly
@@ -1116,6 +1134,15 @@ async function main() {
     await actionEngine.restartWorkerWarmPool();
     await reloadLifecycleHooks("app-keys-change");
     await reloadTurnMiddlewareHooks("app-keys-change");
+    if (reloadChannelMessageHook) {
+      try {
+        await reloadChannelMessageHook();
+      } catch (err) {
+        log.warn("channel-message hook reload failed; keeping the previous instance", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   };
   const publicAccessState = new PublicAccessState();
   try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,6 +76,7 @@ import {
 } from "./actions/global-actions.js";
 import { ActionLoader } from "./actions/loader.js";
 import { ActionEngine } from "./actions/engine.js";
+import { bumpModuleEnvEpoch } from "./actions/module-loader.js";
 import { ActionWorkerCoordinator } from "./actions/action-subprocess.js";
 import { WorkerRpcServer } from "./actions/worker-rpc.js";
 import { setWorkerRpcInProcessDispatcher } from "./actions/worker-rpc-client.js";
@@ -853,8 +854,9 @@ async function main() {
     }
   }
   // App hooks discovered from the catalog share one load+report+subscribe
-  // ritual: (re)load on startup and on every catalog change (install/uninstall),
-  // clear this kind's prior failures, surface new ones as runtime status, and
+  // ritual: (re)load on startup, on every catalog change (install/uninstall),
+  // and on an app-keys change (the reload picks up the new environment), clear
+  // this kind's prior failures, surface new ones as runtime status, and
   // persist status on change. Each kind differs only in its loader and the
   // failure-source key it stamps. An empty chain is a pure passthrough.
   const registerCatalogHookLoad = async <F extends { appId: string; error: string }>(opts: {
@@ -862,8 +864,8 @@ async function main() {
     warnMessage: string;
     load: () => Promise<F[]>;
     failureSource: (failure: F) => string;
-  }): Promise<void> => {
-    const run = async (source: "startup" | "catalog-change") => {
+  }): Promise<(source: "catalog-change" | "app-keys-change") => Promise<void>> => {
+    const run = async (source: "startup" | "catalog-change" | "app-keys-change") => {
       const failures = await opts.load();
       runtimeStatusFailures.clearSources((failureSource) =>
         failureSource.startsWith(`${opts.sourcePrefix}:`),
@@ -874,7 +876,7 @@ async function main() {
           markAppFailed(opts.failureSource(failure), failure.appId, failure.error);
         }
       }
-      if (source === "catalog-change") {
+      if (source !== "startup") {
         try {
           await writeAppRuntimeStatus(refreshRuntimeAppStatus());
         } catch (err) {
@@ -890,9 +892,10 @@ async function main() {
     };
     Object.defineProperty(subscriber, "name", { value: `${opts.sourcePrefix}HookSubscriber` });
     appCatalog.subscribe(subscriber);
+    return run;
   };
 
-  await registerCatalogHookLoad({
+  const reloadLifecycleHooks = await registerCatalogHookLoad({
     sourcePrefix: "lifecycle",
     warnMessage: "some agent lifecycle hooks failed to initialize",
     load: () => lifecycleDispatcher.loadFromCatalog(appCatalog),
@@ -900,7 +903,7 @@ async function main() {
   });
 
   // Turn-middleware artifacts load alongside the lifecycle hooks.
-  await registerCatalogHookLoad({
+  const reloadTurnMiddlewareHooks = await registerCatalogHookLoad({
     sourcePrefix: "turn-middleware",
     warnMessage: "some turn-middleware hooks failed to initialize",
     load: () => turnMiddlewareChain.loadFromCatalog(appCatalog),
@@ -1101,6 +1104,19 @@ async function main() {
   appCatalog.subscribe(async function actionWorkerWarmPoolInvalidator() {
     await actionEngine.restartWorkerWarmPool();
   });
+  // An app-keys change edits process.env after app code may have captured it:
+  // warm workers hold a fork-time env snapshot, and main-process app modules
+  // (API handlers via AppApiDispatcher, hook chains) can read env at module
+  // scope and stay cached — the import cache key is file identity, which an
+  // env change never touches. Salt the cache (so every later import
+  // re-evaluates), recycle the workers, and reload the hook chains, in that
+  // order — a reload before the bump would reinstall the stale modules.
+  const refreshAppRuntimeEnv = async (): Promise<void> => {
+    bumpModuleEnvEpoch();
+    await actionEngine.restartWorkerWarmPool();
+    await reloadLifecycleHooks("app-keys-change");
+    await reloadTurnMiddlewareHooks("app-keys-change");
+  };
   const publicAccessState = new PublicAccessState();
   try {
     await publicAccessState.load(db);
@@ -1189,6 +1205,7 @@ async function main() {
       settingsRepo,
       appKeysRepo,
       appKeyInjector,
+      refreshAppRuntime: refreshAppRuntimeEnv,
       appRuntimeRepositories,
       sentinelLogRepo,
       actionExecutionsRepo,

--- a/packages/core/src/test/helpers.ts
+++ b/packages/core/src/test/helpers.ts
@@ -556,6 +556,9 @@ export async function buildTestDeps(
     settingsRepo,
     appKeysRepo,
     appKeyInjector,
+    // Production's refresh also salts the module cache and reloads hook
+    // chains; the deps bag has neither, so mirror the worker-pool slice.
+    refreshAppRuntime: () => actionEngine.restartWorkerWarmPool(),
     appRuntimeRepositories,
     policiesRepo,
     webchatRepo,

--- a/packages/core/src/test/helpers.ts
+++ b/packages/core/src/test/helpers.ts
@@ -57,6 +57,8 @@ import { createAccountNames } from "../channels/account-names.js";
 import { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
 import { ApprovalsRepository } from "../db/repositories/approvals.js";
 import { SettingsRepository } from "../db/repositories/settings.js";
+import { AppKeysRepository } from "../db/repositories/app-keys.js";
+import { AppKeyInjector } from "../app-keys/injector.js";
 import { PoliciesRepository } from "../db/repositories/policies.js";
 import { WebChatRepository } from "../db/repositories/webchat.js";
 import { ActionExecutionsRepository } from "../db/repositories/action-executions.js";
@@ -385,6 +387,10 @@ export async function buildTestDeps(
   });
   const approvalsRepo = new ApprovalsRepository(db);
   const settingsRepo = new SettingsRepository(db);
+  // A private env object per deps bag: route tests exercise apply/remove
+  // without touching the real process.env of the test runner.
+  const appKeysRepo = new AppKeysRepository(db);
+  const appKeyInjector = new AppKeyInjector({});
   const policiesRepo = new PoliciesRepository(db);
   const webchatRepo = new WebChatRepository(db);
   const appRuntimeRepositories = createAppRuntimeRepositories({ settingsRepo, webchatRepo });
@@ -548,6 +554,8 @@ export async function buildTestDeps(
     approvalHandler,
     backendTurnRunner,
     settingsRepo,
+    appKeysRepo,
+    appKeyInjector,
     appRuntimeRepositories,
     policiesRepo,
     webchatRepo,

--- a/packages/web/mock/handlers/app-keys.ts
+++ b/packages/web/mock/handlers/app-keys.ts
@@ -1,0 +1,60 @@
+import {
+  APP_KEY_MAX_VALUE_LENGTH,
+  type AppKeyDto,
+  appKeyNameError,
+} from "@rome/api-types/app-keys";
+import { http, HttpResponse } from "msw";
+
+// App keys fixtures. Name validation is imported, not restated — the mock
+// rejects exactly the names core rejects. `overridden` is data here: the mock
+// has no process environment, so every stored key reads as live.
+const store = new Map<string, { label: string; updatedAt: string }>([
+  [
+    "DEMO_API_KEY",
+    { label: "Demo service API key", updatedAt: new Date(Date.now() - 3600_000).toISOString() },
+  ],
+]);
+
+function list(): AppKeyDto[] {
+  return [...store.entries()]
+    .map(([name, entry]) => ({
+      name,
+      label: entry.label,
+      updatedAt: entry.updatedAt,
+      overridden: false,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export const appKeysHandlers = [
+  http.get("/api/app-keys", () => HttpResponse.json({ keys: list() })),
+
+  http.put("/api/app-keys/:name", async ({ params, request }) => {
+    const name = String(params.name);
+    const nameError = appKeyNameError(name);
+    if (nameError) return HttpResponse.json({ error: nameError }, { status: 400 });
+
+    const body = (await request.json().catch(() => ({}))) as { label?: unknown; value?: unknown };
+    if (typeof body.value !== "string" || body.value.length === 0) {
+      return HttpResponse.json({ error: "Value is required." }, { status: 400 });
+    }
+    if (body.value.length > APP_KEY_MAX_VALUE_LENGTH) {
+      return HttpResponse.json(
+        { error: `Value must be at most ${APP_KEY_MAX_VALUE_LENGTH} characters.` },
+        { status: 400 },
+      );
+    }
+    const label = typeof body.label === "string" && body.label.trim() ? body.label.trim() : name;
+    store.set(name, { label, updatedAt: new Date().toISOString() });
+    return HttpResponse.json({ ok: true, overridden: false });
+  }),
+
+  http.delete("/api/app-keys/:name", ({ params }) => {
+    const name = String(params.name);
+    if (!store.has(name)) {
+      return HttpResponse.json({ error: "Unknown app key." }, { status: 404 });
+    }
+    store.delete(name);
+    return HttpResponse.json({ ok: true });
+  }),
+];

--- a/packages/web/mock/handlers/index.ts
+++ b/packages/web/mock/handlers/index.ts
@@ -46,6 +46,7 @@ import type {
 import type { FileBrowserTreeNode } from "@/lib/file-browser-tree";
 import { activityHandlers, approvalCardId } from "./activity";
 import { appHandlers } from "./apps";
+import { appKeysHandlers } from "./app-keys";
 import { connections } from "./connections-store";
 import { peopleHandlers } from "./people";
 import { proposedPeopleHandlers } from "./people-proposed";
@@ -1301,4 +1302,5 @@ export const handlers = [
   ...proposedPeopleHandlers,
   ...routineHandlers,
   ...settingsHandlers,
+  ...appKeysHandlers,
 ];

--- a/packages/web/src/components/connections/app-keys-section.tsx
+++ b/packages/web/src/components/connections/app-keys-section.tsx
@@ -1,0 +1,251 @@
+import { appKeyNameError } from "@rome/api-types/app-keys";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CircleAlert, KeyRound, Plus, RefreshCw } from "lucide-react";
+import { useId, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EmptyState, EmptyStateIcon, EmptyStateTitle } from "@/components/ui/empty-state";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { RomeConfirmDialog } from "@/components/rome-confirm-dialog";
+import { type AppKeyDto, deleteAppKey, fetchAppKeys, saveAppKey } from "@/lib/app-keys-api";
+
+const QUERY_KEY = ["app-keys"];
+
+/** Blank form for "add"; prefilled name+label (value always retyped) for
+ * "replace". The value is write-only end to end: the API never returns it, so
+ * the form never has anything to show back. */
+type FormState = { mode: "add" } | { mode: "replace"; name: string; label: string };
+
+export function AppKeysSection() {
+  const { t } = useTranslation("settings");
+  const uid = useId();
+  const queryClient = useQueryClient();
+  const keysQuery = useQuery({ queryKey: QUERY_KEY, queryFn: fetchAppKeys });
+
+  const [form, setForm] = useState<FormState | null>(null);
+  const [label, setLabel] = useState("");
+  const [name, setName] = useState("");
+  const [value, setValue] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<AppKeyDto | null>(null);
+
+  const openForm = (next: FormState) => {
+    setForm(next);
+    setLabel(next.mode === "replace" ? next.label : "");
+    setName(next.mode === "replace" ? next.name : "");
+    setValue("");
+    setFormError(null);
+  };
+  const closeForm = () => {
+    setForm(null);
+    setValue("");
+    setFormError(null);
+  };
+
+  const saveMutation = useMutation({
+    mutationFn: saveAppKey,
+    onSuccess: async (result, input) => {
+      closeForm();
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      if (result.overridden) {
+        toast.warning(t("appKeys.savedOverridden"));
+      } else {
+        toast.success(t("appKeys.saved", { name: input.name }));
+      }
+    },
+    onError: (error: Error) => setFormError(error.message),
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: deleteAppKey,
+    onSuccess: async (_result, removedName) => {
+      setRemoving(null);
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      toast.success(t("appKeys.removed", { name: removedName }));
+    },
+    onError: (error: Error) => {
+      setRemoving(null);
+      toast.error(error.message);
+    },
+  });
+
+  const submit = () => {
+    const trimmedName = name.trim();
+    const nameError = appKeyNameError(trimmedName);
+    if (nameError) {
+      setFormError(nameError);
+      return;
+    }
+    if (!value) {
+      setFormError(t("appKeys.form.valueRequired"));
+      return;
+    }
+    saveMutation.mutate({ name: trimmedName, label: label.trim() || trimmedName, value });
+  };
+
+  const keys = keysQuery.data ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-title text-foreground">{t("appKeys.title")}</h2>
+          <p className="mt-1 text-body text-muted-foreground">{t("appKeys.subtitle")}</p>
+        </div>
+        {form === null && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => openForm({ mode: "add" })}
+          >
+            <Plus aria-hidden />
+            {t("appKeys.add")}
+          </Button>
+        )}
+      </div>
+
+      {keysQuery.isLoading ? (
+        <div className="flex flex-col gap-2" role="status" aria-label={t("appKeys.loading")}>
+          {[0, 1].map((index) => (
+            <Skeleton key={index} className="h-14 w-full" />
+          ))}
+        </div>
+      ) : keysQuery.isError ? (
+        <Alert variant="destructive">
+          <CircleAlert aria-hidden />
+          <AlertTitle>{t("appKeys.errorTitle")}</AlertTitle>
+          <AlertDescription>
+            <p>{keysQuery.error.message}</p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-3"
+              onClick={() => void keysQuery.refetch()}
+            >
+              <RefreshCw aria-hidden />
+              {t("page.retry")}
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : keys.length === 0 && form === null ? (
+        <EmptyState className="rounded-8 border border-dashed border-border bg-surface/50">
+          <EmptyStateIcon>
+            <KeyRound aria-hidden />
+          </EmptyStateIcon>
+          <EmptyStateTitle>{t("appKeys.emptyTitle")}</EmptyStateTitle>
+          <p className="text-body text-muted-foreground">{t("appKeys.emptyBody")}</p>
+        </EmptyState>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {keys.map((key) => (
+            <li
+              key={key.name}
+              className="flex items-center justify-between gap-3 rounded-8 border border-border bg-surface px-4 py-3"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-ui text-foreground">{key.label}</p>
+                <p className="truncate font-mono text-body text-muted-foreground">{key.name}</p>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                {key.overridden ? (
+                  <Badge variant="warning" title={t("appKeys.overriddenHint")}>
+                    {t("appKeys.overridden")}
+                  </Badge>
+                ) : (
+                  <Badge variant="success">{t("appKeys.set")}</Badge>
+                )}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => openForm({ mode: "replace", name: key.name, label: key.label })}
+                >
+                  {t("appKeys.replace")}
+                </Button>
+                <Button type="button" variant="outline" size="sm" onClick={() => setRemoving(key)}>
+                  {t("appKeys.remove")}
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {form !== null && (
+        <form
+          className="space-y-4 rounded-8 border border-border bg-surface p-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            submit();
+          }}
+        >
+          <Field>
+            <FieldLabel htmlFor={`${uid}-app-key-label`}>{t("appKeys.form.labelField")}</FieldLabel>
+            <Input
+              id={`${uid}-app-key-label`}
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder={t("appKeys.form.labelPlaceholder")}
+              className="w-full"
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={`${uid}-app-key-name`}>{t("appKeys.form.nameField")}</FieldLabel>
+            <Input
+              id={`${uid}-app-key-name`}
+              value={name}
+              onChange={(e) => setName(e.target.value.toUpperCase())}
+              placeholder={t("appKeys.form.namePlaceholder")}
+              disabled={form.mode === "replace"}
+              className="w-full font-mono"
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={`${uid}-app-key-value`}>{t("appKeys.form.valueField")}</FieldLabel>
+            <Input
+              id={`${uid}-app-key-value`}
+              type="password"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              autoComplete="off"
+              className="w-full"
+            />
+            <p className="mt-1 text-body text-muted-foreground">{t("appKeys.form.valueHint")}</p>
+          </Field>
+          {formError && <p className="text-body text-destructive">{formError}</p>}
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-body text-muted-foreground">{t("appKeys.form.consent")}</p>
+            <div className="flex shrink-0 gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={closeForm}>
+                {t("appKeys.form.cancel")}
+              </Button>
+              <Button type="submit" size="sm" disabled={saveMutation.isPending}>
+                {saveMutation.isPending ? t("appKeys.form.saving") : t("appKeys.form.save")}
+              </Button>
+            </div>
+          </div>
+        </form>
+      )}
+
+      <RomeConfirmDialog
+        open={removing !== null}
+        title={t("appKeys.removeTitle", { name: removing?.name ?? "" })}
+        description={t("appKeys.removeBody")}
+        destructive
+        confirmLabel={t("appKeys.remove")}
+        confirmDisabled={removeMutation.isPending}
+        onConfirm={() => {
+          if (removing) removeMutation.mutate(removing.name);
+        }}
+        onCancel={() => setRemoving(null)}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/i18n/locales/en/settings.json
+++ b/packages/web/src/i18n/locales/en/settings.json
@@ -203,6 +203,38 @@
       }
     }
   },
+  "appKeys": {
+    "title": "App keys",
+    "subtitle": "Passwords and API keys that apps on your Rome can use.",
+    "loading": "Loading app keys",
+    "errorTitle": "App keys couldn't be loaded",
+    "emptyTitle": "No app keys yet",
+    "emptyBody": "Add a key when an app asks for one — like a database password or an API key.",
+    "add": "Add key",
+    "set": "Set",
+    "overridden": "Overridden by server settings",
+    "overriddenHint": "A server environment variable with this name takes precedence, so this stored value is not used.",
+    "replace": "Replace",
+    "remove": "Remove",
+    "removeTitle": "Remove {{name}}?",
+    "removeBody": "Apps will no longer be able to read this value. This can't be undone.",
+    "form": {
+      "labelField": "What is this key for?",
+      "labelPlaceholder": "e.g. My shop database password",
+      "nameField": "Name apps use",
+      "namePlaceholder": "e.g. SHOP_DB_PASSWORD",
+      "valueField": "Secret value",
+      "valueHint": "Rome keeps this hidden after you save it. To change it later, you'll retype it.",
+      "valueRequired": "Enter the secret value.",
+      "consent": "Any app installed on your Rome will be able to read this.",
+      "save": "Save for all apps",
+      "saving": "Saving…",
+      "cancel": "Cancel"
+    },
+    "saved": "Saved. Apps can now read {{name}}.",
+    "savedOverridden": "Saved, but a server setting with the same name takes precedence — the value you entered is not in use.",
+    "removed": "Removed {{name}}."
+  },
   "trust": {
     "title": "Bond Level Rules",
     "trustedLevels": {

--- a/packages/web/src/i18n/locales/zh-CN/settings.json
+++ b/packages/web/src/i18n/locales/zh-CN/settings.json
@@ -203,6 +203,38 @@
       }
     }
   },
+  "appKeys": {
+    "title": "应用密钥",
+    "subtitle": "供你 Rome 上的应用使用的密码和 API 密钥。",
+    "loading": "正在加载应用密钥",
+    "errorTitle": "应用密钥加载失败",
+    "emptyTitle": "还没有应用密钥",
+    "emptyBody": "当应用需要时再添加密钥——例如数据库密码或 API 密钥。",
+    "add": "添加密钥",
+    "set": "已设置",
+    "overridden": "已被服务器设置覆盖",
+    "overriddenHint": "存在同名的服务器环境变量并优先生效，此处保存的值不会被使用。",
+    "replace": "替换",
+    "remove": "移除",
+    "removeTitle": "移除 {{name}}？",
+    "removeBody": "应用将无法再读取该值。此操作无法撤销。",
+    "form": {
+      "labelField": "这个密钥是做什么用的？",
+      "labelPlaceholder": "例如：我的商店数据库密码",
+      "nameField": "应用读取的名称",
+      "namePlaceholder": "例如：SHOP_DB_PASSWORD",
+      "valueField": "秘密值",
+      "valueHint": "保存后 Rome 会一直隐藏它。以后修改时需要重新输入。",
+      "valueRequired": "请输入秘密值。",
+      "consent": "安装在你 Rome 上的任何应用都能读取它。",
+      "save": "对所有应用保存",
+      "saving": "保存中…",
+      "cancel": "取消"
+    },
+    "saved": "已保存。应用现在可以读取 {{name}}。",
+    "savedOverridden": "已保存，但存在同名的服务器设置并优先生效——你输入的值不会被使用。",
+    "removed": "已移除 {{name}}。"
+  },
   "trust": {
     "title": "关系层级规则",
     "trustedLevels": {

--- a/packages/web/src/lib/app-keys-api.ts
+++ b/packages/web/src/lib/app-keys-api.ts
@@ -1,0 +1,33 @@
+import type { AppKeyDto, AppKeysListResponse } from "@rome/api-types/app-keys";
+import { fetchJson } from "@/lib/fetch-json";
+
+export type { AppKeyDto };
+
+export async function fetchAppKeys(): Promise<AppKeyDto[]> {
+  const payload = await fetchJson<AppKeysListResponse>("/api/app-keys", {
+    fallback: "Failed to load app keys.",
+  });
+  return Array.isArray(payload.keys) ? payload.keys : [];
+}
+
+export async function saveAppKey(input: {
+  name: string;
+  label: string;
+  value: string;
+}): Promise<{ overridden: boolean }> {
+  return await fetchJson<{ ok: boolean; overridden: boolean }>(
+    `/api/app-keys/${encodeURIComponent(input.name)}`,
+    {
+      method: "PUT",
+      json: { label: input.label, value: input.value },
+      fallback: "Failed to save app key.",
+    },
+  );
+}
+
+export async function deleteAppKey(name: string): Promise<void> {
+  await fetchJson<{ ok: boolean }>(`/api/app-keys/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+    fallback: "Failed to remove app key.",
+  });
+}

--- a/packages/web/src/pages/SettingsTabPage.app-keys.test.tsx
+++ b/packages/web/src/pages/SettingsTabPage.app-keys.test.tsx
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import i18n from "@/i18n";
+import SettingsPage from "./SettingsTabPage";
+
+// The Toaster mounts in App.tsx, outside this tree — spy on the calls instead.
+vi.mock("sonner", () => ({
+  toast: Object.assign(
+    vi.fn(() => "toast-id"),
+    {
+      success: vi.fn(),
+      warning: vi.fn(),
+      error: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  ),
+}));
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function ok(json: unknown): Response {
+  return new Response(JSON.stringify(json), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface AppKeysCall {
+  method: string;
+  url: string;
+  body: unknown;
+}
+
+function mockAppKeysFetch(
+  loadKeys: () => Response | Promise<Response>,
+  onWrite?: (call: AppKeysCall) => Response | Promise<Response>,
+): AppKeysCall[] {
+  const writes: AppKeysCall[] = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation((async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    if (url === "/api/settings") return ok({});
+    if (url === "/api/tailscale/devices") {
+      return ok({ mode: "oauth", configured: false, devices: [] });
+    }
+    if (url === "/api/integrations/composio/status") return ok({});
+    if (url === "/api/connections") return ok({ connections: [] });
+    if (url.startsWith("/api/app-keys")) {
+      if (method === "GET") return loadKeys();
+      const call: AppKeysCall = {
+        method,
+        url,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      };
+      writes.push(call);
+      if (onWrite) return onWrite(call);
+      return ok({ ok: true, overridden: false });
+    }
+    return ok({});
+  }) as typeof fetch);
+  return writes;
+}
+
+function renderConnectionsSettings() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/settings/connections"]}>
+        <Routes>
+          <Route path="/settings/:tab" element={<SettingsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const storedKey = {
+  name: "SHOP_DB_PASSWORD",
+  label: "My shop database password",
+  updatedAt: "2026-08-27T00:00:00.000Z",
+  overridden: false,
+};
+
+describe("Settings app keys section", () => {
+  it("lists stored keys with label, name, and a Set badge — never the value", async () => {
+    mockAppKeysFetch(() => ok({ keys: [storedKey] }));
+
+    renderConnectionsSettings();
+
+    expect(await screen.findByRole("heading", { level: 2, name: "App keys" })).toBeTruthy();
+    expect(await screen.findByText("My shop database password")).toBeTruthy();
+    expect(screen.getByText("SHOP_DB_PASSWORD")).toBeTruthy();
+    expect(screen.getByText("Set")).toBeTruthy();
+  });
+
+  it("shows the empty state when no keys exist", async () => {
+    mockAppKeysFetch(() => ok({ keys: [] }));
+
+    renderConnectionsSettings();
+
+    expect(await screen.findByText("No app keys yet")).toBeTruthy();
+  });
+
+  it("saves a new key through the add form with the all-apps consent visible", async () => {
+    const writes = mockAppKeysFetch(() => ok({ keys: [] }));
+
+    renderConnectionsSettings();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Add key" }));
+
+    expect(
+      screen.getByText("Any app installed on your Rome will be able to read this."),
+    ).toBeTruthy();
+
+    await userEvent.type(
+      screen.getByLabelText("What is this key for?"),
+      "My shop database password",
+    );
+    await userEvent.type(screen.getByLabelText("Name apps use"), "shop_db_password");
+    await userEvent.type(screen.getByLabelText("Secret value"), "hunter2");
+    await userEvent.click(screen.getByRole("button", { name: "Save for all apps" }));
+
+    const { toast } = await import("sonner");
+    await vi.waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("Saved. Apps can now read SHOP_DB_PASSWORD."),
+    );
+    expect(writes).toHaveLength(1);
+    // The name input upcases as the user types.
+    expect(writes[0].url).toBe("/api/app-keys/SHOP_DB_PASSWORD");
+    expect(writes[0].method).toBe("PUT");
+    expect(writes[0].body).toEqual({
+      label: "My shop database password",
+      value: "hunter2",
+    });
+  });
+
+  it("rejects a reserved name client-side without calling the API", async () => {
+    const writes = mockAppKeysFetch(() => ok({ keys: [] }));
+
+    renderConnectionsSettings();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Add key" }));
+    await userEvent.type(screen.getByLabelText("Name apps use"), "ROME_PROFILE");
+    await userEvent.type(screen.getByLabelText("Secret value"), "v");
+    await userEvent.click(screen.getByRole("button", { name: "Save for all apps" }));
+
+    expect(
+      await screen.findByText(
+        "Names starting with ROME_ are reserved by Rome. Pick a different name.",
+      ),
+    ).toBeTruthy();
+    expect(writes).toHaveLength(0);
+  });
+
+  it("removes a key after confirmation", async () => {
+    const writes = mockAppKeysFetch(
+      () => ok({ keys: [storedKey] }),
+      () => ok({ ok: true }),
+    );
+
+    renderConnectionsSettings();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Remove" }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Remove SHOP_DB_PASSWORD?")).toBeTruthy();
+    await userEvent.click(within(dialog).getByRole("button", { name: "Remove" }));
+
+    const { toast } = await import("sonner");
+    await vi.waitFor(() => expect(toast.success).toHaveBeenCalledWith("Removed SHOP_DB_PASSWORD."));
+    expect(writes).toHaveLength(1);
+    expect(writes[0].method).toBe("DELETE");
+    expect(writes[0].url).toBe("/api/app-keys/SHOP_DB_PASSWORD");
+  });
+
+  it("marks an operator-overridden key and warns on save", async () => {
+    mockAppKeysFetch(
+      () => ok({ keys: [{ ...storedKey, overridden: true }] }),
+      () => ok({ ok: true, overridden: true }),
+    );
+
+    renderConnectionsSettings();
+
+    expect(await screen.findByText("Overridden by server settings")).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: "Replace" }));
+    // Replace locks the name and only asks for a new value.
+    expect((screen.getByLabelText("Name apps use") as HTMLInputElement).disabled).toBe(true);
+    await userEvent.type(screen.getByLabelText("Secret value"), "new-secret");
+    await userEvent.click(screen.getByRole("button", { name: "Save for all apps" }));
+
+    const { toast } = await import("sonner");
+    await vi.waitFor(() =>
+      expect(toast.warning).toHaveBeenCalledWith(
+        "Saved, but a server setting with the same name takes precedence — the value you entered is not in use.",
+      ),
+    );
+  });
+});

--- a/packages/web/src/pages/SettingsTabPage.tsx
+++ b/packages/web/src/pages/SettingsTabPage.tsx
@@ -78,6 +78,7 @@ import {
   advanceAdvancedEasterEggSequence,
 } from "@/lib/advanced-easter-egg";
 import { ConnectionsSection } from "@/components/ConnectionsSection";
+import { AppKeysSection } from "@/components/connections/app-keys-section";
 import { ChannelsSettingsPage } from "@/components/channels/channels-settings-page";
 import { AiToolsPanel } from "@/components/ai-tools-panel";
 import { SystemUpgradeSection } from "@/components/system-upgrade-section";
@@ -407,15 +408,18 @@ export default function SettingsPage() {
             <>
               {activeTab === "Appearance" && <AppearanceSection />}
               {activeTab === "Connections" && (
-                <ConnectionsSection
-                  connections={connections}
-                  composio={composio}
-                  loading={connectionsLoading}
-                  error={connectionsError}
-                  onRetry={loadConnections}
-                  onRefresh={loadConnections}
-                  onFlash={(message) => toast.error(message)}
-                />
+                <>
+                  <ConnectionsSection
+                    connections={connections}
+                    composio={composio}
+                    loading={connectionsLoading}
+                    error={connectionsError}
+                    onRetry={loadConnections}
+                    onRefresh={loadConnections}
+                    onFlash={(message) => toast.error(message)}
+                  />
+                  <AppKeysSection />
+                </>
               )}
               {activeTab === "Channels" && <ChannelsSettingsPage />}
               {activeTab === "Favors" && <FavorsSection />}

--- a/rome_apps/inbox/src/hooks/channel-message/channel-message.test.ts
+++ b/rome_apps/inbox/src/hooks/channel-message/channel-message.test.ts
@@ -235,4 +235,17 @@ describe("ChannelMessageHook", () => {
       expect.objectContaining({ channel: "whatsapp", connectionId: WHATSAPP_ID }),
     );
   });
+
+  it("unregister detaches every subscription and a fresh register resubscribes", async () => {
+    harness.hook.unregister();
+
+    await expect(harness.emit(TELEGRAM_ID, message())).rejects.toThrow("no subscription");
+    await expect(harness.emit(WHATSAPP_ID, message())).rejects.toThrow("no subscription");
+
+    // The host swaps in a replacement after an app-keys change; register() on
+    // the (here: same) instance must resubscribe everything talkRouter lists.
+    await harness.hook.register();
+    await harness.emit(TELEGRAM_ID, message({ text: "after reload" }));
+    expect(harness.run).toHaveBeenCalledTimes(1);
+  });
 });

--- a/rome_apps/inbox/src/hooks/channel-message/index.ts
+++ b/rome_apps/inbox/src/hooks/channel-message/index.ts
@@ -32,6 +32,13 @@ export class ChannelMessageHook implements ChannelMessageHookInterface {
     this.subscriptions.set(connectionId, unsubscribe);
   }
 
+  unregister(): void {
+    for (const unsubscribe of this.subscriptions.values()) {
+      unsubscribe();
+    }
+    this.subscriptions.clear();
+  }
+
   private async handleMessage(
     connectionId: string,
     service: string,


### PR DESCRIPTION
## What this PR does

Apps read their configuration from the Rome process environment (`TAELOR_DB_*`, `ROME_SLACK_TOKEN_FILE`, …), but a Rome user has no way to put a value there: users don't edit env files, and the in-Rome coding agent rightly refuses to read a credentials file on their behalf. Any app that needs a per-user secret — a database password, an API key — was stuck.

App keys close that gap. A guardian enters named values in **Settings → Connections → App keys**; core stores them in the instance DB (`app_keys`) and injects them into `process.env` at boot and on every save, so app routes, actions, and workers read them exactly the way they already read operator env.

## Design & Invariants

- **Values are write-only through the API.** The read surface returns names, labels, and an `overridden` flag — never values. Replacing a value means retyping it. The dashboard renders a "Set" badge, not the secret.
- **The real process environment always wins.** A name that already had a value at injection time is never overwritten; it is reported as `overridden` in the API and badged in the UI. Operator config (env files, container env, CI) cannot be shadowed from the dashboard, and removing a stored key can never unset an operator-set variable (the injector only deletes names it set itself).
- **Reserved names are refused, and the rule lives in one place.** `@rome/api-types/app-keys` carries the name grammar and the platform denylist (`ROME_*`, `NODE_*`, `DATABASE_*`, `PATH`, …— every prefix family `config.ts` consumes plus ambient OS names), imported by core's route, the web form, and the mock handler, so all three reject exactly the same names.
- **Guardian-only by construction.** The route group mounts under `/api` and is absent from the public-path allowlist in `auth.ts`, so the edge `forward_auth` gate applies as with every other private route.
- **No new leak into agent transcripts.** The in-Rome coding agent (codex app-server) is spawned with the `CODEX_ENV_ALLOWLIST` minimal env, which excludes stored keys by construction. Action workers inherit the full env deliberately — that is the delivery mechanism for apps.
- The saving moment carries the consent: the form states "Any app installed on your Rome will be able to read this." and the submit button reads "Save for all apps". Trust is all-apps-or-nothing by design (single process, single tenant); scoping is future work, below.

## Test plan

- [x] `pnpm --filter @rome/api-types typecheck`, `pnpm --filter @rome/core typecheck` clean; `rome-web` typecheck fails only with the known host-only implicit-any noise in six pre-existing files (none touched here, green in CI)
- [x] `pnpm test:unit` — full suite green (core 4080, web 1172, ui 528, rest 153), including new tests: reserved-name guard, injector precedence/ownership, repository CRUD, route CRUD + validation + no-value-leak, and six jsdom tests for the settings section
- [x] Browser (mock mode, playwright): 18/18 checks — list with Set badge, add form with consent line and password input, reserved-name rejection, lowercase→uppercase name input, save lands in list with success toast, secret never rendered in the DOM, confirm-dialog remove, dark mode render
- [x] Live backend (scratch-profile host run, `ROME_PROFILE=appkeys-scratch pnpm start`): boot reaches `Rome started`; loopback CRUD on `/api/app-keys` (create, list, reserved/malformed 400s, sqlite row present); second boot re-hydrates the stored key from the DB and serves it
- [ ] `pnpm dev:all` container validation — not run: the live `rome-rome-1` container holds `:80` on this machine, so the containerized loop was substituted with the host-run validation above

## Not in this PR

- App-declared key manifests (`app.yaml` listing needed keys with human labels), which would pre-fill the form at install time and let the UI truthfully show "requested by <app>" — the friendliest flow for non-technical users; the schema here doesn't change for it.
- Per-app read scoping or a brokered-use surface (e.g. a `db_query` action that spends a credential host-side) for secrets that should never enter app code; the connections/grants model is the natural home.
- Scrubbing stored keys from the remaining full-env spawn sites (`opencli`, `composio`, `gh`, tailscale helpers) — fixed-argument commands, not agent shells; the agent-shell path is already allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)