### PR TITLE
feat(core): read the agent transcript and sentinel log as Messages

### DIFF
--- a/packages/core/src/channels/linkedin-messages.ts
+++ b/packages/core/src/channels/linkedin-messages.ts
@@ -1,7 +1,7 @@
 import { sql } from "drizzle-orm";
 import type { DrizzleDb } from "../db/index.js";
 import type { Messages } from "./messages.js";
-import { inList, sqlMessages } from "./messages-sql.js";
+import { addressesIn, inList, sqlMessages } from "./messages-sql.js";
 
 /**
  * `Messages` over the LinkedIn inbox mirror (`linkedin_messages`), restricted
@@ -25,7 +25,8 @@ export function linkedInMessages(db: DrizzleDb): Messages {
   return sqlMessages({
     channel: "linkedin",
     db,
-    view(addresses) {
+    view(scope) {
+      const addresses = addressesIn(scope);
       const members = inList(sql`tp.participant_id`, addresses);
       if (members === null) return null;
       return sql`

--- a/packages/core/src/channels/messages-agent.test.ts
+++ b/packages/core/src/channels/messages-agent.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { DrizzleDb } from "../db/index.js";
+import { WebChatRepository } from "../db/repositories/webchat.js";
+import { romeAgentMessages, romeSessions } from "../db/schema.js";
+import { countingDb, createTestDb } from "../test/helpers.js";
+import {
+  testMessagesContract,
+  WHOLE_HISTORY,
+  type MessagesContractSubject,
+} from "./messages-contract.js";
+import { agentMessages } from "./messages-agent.js";
+
+// `rome_agent_messages` read as a `Messages` store, holding exactly what
+// `agentMessagesSource` holds today: the roles that carry conversation, on
+// channel sessions the account itself addresses.
+
+const CHANNEL = "telegram";
+/** The two addressings of the one account the fixtures speak to. */
+const DIRECT = "tg-777";
+const DIRECT_ALT = "tg-777-alt";
+const GROUP = "tg-group-1";
+const OTHER_CHANNEL = "discord";
+
+const account = { channel: CHANNEL, addresses: [DIRECT, DIRECT_ALT] };
+const silent = [{ channel: CHANNEL, addresses: ["tg-nobody"] }];
+
+const text = (line: string) => JSON.stringify([{ type: "text", content: line }]);
+
+function session(
+  db: DrizzleDb,
+  id: string,
+  fields: {
+    type?: string;
+    threadId: string | null;
+    threadType?: string | null;
+    channel?: string;
+  },
+) {
+  const now = new Date(0);
+  return db.insert(romeSessions).values({
+    id,
+    name: id,
+    type: fields.type ?? "channel",
+    sourceChannel: fields.channel ?? CHANNEL,
+    sourceThreadId: fields.threadId,
+    sourceThreadType: fields.threadType ?? "private",
+    createdAt: now,
+    activityAt: now,
+  });
+}
+
+function message(
+  db: DrizzleDb,
+  id: string,
+  fields: { sessionId: string; role: string; at: number; content?: string; senderId?: string },
+) {
+  return db.insert(romeAgentMessages).values({
+    id,
+    sessionId: fields.sessionId,
+    role: fields.role,
+    content: fields.content ?? text(id),
+    senderId: fields.senderId ?? null,
+    createdAt: new Date(fields.at * 1000),
+  });
+}
+
+async function seed(db: DrizzleDb) {
+  await session(db, "s-direct", { threadId: DIRECT });
+  await session(db, "s-direct-alt", { threadId: DIRECT_ALT });
+  await session(db, "s-group", { threadId: GROUP, threadType: "group" });
+  await session(db, "s-webchat", { type: "webchat", threadId: null, threadType: null });
+  // Another channel spelling a thread id exactly as Telegram spells this
+  // account's. The store holds every channel side by side, so nothing but the
+  // pair keeps the two conversations apart.
+  await session(db, "s-elsewhere", { threadId: DIRECT, channel: OTHER_CHANNEL });
+
+  // The same second twice, so the ordering and the cursor have a tie to settle.
+  await message(db, "m-hello", { sessionId: "s-direct", role: "user", at: 100 });
+  await message(db, "m-reply", { sessionId: "s-direct", role: "assistant", at: 100 });
+  // A message that did not wake the agent is still something the person said.
+  await message(db, "m-note", { sessionId: "s-direct", role: "notification", at: 200 });
+  await message(db, "m-later", { sessionId: "s-direct", role: "user", at: 300 });
+  // The account's other addressing: one history, not two halves of one.
+  await message(db, "m-alt", { sessionId: "s-direct-alt", role: "user", at: 250 });
+
+  // Out of scope, each for its own reason.
+  await message(db, "m-trace", { sessionId: "s-direct", role: "trace", at: 400 });
+  // Sent by the account, but into a thread the group addresses.
+  await message(db, "m-group", {
+    sessionId: "s-group",
+    role: "user",
+    at: 500,
+    senderId: DIRECT,
+  });
+  await message(db, "m-webchat", { sessionId: "s-webchat", role: "user", at: 600 });
+  await message(db, "m-elsewhere", { sessionId: "s-elsewhere", role: "user", at: 550 });
+}
+
+describe("agentMessages", () => {
+  let db: DrizzleDb;
+  let close: () => void;
+
+  beforeEach(async () => {
+    const test = createTestDb();
+    db = test.db;
+    close = test.close;
+    await seed(db);
+  });
+
+  afterEach(() => close());
+
+  const refs = async () =>
+    (await agentMessages(db).read({ accounts: [account], limit: WHOLE_HISTORY })).map(
+      (entry) => entry.ref,
+    );
+
+  it("answers the roles that carry conversation, newest first", async () => {
+    expect(await refs()).toEqual([
+      "agent:m-later",
+      "agent:m-alt",
+      "agent:m-note",
+      "agent:m-reply",
+      "agent:m-hello",
+    ]);
+  });
+
+  it("leaves out a trace row, which belongs to no conversation", async () => {
+    expect(await refs()).not.toContain("agent:m-trace");
+  });
+
+  it("leaves out a session a group addresses, whoever sent the message", async () => {
+    expect(await refs()).not.toContain("agent:m-group");
+    // And nothing reaches the group's own address either: it is not an account.
+    const asGroup = await agentMessages(db).read({
+      accounts: [{ channel: CHANNEL, addresses: [GROUP] }],
+      limit: WHOLE_HISTORY,
+    });
+    expect(asGroup).toEqual([]);
+  });
+
+  it("leaves out a session that is not a channel's", async () => {
+    expect(await refs()).not.toContain("agent:m-webchat");
+  });
+
+  it("names the channel as the source and the direction by the role", async () => {
+    const page = await agentMessages(db).read({ accounts: [account], limit: WHOLE_HISTORY });
+    expect(page.every((entry) => entry.source === CHANNEL)).toBe(true);
+    const byRef = new Map(page.map((entry) => [entry.ref, entry]));
+    expect(byRef.get("agent:m-reply")?.direction).toBe("outbound");
+    expect(byRef.get("agent:m-hello")?.direction).toBe("inbound");
+    expect(byRef.get("agent:m-note")?.direction).toBe("inbound");
+  });
+
+  // The role cannot settle a notification's direction on its own: the writer
+  // stores an undelivered *outbound* message under it too. Both sides of that
+  // are written here through the repository that stores them, so the fixture
+  // is the row the persistence layer really produces rather than one this test
+  // believes it produces.
+  describe("a notification, which the writer stores in both directions", () => {
+    let repo: WebChatRepository;
+
+    beforeEach(() => {
+      repo = new WebChatRepository(db);
+    });
+
+    it("reads one Rome sent out of band as outbound", async () => {
+      await repo.recordOutboundConversationMessage({
+        sessionId: "s-direct",
+        content: text("delivered without a turn"),
+        platformMessageId: "pm-out-of-band",
+        senderId: "rome",
+        senderName: "Rome",
+        knownToProvider: false,
+      });
+      expect(await agentMessages(db).latest([account])).toMatchObject({
+        direction: "outbound",
+        body: "delivered without a turn",
+      });
+    });
+
+    // `sender_id` is a provider's own opaque string, so a channel is free to
+    // hand out one that reads as Rome's marker. Only the role that cannot say
+    // which way it went asks the sender, so the collision decides nothing
+    // where the role already answers.
+    it("leaves a role that already answers alone, whatever the sender is called", async () => {
+      await repo.addConversationMessage({
+        sessionId: "s-direct",
+        role: "user",
+        content: text("a provider that names its people 'rome'"),
+        platformMessageId: "pm-collision",
+        senderId: "rome",
+        senderName: "Ada",
+      });
+      expect(await agentMessages(db).latest([account])).toMatchObject({
+        direction: "inbound",
+        body: "a provider that names its people 'rome'",
+      });
+    });
+
+    it("reads one the person sent as inbound", async () => {
+      await repo.addConversationMessage({
+        sessionId: "s-direct",
+        role: "notification",
+        content: text("said while Rome slept"),
+        platformMessageId: "pm-unwoken",
+        senderId: DIRECT,
+        senderName: "Ada",
+      });
+      expect(await agentMessages(db).latest([account])).toMatchObject({
+        direction: "inbound",
+        body: "said while Rome slept",
+      });
+    });
+  });
+
+  it("renders a message as its text parts, joined", async () => {
+    await message(db, "m-parts", {
+      sessionId: "s-direct",
+      role: "user",
+      at: 700,
+      content: JSON.stringify([
+        { type: "text", content: "first" },
+        { type: "tool_use", name: "search" },
+        { type: "text", content: "second" },
+      ]),
+    });
+    expect(await agentMessages(db).latest([account])).toMatchObject({
+      ref: "agent:m-parts",
+      body: "first\nsecond",
+    });
+  });
+
+  it("answers a row with nothing to show rather than failing the read", async () => {
+    await message(db, "m-card", {
+      sessionId: "s-direct",
+      role: "assistant",
+      at: 800,
+      content: JSON.stringify([{ type: "card", payload: {} }]),
+    });
+    await message(db, "m-broken", { sessionId: "s-direct", role: "user", at: 900, content: "{" });
+    const page = await agentMessages(db).read({ accounts: [account], limit: 2 });
+    expect(page.map((entry) => [entry.ref, entry.body])).toEqual([
+      ["agent:m-broken", null],
+      ["agent:m-card", null],
+    ]);
+  });
+
+  it("scopes an address to its own channel", async () => {
+    expect(await refs()).not.toContain("agent:m-elsewhere");
+    const elsewhere = await agentMessages(db).read({
+      accounts: [{ channel: OTHER_CHANNEL, addresses: [DIRECT] }],
+      limit: WHOLE_HISTORY,
+    });
+    expect(elsewhere.map((entry) => entry.ref)).toEqual(["agent:m-elsewhere"]);
+  });
+
+  // The scope is carried into the batch as pairs, so two calls that name one
+  // address on two channels are answered from one pass without either taking
+  // the other's rows. A store bound to a single channel cannot be asked this.
+  it("keeps two channels apart inside one batch", async () => {
+    const messages = agentMessages(db);
+    const [here, there] = await Promise.all([
+      messages.read({ accounts: [account], limit: WHOLE_HISTORY }),
+      messages.read({
+        accounts: [{ channel: OTHER_CHANNEL, addresses: [DIRECT] }],
+        limit: WHOLE_HISTORY,
+      }),
+    ]);
+    expect(here.map((entry) => entry.ref)).not.toContain("agent:m-elsewhere");
+    expect(there.map((entry) => entry.ref)).toEqual(["agent:m-elsewhere"]);
+  });
+
+  it("costs one pass per round of calls, not one per account", async () => {
+    const counted = countingDb(db);
+    const messages = agentMessages(counted.db);
+    const before = counted.passes();
+
+    await Promise.all([
+      messages.latest([account]),
+      messages.latest([{ channel: OTHER_CHANNEL, addresses: [DIRECT] }]),
+      messages.count([account]),
+      messages.read({ accounts: [account], limit: 2 }),
+    ]);
+
+    expect(counted.passes() - before).toBe(1);
+  });
+
+  it("holds nothing for an empty scope", async () => {
+    expect(await agentMessages(db).latest([])).toBeNull();
+    expect(await agentMessages(db).count([])).toBe(0);
+    expect(await agentMessages(db).read({ accounts: [], limit: WHOLE_HISTORY })).toEqual([]);
+  });
+});
+
+// One seeded database for the whole suite: every assertion in it reads, so a
+// fresh one per case would only buy migrations.
+let enrolled: Promise<MessagesContractSubject> | null = null;
+
+testMessagesContract("agentMessages", () => {
+  enrolled ??= (async () => {
+    const { db } = createTestDb();
+    await seed(db);
+    return { messages: agentMessages(db), accounts: [account], silent };
+  })();
+  return enrolled;
+});

--- a/packages/core/src/channels/messages-agent.ts
+++ b/packages/core/src/channels/messages-agent.ts
@@ -1,0 +1,115 @@
+// `rome_agent_messages` as a {@link Messages} store: what Rome was told and
+// what it said back, for every channel with no mirror of its own.
+
+import { sql, type SQL } from "drizzle-orm";
+import type { DrizzleDb } from "../db/index.js";
+import type { MessagePart } from "../types.js";
+import type { Messages } from "./messages.js";
+import { scopePairs, sqlMessages } from "./messages-sql.js";
+
+/**
+ * The sender id Rome stamps on a message it sent itself.
+ *
+ * Written by every outbound path that records a channel message — the
+ * `send_message` action and the backend turn — and already how
+ * `loadConversationContext` picks Rome's own rows out of the pending
+ * notifications. Read here for the same reason: it is the one persisted mark
+ * that survives a row whose role does not say which way it went.
+ */
+const ROME_SENDER_ID = "rome";
+
+/**
+ * Which way a stored agent message went, as SQL over its role and sender.
+ *
+ * The role alone cannot answer it. `assistant` is Rome's and `user` is the
+ * person's, but `notification` is written in both directions:
+ * `addConversationMessage` stores an inbound line that did not wake the agent
+ * under it, and `recordOutboundConversationMessage` stores a *delivered* Rome
+ * message under it whenever the send was not tied to a turn
+ * (`knownToProvider: false`). Reading the role alone puts those replies on the
+ * person's side of the conversation.
+ *
+ * So the sender settles what the role leaves open, and this is stated once for
+ * both stores that read these rows: two spellings would put one message on two
+ * sides.
+ */
+export function agentMessageOutbound(role: SQL, senderId: SQL): SQL {
+  return sql`CASE
+    WHEN ${role} = 'assistant' THEN 1
+    -- Asked of a notification alone, and not as a rule over every row: a
+    -- sender id is a provider's own opaque string, so a channel is free to
+    -- hand out one that reads as Rome's marker. Where the role already
+    -- answers, that collision decides nothing.
+    WHEN ${role} = 'notification' AND ${senderId} = ${ROME_SENDER_ID} THEN 1
+    ELSE 0
+  END`;
+}
+
+/**
+ * Rome's own transcript of a channel conversation.
+ *
+ * Reached through the session's channel address: a channel session is keyed by
+ * the thread it belongs to, so a session addressed by the account is that
+ * account's direct conversation, and a group's session — addressed by the
+ * group rather than by anyone on it — is named by no account and never
+ * matches. Which sender a message carries makes no difference: a line the
+ * account wrote into a group belongs to the group's thread.
+ */
+export function agentMessages(db: DrizzleDb): Messages {
+  // No `channel`: the transcript holds every channel that has no mirror of its
+  // own, side by side, so it is scoped by the pair throughout.
+  return sqlMessages({
+    db,
+    view(scope) {
+      const addressed = scopePairs(scope, sql`s.source_channel`, sql`s.source_thread_id`);
+      if (addressed === null) return null;
+      return sql`
+        SELECT
+          s.source_channel AS source,
+          s.source_thread_id AS address,
+          m.created_at AS at,
+          ${agentMessageOutbound(sql`m.role`, sql`m.sender_id`)} AS outbound,
+          'agent:' || m.id AS ref,
+          m.content AS body
+        FROM rome_agent_messages m
+        JOIN rome_sessions s ON s.id = m.session_id
+        WHERE s.type = 'channel'
+          AND ${addressed}
+          -- Addressing already leaves a group out, since a group's session is
+          -- keyed by the group and no account answers to that. Said again on
+          -- the store's own terms so the guarantee survives a caller that
+          -- hands over a group id as if it were an account's address.
+          AND coalesce(s.source_thread_type, '') <> 'group'
+          -- 'notification' is a line that passed outside a turn — something
+          -- the person said without waking the agent, or something Rome sent
+          -- untied to one. Either way it is conversation, and the direction
+          -- above is what tells the two apart. 'trace' is the turn's own
+          -- machinery and belongs to no conversation.
+          AND m.role IN ('user', 'assistant', 'notification')`;
+    },
+    body: messageContentText,
+  });
+}
+
+/** The line a stored agent message renders as: its text parts, joined.
+ *  Non-text parts (cards, recaps, errors) carry no conversation, and content
+ *  that does not parse is a row with nothing to show rather than a failed read. */
+export function messageContentText(raw: string | null): string | null {
+  if (raw === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  const text = parsed
+    .filter((part): part is Extract<MessagePart, { type: "text" }> => {
+      if (typeof part !== "object" || part === null) return false;
+      const candidate = part as { type?: unknown; content?: unknown };
+      return candidate.type === "text" && typeof candidate.content === "string";
+    })
+    .map((part) => part.content)
+    .join("\n");
+  return text.length > 0 ? text : null;
+}

--- a/packages/core/src/channels/messages-sentinel.test.ts
+++ b/packages/core/src/channels/messages-sentinel.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { DrizzleDb } from "../db/index.js";
+import { romeSessions, sentinelLog } from "../db/schema.js";
+import { createTestDb } from "../test/helpers.js";
+import {
+  testMessagesContract,
+  WHOLE_HISTORY,
+  type MessagesContractSubject,
+} from "./messages-contract.js";
+import { sentinelLogMessages } from "./messages-sentinel.js";
+
+// `sentinel_log` read as a `Messages` store, holding exactly what
+// `sentinelLogSource` holds today: one row as the two lines it records, and
+// the threads Rome knows to be groups subtracted.
+
+const CHANNEL = "telegram";
+const DIRECT = "tg-777";
+const DIRECT_ALT = "tg-777-alt";
+const GROUP = "tg-group-1";
+
+const account = { channel: CHANNEL, addresses: [DIRECT, DIRECT_ALT] };
+const silent = [{ channel: CHANNEL, addresses: ["tg-nobody"] }];
+
+function row(
+  db: DrizzleDb,
+  id: string,
+  fields: {
+    at: number;
+    text: string;
+    response?: string | null;
+    channelUserId?: string;
+    channel?: string;
+    threadId?: string | null;
+  },
+) {
+  return db.insert(sentinelLog).values({
+    id,
+    messageId: `msg-${id}`,
+    channel: fields.channel ?? CHANNEL,
+    channelUserId: fields.channelUserId ?? DIRECT,
+    threadId: fields.threadId ?? null,
+    text: fields.text,
+    action: fields.response ? "replied" : "ignored",
+    response: fields.response ?? null,
+    createdAt: new Date(fields.at * 1000),
+  });
+}
+
+function groupSession(db: DrizzleDb, id: string, fields: { channel?: string; threadId: string }) {
+  const now = new Date(0);
+  return db.insert(romeSessions).values({
+    id,
+    name: id,
+    type: "channel",
+    sourceChannel: fields.channel ?? CHANNEL,
+    sourceThreadId: fields.threadId,
+    sourceThreadType: "group",
+    createdAt: now,
+    activityAt: now,
+  });
+}
+
+async function seed(db: DrizzleDb) {
+  await groupSession(db, "s-group", { threadId: GROUP });
+  // The same thread id on another channel: a group there subtracts nothing here.
+  await groupSession(db, "s-group-elsewhere", { channel: "discord", threadId: "tg-quiet-thread" });
+
+  await row(db, "answered", { at: 1000, text: "ping", response: "pong", threadId: DIRECT });
+  // The account's other addressing: one history, not two halves of one.
+  await row(db, "alt", { at: 1050, text: "over here", channelUserId: DIRECT_ALT });
+  // A thread no session covers is a direct exchange until something says so.
+  await row(db, "unheard", { at: 1100, text: "solo", threadId: "tg-unknown-thread" });
+  // An empty reply is no reply.
+  await row(db, "quiet", { at: 1200, text: "hm", response: "", threadId: "tg-quiet-thread" });
+
+  // Out of scope: the thread a group session covers, and another sender.
+  await row(db, "in-group", { at: 900, text: "hi all", response: "hello", threadId: GROUP });
+  await row(db, "stranger", { at: 1300, text: "who?", channelUserId: "tg-stranger" });
+}
+
+describe("sentinelLogMessages", () => {
+  let db: DrizzleDb;
+  let close: () => void;
+
+  beforeEach(async () => {
+    const test = createTestDb();
+    db = test.db;
+    close = test.close;
+    await seed(db);
+  });
+
+  afterEach(() => close());
+
+  const page = () => sentinelLogMessages(db).read({ accounts: [account], limit: WHOLE_HISTORY });
+  const refs = async () => (await page()).map((entry) => entry.ref);
+
+  it("reads a row with a reply as two messages, inbound then outbound", async () => {
+    const entries = await page();
+    const inbound = entries.find((entry) => entry.ref === "sentinel:answered");
+    const outbound = entries.find((entry) => entry.ref === "sentinel:answered:reply");
+    expect(inbound).toMatchObject({ direction: "inbound", body: "ping", timestamp: 1000 });
+    expect(outbound).toMatchObject({ direction: "outbound", body: "pong", timestamp: 1000 });
+    // Rome's answer sits above the line it answers, on the one second they share.
+    expect(entries.indexOf(outbound!)).toBeLessThan(entries.indexOf(inbound!));
+  });
+
+  it("reads a row with no reply as the inbound message alone", async () => {
+    expect(await refs()).toContain("sentinel:unheard");
+    expect(await refs()).not.toContain("sentinel:unheard:reply");
+  });
+
+  it("counts an empty reply as no reply", async () => {
+    expect(await refs()).toContain("sentinel:quiet");
+    expect(await refs()).not.toContain("sentinel:quiet:reply");
+  });
+
+  it("subtracts a thread Rome knows to be a group, reply included", async () => {
+    expect(await refs()).not.toContain("sentinel:in-group");
+    expect(await refs()).not.toContain("sentinel:in-group:reply");
+  });
+
+  it("subtracts only a group on the row's own channel", async () => {
+    // "quiet" sits on a thread id a *discord* group session names.
+    expect(await refs()).toContain("sentinel:quiet");
+  });
+
+  it("merges every addressing of the account into one newest-first history", async () => {
+    expect(await refs()).toEqual([
+      "sentinel:quiet",
+      "sentinel:unheard",
+      "sentinel:alt",
+      "sentinel:answered:reply",
+      "sentinel:answered",
+    ]);
+  });
+
+  it("names the channel as the source", async () => {
+    expect((await page()).every((entry) => entry.source === CHANNEL)).toBe(true);
+  });
+
+  it("scopes an address to its own channel", async () => {
+    const elsewhere = await sentinelLogMessages(db).read({
+      accounts: [{ channel: "discord", addresses: [DIRECT] }],
+      limit: WHOLE_HISTORY,
+    });
+    expect(elsewhere).toEqual([]);
+  });
+
+  it("holds nothing for an empty scope", async () => {
+    const messages = sentinelLogMessages(db);
+    expect(await messages.latest([])).toBeNull();
+    expect(await messages.count([])).toBe(0);
+    expect(await messages.read({ accounts: [], limit: WHOLE_HISTORY })).toEqual([]);
+  });
+});
+
+// One seeded database for the whole suite: every assertion in it reads, so a
+// fresh one per case would only buy migrations.
+let enrolled: Promise<MessagesContractSubject> | null = null;
+
+testMessagesContract("sentinelLogMessages", () => {
+  enrolled ??= (async () => {
+    const { db } = createTestDb();
+    await seed(db);
+    return { messages: sentinelLogMessages(db), accounts: [account], silent };
+  })();
+  return enrolled;
+});

--- a/packages/core/src/channels/messages-sentinel.ts
+++ b/packages/core/src/channels/messages-sentinel.ts
@@ -1,0 +1,60 @@
+// `sentinel_log` as a {@link Messages} store: the triage record, and the only
+// place an exchange the sentinel handled alone is written down.
+
+import { sql } from "drizzle-orm";
+import type { DrizzleDb } from "../db/index.js";
+import type { Messages } from "./messages.js";
+import { scopePairs, sqlMessages } from "./messages-sql.js";
+
+/**
+ * What the sentinel logged, one row read as the two lines it records: what the
+ * sender said, and what Rome answered when it answered at all.
+ *
+ * Both halves share the row's one timestamp, and the ordering puts the reply
+ * above the line it answers. Each carries its own `ref`, so the two never
+ * collapse to one cursor position.
+ */
+export function sentinelLogMessages(db: DrizzleDb): Messages {
+  // No `channel`: the log holds every channel's triage side by side, so it is
+  // scoped by the pair throughout.
+  return sqlMessages({
+    db,
+    view(scope) {
+      const addressed = scopePairs(scope, sql`l.channel`, sql`l.channel_user_id`);
+      if (addressed === null) return null;
+      // A log row names its sender but not whether they were alone. The
+      // session that recorded the same thread does, so a thread Rome knows to
+      // be a group is what the scope subtracts — a row whose thread no session
+      // covers is a direct exchange until something says otherwise.
+      const direct = sql`
+        ${addressed}
+        AND NOT EXISTS (
+          SELECT 1 FROM rome_sessions s
+          WHERE s.type = 'channel'
+            AND s.source_channel = l.channel
+            AND s.source_thread_id = l.thread_id
+            AND s.source_thread_type = 'group'
+        )`;
+      return sql`
+        SELECT
+          l.channel AS source,
+          l.channel_user_id AS address,
+          l.created_at AS at,
+          0 AS outbound,
+          'sentinel:' || l.id AS ref,
+          l.text AS body
+        FROM sentinel_log l
+        WHERE ${direct}
+        UNION ALL
+        SELECT
+          l.channel,
+          l.channel_user_id,
+          l.created_at,
+          1,
+          'sentinel:' || l.id || ':reply',
+          l.response
+        FROM sentinel_log l
+        WHERE ${direct} AND l.response IS NOT NULL AND l.response <> ''`;
+    },
+  });
+}

--- a/packages/core/src/channels/messages-sql.ts
+++ b/packages/core/src/channels/messages-sql.ts
@@ -32,19 +32,42 @@ import type { MessageAccount, MessageRead, Messages } from "./messages.js";
  */
 export type MessageViewSql = SQL;
 
-export interface SqlMessagesOptions {
-  /** The channel this store serves. Accounts on any other are out of its
-   *  scope, however their addresses read. */
+/** One address, on the channel that holds it. What a store is scoped by, since
+ *  the pair is what names a conversation: two channels are free to spell an
+ *  address the same way and mean two different people. */
+export interface MessageAddress {
   channel: string;
+  address: string;
+}
+
+export interface SqlMessagesOptions {
+  /**
+   * The channel this store serves, when it serves exactly one — a channel's
+   * own mirror. Accounts on any other are out of its scope, however their
+   * addresses read.
+   *
+   * Absent for a store that holds every channel's messages side by side and
+   * keys them by the pair: Rome's own transcript, the sentinel's log. Such a
+   * store is scoped by `(channel, address)` throughout, and its view is handed
+   * the pairs rather than bare addresses so it can say the same.
+   */
+  channel?: string;
   db: DrizzleDb;
   /**
-   * The store's rows, scoped to `addresses` — every address of every account
-   * a batch of calls named, deduplicated.
+   * The store's rows, scoped to every address of every account a batch of
+   * calls named, deduplicated.
    *
    * Null when the request can hold nothing, and the store then answers empty
    * without a query.
    */
-  view(addresses: readonly string[]): MessageViewSql | null;
+  view(scope: readonly MessageAddress[]): MessageViewSql | null;
+  /**
+   * The view's `body` column mapped to the line to render, for a store whose
+   * text is not stored as text — Rome's transcript keeps a JSON array of
+   * blocks. Runs on the answered page rather than on the scope, so it can be
+   * as expensive as the parse it wraps.
+   */
+  body?(raw: string | null): string | null;
 }
 
 /**
@@ -67,7 +90,7 @@ export function sqlMessages(options: SqlMessagesOptions): Messages {
   const submit = batched<Job, JobResult>((jobs) => runBatch(options, jobs));
 
   const job = (accounts: readonly MessageAccount[], after: TimelineEntry | null, limit: number) =>
-    submit({ addresses: addressesOn(accounts, options.channel), after, limit });
+    submit({ scope: scopeOf(accounts, options.channel), after, limit });
 
   return {
     async read(request: MessageRead) {
@@ -85,23 +108,38 @@ export function sqlMessages(options: SqlMessagesOptions): Messages {
   };
 }
 
-/** Every address of every account on `channel`, each once. `(channel,
- *  address)` is matched as a pair — an address on one channel must never
- *  select a row another channel stores under the same string. */
-function addressesOn(accounts: readonly MessageAccount[], channel: string): string[] {
-  return [
-    ...new Set(
-      accounts
-        .filter((account) => account.channel === channel)
-        .flatMap((account) => account.addresses),
-    ),
-  ];
+/**
+ * Every address of every account the store serves, each pair once.
+ *
+ * `(channel, address)` throughout — an address on one channel must never
+ * select a row another channel stores under the same string. A store bound to
+ * one channel drops the accounts on every other here; a store that serves them
+ * all keeps the channel beside each address and matches on both.
+ */
+function scopeOf(
+  accounts: readonly MessageAccount[],
+  channel: string | undefined,
+): MessageAddress[] {
+  const scope = new Map<string, MessageAddress>();
+  for (const account of accounts) {
+    if (channel !== undefined && account.channel !== channel) continue;
+    for (const address of account.addresses) {
+      scope.set(`${account.channel}\n${address}`, { channel: account.channel, address });
+    }
+  }
+  return [...scope.values()];
+}
+
+/** Every address in a scope, each once — what a view on a single channel needs,
+ *  the channel being its own. */
+export function addressesIn(scope: readonly MessageAddress[]): string[] {
+  return [...new Set(scope.map((entry) => entry.address))];
 }
 
 /** One call, as the batch sees it. `limit` of {@link COUNT_ONLY} is a job that
  *  wants the length of a history and none of it. */
 interface Job {
-  addresses: readonly string[];
+  scope: readonly MessageAddress[];
   after: TimelineEntry | null;
   limit: number;
 }
@@ -128,14 +166,20 @@ const nothing = (): JobResult => ({ entries: [], total: 0 });
  * rather than once per job.
  */
 async function runBatch(options: SqlMessagesOptions, jobs: Job[]): Promise<JobResult[]> {
-  const asked = jobs.flatMap((job, index) => job.addresses.map((address) => ({ index, address })));
+  const asked = jobs.flatMap((job, index) => job.scope.map((entry) => ({ index, ...entry })));
   if (asked.length === 0) return jobs.map(nothing);
 
-  const rows = options.view([...new Set(asked.map((entry) => entry.address))]);
+  const wanted = new Map(asked.map((entry) => [`${entry.channel}\n${entry.address}`, entry]));
+  const rows = options.view(
+    [...wanted.values()].map(({ channel, address }) => ({
+      channel,
+      address,
+    })),
+  );
   if (rows === null) return jobs.map(nothing);
 
   const scope = sql.join(
-    asked.map((entry) => sql`(${entry.index}, ${entry.address})`),
+    asked.map((entry) => sql`(${entry.index}, ${entry.channel}, ${entry.address})`),
     sql`, `,
   );
   const ask = sql.join(
@@ -144,7 +188,7 @@ async function runBatch(options: SqlMessagesOptions, jobs: Job[]): Promise<JobRe
   );
 
   const answered = (await options.db.all(sql`
-    WITH scope(rq, address) AS (VALUES ${scope}),
+    WITH scope(rq, source, address) AS (VALUES ${scope}),
     ask(rq, cap, has_cursor, c_at, c_outbound, c_source, c_ref) AS (VALUES ${ask}),
     -- One row per (job, message). DISTINCT because a view may attribute one
     -- message to several of a job's addresses — a LinkedIn thread carrying two
@@ -159,7 +203,10 @@ async function runBatch(options: SqlMessagesOptions, jobs: Job[]): Promise<JobRe
         held.ref AS ref,
         held.body AS body
       FROM (${rows}) held
-      JOIN scope ON scope.address = held.address
+      -- The pair, never the address alone: a store holding several channels
+      -- side by side would otherwise hand one channel's message to a job that
+      -- asked about the same string on another.
+      JOIN scope ON scope.source = held.source AND scope.address = held.address
     ),
     -- Each job's own history, ranked and measured in one pass. One named
     -- window rather than two inline ones: SQLite shares a partition pass only
@@ -207,7 +254,7 @@ async function runBatch(options: SqlMessagesOptions, jobs: Job[]): Promise<JobRe
     // The head of a history is answered whether or not the job asked for a
     // page, so a job that only wanted the length discards the row it read it
     // off.
-    if (Number(row.position) <= job.limit) result.entries.push(toEntry(row));
+    if (Number(row.position) <= job.limit) result.entries.push(toEntry(row, options.body));
   }
   return results;
 }
@@ -242,13 +289,17 @@ const AFTER_CURSOR = sql`
                AND (scoped.source > ask.c_source
                     OR (scoped.source = ask.c_source AND scoped.ref > ask.c_ref)))))`;
 
-function toEntry(row: Record<string, unknown>): TimelineEntry {
+function toEntry(
+  row: Record<string, unknown>,
+  body?: (raw: string | null) => string | null,
+): TimelineEntry {
+  const raw = (row.body as string | null) ?? null;
   return {
     source: String(row.source),
     timestamp: Number(row.at),
     direction: Number(row.outbound) === 1 ? "outbound" : "inbound",
     ref: String(row.ref),
-    body: (row.body as string | null) ?? null,
+    body: body ? body(raw) : raw,
   };
 }
 
@@ -287,6 +338,35 @@ function batched<J, R>(run: (jobs: J[]) => Promise<R[]>): (job: J) => Promise<R>
       }
       pending.push({ job, settle, fail });
     });
+}
+
+/**
+ * A whole scope as a WHERE clause: `(channel = … AND address IN (…))` per
+ * channel, or'd together, and null when the scope is empty.
+ *
+ * What a store holding several channels side by side scopes itself with. The
+ * pair rather than the address alone, for the reason the batch's join gives:
+ * two channels may spell an address the same way and mean two people.
+ */
+export function scopePairs(
+  scope: readonly MessageAddress[],
+  channelColumn: SQL,
+  addressColumn: SQL,
+): SQL | null {
+  const byChannel = new Map<string, string[]>();
+  for (const { channel, address } of scope) {
+    const addresses = byChannel.get(channel);
+    if (addresses) addresses.push(address);
+    else byChannel.set(channel, [address]);
+  }
+  const clauses = [...byChannel]
+    .map(([channel, addresses]) => {
+      const held = inList(addressColumn, addresses);
+      return held === null ? null : sql`(${channelColumn} = ${channel} AND ${held})`;
+    })
+    .filter((clause): clause is SQL => clause !== null);
+  if (clauses.length === 0) return null;
+  return sql`(${sql.join(clauses, sql` OR `)})`;
 }
 
 /** `column IN (…)` over `values`, or null when there is nothing to match —

--- a/packages/core/src/channels/whatsapp-messages.ts
+++ b/packages/core/src/channels/whatsapp-messages.ts
@@ -1,7 +1,7 @@
 import { sql } from "drizzle-orm";
 import type { DrizzleDb } from "../db/index.js";
 import type { Messages } from "./messages.js";
-import { inList, sqlMessages } from "./messages-sql.js";
+import { addressesIn, inList, sqlMessages } from "./messages-sql.js";
 
 /**
  * `Messages` over the WhatsApp message mirror (`wa_messages`) — the thread as
@@ -29,7 +29,8 @@ export function whatsAppMessages(db: DrizzleDb): Messages {
   return sqlMessages({
     channel: "whatsapp",
     db,
-    view(addresses) {
+    view(scope) {
+      const addresses = addressesIn(scope);
       const chats = inList(sql`m.chat_jid`, addresses);
       if (chats === null) return null;
       return sql`

--- a/packages/core/src/people/timeline-sources.test.ts
+++ b/packages/core/src/people/timeline-sources.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Account, AccountId } from "../channels/accounts.js";
-import { timelineAccounts } from "./timeline-sources.js";
+import { WebChatRepository } from "../db/repositories/webchat.js";
+import { romeSessions } from "../db/schema.js";
+import { createTestDb } from "../test/helpers.js";
+import { agentMessagesSource, timelineAccounts } from "./timeline-sources.js";
 
 const account = (id: string, addresses: string[] = [id]): Account => ({
   id: id as AccountId,
@@ -106,5 +109,65 @@ describe("timelineAccounts", () => {
     expect(groups[2]?.[0]?.channel).toBe("whatsapp");
     // One read serves every group.
     expect(whatsAppAccounts.listings).toBe(1);
+  });
+});
+
+describe("agentMessagesSource", () => {
+  const CHANNEL = "telegram";
+  const THREAD = "tg-777";
+  const accounts = [{ channel: CHANNEL, addresses: [THREAD] }];
+
+  /** A channel session for the thread, and the repository that writes to it —
+   *  the rows this source reads come from the writer that really stores them. */
+  async function conversation() {
+    const { db } = createTestDb();
+    const now = new Date(0);
+    await db.insert(romeSessions).values({
+      id: "session",
+      name: "session",
+      type: "channel",
+      sourceChannel: CHANNEL,
+      sourceThreadId: THREAD,
+      sourceThreadType: "private",
+      createdAt: now,
+      activityAt: now,
+    });
+    return { source: agentMessagesSource(db), repo: new WebChatRepository(db) };
+  }
+
+  const content = (line: string) => JSON.stringify([{ type: "text", content: line }]);
+
+  // `notification` is written in both directions, so the role cannot settle
+  // one on its own: a Rome message the send path did not tie to a turn is
+  // stored under it, and reading the role alone puts Rome's own line on the
+  // person's side of their timeline.
+  it("puts a notification Rome sent on Rome's side", async () => {
+    const { source, repo } = await conversation();
+    await repo.recordOutboundConversationMessage({
+      sessionId: "session",
+      content: content("delivered without a turn"),
+      platformMessageId: "pm-out-of-band",
+      senderId: "rome",
+      senderName: "Rome",
+      knownToProvider: false,
+    });
+
+    const [entry] = await source.read({ accounts, cursor: null, limit: 10 });
+    expect(entry).toMatchObject({ direction: "outbound", body: "delivered without a turn" });
+  });
+
+  it("puts a notification the person sent on theirs", async () => {
+    const { source, repo } = await conversation();
+    await repo.addConversationMessage({
+      sessionId: "session",
+      role: "notification",
+      content: content("said while Rome slept"),
+      platformMessageId: "pm-unwoken",
+      senderId: THREAD,
+      senderName: "Ada",
+    });
+
+    const [entry] = await source.read({ accounts, cursor: null, limit: 10 });
+    expect(entry).toMatchObject({ direction: "inbound", body: "said while Rome slept" });
   });
 });

--- a/packages/core/src/people/timeline-sources.ts
+++ b/packages/core/src/people/timeline-sources.ts
@@ -8,8 +8,10 @@
 
 import { sql } from "drizzle-orm";
 import type { TalkAccounts } from "../channels/accounts.js";
+// How a stored agent message reads — which way it went, and the line it
+// renders as — defined once beside the `Messages` store over the same rows.
+import { agentMessageOutbound, messageContentText } from "../channels/messages-agent.js";
 import type { DrizzleDb } from "../db/index.js";
-import type { MessagePart } from "../types.js";
 import type { TimelineAccount, TimelineSource } from "./timeline.js";
 import { accountPairs, addressesOn, inList, sqlTimelineSource } from "./timeline-sql.js";
 
@@ -126,15 +128,17 @@ export function agentMessagesSource(db: DrizzleDb): TimelineSource {
           s.source_channel AS source,
           s.source_thread_id AS address,
           m.created_at AS at,
-          CASE WHEN m.role = 'assistant' THEN 1 ELSE 0 END AS outbound,
+          ${agentMessageOutbound(sql`m.role`, sql`m.sender_id`)} AS outbound,
           'agent:' || m.id AS ref,
           m.content AS body
         FROM rome_agent_messages m
         JOIN rome_sessions s ON s.id = m.session_id
         WHERE s.type = 'channel'
           AND ${addressed}
-          -- 'notification' is an inbound message that did not wake the agent;
-          -- it is still something the person said. 'trace' is the turn's
+          -- 'notification' is a line that passed outside a turn — something
+          -- the person said without waking the agent, or something Rome sent
+          -- untied to one. Either way it is conversation, and the direction
+          -- above is what tells the two apart. 'trace' is the turn's own
           -- machinery and belongs to no conversation.
           AND m.role IN ('user', 'assistant', 'notification')`;
     },
@@ -289,26 +293,3 @@ function foldAccounts(
 /** One page big enough to hold any listing — what `TalkAccounts.listAccounts`
  *  says to ask for when a caller needs every account exactly once. */
 const WHOLE_LISTING = Number.MAX_SAFE_INTEGER;
-
-/** The line a stored agent message renders as: its text parts, joined.
- *  Non-text parts (cards, recaps, errors) carry no conversation, and content
- *  that does not parse is a row with nothing to show rather than a failed read. */
-function messageContentText(raw: string | null): string | null {
-  if (raw === null) return null;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return null;
-  }
-  if (!Array.isArray(parsed)) return null;
-  const text = parsed
-    .filter((part): part is Extract<MessagePart, { type: "text" }> => {
-      if (typeof part !== "object" || part === null) return false;
-      const candidate = part as { type?: unknown; content?: unknown };
-      return candidate.type === "text" && typeof candidate.content === "string";
-    })
-    .map((part) => part.content)
-    .join("\n");
-  return text.length > 0 ? text : null;
-}

--- a/packages/core/src/people/timeline-sql.ts
+++ b/packages/core/src/people/timeline-sql.ts
@@ -4,7 +4,7 @@
 
 import { sql, type SQL } from "drizzle-orm";
 import { compareTimelineEntries, type TimelineEntry } from "@rome/api-types/people";
-import { inList } from "../channels/messages-sql.js";
+import { inList, scopePairs } from "../channels/messages-sql.js";
 import type { DrizzleDb } from "../db/index.js";
 import type { AccountDigest, TimelineAccount, TimelineSource, TimelineRead } from "./timeline.js";
 
@@ -178,20 +178,21 @@ export function addressesOn(accounts: readonly TimelineAccount[], channel: strin
 }
 
 /** `(channel, address)` matched as a pair, so an address on one channel never
- *  selects a row another channel stores under the same string. */
+ *  selects a row another channel stores under the same string.
+ *
+ *  The accounts flattened to the pairs they name, and the clause itself is the
+ *  channel-side one: the two sides of the migration scope the same rows, and a
+ *  second spelling here is a second set of rows to disagree about. */
 export function accountPairs(
   accounts: readonly TimelineAccount[],
   channelColumn: SQL,
   addressColumn: SQL,
 ): SQL | null {
-  const clauses = accounts
-    .map((account) => {
-      const addresses = inList(addressColumn, account.addresses);
-      return addresses === null
-        ? null
-        : sql`(${channelColumn} = ${account.channel} AND ${addresses})`;
-    })
-    .filter((clause): clause is SQL => clause !== null);
-  if (clauses.length === 0) return null;
-  return sql`(${sql.join(clauses, sql` OR `)})`;
+  return scopePairs(
+    accounts.flatMap((account) =>
+      account.addresses.map((address) => ({ channel: account.channel, address })),
+    ),
+    channelColumn,
+    addressColumn,
+  );
 }


### PR DESCRIPTION
Phase 2 of the channel-interface migration, over the two Rome-side stores that back the fallback tiers. Callsites are untouched: the `TimelineSource` implementations stay until the merge switches.

## What lands

- **`messages-sql.ts`** — the SQL half of the message plane. A store describes its rows as timeline entries once (`source`, `at`, `outbound`, `ref`, `body`) and this orders, pages and scopes them. The ORDER BY is `compareTimelineEntries` written as SQL and the cursor is the whole tuple that comparison reads, so a page resumes inside a second rather than after it.
- **`messages-agent.ts`** — `rome_agent_messages` on channel sessions: roles `user`, `assistant` and `notification`, reached through the session's channel address, with the content's text parts joined into the rendered line.
- **`messages-sentinel.ts`** — `sentinel_log`, one row read as the two lines it records.

## Acceptance

- **Both adapters pass the contract suite.** Enrolled against real SQLite fixtures, so `count` and `latest` are proved to agree with `read` on rows a migration produced rather than on a hand-built double.
- **A sentinel row with a reply yields two messages; without one, only the inbound.** An empty response counts as no reply. The two halves share the row's second, the reply sits above the line it answers, and each carries its own `ref` so they never collapse to one cursor position.
- **A group-addressed session or thread contributes nothing.** The sentinel subtracts a thread a group session covers — on that row's own channel, so the same thread id under another channel subtracts nothing. The transcript is already safe by addressing, since a group's session is keyed by the group and no account answers to that; it now says so on the store's own terms too, which is what a test asking for the group's id directly demanded.

## Notes

`inList`, `accountPairs` and the agent message's rendered line had one definition each in `people/`, and the new adapters need the same three. They are shared rather than restated — two spellings of one scope are two sets of rows to disagree about — with `people/timeline-sql.ts` re-exporting for its existing callers. Dependency direction is unchanged: `people/` already reads `channels/`.

## Testing

- `vitest run src/channels/messages-agent.test.ts src/channels/messages-sentinel.test.ts` — 38 passing, 19 per adapter (contract suite + the scoping each one owes).
- Full core unit suite: 4130 passing. Two suites fail to collect in this sandbox on a `node-pty` prebuild that will not compile here (`terminal-server`, `auth-me`); both are untouched by this change.
- `tsc --noEmit` and `biome check` clean over `packages/core/src`.

Closes rome-os/rome#96