### PR TITLE
feat(core): move the WhatsApp and LinkedIn mirrors onto Messages

### DIFF
--- a/packages/core/src/channels/linkedin-messages.test.ts
+++ b/packages/core/src/channels/linkedin-messages.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { countingDb, createTestDb, type TestDb } from "../test/helpers.js";
+import { linkedinMessages, linkedinThreadParticipants, linkedinThreads } from "../db/schema.js";
+import { linkedInMirrorSource } from "../people/timeline-sources.js";
+import { testMessagesContract, WHOLE_HISTORY } from "./messages-contract.js";
+import { linkedInMessages } from "./linkedin-messages.js";
+import type { MessageAccount } from "./messages.js";
+
+// `linkedin_messages` as a `Messages` store. The mirror holds group threads
+// and rooms the guardian is one of many in; a person's history is the threads
+// that are a conversation between two people, and this checks that scope
+// against the `TimelineSource` the store is moving off.
+
+const SELF = "ACoAASELF";
+const MEMBER = "ACoAAMEMBER";
+const OTHER = "ACoAAOTHER";
+// One person holding two member ids, both on one thread of their own — the
+// case an attribution that answered per participant would show twice.
+const TWIN_A = "ACoAATWINA";
+const TWIN_B = "ACoAATWINB";
+
+// Mutable `addresses`, so one scope serves both the store under test and the
+// timeline source it is checked against.
+const account = { channel: "linkedin", addresses: [MEMBER] };
+const accounts = [account];
+const silent = [{ channel: "linkedin", addresses: ["ACoAASILENT"] }];
+
+interface ThreadSeed {
+  thread: string;
+  participants: string[];
+  isGroup?: boolean | null;
+  messages: Array<{ id: string; at: number; self?: boolean; text?: string; sentAt?: boolean }>;
+}
+
+const threads: ThreadSeed[] = [
+  {
+    thread: "t-direct",
+    participants: [SELF, MEMBER],
+    messages: [
+      { id: "a", at: 100, text: "first" },
+      // No `sent_at`: the mirror falls back on when it stored the message.
+      { id: "b", at: 200, text: "no delivery time", sentAt: false },
+      { id: "c", at: 300, self: true, text: "answered" },
+      // The same second as `c`; the direction settles the tie.
+      { id: "d", at: 300, text: "crossed in flight" },
+      { id: "e", at: 500, text: "latest" },
+    ],
+  },
+  // Three on the thread: nobody's direct history, whatever LinkedIn's own flag
+  // says about it.
+  {
+    thread: "t-room",
+    participants: [SELF, MEMBER, OTHER],
+    messages: [{ id: "f", at: 700, text: "in the room" }],
+  },
+  // Two on the thread, but LinkedIn calls it a group.
+  {
+    thread: "t-flagged",
+    participants: [SELF, MEMBER],
+    isGroup: true,
+    messages: [{ id: "g", at: 800, text: "flagged as a group" }],
+  },
+  {
+    thread: "t-other",
+    participants: [SELF, OTHER],
+    messages: [{ id: "h", at: 900, text: "another member" }],
+  },
+  {
+    thread: "t-twins",
+    participants: [TWIN_A, TWIN_B],
+    messages: [{ id: "i", at: 1000, text: "one message, two member ids" }],
+  },
+];
+
+function seedMirror(testDb: TestDb): void {
+  const now = new Date();
+  testDb.db
+    .insert(linkedinThreads)
+    .values(
+      threads.map((seed) => ({
+        threadId: seed.thread,
+        threadUrl: `https://www.linkedin.com/messaging/thread/${seed.thread}/`,
+        isGroup: seed.isGroup ?? null,
+        unread: false,
+        firstSyncedAt: now,
+        updatedAt: now,
+      })),
+    )
+    .run();
+
+  testDb.db
+    .insert(linkedinThreadParticipants)
+    .values(
+      threads.flatMap((seed) =>
+        seed.participants.map((participantId) => ({
+          threadId: seed.thread,
+          participantId,
+          firstSyncedAt: now,
+        })),
+      ),
+    )
+    .run();
+
+  testDb.db
+    .insert(linkedinMessages)
+    .values(
+      threads.flatMap((seed) =>
+        seed.messages.map((message) => ({
+          messageId: message.id,
+          threadId: seed.thread,
+          sentAt: message.sentAt === false ? null : new Date(message.at * 1000),
+          senderIsSelf: message.self ?? false,
+          text: message.text ?? null,
+          createdAt: new Date(message.at * 1000),
+        })),
+      ),
+    )
+    .run();
+}
+
+describe("linkedInMessages", () => {
+  let testDb: TestDb;
+
+  beforeEach(() => {
+    testDb = createTestDb();
+    seedMirror(testDb);
+  });
+
+  afterEach(() => {
+    testDb.close();
+  });
+
+  const refs = (entries: { ref: string }[]) => entries.map((entry) => entry.ref);
+
+  it("answers the member's direct thread, newest first", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const page = await messages.read({ accounts, limit: WHOLE_HISTORY });
+    expect(refs(page)).toEqual([
+      "t-direct:e",
+      "t-direct:c",
+      "t-direct:d",
+      "t-direct:b",
+      "t-direct:a",
+    ]);
+    expect(page[0]).toEqual({
+      source: "linkedin",
+      timestamp: 500,
+      direction: "inbound",
+      ref: "t-direct:e",
+      body: "latest",
+    });
+  });
+
+  it("leaves out a thread of more than two participants", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const page = await messages.read({ accounts, limit: WHOLE_HISTORY });
+    expect(refs(page)).not.toContain("t-room:f");
+  });
+
+  it("leaves out a thread LinkedIn calls a group", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const page = await messages.read({ accounts, limit: WHOLE_HISTORY });
+    expect(refs(page)).not.toContain("t-flagged:g");
+  });
+
+  it("answers a message once when the person holds both member ids on it", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const twins = [
+      { channel: "linkedin", addresses: [TWIN_A] },
+      { channel: "linkedin", addresses: [TWIN_B] },
+    ];
+    expect(refs(await messages.read({ accounts: twins, limit: WHOLE_HISTORY }))).toEqual([
+      "t-twins:i",
+    ]);
+    expect(await messages.count(twins)).toBe(1);
+  });
+
+  it("holds nothing for an account on another channel", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const elsewhere: MessageAccount[] = [{ channel: "whatsapp", addresses: [MEMBER] }];
+    expect(await messages.latest(elsewhere)).toBeNull();
+    expect(await messages.count(elsewhere)).toBe(0);
+    expect(await messages.read({ accounts: elsewhere, limit: WHOLE_HISTORY })).toEqual([]);
+  });
+
+  it("holds nothing for an empty scope", async () => {
+    const messages = linkedInMessages(testDb.db);
+    expect(await messages.latest([])).toBeNull();
+    expect(await messages.count([])).toBe(0);
+    expect(await messages.read({ accounts: [], limit: WHOLE_HISTORY })).toEqual([]);
+  });
+
+  it("scopes exactly as the timeline source it replaces", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const source = linkedInMirrorSource(testDb.db);
+    const scopes = [
+      accounts,
+      [{ channel: "linkedin", addresses: [OTHER] }],
+      [
+        { channel: "linkedin", addresses: [TWIN_A] },
+        { channel: "linkedin", addresses: [TWIN_B] },
+      ],
+      silent,
+    ];
+    for (const scope of scopes) {
+      const mirrored = await source.read({ accounts: scope, cursor: null, limit: WHOLE_HISTORY });
+      expect(await messages.read({ accounts: scope, limit: WHOLE_HISTORY })).toEqual(mirrored);
+      expect(await messages.count(scope)).toBe(mirrored.length);
+      expect(await messages.latest(scope)).toEqual(mirrored[0] ?? null);
+    }
+  });
+
+  it("serves concurrent latest and read calls from one store pass", async () => {
+    const cursor = await linkedInMessages(testDb.db).latest(accounts);
+    if (!cursor) throw new Error("the mirror answered nothing to resume from");
+
+    const counted = countingDb(testDb.db);
+    const messages = linkedInMessages(counted.db);
+    const before = counted.passes();
+
+    const [newest, otherNewest, page, tail, total] = await Promise.all([
+      messages.latest(accounts),
+      messages.latest([{ channel: "linkedin", addresses: [OTHER] }]),
+      messages.read({ accounts, limit: 2 }),
+      messages.read({ accounts, after: cursor, limit: WHOLE_HISTORY }),
+      messages.count(accounts),
+    ]);
+
+    expect(counted.passes() - before).toBe(1);
+    expect(newest?.ref).toBe("t-direct:e");
+    expect(otherNewest?.ref).toBe("t-other:h");
+    expect(refs(page)).toEqual(["t-direct:e", "t-direct:c"]);
+    expect(refs(tail)).toEqual(["t-direct:c", "t-direct:d", "t-direct:b", "t-direct:a"]);
+    expect(total).toBe(5);
+  });
+
+  it("costs one pass per round of calls, not one per account", async () => {
+    const counted = countingDb(testDb.db);
+    const messages = linkedInMessages(counted.db);
+    const directory = [MEMBER, OTHER, TWIN_A, TWIN_B, "ACoAASILENT"].map(
+      (address): MessageAccount[] => [{ channel: "linkedin", addresses: [address] }],
+    );
+
+    const before = counted.passes();
+    await Promise.all(directory.map((row) => messages.latest(row)));
+    expect(counted.passes() - before).toBe(1);
+  });
+});
+
+testMessagesContract("linkedInMessages", () => {
+  const testDb = createTestDb();
+  seedMirror(testDb);
+  return { messages: linkedInMessages(testDb.db), accounts, silent };
+});

--- a/packages/core/src/channels/linkedin-messages.ts
+++ b/packages/core/src/channels/linkedin-messages.ts
@@ -1,0 +1,49 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleDb } from "../db/index.js";
+import type { Messages } from "./messages.js";
+import { inList, sqlMessages } from "./messages-sql.js";
+
+/**
+ * `Messages` over the LinkedIn inbox mirror (`linkedin_messages`), restricted
+ * to threads that are a conversation between two people.
+ *
+ * A LinkedIn message hangs off a thread rather than off a member, so the scope
+ * is reached through the thread's membership: a member's history is the
+ * messages of the threads they are on. Two conditions keep that to a direct
+ * conversation, and both are needed — LinkedIn's own group flag is null until
+ * a thread has been snapshotted, so the membership decides the threads it has
+ * not answered for yet.
+ *
+ * A message is answered once for each scoped member of its thread, and the
+ * read above folds those together. That is what makes a person holding two
+ * member ids on one thread read one history rather than the same messages
+ * twice — and, unlike picking a single member per thread, it holds however
+ * many members of however many people the scope names at once, which a read
+ * grouping a whole directory into one pass depends on.
+ */
+export function linkedInMessages(db: DrizzleDb): Messages {
+  return sqlMessages({
+    channel: "linkedin",
+    db,
+    view(addresses) {
+      const members = inList(sql`tp.participant_id`, addresses);
+      if (members === null) return null;
+      return sql`
+        SELECT
+          'linkedin' AS source,
+          tp.participant_id AS address,
+          coalesce(m.sent_at, m.created_at) AS at,
+          CASE WHEN m.sender_is_self THEN 1 ELSE 0 END AS outbound,
+          m.thread_id || ':' || m.message_id AS ref,
+          m.text AS body
+        FROM linkedin_messages m
+        JOIN linkedin_threads t ON t.thread_id = m.thread_id
+        JOIN linkedin_thread_participants tp
+          ON tp.thread_id = m.thread_id AND ${members}
+        WHERE coalesce(t.is_group, 0) = 0
+          AND (
+            SELECT count(*) FROM linkedin_thread_participants x WHERE x.thread_id = m.thread_id
+          ) <= 2`;
+    },
+  });
+}

--- a/packages/core/src/channels/messages-sql.ts
+++ b/packages/core/src/channels/messages-sql.ts
@@ -1,0 +1,301 @@
+// The SQL half of `Messages`: a store that lives in this database becomes one
+// by describing its rows as timeline entries once, and this module scopes,
+// orders, pages and — the part that is not just plumbing — groups the calls
+// made against it.
+//
+// Grouping is the point. The People surface reads a whole directory at once:
+// one `latest` and one `count` per row, all issued together. Served one query
+// each, a directory of a thousand people is a thousand passes over the same
+// mirror. Served here, it is one, the way the WhatsApp account plane already
+// answers concurrent `resolve` calls from a single shared load.
+
+import { sql, type SQL } from "drizzle-orm";
+import type { TimelineEntry } from "@rome/api-types/people";
+import type { DrizzleDb } from "../db/index.js";
+import type { MessageAccount, MessageRead, Messages } from "./messages.js";
+
+/**
+ * A store's rows as timeline entries: a SELECT producing exactly the columns
+ * `source`, `address`, `at`, `outbound`, `ref`, `body`.
+ *
+ * - `source` is the channel an entry arrived on, and `address` an address of
+ *   the account it belongs to — one of the addresses the view was given.
+ * - `at` is epoch seconds, `outbound` is 1 for something Rome said and 0 for
+ *   something it was told, `body` is the line to render or NULL.
+ * - `ref` must be unique across everything the store can put on one person's
+ *   timeline. Ids unique only within a conversation (a WhatsApp message id, a
+ *   LinkedIn message id) are qualified by the conversation.
+ *
+ * A row may repeat one message under several addresses — a LinkedIn thread
+ * carrying two member ids of the same person answers under both. The reads
+ * below fold those together, so a view is free to attribute rather than choose.
+ */
+export type MessageViewSql = SQL;
+
+export interface SqlMessagesOptions {
+  /** The channel this store serves. Accounts on any other are out of its
+   *  scope, however their addresses read. */
+  channel: string;
+  db: DrizzleDb;
+  /**
+   * The store's rows, scoped to `addresses` — every address of every account
+   * a batch of calls named, deduplicated.
+   *
+   * Null when the request can hold nothing, and the store then answers empty
+   * without a query.
+   */
+  view(addresses: readonly string[]): MessageViewSql | null;
+}
+
+/**
+ * `Messages` over one SQL view.
+ *
+ * Every call — `read`, `count`, `latest` — is one job on one queue, and the
+ * jobs raised in a tick are answered by a single statement. What differs
+ * between them is only the shape of the job:
+ *
+ * - `read` asks for a page and takes the entries.
+ * - `latest` asks for a page of one and takes its head.
+ * - `count` asks for no page at all and takes the length the statement reports
+ *   alongside it.
+ *
+ * So the law messages.ts states holds by construction rather than by three
+ * queries agreeing: the count is the length of the history the page walks,
+ * because both are read off the same ranking of the same rows.
+ */
+export function sqlMessages(options: SqlMessagesOptions): Messages {
+  const submit = batched<Job, JobResult>((jobs) => runBatch(options, jobs));
+
+  const job = (accounts: readonly MessageAccount[], after: TimelineEntry | null, limit: number) =>
+    submit({ addresses: addressesOn(accounts, options.channel), after, limit });
+
+  return {
+    async read(request: MessageRead) {
+      const limit = Math.max(1, Math.floor(request.limit));
+      return (await job(request.accounts, request.after ?? null, limit)).entries;
+    },
+
+    async count(accounts) {
+      return (await job(accounts, null, COUNT_ONLY)).total;
+    },
+
+    async latest(accounts) {
+      return (await job(accounts, null, 1)).entries[0] ?? null;
+    },
+  };
+}
+
+/** Every address of every account on `channel`, each once. `(channel,
+ *  address)` is matched as a pair — an address on one channel must never
+ *  select a row another channel stores under the same string. */
+function addressesOn(accounts: readonly MessageAccount[], channel: string): string[] {
+  return [
+    ...new Set(
+      accounts
+        .filter((account) => account.channel === channel)
+        .flatMap((account) => account.addresses),
+    ),
+  ];
+}
+
+/** One call, as the batch sees it. `limit` of {@link COUNT_ONLY} is a job that
+ *  wants the length of a history and none of it. */
+interface Job {
+  addresses: readonly string[];
+  after: TimelineEntry | null;
+  limit: number;
+}
+
+interface JobResult {
+  entries: TimelineEntry[];
+  /** The length of the job's whole history — meaningful for a job with no
+   *  cursor, which is every job `count` raises. */
+  total: number;
+}
+
+const COUNT_ONLY = 0;
+
+/** A history the store holds none of. Built per job rather than shared: the
+ *  entries are the caller's array to do as it likes with. */
+const nothing = (): JobResult => ({ entries: [], total: 0 });
+
+/**
+ * One statement for a whole batch.
+ *
+ * The jobs enter the query as two tables of their own — which addresses each
+ * asked about, and where each wants to resume and how much of the history it
+ * wants — so the rows are scoped, ranked and cut per job inside a single pass
+ * rather than once per job.
+ */
+async function runBatch(options: SqlMessagesOptions, jobs: Job[]): Promise<JobResult[]> {
+  const asked = jobs.flatMap((job, index) => job.addresses.map((address) => ({ index, address })));
+  if (asked.length === 0) return jobs.map(nothing);
+
+  const rows = options.view([...new Set(asked.map((entry) => entry.address))]);
+  if (rows === null) return jobs.map(nothing);
+
+  const scope = sql.join(
+    asked.map((entry) => sql`(${entry.index}, ${entry.address})`),
+    sql`, `,
+  );
+  const ask = sql.join(
+    jobs.map((job, index) => askRow(index, job)),
+    sql`, `,
+  );
+
+  const answered = (await options.db.all(sql`
+    WITH scope(rq, address) AS (VALUES ${scope}),
+    ask(rq, cap, has_cursor, c_at, c_outbound, c_source, c_ref) AS (VALUES ${ask}),
+    -- One row per (job, message). DISTINCT because a view may attribute one
+    -- message to several of a job's addresses — a LinkedIn thread carrying two
+    -- member ids of the same person — and a person's history shows a message
+    -- once however many ways they are named on it.
+    scoped AS (
+      SELECT DISTINCT
+        scope.rq AS rq,
+        held.source AS source,
+        held.at AS at,
+        held.outbound AS outbound,
+        held.ref AS ref,
+        held.body AS body
+      FROM (${rows}) held
+      JOIN scope ON scope.address = held.address
+    ),
+    -- Each job's own history, ranked and measured in one pass. One named
+    -- window rather than two inline ones: SQLite shares a partition pass only
+    -- between windows spelled the same way, and two spellings sort every job's
+    -- history twice.
+    --
+    -- The frame is explicit because the window's ORDER BY would otherwise make
+    -- count(*) a running total — the length of the history above each row
+    -- rather than the length of the history.
+    ranked AS (
+      SELECT
+        scoped.rq AS rq,
+        scoped.source AS source,
+        scoped.at AS at,
+        scoped.outbound AS outbound,
+        scoped.ref AS ref,
+        scoped.body AS body,
+        ask.cap AS cap,
+        row_number() OVER w AS position,
+        count(*) OVER w AS total
+      FROM scoped
+      JOIN ask ON ask.rq = scoped.rq
+      WHERE ${AFTER_CURSOR}
+      WINDOW w AS (
+        PARTITION BY scoped.rq
+        ORDER BY scoped.at DESC, scoped.outbound DESC, scoped.source ASC, scoped.ref ASC
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      )
+    )
+    -- Never fewer than one row per job: a job that asked for no page still has
+    -- to be told how long the history it did not ask for is.
+    SELECT rq, source, at, outbound, ref, body, position, total
+    FROM ranked
+    WHERE position <= max(cap, 1)
+    ORDER BY rq ASC, position ASC
+  `)) as Array<Record<string, unknown>>;
+
+  const results = jobs.map(nothing);
+  for (const row of answered) {
+    const rq = Number(row.rq);
+    const result = results[rq];
+    const job = jobs[rq];
+    if (!result || !job) continue;
+    result.total = Number(row.total);
+    // The head of a history is answered whether or not the job asked for a
+    // page, so a job that only wanted the length discards the row it read it
+    // off.
+    if (Number(row.position) <= job.limit) result.entries.push(toEntry(row));
+  }
+  return results;
+}
+
+/** A job as a row of the `ask` table: how much of its history it wants, and
+ *  the cursor it resumes from, spread across columns so the comparison below
+ *  can be written once for the whole batch. */
+function askRow(index: number, job: Job): SQL {
+  const after = job.after;
+  if (after === null) return sql`(${index}, ${job.limit}, 0, 0, 0, '', '')`;
+  const outbound = after.direction === "outbound" ? 1 : 0;
+  return sql`(${index}, ${job.limit}, 1, ${after.timestamp}, ${outbound}, ${after.source}, ${after.ref})`;
+}
+
+/**
+ * The rows that fall strictly after a job's cursor, in the order the window's
+ * ORDER BY imposes — which is `compareTimelineEntries` read as SQL.
+ *
+ * The whole tuple, not `at < c_at`: a second holds more than one entry, and
+ * resuming from the bare timestamp drops the rest of that second.
+ *
+ * The two text comparisons ride SQLite's BINARY collation, which orders UTF-8
+ * by byte and therefore by code point — the same answer `compareCodePoints`
+ * gives, which is what makes a cursor mean one position on both ends.
+ */
+const AFTER_CURSOR = sql`
+  ask.has_cursor = 0
+  OR scoped.at < ask.c_at
+  OR (scoped.at = ask.c_at
+      AND (scoped.outbound < ask.c_outbound
+           OR (scoped.outbound = ask.c_outbound
+               AND (scoped.source > ask.c_source
+                    OR (scoped.source = ask.c_source AND scoped.ref > ask.c_ref)))))`;
+
+function toEntry(row: Record<string, unknown>): TimelineEntry {
+  return {
+    source: String(row.source),
+    timestamp: Number(row.at),
+    direction: Number(row.outbound) === 1 ? "outbound" : "inbound",
+    ref: String(row.ref),
+    body: (row.body as string | null) ?? null,
+  };
+}
+
+/**
+ * `run` over every call raised in one tick, each caller answered with the
+ * result at its own position.
+ *
+ * A microtask rather than a timer, so "together" means what a caller means by
+ * it: the calls of one `Promise.all` batch, and a call awaited before the next
+ * is made does not. Nothing is held across a turn, so no answer is ever older
+ * than the call that asked for it.
+ */
+function batched<J, R>(run: (jobs: J[]) => Promise<R[]>): (job: J) => Promise<R> {
+  type Waiting = { job: J; settle: (result: R) => void; fail: (error: unknown) => void };
+  let pending: Waiting[] | null = null;
+
+  return (job) =>
+    new Promise<R>((settle, fail) => {
+      if (pending === null) {
+        const batch: Waiting[] = [];
+        pending = batch;
+        queueMicrotask(() => {
+          pending = null;
+          run(batch.map((waiting) => waiting.job)).then(
+            (results) =>
+              batch.forEach((waiting, index) => {
+                const result = results[index];
+                if (result === undefined) waiting.fail(new Error("the batch answered no result"));
+                else waiting.settle(result);
+              }),
+            (error) => {
+              for (const waiting of batch) waiting.fail(error);
+            },
+          );
+        });
+      }
+      pending.push({ job, settle, fail });
+    });
+}
+
+/** `column IN (…)` over `values`, or null when there is nothing to match —
+ *  `IN ()` is not SQL, and a caller that emitted it would fail the whole read
+ *  rather than answer the empty page an empty scope means. */
+export function inList(column: SQL, values: readonly string[]): SQL | null {
+  if (values.length === 0) return null;
+  return sql`${column} IN (${sql.join(
+    values.map((value) => sql`${value}`),
+    sql`, `,
+  )})`;
+}

--- a/packages/core/src/channels/whatsapp-messages.test.ts
+++ b/packages/core/src/channels/whatsapp-messages.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { countingDb, createTestDb, type TestDb } from "../test/helpers.js";
+import { waMessages } from "../db/schema.js";
+import { whatsAppMirrorSource } from "../people/timeline-sources.js";
+import { testMessagesContract, WHOLE_HISTORY } from "./messages-contract.js";
+import { whatsAppMessages } from "./whatsapp-messages.js";
+import type { MessageAccount } from "./messages.js";
+
+// `wa_messages` as a `Messages` store. What it must answer is the contract
+// suite's; what it must leave out is the mirror's own scoping, which this
+// checks against the `TimelineSource` the store is moving off — the two read
+// the same mirror, so an answer they disagree about is a message a person's
+// timeline gains or loses in the move.
+
+// One account, addressed both ways WhatsApp addresses a contact.
+const PHONE = "15550001@s.whatsapp.net";
+const LID = "8877@lid";
+// A second contact, and a group. Neither is in any scope below.
+const OTHER = "15559999@s.whatsapp.net";
+const GROUP = "1200000@g.us";
+
+// Mutable `addresses`, so one scope serves both the store under test and the
+// timeline source it is checked against.
+const account = { channel: "whatsapp", addresses: [PHONE, LID] };
+const accounts = [account];
+const silent = [{ channel: "whatsapp", addresses: ["15554444@s.whatsapp.net"] }];
+
+interface Seed {
+  id: string;
+  chat: string;
+  at: number;
+  fromMe?: boolean;
+  type?: string;
+  text?: string;
+}
+
+const seeds: Seed[] = [
+  { id: "a", chat: PHONE, at: 100, text: "first" },
+  { id: "c", chat: PHONE, at: 300, fromMe: true, text: "answered" },
+  // The same second as `c`, on the account's other addressing: the direction
+  // settles the tie, and both have to survive a page boundary.
+  { id: "d", chat: LID, at: 300, text: "and on the lid" },
+  { id: "e", chat: PHONE, at: 500, text: "latest" },
+  // Out of scope, each for its own reason.
+  { id: "r", chat: PHONE, at: 600, type: "reaction", text: "👍" },
+  { id: "g", chat: GROUP, at: 700, text: "in the group" },
+  { id: "o", chat: OTHER, at: 800, text: "another contact" },
+];
+
+function seedMirror(testDb: TestDb): void {
+  const now = new Date();
+  testDb.db
+    .insert(waMessages)
+    .values(
+      seeds.map((seed) => ({
+        id: seed.id,
+        chatJid: seed.chat,
+        senderJid: seed.fromMe ? null : seed.chat,
+        fromMe: seed.fromMe ?? false,
+        timestamp: new Date(seed.at * 1000),
+        type: seed.type ?? "text",
+        text: seed.text ?? null,
+        hasMedia: false,
+        createdAt: now,
+      })),
+    )
+    .run();
+}
+
+describe("whatsAppMessages", () => {
+  let testDb: TestDb;
+
+  beforeEach(() => {
+    testDb = createTestDb();
+    seedMirror(testDb);
+  });
+
+  afterEach(() => {
+    testDb.close();
+  });
+
+  const refs = (entries: { ref: string }[]) => entries.map((entry) => entry.ref);
+
+  it("merges both addressings of the account, newest first", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    const page = await messages.read({ accounts, limit: WHOLE_HISTORY });
+    expect(refs(page)).toEqual([`${PHONE}:e`, `${PHONE}:c`, `${LID}:d`, `${PHONE}:a`]);
+    expect(page[0]).toEqual({
+      source: "whatsapp",
+      timestamp: 500,
+      direction: "inbound",
+      ref: `${PHONE}:e`,
+      body: "latest",
+    });
+  });
+
+  it("leaves out reactions", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    const page = await messages.read({ accounts, limit: WHOLE_HISTORY });
+    expect(refs(page)).not.toContain(`${PHONE}:r`);
+  });
+
+  it("leaves out group threads", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    const group: MessageAccount[] = [{ channel: "whatsapp", addresses: [GROUP] }];
+    expect(await messages.latest(group)).toBeNull();
+    expect(await messages.count(group)).toBe(0);
+  });
+
+  it("holds nothing for an account on another channel", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    // The same string, on a channel this store does not serve.
+    const elsewhere: MessageAccount[] = [{ channel: "linkedin", addresses: [PHONE] }];
+    expect(await messages.latest(elsewhere)).toBeNull();
+    expect(await messages.count(elsewhere)).toBe(0);
+    expect(await messages.read({ accounts: elsewhere, limit: WHOLE_HISTORY })).toEqual([]);
+  });
+
+  it("holds nothing for an empty scope", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    expect(await messages.latest([])).toBeNull();
+    expect(await messages.count([])).toBe(0);
+    expect(await messages.read({ accounts: [], limit: WHOLE_HISTORY })).toEqual([]);
+  });
+
+  it("scopes exactly as the timeline source it replaces", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    const source = whatsAppMirrorSource(testDb.db);
+    const scopes = [accounts, [{ channel: "whatsapp", addresses: [PHONE] }], silent];
+    for (const scope of scopes) {
+      const mirrored = await source.read({ accounts: scope, cursor: null, limit: WHOLE_HISTORY });
+      expect(await messages.read({ accounts: scope, limit: WHOLE_HISTORY })).toEqual(mirrored);
+      expect(await messages.count(scope)).toBe(mirrored.length);
+      expect(await messages.latest(scope)).toEqual(mirrored[0] ?? null);
+    }
+  });
+
+  it("serves concurrent latest and read calls from one store pass", async () => {
+    const cursor = await whatsAppMessages(testDb.db).latest(accounts);
+    if (!cursor) throw new Error("the mirror answered nothing to resume from");
+
+    const counted = countingDb(testDb.db);
+    const messages = whatsAppMessages(counted.db);
+    const before = counted.passes();
+
+    // Every shape at once — two scopes, a first page, a page resuming from a
+    // cursor, and a count — because a batch that only served identical
+    // requests would not be serving the directory read this exists for.
+    const [newest, otherNewest, page, tail, total] = await Promise.all([
+      messages.latest(accounts),
+      messages.latest([{ channel: "whatsapp", addresses: [OTHER] }]),
+      messages.read({ accounts, limit: 2 }),
+      messages.read({ accounts, after: cursor, limit: WHOLE_HISTORY }),
+      messages.count(accounts),
+    ]);
+
+    expect(counted.passes() - before).toBe(1);
+    expect(newest?.ref).toBe(`${PHONE}:e`);
+    expect(otherNewest?.ref).toBe(`${OTHER}:o`);
+    expect(refs(page)).toEqual([`${PHONE}:e`, `${PHONE}:c`]);
+    expect(refs(tail)).toEqual([`${PHONE}:c`, `${LID}:d`, `${PHONE}:a`]);
+    expect(total).toBe(4);
+  });
+
+  it("costs one pass per round of calls, not one per account", async () => {
+    const counted = countingDb(testDb.db);
+    const messages = whatsAppMessages(counted.db);
+    const directory = [PHONE, LID, OTHER, GROUP, "15554444@s.whatsapp.net"].map(
+      (address): MessageAccount[] => [{ channel: "whatsapp", addresses: [address] }],
+    );
+
+    const before = counted.passes();
+    await Promise.all(directory.map((row) => messages.latest(row)));
+    expect(counted.passes() - before).toBe(1);
+  });
+});
+
+testMessagesContract("whatsAppMessages", () => {
+  const testDb = createTestDb();
+  seedMirror(testDb);
+  return { messages: whatsAppMessages(testDb.db), accounts, silent };
+});

--- a/packages/core/src/channels/whatsapp-messages.ts
+++ b/packages/core/src/channels/whatsapp-messages.ts
@@ -1,0 +1,49 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleDb } from "../db/index.js";
+import type { Messages } from "./messages.js";
+import { inList, sqlMessages } from "./messages-sql.js";
+
+/**
+ * `Messages` over the WhatsApp message mirror (`wa_messages`) — the thread as
+ * the channel has it, which is the fullest record of a WhatsApp conversation
+ * Rome holds.
+ *
+ * Scoped by chat: a WhatsApp message hangs off the chat it was said in, and a
+ * direct chat is addressed by the contact, so the account's own addresses are
+ * the whole scope. A contact reachable both as a phone JID and as a `@lid` JID
+ * has a chat under each, and `WhatsAppAccounts` folds both onto one account —
+ * so a caller that passes the account's addresses reads one history rather
+ * than whichever half its person mapping happened to name.
+ *
+ * Two things the mirror holds are left out:
+ *
+ * - Group chats (`@g.us`). A group is addressed by the group rather than by
+ *   anyone on it, so no address of an account names one — the `NOT LIKE` is
+ *   belt and braces against a group JID arriving as an address.
+ * - Reactions. A reaction answers a line rather than being one, and the
+ *   account plane's own activity already leaves it out of what an account last
+ *   did. Carrying it here would let a directory row preview a thumbs-up and
+ *   open on the message it was aimed at.
+ */
+export function whatsAppMessages(db: DrizzleDb): Messages {
+  return sqlMessages({
+    channel: "whatsapp",
+    db,
+    view(addresses) {
+      const chats = inList(sql`m.chat_jid`, addresses);
+      if (chats === null) return null;
+      return sql`
+        SELECT
+          'whatsapp' AS source,
+          m.chat_jid AS address,
+          m.timestamp AS at,
+          CASE WHEN m.from_me THEN 1 ELSE 0 END AS outbound,
+          m.chat_jid || ':' || m.id AS ref,
+          m.text AS body
+        FROM wa_messages m
+        WHERE ${chats}
+          AND m.chat_jid NOT LIKE '%@g.us'
+          AND coalesce(m.type, '') <> 'reaction'`;
+    },
+  });
+}

--- a/packages/core/src/people/timeline-sql.ts
+++ b/packages/core/src/people/timeline-sql.ts
@@ -4,6 +4,7 @@
 
 import { sql, type SQL } from "drizzle-orm";
 import { compareTimelineEntries, type TimelineEntry } from "@rome/api-types/people";
+import { inList } from "../channels/messages-sql.js";
 import type { DrizzleDb } from "../db/index.js";
 import type { AccountDigest, TimelineAccount, TimelineSource, TimelineRead } from "./timeline.js";
 
@@ -166,16 +167,10 @@ function afterCursor(cursor: TimelineEntry | null): SQL {
                       OR (source = ${cursor.source} AND ref > ${cursor.ref})))))`;
 }
 
-/** `column IN (…)` over `values`, or null when there is nothing to match —
- *  `IN ()` is not SQL, and a caller that emitted it would fail the whole read
- *  rather than answer the empty page an empty scope means. */
-export function inList(column: SQL, values: readonly string[]): SQL | null {
-  if (values.length === 0) return null;
-  return sql`${column} IN (${sql.join(
-    values.map((value) => sql`${value}`),
-    sql`, `,
-  )})`;
-}
+// `column IN (…)` is the same clause on both sides of the migration, so it has
+// one definition — the channel-side one — rather than a copy here that could
+// answer an empty scope differently.
+export { inList };
 
 /** Every address of every account, for a store that serves one channel. */
 export function addressesOn(accounts: readonly TimelineAccount[], channel: string): string[] {

--- a/packages/core/src/test/helpers.ts
+++ b/packages/core/src/test/helpers.ts
@@ -123,6 +123,30 @@ export function createTestDb(): TestDb {
   };
 }
 
+// countingDb — a database that records how many passes are made over it
+
+/**
+ * `db` with every read counted, for a test that asserts how many times a store
+ * was walked rather than what it answered.
+ *
+ * Only `all` is counted, which is the one verb a read-only SQL adapter uses.
+ * Everything else — the inserts a test seeds with, the schema it seeds into —
+ * passes through untouched and uncounted.
+ */
+export function countingDb(db: DrizzleDb): { db: DrizzleDb; passes: () => number } {
+  let passes = 0;
+  const counted = new Proxy(db, {
+    get(target, property, receiver) {
+      if (property !== "all") return Reflect.get(target, property, receiver);
+      return (...args: Parameters<DrizzleDb["all"]>) => {
+        passes += 1;
+        return target.all(...args);
+      };
+    },
+  });
+  return { db: counted as DrizzleDb, passes: () => passes };
+}
+
 // MockModelProvider — returns predetermined AgentMessage sequences
 
 export class MockModelProvider implements ModelProvider {


### PR DESCRIPTION
Phase 2 of the channel-interface migration. Implements `Messages` over `wa_messages` and `linkedin_messages` and enrolls both in the contract suite.

## What it does

- **`channels/messages-sql.ts`** — the SQL half of `Messages`: a store describes its rows as timeline entries once, and this scopes, orders, pages and *groups* the calls made against it.
- **`channels/whatsapp-messages.ts`** — `wa_messages`, scoped by chat, no groups, no reactions.
- **`channels/linkedin-messages.ts`** — `linkedin_messages`, reached through thread membership, threads of at most two participants and not flagged a group.

## Scoping

Exactly what the `TimelineSource` adapters apply today. Rather than assert that by reading, each store is checked against the source it replaces over the same seeded mirror — `read`, `count` and `latest` against `read`, for several scopes — so a message a person's timeline would gain or lose in the move fails the suite.

One deliberate difference in how, not in what: LinkedIn attributes a message to *every* scoped member of its thread and the read folds the duplicates, where the timeline source picks `min(participant)`. Picking one member per thread is a choice a single-scope read can make and a read grouping a whole directory cannot — the two agree on every answer, and the parity test covers the person-holds-two-member-ids case that forced the `min()` in the first place.

## One store pass

The People surface reads a whole directory at once: one `latest` and one `count` per row, all issued together. Served a query each, that is a pass over the mirror per person.

Every call is instead a job on one queue, and the jobs raised in a tick become a single statement — the jobs enter it as two tables of their own (which addresses each asked about, where each resumes and how much it wants) and the rows are scoped, ranked and cut per job inside one pass. Same shape as the WhatsApp account plane already serving concurrent `resolve` calls from one shared load.

`latest` is a page of one and `count` the length that same ranking reports, so the law binding the three verbs holds by construction rather than by three queries agreeing.

Tests assert it with a counting db: five concurrent calls of every shape — two scopes, a first page, a page resuming from a cursor, a count — cost one pass, and so does a five-row directory of `latest` calls.

## Verification

- 4139 core tests pass, `tsc --noEmit` clean, biome clean.
- Mutation-checked: removing the batching fails both pass-count tests; removing the reaction filter fails the scoping and parity tests.

## Out of scope

No callsite changes. The `TimelineSource` implementations stay until the merge switches (separate issue). `inList` moves to the channel side so both halves share one definition instead of a copy each.

Closes rome-os/rome#95

🤖 Generated with [Claude Code](https://claude.com/claude-code)