### PR TITLE
refactor(core): fold accounts through Account.addresses

### DIFF
--- a/packages/core/src/channels/account-fold.test.ts
+++ b/packages/core/src/channels/account-fold.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import type { AccountActivity } from "./account-activity.js";
+import { foldAccounts, type MirrorPlane } from "./account-fold.js";
+import type { Account, AccountId } from "./accounts.js";
+import type { SentinelSenderActivity } from "../db/repositories/sentinel-log.js";
+
+const account = (id: string, addresses: string[] = [id], name: string | null = null): Account => ({
+  id: id as AccountId,
+  addresses,
+  name,
+  identifiers: {},
+});
+
+const sender = (
+  channel: string,
+  channelUserId: string,
+  row: Partial<SentinelSenderActivity> = {},
+): SentinelSenderActivity => ({
+  channel,
+  channelUserId,
+  displayName: null,
+  lastMessage: null,
+  lastMessageAt: null,
+  messageCount: 1,
+  ...row,
+});
+
+/**
+ * A channel that answers only what the fold is allowed to ask: a listing whose
+ * accounts carry their own addressing sets, `resolve` for an address the
+ * listing does not carry, and the activity half.
+ *
+ * It holds no separate address map, so a fold that reaches for one fails here
+ * rather than quietly reading a second source of the same answer.
+ */
+class FakePlane implements MirrorPlane {
+  listings = 0;
+  readonly resolved: string[] = [];
+
+  constructor(
+    private readonly accounts: readonly Account[],
+    private readonly options: {
+      activity?: Map<string, AccountActivity>;
+      /** Addresses the listing does not carry, and the account each names. */
+      resolves?: Map<string, Account>;
+    } = {},
+  ) {}
+
+  async listAccounts(_input: { query?: string; cursor?: string; limit: number }) {
+    this.listings++;
+    return { accounts: [...this.accounts] };
+  }
+
+  async resolve(address: string): Promise<Account | null> {
+    this.resolved.push(address);
+    return (
+      this.options.resolves?.get(address) ??
+      this.accounts.find((candidate) => candidate.addresses.includes(address)) ??
+      null
+    );
+  }
+
+  async listActivity(): Promise<Map<AccountId, AccountActivity>> {
+    return (this.options.activity ?? new Map()) as Map<AccountId, AccountActivity>;
+  }
+}
+
+const ada = "12025550100@s.whatsapp.net";
+const adaLid = "77770001@lid";
+const grace = "12025550111@s.whatsapp.net";
+
+describe("foldAccounts", () => {
+  it("takes an account's addressing set from the account itself", async () => {
+    const whatsapp = new FakePlane([account(ada, [ada, adaLid], "Ada")]);
+
+    const fold = await foldAccounts({ whatsapp }, { senders: [], stored: [] });
+
+    expect(fold.accounts).toEqual([
+      {
+        channel: "whatsapp",
+        channelUserId: ada,
+        aliases: [ada, adaLid].sort(),
+        name: "Ada",
+        latest: null,
+        messageCount: 0,
+      },
+    ]);
+    // Both addressings name the one account, whichever one a caller holds.
+    expect(fold.canonical("whatsapp", adaLid)).toBe(ada);
+    expect(fold.canonical("whatsapp", ada)).toBe(ada);
+    expect(fold.mirrorFor("whatsapp", adaLid)?.name).toBe("Ada");
+    expect(whatsapp.listings).toBe(1);
+  });
+
+  it("leaves an account the channel holds one address for addressing itself", async () => {
+    const linkedin = new FakePlane([account("ACoAAAda0001")]);
+
+    const fold = await foldAccounts({ linkedin }, { senders: [], stored: [] });
+
+    expect(fold.accounts[0]?.aliases).toEqual(["ACoAAAda0001"]);
+    expect(fold.canonical("linkedin", "ACoAAAda0001")).toBe("ACoAAAda0001");
+  });
+
+  it("folds a stored address the listing does not carry through resolve", async () => {
+    const member = account("ACoAAAda0001");
+    const profileUrl = "https://www.linkedin.com/in/ACoAAAda0001/";
+    const linkedin = new FakePlane([member], { resolves: new Map([[profileUrl, member]]) });
+
+    const fold = await foldAccounts(
+      { linkedin },
+      { senders: [], stored: [{ channel: "linkedin", channelUserId: profileUrl }] },
+    );
+
+    expect(linkedin.resolved).toEqual([profileUrl]);
+    expect(fold.canonical("linkedin", profileUrl)).toBe("ACoAAAda0001");
+    expect(fold.mirrorFor("linkedin", profileUrl)?.channelUserId).toBe("ACoAAAda0001");
+    // The stored form stays the caller's: the fold reads it, it does not
+    // publish it as an address of the account.
+    expect(fold.accounts[0]?.aliases).toEqual(["ACoAAAda0001"]);
+  });
+
+  it("keeps the listing's owner for a stored address the listing already carries", async () => {
+    const whatsapp = new FakePlane([account(ada, [ada, adaLid]), account(grace)], {
+      // A channel that answered otherwise must not move an address its own
+      // listing already placed.
+      resolves: new Map([[adaLid, account(grace)]]),
+    });
+
+    const fold = await foldAccounts(
+      { whatsapp },
+      { senders: [], stored: [{ channel: "whatsapp", channelUserId: adaLid }] },
+    );
+
+    expect(fold.canonical("whatsapp", adaLid)).toBe(ada);
+  });
+
+  it("files a triage row under the account, whichever address it named", async () => {
+    const whatsapp = new FakePlane([account(ada, [ada, adaLid], "Ada")], {
+      activity: new Map([
+        [ada, { lastMessageAt: 100, lastMessagePreview: "from the mirror", messageCount: 3 }],
+      ]),
+    });
+
+    const fold = await foldAccounts(
+      { whatsapp },
+      {
+        senders: [
+          sender("whatsapp", adaLid, { lastMessageAt: 200, lastMessage: "seen by triage" }),
+        ],
+        stored: [],
+      },
+    );
+
+    expect(fold.sendersFor("whatsapp", ada)).toHaveLength(1);
+    expect(fold.recordFor("whatsapp", adaLid)).toEqual({
+      latest: { source: "whatsapp", timestamp: 200, preview: "seen by triage" },
+      // The mirror's own count stands: a mirrored message and the triage row
+      // that saw it are one message.
+      messageCount: 3,
+    });
+  });
+
+  it("reads each channel once, whatever it is asked afterwards", async () => {
+    const whatsapp = new FakePlane([account(ada, [ada, adaLid])]);
+    const linkedin = new FakePlane([account("ACoAAAda0001")]);
+
+    const fold = await foldAccounts(
+      { whatsapp, linkedin },
+      {
+        senders: [],
+        stored: [
+          { channel: "whatsapp", channelUserId: adaLid },
+          { channel: "whatsapp", channelUserId: adaLid },
+        ],
+      },
+    );
+
+    expect(fold.accounts).toHaveLength(2);
+    expect(whatsapp.listings).toBe(1);
+    expect(linkedin.listings).toBe(1);
+    // The duplicate stored address is one question, not two.
+    expect(whatsapp.resolved).toEqual([adaLid]);
+  });
+});

--- a/packages/core/src/channels/account-fold.ts
+++ b/packages/core/src/channels/account-fold.ts
@@ -61,9 +61,18 @@ export function mirrorRegistry<T>(deps: {
   return { whatsapp: deps.whatsAppAccounts, linkedin: deps.linkedInAccounts };
 }
 
-/** A channel that answers both halves of its address book: who it can reach,
- *  and what was last said to each of them. */
-export type MirrorPlane = TalkAccounts & TalkAccountActivity;
+/**
+ * A channel that answers both halves of its address book: who it can reach,
+ * and what was last said to each of them.
+ *
+ * The listing half is read as the listing gives it — each account carrying its
+ * own addressing set — so the whole address book arrives as accounts rather
+ * than as a map of addresses a caller has to invert back into them. A separate
+ * address map is deliberately not part of what a plane owes here: it is a
+ * second answer to a question the listing already answers, and two sources of
+ * one truth is how they drift.
+ */
+export type MirrorPlane = Omit<TalkAccounts, "listAddresses"> & TalkAccountActivity;
 
 export type MirrorPlanes = Readonly<Record<string, MirrorPlane>>;
 
@@ -234,28 +243,16 @@ async function readPlane(
 ): Promise<{ accounts: MirrorAccount[]; byAddress: Map<string, MirrorAccount> }> {
   // Every read this channel owes, issued in one batch so the plane serves them
   // all from a single fold of its address book. The stored addresses are
-  // resolved without waiting to learn which of them the address map already
-  // covers: a channel can accept an address it stores no row for — LinkedIn
-  // derives a member id from a profile URL naming it — and asking after the map
+  // resolved without waiting to learn which of them the listing already covers:
+  // a channel can accept an address it stores no row for — LinkedIn derives a
+  // member id from a profile URL naming it — and asking after the listing
   // arrived would fall outside the shared read and cost a second fold of the
   // whole address book.
-  const [listing, activity, addresses, resolved] = await Promise.all([
+  const [listing, activity, resolved] = await Promise.all([
     plane.listAccounts({ limit: WHOLE_LISTING }),
     plane.listActivity(),
-    plane.listAddresses(),
     Promise.all(stored.map((address) => plane.resolve(address.channelUserId))),
   ]);
-
-  // The addressing set of each account, which is the address map read the other
-  // way round. An account carries all of them because a search reads them: an
-  // omitted address is a contact the guardian cannot reach by the phone number
-  // they know.
-  const aliasesOf = new Map<string, string[]>();
-  for (const [address, accountId] of addresses) {
-    const group = aliasesOf.get(accountId);
-    if (group) group.push(address);
-    else aliasesOf.set(accountId, [address]);
-  }
 
   const accounts: MirrorAccount[] = [];
   const byAddress = new Map<string, MirrorAccount>();
@@ -265,7 +262,13 @@ async function readPlane(
     const mirrored: MirrorAccount = {
       channel,
       channelUserId: account.id,
-      aliases: (aliasesOf.get(account.id) ?? [account.id]).sort(compareCodePoints),
+      // The account's own addressing set, as the channel gave it. An account
+      // carries all of them because a search reads them: an omitted address is
+      // a contact the guardian cannot reach by the phone number they know. An
+      // account the channel holds no address for still answers to its id.
+      aliases: (account.addresses.length > 0 ? [...account.addresses] : [account.id]).sort(
+        compareCodePoints,
+      ),
       name: account.name,
       latest:
         seen == null
@@ -278,12 +281,12 @@ async function readPlane(
     for (const alias of mirrored.aliases) byAddress.set(addressKey(channel, alias), mirrored);
   }
 
-  // A stored address the channel's address map did not cover. Left unfolded, a
-  // mapping written in that form is a second account for someone the caller
-  // already lists, and half their history hangs off it. The address stays as
-  // the caller gave it: this is the fold, not a new alias to publish.
+  // A stored address no listed account named. Left unfolded, a mapping written
+  // in that form is a second account for someone the caller already lists, and
+  // half their history hangs off it. The address stays as the caller gave it:
+  // this is the fold, not a new alias to publish.
   stored.forEach((address, i) => {
-    if (addresses.has(address.channelUserId)) return;
+    if (byAddress.has(addressKey(channel, address.channelUserId))) return;
     const found = resolved[i];
     const account = found && byId.get(found.id);
     if (account) byAddress.set(addressKey(channel, address.channelUserId), account);

--- a/packages/core/src/people/timeline-sources.test.ts
+++ b/packages/core/src/people/timeline-sources.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { Account, AccountId } from "../channels/accounts.js";
+import { timelineAccounts } from "./timeline-sources.js";
+
+const account = (id: string, addresses: string[] = [id]): Account => ({
+  id: id as AccountId,
+  addresses,
+  name: null,
+  identifiers: {},
+});
+
+/** A channel that answers the listing and `resolve`, and holds no separate
+ *  address map — so a caller that reaches for one fails here. */
+class FakeAccounts {
+  listings = 0;
+
+  constructor(private readonly accounts: readonly Account[]) {}
+
+  async listAccounts(_input: { query?: string; cursor?: string; limit: number }) {
+    this.listings++;
+    return { accounts: [...this.accounts] };
+  }
+
+  async resolve(address: string): Promise<Account | null> {
+    return this.accounts.find((candidate) => candidate.addresses.includes(address)) ?? null;
+  }
+}
+
+const ada = "12025550100@s.whatsapp.net";
+const adaLid = "77770001@lid";
+const grace = "12025550111@s.whatsapp.net";
+
+describe("timelineAccounts", () => {
+  it("collapses two addressings of one account onto one account", async () => {
+    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid])]);
+
+    const [accounts] = await timelineAccounts({ whatsAppAccounts }, [
+      [
+        { channel: "whatsapp", channelUserId: ada },
+        { channel: "whatsapp", channelUserId: adaLid },
+      ],
+    ]);
+
+    expect(accounts).toEqual([{ channel: "whatsapp", addresses: [ada, adaLid] }]);
+    expect(whatsAppAccounts.listings).toBe(1);
+  });
+
+  it("carries every address of an account a mapping names under one of them", async () => {
+    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid])]);
+
+    const [accounts] = await timelineAccounts({ whatsAppAccounts }, [
+      [{ channel: "whatsapp", channelUserId: adaLid }],
+    ]);
+
+    expect(accounts).toHaveLength(1);
+    expect([...(accounts[0]?.addresses ?? [])].sort()).toEqual([ada, adaLid].sort());
+  });
+
+  it("keeps two accounts apart", async () => {
+    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid]), account(grace)]);
+
+    const [accounts] = await timelineAccounts({ whatsAppAccounts }, [
+      [
+        { channel: "whatsapp", channelUserId: adaLid },
+        { channel: "whatsapp", channelUserId: grace },
+      ],
+    ]);
+
+    expect(accounts).toHaveLength(2);
+  });
+
+  it("gives an address the address book does not hold its own timeline", async () => {
+    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid])]);
+
+    const [accounts] = await timelineAccounts({ whatsAppAccounts }, [
+      [{ channel: "whatsapp", channelUserId: "12025550999@s.whatsapp.net" }],
+    ]);
+
+    expect(accounts).toEqual([{ channel: "whatsapp", addresses: ["12025550999@s.whatsapp.net"] }]);
+  });
+
+  it("gives a channel with no account plane the mapping's own address", async () => {
+    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid])]);
+
+    const [accounts] = await timelineAccounts({ whatsAppAccounts }, [
+      [{ channel: "linkedin", channelUserId: "ACoAAAda0001" }],
+    ]);
+
+    expect(accounts).toEqual([{ channel: "linkedin", addresses: ["ACoAAAda0001"] }]);
+    // No mapping named WhatsApp, so its address book is never read.
+    expect(whatsAppAccounts.listings).toBe(0);
+  });
+
+  it("answers one result per group, in the order given", async () => {
+    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid]), account(grace)]);
+
+    const groups = await timelineAccounts({ whatsAppAccounts }, [
+      [{ channel: "whatsapp", channelUserId: grace }],
+      [],
+      [{ channel: "whatsapp", channelUserId: adaLid }],
+    ]);
+
+    expect(groups).toHaveLength(3);
+    expect(groups[0]).toEqual([{ channel: "whatsapp", addresses: [grace] }]);
+    expect(groups[1]).toEqual([]);
+    expect(groups[2]?.[0]?.channel).toBe("whatsapp");
+    // One read serves every group.
+    expect(whatsAppAccounts.listings).toBe(1);
+  });
+});

--- a/packages/core/src/people/timeline-sources.ts
+++ b/packages/core/src/people/timeline-sources.ts
@@ -208,7 +208,7 @@ export function sentinelLogSource(db: DrizzleDb): TimelineSource {
  * asking about a directory of people must not pay for one read per row.
  */
 export async function timelineAccounts(
-  deps: { whatsAppAccounts: TalkAccounts },
+  deps: { whatsAppAccounts: AddressBook },
   groups: readonly (readonly ChannelMapping[])[],
 ): Promise<TimelineAccount[][]> {
   const channels = new Set(groups.flatMap((group) => group.map((mapping) => mapping.channel)));
@@ -221,9 +221,13 @@ interface ChannelMapping {
   channelUserId: string;
 }
 
-/** Every address a channel folds onto an account, grouped by the account —
- *  the address map read the way the fold needs it, inverted once per request
- *  rather than re-scanned per person.
+/** The listing half of a channel's address book: the accounts, each carrying
+ *  every address it answers to. A separate address map is not asked for — the
+ *  listing already says which addresses are one account. */
+type AddressBook = Omit<TalkAccounts, "listAddresses">;
+
+/** Each channel's accounts, indexed the two ways the fold reads them: which
+ *  account an address belongs to, and every address of that account.
  *
  *  Read only for the channels the mappings name, since a plane costs a full
  *  address-book read. LinkedIn has a plane too but is deliberately absent: it
@@ -231,27 +235,33 @@ interface ChannelMapping {
  *  buy a whole mirror read and change no answer. It joins here when it starts
  *  storing a second addressing. */
 async function readAddressBooks(
-  deps: { whatsAppAccounts: TalkAccounts },
+  deps: { whatsAppAccounts: AddressBook },
   channels: ReadonlySet<string>,
-): Promise<Map<string, AddressBook>> {
-  const planes = new Map<string, TalkAccounts>([["whatsapp", deps.whatsAppAccounts]]);
-  const books = new Map<string, AddressBook>();
+): Promise<Map<string, FoldedBook>> {
+  const planes = new Map<string, AddressBook>([["whatsapp", deps.whatsAppAccounts]]);
+  const books = new Map<string, FoldedBook>();
   for (const [channel, accounts] of planes) {
     if (!channels.has(channel)) continue;
-    const addresses = await accounts.listAddresses();
-    const byAccount = new Map<string, string[]>();
-    for (const [address, accountId] of addresses) {
-      const folded = byAccount.get(accountId);
-      if (folded) folded.push(address);
-      else byAccount.set(accountId, [address]);
+    // One page big enough to hold the listing: its order is stable but the
+    // listing under it is not, so walking cursors across a live mirror would
+    // skip or repeat an account as an inbound message reordered it.
+    const { accounts: listing } = await accounts.listAccounts({ limit: WHOLE_LISTING });
+    const of = new Map<string, string>();
+    const folded = new Map<string, string[]>();
+    for (const account of listing) {
+      // The id among them, whether or not the channel spelled it out as an
+      // address: it is a form the account answers to.
+      const addresses = [...new Set([account.id as string, ...account.addresses])];
+      folded.set(account.id, addresses);
+      for (const address of addresses) of.set(address, account.id);
     }
-    books.set(channel, { of: addresses, folded: byAccount });
+    books.set(channel, { of, folded });
   }
   return books;
 }
 
-/** One channel's address map, and the same map read the other way round. */
-interface AddressBook {
+/** One channel's listing, indexed by address and by account. */
+interface FoldedBook {
   /** Which account each address belongs to. */
   of: Map<string, string>;
   /** Every address of each account. */
@@ -259,7 +269,7 @@ interface AddressBook {
 }
 
 function foldAccounts(
-  books: Map<string, AddressBook>,
+  books: Map<string, FoldedBook>,
   mappings: readonly ChannelMapping[],
 ): TimelineAccount[] {
   const byAccount = new Map<string, TimelineAccount>();
@@ -275,6 +285,10 @@ function foldAccounts(
   }
   return [...byAccount.values()];
 }
+
+/** One page big enough to hold any listing — what `TalkAccounts.listAccounts`
+ *  says to ask for when a caller needs every account exactly once. */
+const WHOLE_LISTING = Number.MAX_SAFE_INTEGER;
 
 /** The line a stored agent message renders as: its text parts, joined.
  *  Non-text parts (cards, recaps, errors) carry no conversation, and content


### PR DESCRIPTION
Phase 2 of the channel-interface migration.

## What

The fold (`account-fold.ts`) and `timelineAccounts` (`people/timeline-sources.ts`) each read a channel's whole address map and inverted it back into the addressing set of every account — the answer the listing now carries on `Account.addresses`, computed a second time from a second read of the same mirror.

Both now take the addressing set off the account:

- `readPlane` drops its `listAddresses` read. The guard that leaves a stored address alone when the channel already places it asks the index the listing built rather than the address map — the listing is read whole, so it covers the same addresses.
- `resolve` still covers the stored addresses no listed account names: a LinkedIn profile URL naming a member id folds onto that member as before.
- `readAddressBooks` builds its two indexes from the listing, keeping the id among an account's addresses whether or not the channel spells it out.

`MirrorPlane` and `timelineAccounts`' dependency drop `listAddresses` from what they ask a channel for, so the second source cannot grow a caller back while it is still on `TalkAccounts`. Deleting the method is the removal issue.

Behavior is unchanged. Both mirrors serve every read of a call from one shared fold of their snapshot, so the listing read costs what the address-map read cost.

## Tests

Written first, against the two seams, and failing on `main` (11 of 12) because the fakes answer a listing and `resolve` and hold no address map at all:

- `packages/core/src/channels/account-fold.test.ts` — the addressing set comes off the account; a one-address account addresses itself; a stored address the listing does not carry folds through `resolve`; a stored address the listing does carry keeps the listing's owner even when the channel resolves it elsewhere; a triage row files under the account whichever address it named; each channel is read once and a duplicate stored address asked once.
- `packages/core/src/people/timeline-sources.test.ts` — two addressings of one account collapse to one; a mapping under one addressing carries them all; an address the book does not hold gets its own timeline; a channel with no plane contributes the mapping's own address; one result per group in the order given, off one read.

## Acceptance

- [x] Existing fold and timeline-accounts tests pass unchanged — full `packages/core` unit suite green (4104 tests; the two files that fail to load are `node-pty`'s unbuilt native module in this sandbox, unrelated).
- [x] `listAddresses` has no production caller left — only the `TalkAccounts` declaration, the two implementations, and their own tests remain.

Closes rome-os/rome#98