### PR TITLE
fix(ui): give ghost and outline buttons a resting text color

### DIFF
--- a/packages/ui/src/button-group.tsx
+++ b/packages/ui/src/button-group.tsx
@@ -50,7 +50,7 @@ function ButtonGroupText({
   return (
     <Comp
       className={cn(
-        "flex items-center gap-2 rounded-8 border bg-muted px-2 text-ui [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "flex items-center gap-2 rounded-8 border bg-muted px-2 text-ui text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -29,14 +29,21 @@ const buttonVariants = cva(
   "group/button inline-flex shrink-0 items-center justify-center border border-transparent text-ui whitespace-nowrap transition-all outline-none select-none focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:outline-solid aria-invalid:outline-2 aria-invalid:outline-offset-0 aria-invalid:outline-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
+      // `outline` and `ghost` name their resting foreground, which the page
+      // would otherwise supply by inheritance — so inside a status-colored card
+      // the label stayed neutral only by accident. Naming it makes the `hover:`
+      // and `aria-expanded:` promotions below look dead, and they are not: a
+      // caller that de-emphasizes the control writes a bare
+      // `text-muted-foreground`, which lands in a different tailwind-merge group
+      // than the prefixed ones, so the promotion still fires.
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/80",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border-border bg-background text-foreground hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "text-foreground hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:outline-destructive dark:bg-destructive/20 dark:hover:bg-destructive/30",
         link: "text-primary underline-offset-4 hover:underline",

--- a/packages/web/src/components/AppInstallConfirm.tsx
+++ b/packages/web/src/components/AppInstallConfirm.tsx
@@ -188,15 +188,7 @@ export function AppInstallConfirm({
           <Button type="button" size="sm" onClick={() => void refresh()}>
             {t("listing.retry")}
           </Button>
-          {/* `outline` sets no text color, so inside these status-colored cards
-              it would inherit the card's tone; the label is neutral by intent. */}
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={onCancel}
-            className="text-foreground"
-          >
+          <Button type="button" variant="outline" size="sm" onClick={onCancel}>
             {t("install.cancel")}
           </Button>
         </div>
@@ -209,13 +201,7 @@ export function AppInstallConfirm({
       <EmptyState className="rounded-12 border border-dashed border-border bg-surface/50">
         <EmptyStateTitle>{data.reason ?? t("install.unavailable")}</EmptyStateTitle>
         <EmptyStateAction>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={onCancel}
-            className="text-foreground"
-          >
+          <Button type="button" variant="outline" size="sm" onClick={onCancel}>
             {t("install.cancel")}
           </Button>
         </EmptyStateAction>

--- a/packages/web/src/components/app-action-menu.tsx
+++ b/packages/web/src/components/app-action-menu.tsx
@@ -312,7 +312,7 @@ export function AppActionSheet({
                 size="icon-lg"
                 aria-label={closeLabel}
                 title={closeLabel}
-                className="rounded-full text-muted-foreground hover:bg-surface-muted hover:text-foreground dark:hover:bg-surface-muted"
+                className="rounded-full text-muted-foreground hover:bg-surface-muted dark:hover:bg-surface-muted"
               >
                 <X className="size-5" aria-hidden />
               </Button>

--- a/packages/web/src/components/chat/ChatComposer.tsx
+++ b/packages/web/src/components/chat/ChatComposer.tsx
@@ -813,7 +813,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
           Approve. Neutral throughout except the single Approve CTA. */}
       {designingInteraction?.onApprove && (
         <ButtonGroup className="mb-2 w-full rounded-12 shadow-card-hover">
-          <ButtonGroupText className="min-w-0 flex-1 gap-2 border-border bg-surface px-3 text-foreground">
+          <ButtonGroupText className="min-w-0 flex-1 gap-2 border-border bg-surface px-3">
             <Sparkles className="size-3.5 shrink-0 text-muted-foreground" />
             <span className="truncate">
               <span>{designingInteraction.agentLabel}</span> submitted a result — approve it, or

--- a/packages/web/src/components/file-browser/ContextMenu.tsx
+++ b/packages/web/src/components/file-browser/ContextMenu.tsx
@@ -312,7 +312,7 @@ export function FileActionSheet({
                 size="icon-lg"
                 aria-label={closeLabel}
                 title={closeLabel}
-                className="rounded-full text-muted-foreground hover:bg-surface-muted hover:text-foreground dark:hover:bg-surface-muted"
+                className="rounded-full text-muted-foreground hover:bg-surface-muted dark:hover:bg-surface-muted"
               >
                 <X className="size-5" aria-hidden />
               </Button>

--- a/packages/web/src/pages/SettingsTabPage.tsx
+++ b/packages/web/src/pages/SettingsTabPage.tsx
@@ -1493,7 +1493,7 @@ function AdvancedEasterEggOverlay({ onClose }: { onClose: () => void }) {
             size="icon-sm"
             onClick={onClose}
             aria-label={t("easterEgg.closeLabel")}
-            className="rounded-full border border-surface/10 text-subtle-foreground hover:border-surface/30 hover:bg-surface/5 hover:text-foreground"
+            className="rounded-full border border-surface/10 text-subtle-foreground hover:border-surface/30 hover:bg-surface/5"
           >
             <X aria-hidden />
           </Button>


### PR DESCRIPTION
## What this PR does

`Button`'s `outline` and `ghost` variants declared a hover text color and no resting one. Both promote to `text-foreground` on `hover:` and `aria-expanded:`, so at rest each control took whatever color its container carried. An outline button inside a status-colored card rendered in the card's tone. `ButtonGroupText` had the same hole, setting `bg-muted` with no paired foreground.

Callers closed it one site at a time. `AppInstallConfirm` carried a comment naming the cause and pinned `text-foreground` on two buttons to work around it.

All three now name their resting foreground, and six call-site patches come out.

## Design & Invariants

Every surface token in `packages/ui/src/styles.css` has a `-foreground` partner. A variant that sets a background sets the matching foreground. `outline` set `bg-background` and left the foreground half to inheritance, which is the hole this closes.

The `hover:text-foreground` and `aria-expanded:text-foreground` promotions stay. Beside an identical resting class they read as dead code, and they are not. A caller that de-emphasizes a control writes a bare `text-muted-foreground`, which lands in a different tailwind-merge group than the prefixed ones, so the promotion still fires. Eight call sites depend on that. A comment above the variant block carries the rule.

Five controls change appearance. Each one sits under a tone-bearing ancestor and took its color by inheritance:

| Site | Change |
|---|---|
| `agent-trace/AgentTrace.tsx:34` | red to neutral — an outline retry button inheriting `text-destructive` from its error row |
| `chat/Chat.tsx:1626` | muted to neutral — unarchive button in a muted banner |
| `pages/SessionsPage.tsx:810`, `:817` | muted to neutral — pagination buttons |
| `pages/SessionsPage.tsx:1096` | muted to neutral — ghost copy icon |

`text-muted-foreground` was the alternative resting value for `ghost`. The two promotions and all eight existing pins point that way, and it would retire thirteen call-site colors rather than six. It also repaints 29 ghost buttons that inherit `foreground` today. De-emphasis is a tone, orthogonal to shape, so it belongs on its own prop rather than baked into one variant.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 552 files, 5854 tests
- [x] `biome format --write` on the seven changed files
- [ ] Browser pass over the five controls listed above

## Not in this PR

- A `tone` prop for de-emphasis. Eight `text-muted-foreground` pins on `ghost` stay, as do `AvatarFallback`'s three `bg-primary/15 text-primary` pairs.
- Destructive tone on an outline shape (`pages/RoutinesPage.tsx:1053`), which needs the same prop. `variant` currently carries both shape and tone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
