### PR TITLE
fix(web): stop overriding the kit type role at two call sites

### DIFF
--- a/packages/web/src/components/language-switcher.tsx
+++ b/packages/web/src/components/language-switcher.tsx
@@ -28,7 +28,7 @@ export function LanguageSwitcher({ className = "" }: { className?: string }) {
           }
         }}
       >
-        <SelectTrigger size="sm" aria-label={t("language.label")} className="text-aux">
+        <SelectTrigger size="sm" aria-label={t("language.label")}>
           <SelectValue />
         </SelectTrigger>
         <SelectContent>

--- a/packages/web/src/shell/ProfileMenu.tsx
+++ b/packages/web/src/shell/ProfileMenu.tsx
@@ -78,7 +78,7 @@ export function ProfileMenu() {
           >
             <Avatar>
               {avatarUrl ? <AvatarImage src={avatarUrl} alt="" /> : null}
-              <AvatarFallback className="bg-primary/15 text-aux text-primary">
+              <AvatarFallback className="bg-primary/15 text-primary">
                 {initial || <UserRound className="size-4" aria-hidden />}
               </AvatarFallback>
             </Avatar>


### PR DESCRIPTION
## What this PR does

Two call sites in `packages/web` hand-patched a type role that the kit component beside them already owned.

`language-switcher.tsx` passed `className="text-aux"` to a `SelectTrigger`, pulling the value to 13px. `SelectTrigger` is a Control, and [`docs/ui/component-roles.md`](https://github.com/rome-os/rome/blob/main/docs/ui/component-roles.md) gives the role its typography: a role utility, never derived from the size step. `control-typography-roles.test.tsx` holds the sibling members to the same line — a `Button` at `sm` stays on `text-ui`, a `SegmentedControl` at either size stays on `text-ui`. The override was the one place a call site reached past that, so an `sm` select read a step below the `sm` button next to it.

`ProfileMenu.tsx` passed `text-aux` to an `AvatarFallback` at the 32px default size. `AvatarFallback` couples its own type role to the avatar size already: `text-ui` at `default`, `text-aux` at `sm`. The override fought a rule the component holds, and it contradicted itself — the same slot draws a 16px `UserRound` icon whenever the identity carries no initial.

Both fixes delete the override. Neither touches `packages/ui`, so no published package moves.

## Design & Invariants

The Control role owns the typography of its members. A caller picks a size, and the size does not carry a type role with it. A call site that reaches for `text-*` on a Control is the regression this PR removes, not a pattern to extend.

The first commit was scoped the other way at the start: teach `SelectTrigger` to set `data-[size=sm]:text-aux` and drop the caller override. Verification rejected that design. It writes a documented `[mech]` violation into a package that publishes to npm, and it breaks the size agreement the role exists for. The gallery specimen at `packages/web/src/pages/dev/gallery/sections/controls.tsx:253` puts an `Input`, a `Button`, and a `SelectTrigger` at `sm` in one row under the note "a mixed row needs no adjustment". Coupling the select's type role to its size makes it the only member of that row whose role moves, at 13px beside the button's 14px. `people-demo.tsx:576` and `TypographyPage.tsx:640` render the same pairing.

Geometry stays fixed in both changes. The trigger holds 28px, the avatar holds 32px, and the fallback icon holds 16px, so the `control-size-vocabulary` and `glyph-size` layout invariants see nothing move.

## Test plan

- [x] `pnpm typecheck` — clean across 29 workspaces.
- [x] `pnpm test:unit` — 5854 passed, 0 failed. `control-typography-roles.test.tsx` covers the rule this PR restores.
- [x] Language switcher, measured in Chromium against `pnpm start:web:mock` on `/login`: 13px/16px before, **14px/20px** after, trigger height 28px throughout.
- [x] Profile avatar initial, same method on `/chat`: 13px/16px before, **14px/20px** after, avatar 32px throughout.
- [x] Profile avatar with no initial, forced by a 401 on `/api/auth/me`: the `UserRound` icon renders at 16px in the 32px circle, unchanged.
- [x] Both surfaces read correctly against their neighbours — the switcher against the sign-in card, the initial against the two sibling avatars in Settings.
- [ ] `pnpm dev:all` and `Rome started` in `docker logs`. This account is outside the `docker` group and `sudo` wants a password, so the container boot is unverified. Both changes are `className` edits in `packages/web` with no backend surface.

## Not in this PR

- `Avatar`'s `size` prop (`default | sm | lg`) has one caller in the repo, a docs demo at `pages/dev/mdx/docs/people-demo.tsx:556`, while four real call sites size the avatar with `className="size-9"`. Tracked separately.
- The missing `tone` prop on `AvatarFallback`. `bg-primary/15 text-primary` stays at all three call sites that want it. The `text-aux` this PR deletes was the only thing making that slot disagree with its own icon, which is more evidence the tone pair belongs on the component.
- The container check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
