### PR TITLE
feat(core): define the Accounts and Messages channel interfaces

### DIFF
--- a/packages/core/src/channels/account-names.test.ts
+++ b/packages/core/src/channels/account-names.test.ts
@@ -117,7 +117,12 @@ describe("AccountNames", () => {
     const matrix = {
       resolve: async (identifier: string) =>
         identifier === "@ada:matrix.org"
-          ? { id: identifier as AccountId, name: "Ada on Matrix", identifiers: {} }
+          ? {
+              id: identifier as AccountId,
+              addresses: [identifier],
+              name: "Ada on Matrix",
+              identifiers: {},
+            }
           : null,
     };
     const withMatrix = new AccountNames({ matrix }, { listLatestDisplayNames: async () => [] });

--- a/packages/core/src/channels/accounts.ts
+++ b/packages/core/src/channels/accounts.ts
@@ -4,21 +4,9 @@
  * channel can reach, and which of the identifiers a channel hands out name one
  * and the same account.
  *
- * The four invariants below are the contract. The types cannot carry them, and
- * every implementation owes all four:
- *
- * - **I1 Uniqueness.** Exactly one {@link Account} per real account. The same
- *   `id` means the same account. Callers never fold aliases themselves.
- * - **I2 Stability.** `id` does not change for the life of the account — not
- *   across a restart, a re-sync, a message arriving on a different addressing,
- *   or a change to any identifier the account is reachable on.
- * - **I3 Opacity.** Callers never parse or construct an `id`. This is what lets
- *   a channel change its canonical form later without touching a consumer.
- * - **I4 Total resolution.** Every identifier the channel can receive a message
- *   on resolves to that account's `id`.
- *
- * An account answers *who*. What happened — a last message, a count, a preview
- * — is a separate read, keyed by {@link AccountId}, and does not belong here.
+ * An account answers *who*. What was said to it — a last message, a count, a
+ * preview — is a separate read over the same addresses, and it belongs to
+ * `Messages` (messages.ts) rather than here.
  */
 
 /** Opaque provider-owned account address. Callers may persist and round-trip
@@ -27,6 +15,19 @@ export type AccountId = string & { readonly __brand: "AccountId" };
 
 export interface Account {
   id: AccountId;
+  /**
+   * Every address the account answers to, `id` among them.
+   *
+   * The addressing set a channel folds onto one account: a WhatsApp contact
+   * answers to both a phone JID and a `@lid` JID, and history hangs off
+   * either. A caller that has to show or match every form an account can be
+   * reached at reads them here rather than asking the channel a second time.
+   *
+   * The addresses the channel holds, which is not every address it accepts. A
+   * form absent here may still resolve — a LinkedIn profile URL naming a
+   * member id — and {@link Accounts.resolve} is what takes it.
+   */
+  addresses: string[];
   /**
    * What the platform calls the account, or null when it holds no name for it.
    *
@@ -47,6 +48,46 @@ export interface Account {
   identifiers: Record<string, string>;
 }
 
+/**
+ * Who a channel can reach.
+ *
+ * The four invariants below are the contract. The types cannot carry them, and
+ * every implementation owes all four:
+ *
+ * - **I1 Uniqueness.** Exactly one {@link Account} per real account. The same
+ *   `id` means the same account. Callers never fold aliases themselves.
+ * - **I2 Stability.** `id` does not change for the life of the account — not
+ *   across a restart, a re-sync, a message arriving on a different addressing,
+ *   or a change to any identifier the account is reachable on.
+ * - **I3 Opacity.** Callers never parse or construct an `id`. This is what lets
+ *   a channel change its canonical form later without touching a consumer.
+ * - **I4 Total resolution.** Every identifier the channel can receive a message
+ *   on resolves to that account's `id`.
+ */
+export interface Accounts {
+  /**
+   * One page of the channel's accounts, in a stable order. `query` matches the
+   * name and the identifier values. `cursor` is opaque and comes from a prior
+   * page. A missing `nextCursor` means the listing is exhausted.
+   *
+   * The order is stable, the listing underneath it is not. A channel may order
+   * by activity, so an account can move between two pages and be skipped or
+   * repeated. A caller that needs every account exactly once asks for one page
+   * large enough to hold the listing.
+   */
+  list(input: {
+    query?: string;
+    cursor?: string;
+    limit: number;
+  }): Promise<{ accounts: Account[]; nextCursor?: string }>;
+
+  /** The account an address belongs to, or null. Accepts any address the
+   *  channel can receive on — and an {@link AccountId}, which round-trips. */
+  resolve(address: string): Promise<Account | null>;
+}
+
+/** The address book behind the account directory and the fold. Every
+ *  implementation owes {@link Accounts}' four invariants. */
 export interface TalkAccounts {
   /**
    * One page of the channel's accounts, in a stable order. `query` matches the

--- a/packages/core/src/channels/linkedin-accounts.ts
+++ b/packages/core/src/channels/linkedin-accounts.ts
@@ -107,6 +107,10 @@ function memberIdFrom(identifier: string): string | null {
 function toAccount(row: LinkedInParticipantContactRow): Account {
   return {
     id: row.participantId as AccountId,
+    // The member id is the only address LinkedIn stores a member under. A
+    // profile URL naming the same member is a form `resolve` takes, not one
+    // the address book holds.
+    addresses: [row.participantId],
     // A headline is not a name, but it is text LinkedIn holds about the member
     // rather than an identifier of theirs, so it stands as one here: a caller
     // that falls through to the member id has nothing better to show than

--- a/packages/core/src/channels/messages-contract.ts
+++ b/packages/core/src/channels/messages-contract.ts
@@ -1,0 +1,144 @@
+// The obligations messages.ts states, as a suite every `Messages` adapter
+// enrolls in. One store answering them its own way is a preview that opens on
+// an entry its pages never show, so the law is asserted once here rather than
+// re-tested per adapter.
+
+import { describe, expect, it } from "vitest";
+import {
+  compareTimelineEntries,
+  isAfterTimelineCursor,
+  timelineCursor,
+  type TimelineEntry,
+} from "@rome/api-types/people";
+import type { MessageAccount, Messages } from "./messages.js";
+
+/** A limit large enough to hold any history a store can answer — what
+ *  messages.ts calls the full read. */
+export const WHOLE_HISTORY = Number.MAX_SAFE_INTEGER;
+
+/** A store to run the contract against, with the accounts to run it for. */
+export interface MessagesContractSubject {
+  messages: Messages;
+  /**
+   * Accounts the store holds messages for.
+   *
+   * Enroll with at least four messages, two of them in the same second, so the
+   * ordering and cursor assertions bite: a store whose history fits in one
+   * page never pages, and one whose timestamps are all distinct settles no tie.
+   */
+  accounts: MessageAccount[];
+  /** Accounts on the store's own channels that it holds nothing for. */
+  silent: MessageAccount[];
+}
+
+/** Page size the paging assertions walk with. Smaller than the history the
+ *  subject owes, so exhausting it crosses at least one boundary. */
+const PAGE = 2;
+
+export function testMessagesContract(
+  name: string,
+  subject: () => MessagesContractSubject | Promise<MessagesContractSubject>,
+): void {
+  describe(`Messages contract: ${name}`, () => {
+    const fullRead = async ({ messages, accounts }: MessagesContractSubject) =>
+      messages.read({ accounts, limit: WHOLE_HISTORY });
+
+    it("holds enough history to prove the law", async () => {
+      const store = await subject();
+      const full = await fullRead(store);
+      expect(full.length).toBeGreaterThanOrEqual(4);
+      expect(new Set(full.map((entry) => entry.timestamp)).size).toBeLessThan(full.length);
+    });
+
+    it("answers latest as the first entry of the full read", async () => {
+      const store = await subject();
+      const full = await fullRead(store);
+      expect(await store.messages.latest(store.accounts)).toEqual(full[0]);
+    });
+
+    it("answers count as the length of the full read", async () => {
+      const store = await subject();
+      const full = await fullRead(store);
+      expect(await store.messages.count(store.accounts)).toBe(full.length);
+    });
+
+    it("answers latest as a read of one", async () => {
+      const store = await subject();
+      const page = await store.messages.read({ accounts: store.accounts, limit: 1 });
+      expect(await store.messages.latest(store.accounts)).toEqual(page[0] ?? null);
+    });
+
+    it("answers a page newest first, no longer than its limit", async () => {
+      const store = await subject();
+      const page = await store.messages.read({ accounts: store.accounts, limit: PAGE });
+      expect(page.length).toBeLessThanOrEqual(PAGE);
+      expect(page).toEqual([...page].sort(compareTimelineEntries));
+    });
+
+    it("answers only messages strictly after the cursor", async () => {
+      const store = await subject();
+      const first = await store.messages.read({ accounts: store.accounts, limit: PAGE });
+      const cursor = first.at(-1);
+      if (!cursor) throw new Error("the store answered no first page to resume from");
+      const next = await store.messages.read({
+        accounts: store.accounts,
+        after: cursor,
+        limit: WHOLE_HISTORY,
+      });
+      expect(next.every((entry) => isAfterTimelineCursor(entry, cursor))).toBe(true);
+    });
+
+    it("pages to exhaustion over exactly the full read", async () => {
+      const store = await subject();
+      const full = await fullRead(store);
+
+      const walked: TimelineEntry[] = [];
+      let after: TimelineEntry | null = null;
+      // Bounded rather than `while (true)`: a store that answers the same page
+      // forever fails as a wrong page count instead of hanging the suite.
+      for (let page = 0; page <= Math.ceil(full.length / PAGE); page++) {
+        const entries: TimelineEntry[] = await store.messages.read({
+          accounts: store.accounts,
+          after,
+          limit: PAGE,
+        });
+        if (entries.length === 0) break;
+        walked.push(...entries);
+        after = entries[entries.length - 1] ?? null;
+      }
+
+      expect(walked).toEqual(full);
+    });
+
+    it("answers nothing after the oldest message", async () => {
+      const store = await subject();
+      const full = await fullRead(store);
+      const oldest = full.at(-1);
+      expect(oldest).toBeDefined();
+      const past = await store.messages.read({
+        accounts: store.accounts,
+        after: oldest,
+        limit: WHOLE_HISTORY,
+      });
+      expect(past).toEqual([]);
+    });
+
+    it("gives every message its own cursor position", async () => {
+      const store = await subject();
+      const full = await fullRead(store);
+      // Two entries that compare equal serialize to one cursor, so resuming
+      // from it drops one of the pair — the pages above would never show it.
+      expect(new Set(full.map(timelineCursor)).size).toBe(full.length);
+    });
+
+    it("holds nothing for a silent account", async () => {
+      const store = await subject();
+      expect(store.silent.length).toBeGreaterThan(0);
+      expect(await store.messages.latest(store.silent)).toBeNull();
+      expect(await store.messages.count(store.silent)).toBe(0);
+      expect(await store.messages.read({ accounts: store.silent, limit: WHOLE_HISTORY })).toEqual(
+        [],
+      );
+    });
+  });
+}

--- a/packages/core/src/channels/messages-memory.test.ts
+++ b/packages/core/src/channels/messages-memory.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { TimelineEntry } from "@rome/api-types/people";
+import { memoryMessages, type HeldMessage } from "./messages-memory.js";
+import { testMessagesContract, WHOLE_HISTORY } from "./messages-contract.js";
+
+// The reference store, and the contract suite proved against it: a suite that
+// passed nothing would enroll every adapter and assert none of them.
+
+const PHONE = "1555@s.whatsapp.net";
+const LID = "77@lid";
+const MEMBER = "ACoAA1";
+
+const entry = (
+  source: string,
+  timestamp: number,
+  ref: string,
+  direction: "inbound" | "outbound" = "inbound",
+): TimelineEntry => ({ source, timestamp, ref, direction, body: `${ref}@${timestamp}` });
+
+const held: HeldMessage[] = [
+  { channel: "whatsapp", address: PHONE, entry: entry("whatsapp", 100, "wa:a") },
+  { channel: "whatsapp", address: PHONE, entry: entry("whatsapp", 300, "wa:c", "outbound") },
+  // The same second as wa:c, on the account's other addressing: the direction
+  // settles the tie, and both have to survive a page boundary.
+  { channel: "whatsapp", address: LID, entry: entry("whatsapp", 300, "wa:d") },
+  { channel: "whatsapp", address: PHONE, entry: entry("whatsapp", 500, "wa:e") },
+  { channel: "linkedin", address: MEMBER, entry: entry("linkedin", 200, "li:b") },
+  { channel: "linkedin", address: MEMBER, entry: entry("linkedin", 400, "li:f", "outbound") },
+  // Out of every scope below: another account on the same channel, and the
+  // same string as a WhatsApp address on a channel that is not WhatsApp.
+  { channel: "whatsapp", address: "9999@s.whatsapp.net", entry: entry("whatsapp", 600, "wa:x") },
+  { channel: "linkedin", address: PHONE, entry: entry("linkedin", 700, "li:x") },
+];
+
+const accounts = [
+  { channel: "whatsapp", addresses: [PHONE, LID] },
+  { channel: "linkedin", addresses: [MEMBER] },
+];
+
+testMessagesContract("memoryMessages", () => ({
+  messages: memoryMessages(held),
+  accounts,
+  silent: [{ channel: "whatsapp", addresses: ["4444@s.whatsapp.net"] }],
+}));
+
+describe("memoryMessages", () => {
+  const messages = memoryMessages(held);
+
+  it("merges every address of every account into one newest-first history", async () => {
+    const page = await messages.read({ accounts, limit: WHOLE_HISTORY });
+    expect(page.map((e) => e.ref)).toEqual(["wa:e", "li:f", "wa:c", "wa:d", "li:b", "wa:a"]);
+  });
+
+  it("scopes by the channel and the address together", async () => {
+    const page = await messages.read({
+      accounts: [{ channel: "whatsapp", addresses: [PHONE] }],
+      limit: WHOLE_HISTORY,
+    });
+    expect(page.map((e) => e.ref)).toEqual(["wa:e", "wa:c", "wa:a"]);
+  });
+
+  it("answers a message once when two accounts name its address", async () => {
+    const shared = [
+      { channel: "whatsapp", addresses: [PHONE] },
+      { channel: "whatsapp", addresses: [PHONE, LID] },
+    ];
+    expect(await messages.count(shared)).toBe(4);
+  });
+
+  it("holds nothing for an empty scope", async () => {
+    expect(await messages.latest([])).toBeNull();
+    expect(await messages.count([])).toBe(0);
+    expect(await messages.read({ accounts: [], limit: WHOLE_HISTORY })).toEqual([]);
+  });
+});

--- a/packages/core/src/channels/messages-memory.ts
+++ b/packages/core/src/channels/messages-memory.ts
@@ -1,0 +1,60 @@
+// A `Messages` store held in memory: the reference the contract suite is
+// proved against, and a store any test can state whole. The obligations it
+// meets are messages.ts's.
+
+import {
+  compareTimelineEntries,
+  isAfterTimelineCursor,
+  type TimelineEntry,
+} from "@rome/api-types/people";
+import type { MessageAccount, MessageRead, Messages } from "./messages.js";
+
+/** One message the store holds, at the address it arrived on. */
+export interface HeldMessage {
+  channel: string;
+  address: string;
+  entry: TimelineEntry;
+}
+
+/**
+ * `Messages` over `held`, scoped by the `(channel, address)` pair — an address
+ * on one channel never selects a message another channel stores under the same
+ * string.
+ *
+ * A message is answered once however many of the given accounts name its
+ * address, because a read filters the list rather than making a pass per
+ * address.
+ */
+export function memoryMessages(held: readonly HeldMessage[]): Messages {
+  const full = (accounts: readonly MessageAccount[]): TimelineEntry[] => {
+    const scope = new Set(
+      accounts.flatMap((account) =>
+        account.addresses.map((address) => addressKey(account.channel, address)),
+      ),
+    );
+    return held
+      .filter((message) => scope.has(addressKey(message.channel, message.address)))
+      .map((message) => message.entry)
+      .sort(compareTimelineEntries);
+  };
+
+  return {
+    async read(request: MessageRead) {
+      const after = request.after ?? null;
+      const limit = Math.max(1, Math.floor(request.limit));
+      return full(request.accounts)
+        .filter((entry) => after === null || isAfterTimelineCursor(entry, after))
+        .slice(0, limit);
+    },
+
+    async count(accounts) {
+      return full(accounts).length;
+    },
+
+    async latest(accounts) {
+      return full(accounts)[0] ?? null;
+    },
+  };
+}
+
+const addressKey = (channel: string, address: string) => `${channel}\n${address}`;

--- a/packages/core/src/channels/messages.ts
+++ b/packages/core/src/channels/messages.ts
@@ -1,0 +1,88 @@
+/**
+ * The message plane behind a channel's accounts: what was said, as one store
+ * holds it. `Accounts` (accounts.ts) answers who a channel can reach, and this
+ * answers what passed between Rome and them.
+ *
+ * A message is a {@link TimelineEntry}. The shape, the ordering and the cursor
+ * belong to the People contract (`@rome/api-types/people`), because what a
+ * store answers here is what a person's timeline pages. A second definition of
+ * either is a page boundary the two ends disagree about.
+ */
+
+import type { TimelineEntry } from "@rome/api-types/people";
+
+/**
+ * One account a store reads for, named by every address it answers to —
+ * `Account.addresses` on the channel's own account plane.
+ *
+ * The addresses rather than the id, because a store keys its rows by whichever
+ * address a message arrived on. A read that named only the address a person
+ * mapping happens to carry would answer an empty history for a conversation
+ * that plainly exists.
+ */
+export interface MessageAccount {
+  channel: string;
+  /** Non-empty. Order carries no meaning. */
+  addresses: readonly string[];
+}
+
+export interface MessageRead {
+  accounts: readonly MessageAccount[];
+  /** The entry the previous page ended on. Null or absent for the first page. */
+  after?: TimelineEntry | null;
+  limit: number;
+}
+
+/**
+ * One message store, read for a set of accounts at once.
+ *
+ * The set is read as one history: a person holds several accounts and an
+ * account several addresses, and the caller wants the messages merged, not one
+ * sequence per address.
+ *
+ * One law binds the three verbs. Call the *full read* of a set of accounts the
+ * `read` with no cursor and a limit large enough to hold everything the store
+ * can answer for them:
+ *
+ * - `count` is the length of the full read.
+ * - `latest` is its first entry, and null when the full read is empty.
+ *
+ * So a row previewing `latest` previews exactly the entry the page beneath it
+ * opens on, and the count beside it measures exactly the history that page
+ * walks. A store answering the three on their own terms could preview an entry
+ * its own pages never show.
+ *
+ * `latest` answering null is how a caller learns the store holds nothing for
+ * an account. There is no `holds` verb — a second way to ask the same question
+ * is a second answer to disagree with.
+ *
+ * Direct threads only. A group conversation is addressed by the group rather
+ * than by any person on it, so no address of an account names it and none of
+ * its messages reaches these reads.
+ */
+export interface Messages {
+  /**
+   * The store's newest messages for `accounts`, at most `limit` of them, every
+   * one strictly after `after`, in `compareTimelineEntries` order — newest
+   * first, and total.
+   *
+   * "Strictly after `after`" is the store's own obligation and not the
+   * caller's: a store that answered its newest `limit` messages and left the
+   * filtering above it would spend that budget on messages the caller has
+   * already seen, and the ones it dropped to make room are the ones no page
+   * ever shows.
+   */
+  read(request: MessageRead): Promise<TimelineEntry[]>;
+
+  /** How many messages the full read of `accounts` answers. */
+  count(accounts: readonly MessageAccount[]): Promise<number>;
+
+  /**
+   * The first entry of the full read of `accounts`, or null when the store
+   * holds none.
+   *
+   * `read` with a limit of one, declared as its own verb so a store can answer
+   * it in one pass over a whole directory rather than one page per row.
+   */
+  latest(accounts: readonly MessageAccount[]): Promise<TimelineEntry | null>;
+}

--- a/packages/core/src/channels/whatsapp-accounts.ts
+++ b/packages/core/src/channels/whatsapp-accounts.ts
@@ -205,7 +205,11 @@ function toAccount(id: AccountId, group: WhatsAppContactRow[]): Account {
     pick((row) => row.verifiedName) ??
     pick((row) => row.chatName);
 
-  return { id, name, identifiers };
+  // The id first: it is derived from the account's digits, so it is an address
+  // the account answers to whether or not a row spells it out.
+  const addresses = [...new Set([id as string, ...group.flatMap((row) => row.aliases)])];
+
+  return { id, addresses, name, identifiers };
 }
 
 /** Every index key the account answers to, including its own id. */


### PR DESCRIPTION
Closes #94.

## What this PR does

The channel-facing model behind the People surface is spread across three interfaces that overlap and can disagree. `TalkAccounts` answers who a channel can reach. `TalkAccountActivity` answers what was last said to each of them. `TimelineSource` answers that same question a second time, on its own terms, for the pages. So a directory row can preview one entry while the person page it opens on starts at another, and the two counts beside them can differ for the same account.

This is phase 1 of the migration: the interfaces and the suite, with nothing migrated onto them yet. The model is two nouns with verbs.

**Accounts** — who the channel can reach. `list(query?, cursor?, limit)` and `resolve(address)`. The four address-book invariants (uniqueness, stability, opacity, total resolution) move from the module comment onto the interface unchanged. `Account` gains `addresses`, every address the account answers to with its `id` among them.

**Messages** — what was said. `read({accounts, after?, limit})`, `count(accounts)`, `latest(accounts)`.

Plus `testMessagesContract`, the suite every Messages adapter enrolls in, and `memoryMessages`, the in-memory reference that proves the suite passes something.

## Design & Invariants

One law binds the three Messages verbs, and it is the reason the noun exists. Call the *full read* of a set of accounts the `read` with no cursor and a limit large enough to hold everything the store can answer. Then `count` is the length of the full read, and `latest` is its first entry. A row previewing `latest` previews exactly the entry the page beneath it opens on, and the count beside it measures exactly the history that page walks. A store answering the three on their own terms is the regression this forbids.

`latest` answering null is how a caller learns a store holds nothing for an account. There is no `holds` verb, because a second way to ask one question is a second answer to disagree with.

A message is a `TimelineEntry` from `@rome/api-types/people` rather than a new shape. The ordering and the cursor already belong to the People contract, and what a store answers here is what a person's timeline pages. A second definition of either is a page boundary the two ends disagree about.

Ordering, cursor advance, and direct-threads-only scoping are obligations of the store, not of the caller. A store that answered its newest `limit` messages and left the filtering above it would spend that budget on messages the caller has already seen, and the ones it dropped to make room are the ones no page ever shows.

`Account.addresses` is required rather than optional. Optional would let a store answer an empty addressing set silently, which is the bug #98 exists to remove — a WhatsApp contact whose history straddles a phone JID and a `@lid` JID reading as half a conversation. The cost is that the two adapters fill the field now. That is construction, not migration: no caller reads it yet, and `listAddresses` is untouched.

The suite asserts the law self-referentially — every assertion compares the store against its own full read — so an adapter enrolls without restating what it holds. Its paging walk is bounded rather than `while (true)`, so a store that repeats a page fails as a wrong page count instead of hanging the run.

The durable home for this vocabulary is a concepts doc, deferred to #101 so it describes what is true after the migration lands.

## Test plan

- [x] `pnpm typecheck` — passes across the workspace.
- [x] `pnpm test:unit` — 5966 tests pass, 14 of them new. No existing test changed except one `Account` literal that gains `addresses`.
- [x] The suite bites rather than passing vacuously. Throwaway adapters that mis-order pages, inflate `count`, take `latest` from the wrong end, emit colliding refs, or ignore the cursor each fail 5 to 7 of the suite's 10 assertions.
- [x] `biome check packages/core/src/channels/` — clean.
- [ ] `pnpm dev:all` — not run. This PR adds no wiring and changes no runtime path.

## Not in this PR

- Any Messages adapter — the mirrors (#95) and the Rome-side stores (#96).
- Any callsite — the timeline and listing merge (#97), the fold on `Account.addresses` (#98), the account directory (#99).
- Deleting `TimelineSource`, `TalkAccountActivity`, `MirrorPlane`, or `listAddresses` — sequenced last, in #100.
- The concepts doc — #101, written once it describes what is true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
