### PR TITLE
fix(apps): align web SDK dependencies with 0.3.0

### DIFF
--- a/example_apps/morning-brief/package.json
+++ b/example_apps/morning-brief/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "latest",
-    "@rome-os/app-web-sdk": "^0.2.0",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "drizzle-orm": "^0.45.1",
     "react": "^19.1.0",

--- a/packages/app-template/template/package.json
+++ b/packages/app-template/template/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "drizzle-orm": "^0.45.1",
     "lucide-react": "^0.468.0",

--- a/packages/app-template/workflow/package.json
+++ b/packages/app-template/workflow/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "drizzle-orm": "^0.45.1",
     "react": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         specifier: latest
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.0
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       '@rome-os/ui':
         specifier: ^0.2.2
@@ -965,7 +965,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       '@rome-os/ui':
         specifier: ^0.2.2
@@ -1005,7 +1005,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       react:
         specifier: 19.2.6
@@ -1027,7 +1027,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       '@rome-os/ui':
         specifier: ^0.2.2
@@ -1070,7 +1070,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       '@rome-os/ui':
         specifier: ^0.2.2
@@ -1113,7 +1113,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       drizzle-orm:
         specifier: ^0.45.1
@@ -1138,7 +1138,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       react:
         specifier: 19.2.6
@@ -1160,7 +1160,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       '@rome-os/ui':
         specifier: ^0.2.2
@@ -1209,7 +1209,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       '@rome-os/ui':
         specifier: ^0.2.2
@@ -1246,7 +1246,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       '@rome-os/ui':
         specifier: ^0.2.2
@@ -1295,7 +1295,7 @@ importers:
   rome_apps/skills:
     dependencies:
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       '@rome-os/ui':
         specifier: ^0.2.2
@@ -1326,7 +1326,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       react:
         specifier: 19.2.6
@@ -1357,7 +1357,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       '@rome-os/ui':
         specifier: ^0.2.2
@@ -1400,7 +1400,7 @@ importers:
         specifier: ^0.6.0
         version: link:../../packages/app-runtime-sdk
       '@rome-os/app-web-sdk':
-        specifier: ^0.2.21
+        specifier: ^0.3.0
         version: link:../../packages/app-web-sdk
       '@rome-os/ui':
         specifier: ^0.2.2

--- a/rome_apps/briefing/package.json
+++ b/rome_apps/briefing/package.json
@@ -14,7 +14,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.1.2",
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "class-variance-authority": "^0.7.1",
     "drizzle-orm": "^0.45.1",

--- a/rome_apps/browser-automation/package.json
+++ b/rome_apps/browser-automation/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/rome_apps/coding/package.json
+++ b/rome_apps/coding/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/rome_apps/connector/package.json
+++ b/rome_apps/connector/package.json
@@ -14,7 +14,7 @@
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-slot": "^1.1.2",
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "@tanstack/react-query": "^5.62.0",
     "class-variance-authority": "^0.7.1",

--- a/rome_apps/dream/package.json
+++ b/rome_apps/dream/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "drizzle-orm": "^0.45.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/rome_apps/inbox/package.json
+++ b/rome_apps/inbox/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/rome_apps/recap/package.json
+++ b/rome_apps/recap/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "lucide-react": "^0.468.0",
     "node-edge-tts": "^1.2.10",

--- a/rome_apps/replay/package.json
+++ b/rome_apps/replay/package.json
@@ -16,7 +16,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-slider": "^1.4.7",
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "drizzle-orm": "^0.45.1",
     "lucide-react": "^0.468.0",

--- a/rome_apps/showcases/package.json
+++ b/rome_apps/showcases/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "beautiful-mermaid": "^1.1.3",
     "drizzle-orm": "^0.45.1",

--- a/rome_apps/skills/package.json
+++ b/rome_apps/skills/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "lucide-react": "^0.468.0",
     "react": "^19.1.0",

--- a/rome_apps/system/package.json
+++ b/rome_apps/system/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/rome_apps/welcome-to-rome/package.json
+++ b/rome_apps/welcome-to-rome/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "canvas-confetti": "^1.9.4",
     "drizzle-orm": "^0.45.1",

--- a/rome_apps/workflow-studio/package.json
+++ b/rome_apps/workflow-studio/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@rome-os/app-runtime": "^0.6.0",
-    "@rome-os/app-web-sdk": "^0.2.21",
+    "@rome-os/app-web-sdk": "^0.3.0",
     "@rome-os/ui": "^0.2.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"


### PR DESCRIPTION
## What this PR does

The workspace SDK is `0.3.0`, but app dependencies require `0.2.x`. pnpm therefore resolves them from the registry instead of linking the local package.

Set all 16 app, example, and template declarations to `^0.3.0` and regenerate the root lockfile with pnpm. All 14 workspace SDK consumers link to `packages/app-web-sdk`.

## Test plan

- [x] `pnpm install --lockfile-only --ignore-scripts`
- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `pnpm typecheck`
- [x] `pnpm test:unit`
- [x] Verify all 16 manifest ranges, 14 lockfile entries, and 14 installed SDK symlinks.
- [x] `git diff --check` and the Biome pre-commit hook.
- [ ] Container startup with `pnpm dev:all` and a `Rome started` log check. Skipped during validation to avoid restarting another checkout's `main` stack.

Local checks used Node `24.11.1` and pnpm `11.6.0`. Nix is unavailable on this host.

## Not in this PR

- Automatic synchronization of app dependency ranges during SDK releases is outside this dependency update.
