### PR TITLE
feat(web): make the People directory a contacts list

### DIFF
--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -5,6 +5,7 @@
 //   GET    /api/people/:id          -> PersonResource
 //   GET    /api/people/:id/messages -> TimelinePage
 //   GET    /api/accounts            -> AccountDirectory
+//   GET    /api/accounts/stream     -> AccountStream
 //   POST   /api/people              -> PersonResource (201) | LinkConflict (409)
 //   POST   /api/people/:id/accounts -> PersonResource | LinkConflict (409)
 //   DELETE /api/people/:id/accounts/:channel/:channelUserId -> PersonResource
@@ -29,9 +30,19 @@
 // opens, and a cursor written against one has to name a position in the
 // other. A second definition of either is a page boundary the two ends
 // disagree about.
+//
+// The account read is two reads, because two surfaces ask two questions. The
+// directory is a contacts list: every account, ordered by name, carrying
+// nothing about what anyone said — it is where a guardian looks someone up.
+// The stream is the recents surface: ordered by what happened last, carrying
+// the line to preview, and it only ever holds accounts something has happened
+// on. Each has its own row shape and its own cursor, so neither pays for the
+// other's fields and neither order can be resumed with the other's position.
 
 import {
   ASSIGNABLE_BOND_LEVELS,
+  compareCodePoints,
+  compareDisplayNames,
   compareIdentityCursors,
   encodeIdentityCursor,
   identityCursorOf,
@@ -165,6 +176,11 @@ export function accountPresentation(
  * `channel` and `channelUserId` are its identity — the pair a link, a dismissal
  * or a timeline read names. {@link accountRef} renders the pair as the single
  * token a key or a path segment needs.
+ *
+ * A contacts list's row, so it carries who the account is and nothing about
+ * what it has done — not a preview, not a count, not even whether there is
+ * anything to count. {@link StreamAccount} is the same account on the recents
+ * surface, where the activity is the point.
  */
 export interface DirectoryAccount {
   channel: string;
@@ -190,8 +206,19 @@ export interface DirectoryAccount {
   /** Never the stranger sentinel's id — see {@link accountPresentation}. */
   personId: string | null;
   personName: string | null;
-  /** The newest thing on record for this account, or null when nothing is. */
-  latest: AccountDynamic | null;
+}
+
+/**
+ * One account on the stream: the directory's account, plus the activity the
+ * stream orders and previews by.
+ *
+ * `latest` is never null. The stream is the recents surface and only carries
+ * accounts something has happened on, so an account with nothing on record is
+ * absent rather than present with an empty preview.
+ */
+export interface StreamAccount extends DirectoryAccount {
+  /** The newest thing on record for this account. */
+  latest: AccountDynamic;
   /**
    * Every record the producers hold for this account — not every line a
    * timeline renders. A reaction counts, and so does a message Rome sent, so
@@ -201,41 +228,46 @@ export interface DirectoryAccount {
   messageCount: number;
 }
 
-/**
- * An account with nothing on record that nobody has decided about: a synced
- * address-book contact and no more.
- *
- * Derived rather than carried, so no producer can report an account as silent
- * while its own `latest` says otherwise. A link or a dismissal is a decision
- * the guardian made about the account, and a decided account is never held
- * back — the directory's toggle hides the address book, not the guardian's own
- * work.
- */
-export function isSilentAccount(account: DirectoryAccount): boolean {
-  return account.latest === null && account.state === "unlinked";
-}
-
 /** How many accounts sit in each state. */
 export interface AccountCounts extends Record<AccountState, number> {}
 
 /**
- * One page of the account directory, newest activity first.
+ * One page of the account directory, by display name.
  *
- * `counts` and `silentTotal` describe the whole directory the query and the
- * silent toggle admit, never the page — so every number a client renders is the
- * server's, and no chip collapses as the client pages.
+ * `counts` describes the whole directory the query admits, never the page — so
+ * every number a client renders is the server's, and no chip collapses as the
+ * client pages.
  */
 export interface AccountDirectory {
   accounts: DirectoryAccount[];
   /** Opaque, and null on the last page. */
   nextCursor: string | null;
-  /** Per state, over everything the query and the silent toggle admit and
-   *  before `state` narrows the page — so each chip's number is the size of the
-   *  listing that chip shows. */
+  /**
+   * Per state, over everything the query admits and before `state` narrows the
+   * page — so each chip's number is the size of the listing that chip shows.
+   *
+   * Every account, the whole mirrored address book included: the directory is
+   * a contacts list and holds nothing back, so "unlinked" here counts everyone
+   * Rome has not placed rather than the senders waiting on a decision. The
+   * stream's own counts answer that narrower question, over the accounts
+   * something has actually happened on.
+   */
   counts: AccountCounts;
-  /** Every matching silent account, whether or not the toggle let them onto the
-   *  page — the number the toggle itself offers. */
-  silentTotal: number;
+}
+
+/**
+ * One page of the account stream, newest activity first.
+ *
+ * `counts` describes every account with activity the query admits, before
+ * `state` narrows the page — which is what makes the Unknown chip's number the
+ * senders actually waiting on a decision rather than the size of an address
+ * book.
+ */
+export interface AccountStream {
+  accounts: StreamAccount[];
+  /** Opaque, and null on the last page. */
+  nextCursor: string | null;
+  counts: AccountCounts;
 }
 
 /**
@@ -271,34 +303,65 @@ export function accountMatchesQuery(account: DirectoryAccount, query: string): b
 }
 
 /**
- * Where one account sits in the directory's order: the tuple the ordering
- * reads, and nothing else. A cursor carries this rather than a ref, so resuming
- * needs a position rather than an account that still exists.
+ * Where one account sits in the directory's order: the name it is filed under,
+ * and its ref to settle a tie.
  *
- * The identity stream's position, over an account's ref — one activity order
- * and one encoding of it, so the reasons it is a tuple rather than a row id and
- * the reasons every part is escaped hold in one place
- * ({@link encodeIdentityCursor}) rather than two that can be fixed apart.
+ * Not the stream's tuple. The directory is a contacts list — ordered by name,
+ * carrying no activity at all — so a cursor naming a timestamp would name a
+ * position this order does not have, and a page boundary the two ends of the
+ * cursor disagree about.
+ *
+ * A position rather than a row id: between two requests an account is linked,
+ * dismissed or renamed, and a cursor that had to find that row again would
+ * answer the next page empty and truncate the listing.
  */
-export type AccountCursor = IdentityCursor;
-
-export const compareAccountCursors = compareIdentityCursors;
-export const encodeAccountCursor = encodeIdentityCursor;
-export const parseAccountCursor = parseIdentityCursor;
+export interface AccountCursor {
+  displayName: string;
+  /** {@link accountRef} of the account the page ended on. */
+  ref: string;
+}
 
 export function accountCursorOf(account: DirectoryAccount): AccountCursor {
-  return {
-    timestamp: account.latest?.timestamp ?? null,
-    displayName: account.displayName,
-    id: accountRef(account),
-  };
+  return { displayName: account.displayName, ref: accountRef(account) };
 }
 
 /**
- * The directory's order: newest activity first, accounts that have never done
- * anything last, ties broken by name and then ref so the sequence is total —
- * which is what lets a cursor resume it.
+ * The directory's order: by display name, ties broken by ref so the sequence is
+ * total — which is what lets a cursor resume it.
+ *
+ * {@link compareDisplayNames} rather than a collation, for the reason it
+ * states: the dashboard's mock orders in a browser and the route orders in
+ * Node, and a cursor written by one is read by the other.
  */
+export function compareAccountCursors(a: AccountCursor, b: AccountCursor): number {
+  const byName = compareDisplayNames(a.displayName, b.displayName);
+  return byName !== 0 ? byName : compareCodePoints(a.ref, b.ref);
+}
+
+/** Encode the position a page ended at. Both parts are escaped: a display name
+ *  is whatever a platform calls the account, and a ref carries a jid, so
+ *  neither can be trusted to leave the separator alone. */
+export function encodeAccountCursor(cursor: AccountCursor): string {
+  return [cursor.displayName, cursor.ref].map((part) => encodeURIComponent(part)).join("|");
+}
+
+/** Decode an {@link encodeAccountCursor}, or null when it is not one. */
+export function parseAccountCursor(raw: string | undefined | null): AccountCursor | null {
+  if (!raw) return null;
+  const parts = raw.split("|");
+  if (parts.length !== 2) return null;
+  let decoded: string[];
+  try {
+    decoded = parts.map(decodeURIComponent);
+  } catch {
+    return null;
+  }
+  const [displayName, ref] = decoded;
+  if (!ref) return null;
+  return { displayName, ref };
+}
+
+/** {@link compareAccountCursors} over the accounts themselves. */
 export function compareAccounts(a: DirectoryAccount, b: DirectoryAccount): number {
   return compareAccountCursors(accountCursorOf(a), accountCursorOf(b));
 }
@@ -307,6 +370,40 @@ export function compareAccounts(a: DirectoryAccount, b: DirectoryAccount): numbe
  *  i.e. belongs on a later page than the one that cursor ended. */
 export function isAfterAccountCursor(account: DirectoryAccount, cursor: AccountCursor): boolean {
   return compareAccountCursors(cursor, accountCursorOf(account)) < 0;
+}
+
+/**
+ * Where one account sits in the stream's order.
+ *
+ * The identity stream's position, so the recents surface and a person's own
+ * history are one order and one encoding of it, and the reasons every part is
+ * escaped hold in one place ({@link encodeIdentityCursor}) rather than two that
+ * can be fixed apart.
+ */
+export type StreamCursor = IdentityCursor;
+
+export const compareStreamCursors = compareIdentityCursors;
+export const encodeStreamCursor = encodeIdentityCursor;
+export const parseStreamCursor = parseIdentityCursor;
+
+export function streamCursorOf(account: StreamAccount): StreamCursor {
+  return {
+    timestamp: account.latest.timestamp,
+    displayName: account.displayName,
+    id: accountRef(account),
+  };
+}
+
+/** The stream's order: newest activity first, ties broken by name and then ref
+ *  so the sequence is total. */
+export function compareStreamAccounts(a: StreamAccount, b: StreamAccount): number {
+  return compareStreamCursors(streamCursorOf(a), streamCursorOf(b));
+}
+
+/** Whether an account falls after a cursor in {@link compareStreamAccounts}
+ *  order — i.e. belongs on a later page than the one that cursor ended. */
+export function isAfterStreamCursor(account: StreamAccount, cursor: StreamCursor): boolean {
+  return compareStreamCursors(cursor, streamCursorOf(account)) < 0;
 }
 
 /** How many accounts one page carries when the caller names no limit, and the
@@ -331,10 +428,10 @@ export function accountPageLimit(raw: string | number | null | undefined): numbe
  * the page alone, so a client filtered to one chip still reads every chip's
  * number, and a client on page four reads the same numbers it read on page one.
  *
- * A query reaches silent accounts whatever the toggle says. The toggle keeps a
- * 9,000-contact address book out of a browsing view, and a guardian typing a
- * name or a number is not browsing — a lookup that answered "no such account"
- * for a contact the mirror holds would be a worse answer than a long list.
+ * Every account the query matches is on the listing. A contacts app holds
+ * nobody back: a lookup that answered "no such account" for a contact the
+ * mirror holds is a worse answer than a long list, and paging is what a long
+ * list is for.
  */
 export function sliceAccountDirectory(
   directory: readonly DirectoryAccount[],
@@ -343,23 +440,18 @@ export function sliceAccountDirectory(
     state?: AccountState | null;
     cursor?: AccountCursor | null;
     limit?: number | null;
-    /** Whether the page carries silent accounts. Off by default. */
-    includeSilent?: boolean;
   } = {},
 ): AccountDirectory {
   const query = options.query?.trim() ?? "";
   const matching = query ? directory.filter((a) => accountMatchesQuery(a, query)) : directory;
-  const silentTotal = matching.filter(isSilentAccount).length;
 
-  const admitted =
-    options.includeSilent || query !== "" ? matching : matching.filter((a) => !isSilentAccount(a));
   const counts: AccountCounts = { unlinked: 0, linked: 0, dismissed: 0 };
-  for (const account of admitted) counts[account.state] += 1;
+  for (const account of matching) counts[account.state] += 1;
 
   // The sort key is built once per account rather than once per comparison: it
   // renders a ref and a directory is thousands of rows, so a comparator that
   // rebuilds it pays for that on every one of N log N comparisons.
-  const ordered = admitted
+  const ordered = matching
     .map((account) => ({ account, at: accountCursorOf(account) }))
     .sort((a, b) => compareAccountCursors(a.at, b.at))
     .map((entry) => entry.account);
@@ -373,7 +465,53 @@ export function sliceAccountDirectory(
   const nextCursor =
     remaining.length > accounts.length && last ? encodeAccountCursor(accountCursorOf(last)) : null;
 
-  return { accounts, nextCursor, counts, silentTotal };
+  return { accounts, nextCursor, counts };
+}
+
+/**
+ * Cut one page out of the stream, with the counts that describe the whole of
+ * it.
+ *
+ * Takes every account something has happened on, in any order — the ordering is
+ * this function's, as the directory's is {@link sliceAccountDirectory}'s. An
+ * account with nothing on record never reaches here: it has no position in an
+ * order made of timestamps, and no reader of a recents surface is asking after
+ * it.
+ *
+ * `query` scopes the counts as well as the page, and `state` and the cursor
+ * scope the page alone — the same split the directory makes, and for the same
+ * reason: a client filtered to one chip still renders every chip's number.
+ */
+export function sliceAccountStream(
+  stream: readonly StreamAccount[],
+  options: {
+    query?: string | null;
+    state?: AccountState | null;
+    cursor?: StreamCursor | null;
+    limit?: number | null;
+  } = {},
+): AccountStream {
+  const query = options.query?.trim() ?? "";
+  const matching = query ? stream.filter((a) => accountMatchesQuery(a, query)) : stream;
+
+  const counts: AccountCounts = { unlinked: 0, linked: 0, dismissed: 0 };
+  for (const account of matching) counts[account.state] += 1;
+
+  const ordered = matching
+    .map((account) => ({ account, at: streamCursorOf(account) }))
+    .sort((a, b) => compareStreamCursors(a.at, b.at))
+    .map((entry) => entry.account);
+  const state = options.state;
+  const scoped = state ? ordered.filter((a) => a.state === state) : ordered;
+  const cursor = options.cursor;
+  const remaining = cursor ? scoped.filter((a) => isAfterStreamCursor(a, cursor)) : scoped;
+
+  const accounts = remaining.slice(0, accountPageLimit(options.limit));
+  const last = accounts.at(-1);
+  const nextCursor =
+    remaining.length > accounts.length && last ? encodeStreamCursor(streamCursorOf(last)) : null;
+
+  return { accounts, nextCursor, counts };
 }
 
 /**

--- a/packages/core/src/api/routes/accounts.test.ts
+++ b/packages/core/src/api/routes/accounts.test.ts
@@ -1,16 +1,24 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
-import { accountRef, type AccountDirectory, type DirectoryAccount } from "@rome/api-types/people";
+import {
+  accountRef,
+  type AccountDirectory,
+  type AccountStream,
+  type DirectoryAccount,
+  type StreamAccount,
+} from "@rome/api-types/people";
 import { accountsRoutes } from "./accounts.js";
 import { createTestDb, buildTestDeps, type TestDb, type TestDeps } from "../../test/helpers.js";
 import { seedBaseline } from "../../test/seeds.js";
 import { STRANGER_PERSON_ID } from "../../constants.js";
 
-// GET /accounts is the account directory: every account Rome has observed —
-// linked, dismissed, or nobody's decision yet — from the links, the sentinel
-// log and the channel mirrors. These tests pin what the union answers, what
-// each filter narrows, and that the sentinel a dismissal is filed under never
-// reaches a client.
+// The two account reads over one set of sources — the links, the sentinel log
+// and the channel mirrors. GET /accounts is the contacts list: every account
+// Rome has observed, by name, carrying nothing about what anyone said. GET
+// /accounts/stream is the recents surface: the accounts something has happened
+// on, newest first, with the line to preview. These tests pin what each
+// answers, what each filter narrows, and that the sentinel a dismissal is filed
+// under never reaches a client.
 
 const SILENT_JID = "15550001111@s.whatsapp.net";
 const TALKING_JID = "15550002222@s.whatsapp.net";
@@ -95,7 +103,13 @@ describe("Accounts API", () => {
     return (await res.json()) as AccountDirectory;
   }
 
-  const find = (page: AccountDirectory, ref: string): DirectoryAccount | undefined =>
+  async function fetchStream(query = ""): Promise<AccountStream> {
+    const res = await app.request(`/accounts/stream${query}`);
+    expect(res.status).toBe(200);
+    return (await res.json()) as AccountStream;
+  }
+
+  const find = <T extends DirectoryAccount>(page: { accounts: T[] }, ref: string): T | undefined =>
     page.accounts.find((account) => accountRef(account) === ref);
 
   it("lists an observed account nobody has placed, named by its platform", async () => {
@@ -104,12 +118,44 @@ describe("Accounts API", () => {
     expect(tina.personId).toBeNull();
     expect(tina.personName).toBeNull();
     expect(tina.displayName).toBe("Talky Tina");
+  });
+
+  it("says nothing about activity on a directory row", async () => {
+    const page = await fetchPage();
+    // Not merely unrendered: the contacts list carries no message-derived field
+    // at all, so a client cannot start showing one and a read cannot start
+    // computing one for it.
+    for (const account of page.accounts) {
+      expect(Object.keys(account).sort()).toEqual([
+        "addresses",
+        "channel",
+        "channelUserId",
+        "displayName",
+        "personId",
+        "personName",
+        "state",
+      ]);
+    }
+  });
+
+  it("previews the newest thing on a stream row", async () => {
+    const tina = find(await fetchStream(), `whatsapp:${TALKING_JID}`)!;
     expect(tina.latest).toEqual({
       source: "whatsapp",
       timestamp: Math.floor(new Date("2026-08-17T10:00:00Z").getTime() / 1000),
       preview: "hello from tina",
     });
     expect(tina.messageCount).toBeGreaterThan(0);
+  });
+
+  it("keeps an account nothing has happened on off the stream", async () => {
+    const stream = await fetchStream();
+    expect(find(stream, `whatsapp:${SILENT_JID}`)).toBeUndefined();
+    // Including under a search: an account with no dynamic has no position in
+    // an order made of timestamps, whatever was typed.
+    expect((await fetchStream("?q=silent%20sam")).accounts).toEqual([]);
+    // The contacts list is where that contact is looked up.
+    expect(find(await fetchPage("?q=silent%20sam"), `whatsapp:${SILENT_JID}`)).toBeDefined();
   });
 
   it("names the person a linked account belongs to, and keeps the platform's own name", async () => {
@@ -123,7 +169,7 @@ describe("Accounts API", () => {
   });
 
   it("serializes a dismissal as a state, never as the sentinel it is filed under", async () => {
-    const page = await fetchPage("?includeSilent=true");
+    const page = await fetchPage();
     const dismissed = find(page, `telegram:${DISMISSED_SENDER}`)!;
     expect(dismissed.state).toBe("dismissed");
     expect(dismissed.personId).toBeNull();
@@ -147,6 +193,7 @@ describe("Accounts API", () => {
 
     const res = await app.request("/accounts?state=archived");
     expect(res.status).toBe(400);
+    expect((await app.request("/accounts/stream?state=archived")).status).toBe(400);
   });
 
   it("counts every state over the whole directory, not over the page", async () => {
@@ -162,39 +209,31 @@ describe("Accounts API", () => {
     );
   });
 
-  it("keeps silent contacts off the default page and counts them there anyway", async () => {
-    const hidden = await fetchPage();
-    expect(find(hidden, `whatsapp:${SILENT_JID}`)).toBeUndefined();
-    // The offer to show them is made from the view that hides them, so the
-    // number has to be right in that view.
-    expect(hidden.silentTotal).toBe(1);
-
-    const shown = await fetchPage("?includeSilent=true");
-    const silent = find(shown, `whatsapp:${SILENT_JID}`)!;
+  it("carries a contact nobody has ever heard from, like a contacts app", async () => {
+    const page = await fetchPage();
+    const silent = find(page, `whatsapp:${SILENT_JID}`)!;
     expect(silent.displayName).toBe("Silent Sam");
-    expect(silent.latest).toBeNull();
-    expect(shown.silentTotal).toBe(1);
-    expect(shown.counts.unlinked).toBe(hidden.counts.unlinked + 1);
+    // The whole address book is the listing, so the unlinked count is everyone
+    // Rome has not placed rather than the senders waiting on a decision. The
+    // stream's counts answer that narrower question.
+    expect(page.counts.unlinked).toBe(
+      page.accounts.filter((account) => account.state === "unlinked").length,
+    );
+    expect((await fetchStream()).counts.unlinked).toBeLessThan(page.counts.unlinked);
   });
 
-  it("never hides an account the guardian has decided about", async () => {
-    // A dismissed sender whose only message the log holds is still a decision,
-    // and a linked account on a channel with no history is one too. Neither is
-    // an address-book row waiting to be triaged.
+  it("lists an account on a channel with no history at all", async () => {
     const linkedSilent = await deps.personMappingRepo.create({
       displayName: "Quiet Link",
       bondLevel: "other",
       approved: true,
       channelMappings: [{ channel: "signal", channelUserId: "sig-quiet" }],
     });
-    const page = await fetchPage();
-    const account = find(page, "signal:sig-quiet")!;
-    expect(account.latest).toBeNull();
+    const account = find(await fetchPage(), "signal:sig-quiet")!;
     expect(account.personId).toBe(linkedSilent);
-    expect(page.silentTotal).toBe(1);
   });
 
-  it("reaches a silent contact by search whether or not the toggle asked", async () => {
+  it("finds an account by name, by number, and by the person holding it", async () => {
     const byName = await fetchPage("?q=silent%20sam");
     expect(byName.accounts.map(accountRef)).toEqual([`whatsapp:${SILENT_JID}`]);
 
@@ -207,7 +246,7 @@ describe("Accounts API", () => {
   });
 
   it("excludes group chats — a group is not an account", async () => {
-    const page = await fetchPage("?includeSilent=true");
+    const page = await fetchPage();
     expect(page.accounts.some((account) => account.channelUserId.includes(GROUP_JID))).toBe(false);
   });
 
@@ -228,12 +267,17 @@ describe("Accounts API", () => {
       action: "ignored",
     });
 
-    const page = await fetchPage("?includeSilent=true");
+    const page = await fetchPage();
     const split = page.accounts.filter((account) => account.addresses.includes(lidJid));
     expect(split).toHaveLength(1);
     expect(accountRef(split[0])).toBe(`whatsapp:${phoneJid}`);
     expect(split[0].addresses).toEqual([phoneJid, lidJid].sort());
-    expect(split[0].latest?.preview).toBe("from the lid address");
+    // And one row on the stream too, previewing what the other address said.
+    const streamed = (await fetchStream()).accounts.filter((account) =>
+      account.addresses.includes(lidJid),
+    );
+    expect(streamed).toHaveLength(1);
+    expect(streamed[0].latest.preview).toBe("from the lid address");
   });
 
   it("pages by an opaque cursor that visits every account exactly once", async () => {
@@ -242,7 +286,7 @@ describe("Accounts API", () => {
     let pages = 0;
     do {
       const page: AccountDirectory = await fetchPage(
-        `?includeSilent=true&limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
+        `?limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
       );
       expect(page.accounts.length).toBeGreaterThan(0);
       seen.push(...page.accounts.map(accountRef));
@@ -253,20 +297,33 @@ describe("Accounts API", () => {
 
     expect(pages).toBeGreaterThan(1);
     expect(new Set(seen).size).toBe(seen.length);
-    const whole = await fetchPage("?includeSilent=true&limit=500");
-    expect(seen.sort()).toEqual(whole.accounts.map(accountRef).sort());
+    const whole = await fetchPage("?limit=500");
+    // The pages are the whole listing, in the listing's own order.
+    expect(seen).toEqual(whole.accounts.map(accountRef));
   });
 
   it("rejects a cursor that names no position rather than answering the first page", async () => {
-    const res = await app.request("/accounts?cursor=not-a-cursor");
-    expect(res.status).toBe(400);
+    expect((await app.request("/accounts?cursor=not-a-cursor")).status).toBe(400);
+    expect((await app.request("/accounts/stream?cursor=not-a-cursor")).status).toBe(400);
+    // The two orders are different orders: a position in one names none in the
+    // other, and resuming with the wrong one would skip or repeat rows.
+    const streamCursor = (await fetchStream("?limit=1")).nextCursor!;
+    expect((await app.request(`/accounts?cursor=${encodeURIComponent(streamCursor)}`)).status).toBe(
+      400,
+    );
   });
 
-  it("orders by newest activity, silent accounts last", async () => {
-    const page = await fetchPage("?includeSilent=true");
-    const timestamps = page.accounts.map((account) => account.latest?.timestamp ?? null);
-    const active = timestamps.filter((at): at is number => at !== null);
-    expect(active).toEqual([...active].sort((a, b) => b - a));
-    expect(timestamps.slice(active.length).every((at) => at === null)).toBe(true);
+  it("orders the directory by display name", async () => {
+    const page = await fetchPage();
+    const names = page.accounts.map((account) => account.displayName);
+    expect(names).toEqual(
+      [...names].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())),
+    );
+  });
+
+  it("orders the stream by newest activity", async () => {
+    const stream: AccountStream = await fetchStream();
+    const timestamps = stream.accounts.map((account: StreamAccount) => account.latest.timestamp);
+    expect(timestamps).toEqual([...timestamps].sort((a, b) => b - a));
   });
 });

--- a/packages/core/src/api/routes/accounts.ts
+++ b/packages/core/src/api/routes/accounts.ts
@@ -1,32 +1,50 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import {
   accountPageLimit,
   parseAccountCursor,
   parseAccountState,
+  parseStreamCursor,
   sliceAccountDirectory,
+  sliceAccountStream,
+  type AccountState,
 } from "@rome/api-types/people";
-import { readAccountDirectory } from "../../people/account-directory.js";
+import { readAccountDirectory, readAccountStream } from "../../people/account-directory.js";
 import type { ApiDeps } from "../deps.js";
 
-// The account directory: every account Rome has observed, and what the guardian
-// has decided about each. What a page is, how it is ordered, how it resumes and
+// The account reads: every account Rome has observed, and what the guardian has
+// decided about each. What a page is, how it is ordered, how it resumes and
 // what its numbers count are the contract's (@rome/api-types/people). Which
-// sources the directory is folded from is `src/people/account-directory.ts`.
-// This route is the join between a query string and those two, and holds no
-// rule of its own.
+// sources they are folded from is `src/people/account-directory.ts`. These
+// routes are the join between a query string and those two, and hold no rule of
+// their own.
 //
-// A read. Placing an account is a write on the person's own route; dismissing
-// and restoring one are `./account-decisions.ts`.
+// Two of them, because two surfaces ask two questions. `/accounts` is the
+// contacts list: every account, ordered by name, carrying nothing about what
+// anyone said. `/accounts/stream` is the recents surface: ordered by what
+// happened last, carrying the line to preview, and holding only the accounts
+// something has happened on.
+//
+// Both are reads. Placing an account is a write on the person's own route;
+// dismissing and restoring one are `./account-decisions.ts`.
 
 export function accountsRoutes(deps: ApiDeps): Hono {
   const app = new Hono();
 
-  app.get("/accounts", async (c) => {
-    const rawState = c.req.query("state");
-    const state = parseAccountState(rawState);
-    if (rawState != null && rawState !== "" && state === null) {
-      return c.json({ error: "state must name an account state" }, 400);
+  /** The `?state=` both reads narrow by, or the 400 a value that names no state
+   *  earns — answering it as the whole listing would silently show the wrong
+   *  accounts. */
+  const readState = (c: Context): { state: AccountState | null } | { error: string } => {
+    const raw = c.req.query("state");
+    const state = parseAccountState(raw);
+    if (raw != null && raw !== "" && state === null) {
+      return { error: "state must name an account state" };
     }
+    return { state };
+  };
+
+  app.get("/accounts", async (c) => {
+    const state = readState(c);
+    if ("error" in state) return c.json({ error: state.error }, 400);
 
     const rawCursor = c.req.query("cursor");
     const cursor = parseAccountCursor(rawCursor);
@@ -37,10 +55,29 @@ export function accountsRoutes(deps: ApiDeps): Hono {
     return c.json(
       sliceAccountDirectory(await readAccountDirectory(deps), {
         query: c.req.query("q"),
-        state,
+        state: state.state,
         cursor,
         limit: accountPageLimit(c.req.query("limit")),
-        includeSilent: c.req.query("includeSilent") === "true",
+      }),
+    );
+  });
+
+  app.get("/accounts/stream", async (c) => {
+    const state = readState(c);
+    if ("error" in state) return c.json({ error: state.error }, 400);
+
+    const rawCursor = c.req.query("cursor");
+    const cursor = parseStreamCursor(rawCursor);
+    if (rawCursor != null && rawCursor !== "" && cursor === null) {
+      return c.json({ error: "cursor is not a stream cursor" }, 400);
+    }
+
+    return c.json(
+      sliceAccountStream(await readAccountStream(deps), {
+        query: c.req.query("q"),
+        state: state.state,
+        cursor,
+        limit: accountPageLimit(c.req.query("limit")),
       }),
     );
   });

--- a/packages/core/src/api/routes/identities.ts
+++ b/packages/core/src/api/routes/identities.ts
@@ -16,7 +16,7 @@ import {
 import { STRANGER_PERSON_ID } from "../../constants.js";
 import {
   addressKey,
-  foldAccounts,
+  foldAccountRecords,
   mirrorRegistry,
   newer,
   type AccountRecord,
@@ -88,7 +88,7 @@ async function buildIdentityUnion(deps: ApiDeps): Promise<IdentityRow[]> {
   ]);
   const persons = unsorted.sort((a, b) => compareCodePoints(a.id, b.id));
 
-  const fold = await foldAccounts(mirrorRegistry<MirrorPlane>(deps), {
+  const fold = await foldAccountRecords(mirrorRegistry<MirrorPlane>(deps), {
     senders,
     stored: [...senders, ...persons.flatMap((person) => person.channelMappings)],
   });

--- a/packages/core/src/channels/account-fold.test.ts
+++ b/packages/core/src/channels/account-fold.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AccountActivity } from "./account-activity.js";
-import { foldAccounts, type MirrorPlane } from "./account-fold.js";
+import { foldAccountRecords, foldAccounts, type MirrorPlane } from "./account-fold.js";
 import type { Account, AccountId } from "./accounts.js";
 import type { SentinelSenderActivity } from "../db/repositories/sentinel-log.js";
 
@@ -35,6 +35,7 @@ const sender = (
  */
 class FakePlane implements MirrorPlane {
   listings = 0;
+  activityReads = 0;
   readonly resolved: string[] = [];
 
   constructor(
@@ -61,6 +62,7 @@ class FakePlane implements MirrorPlane {
   }
 
   async listActivity(): Promise<Map<AccountId, AccountActivity>> {
+    this.activityReads++;
     return (this.options.activity ?? new Map()) as Map<AccountId, AccountActivity>;
   }
 }
@@ -73,7 +75,7 @@ describe("foldAccounts", () => {
   it("takes an account's addressing set from the account itself", async () => {
     const whatsapp = new FakePlane([account(ada, [ada, adaLid], "Ada")]);
 
-    const fold = await foldAccounts({ whatsapp }, { senders: [], stored: [] });
+    const fold = await foldAccounts({ whatsapp }, { stored: [] });
 
     expect(fold.accounts).toEqual([
       {
@@ -81,8 +83,6 @@ describe("foldAccounts", () => {
         channelUserId: ada,
         aliases: [ada, adaLid].sort(),
         name: "Ada",
-        latest: null,
-        messageCount: 0,
       },
     ]);
     // Both addressings name the one account, whichever one a caller holds.
@@ -92,10 +92,23 @@ describe("foldAccounts", () => {
     expect(whatsapp.listings).toBe(1);
   });
 
+  it("asks no channel for a history", async () => {
+    const whatsapp = new FakePlane([account(ada, [ada, adaLid], "Ada")]);
+    const linkedin = new FakePlane([account("ACoAAAda0001")]);
+
+    await foldAccounts({ whatsapp, linkedin }, { stored: [] });
+
+    // The contacts list is the reason this fold exists apart from
+    // `foldAccountRecords`: it names who is one account and reads no message
+    // store to do it.
+    expect(whatsapp.activityReads).toBe(0);
+    expect(linkedin.activityReads).toBe(0);
+  });
+
   it("leaves an account the channel holds one address for addressing itself", async () => {
     const linkedin = new FakePlane([account("ACoAAAda0001")]);
 
-    const fold = await foldAccounts({ linkedin }, { senders: [], stored: [] });
+    const fold = await foldAccounts({ linkedin }, { stored: [] });
 
     expect(fold.accounts[0]?.aliases).toEqual(["ACoAAAda0001"]);
     expect(fold.canonical("linkedin", "ACoAAAda0001")).toBe("ACoAAAda0001");
@@ -108,7 +121,7 @@ describe("foldAccounts", () => {
 
     const fold = await foldAccounts(
       { linkedin },
-      { senders: [], stored: [{ channel: "linkedin", channelUserId: profileUrl }] },
+      { stored: [{ channel: "linkedin", channelUserId: profileUrl }] },
     );
 
     expect(linkedin.resolved).toEqual([profileUrl]);
@@ -128,7 +141,7 @@ describe("foldAccounts", () => {
 
     const fold = await foldAccounts(
       { whatsapp },
-      { senders: [], stored: [{ channel: "whatsapp", channelUserId: adaLid }] },
+      { stored: [{ channel: "whatsapp", channelUserId: adaLid }] },
     );
 
     expect(fold.canonical("whatsapp", adaLid)).toBe(ada);
@@ -141,7 +154,7 @@ describe("foldAccounts", () => {
       ]),
     });
 
-    const fold = await foldAccounts(
+    const fold = await foldAccountRecords(
       { whatsapp },
       {
         senders: [
@@ -167,7 +180,6 @@ describe("foldAccounts", () => {
     const fold = await foldAccounts(
       { whatsapp, linkedin },
       {
-        senders: [],
         stored: [
           { channel: "whatsapp", channelUserId: adaLid },
           { channel: "whatsapp", channelUserId: adaLid },

--- a/packages/core/src/channels/account-fold.ts
+++ b/packages/core/src/channels/account-fold.ts
@@ -4,7 +4,13 @@
 // `TalkAccounts` (accounts.ts) is one channel's address book and `AccountNames`
 // (account-names.ts) is the display-name half of all of them. This is the fold
 // underneath both reads that have to show every account there is: which
-// addressings are one account, and what that account last did.
+// addressings are one account, and — for the readers that ask — what that
+// account last did.
+//
+// The two halves fold separately, because the contacts list has no use for the
+// second one. `foldAccounts` reads address books alone; `foldAccountRecords`
+// reads them and joins the histories. A caller that only needs to know who is
+// one account therefore never touches a message store.
 
 import type { AccountDynamic } from "@rome/api-types/people";
 import { compareCodePoints } from "@rome/api-types/identities";
@@ -31,8 +37,6 @@ export interface MirrorAccount {
   aliases: string[];
   /** What the channel calls the account, or null when it holds no name. */
   name: string | null;
-  latest: AccountDynamic | null;
-  messageCount: number;
 }
 
 /** What the producers hold for one account: its newest dynamic, and how many
@@ -85,21 +89,19 @@ export interface StoredAddress {
 }
 
 /**
- * Every account the mirrors hold and every sender the triage record saw, folded
- * so that one account answers under every address it is reachable at.
+ * Every account the mirrors hold, folded so that one account answers under
+ * every address it is reachable at.
  *
  * Built by {@link foldAccounts}. A caller asks it questions about a (channel,
  * address) pair and never has to know which of them the channel considers
- * canonical, nor which store the answer came from.
+ * canonical. Nothing here is about what anybody said — {@link AccountRecords}
+ * is the fold that answers that.
  */
 export class AccountFold {
-  private readonly records = new Map<string, AccountRecord>();
-
   constructor(
     /** Every account the mirrors hold. */
     readonly accounts: readonly MirrorAccount[],
-    private readonly byAddress: ReadonlyMap<string, MirrorAccount>,
-    private readonly bySender: ReadonlyMap<string, SentinelSenderActivity[]>,
+    protected readonly byAddress: ReadonlyMap<string, MirrorAccount>,
   ) {}
 
   /**
@@ -127,6 +129,31 @@ export class AccountFold {
   mirrorFor(channel: string, channelUserId: string): MirrorAccount | undefined {
     return this.byAddress.get(this.key(channel, channelUserId));
   }
+}
+
+/**
+ * An {@link AccountFold} joined to what the producers hold for each account:
+ * the newest dynamic, and how many records are behind it.
+ *
+ * Built by {@link foldAccountRecords}, which is the fold that reads a message
+ * store. A caller holding one of these is on the recents surface; a caller who
+ * only has to know who is one account holds the base fold and pays for none of
+ * this.
+ */
+export class AccountRecords extends AccountFold {
+  private readonly records = new Map<string, AccountRecord>();
+
+  constructor(
+    accounts: readonly MirrorAccount[],
+    byAddress: ReadonlyMap<string, MirrorAccount>,
+    /** What each mirror holds for its own accounts, under the account's own
+     *  address. An entry per listed account, whether or not anything has
+     *  happened on it. */
+    private readonly mirrored: ReadonlyMap<string, AccountRecord>,
+    private readonly bySender: ReadonlyMap<string, SentinelSenderActivity[]>,
+  ) {
+    super(accounts, byAddress);
+  }
 
   /** Every triage row filed against this account, under any of its addresses. */
   sendersFor(channel: string, channelUserId: string): readonly SentinelSenderActivity[] {
@@ -146,7 +173,7 @@ export class AccountFold {
     const memoized = this.records.get(key);
     if (memoized) return memoized;
 
-    const fromMirror = this.byAddress.get(key);
+    const fromMirror = this.mirrored.get(key);
     const rows = this.bySender.get(key) ?? [];
     const fromSentinel = rows.reduce<AccountDynamic | null>(
       (best, row) =>
@@ -181,12 +208,17 @@ export function newer(a: AccountDynamic | null, b: AccountDynamic | null): Accou
 }
 
 /**
- * Read every mirror whole and join the triage record to it.
+ * Read every mirror's address book whole and fold it.
  *
  * Whole rather than paged: a caller pages its own answer, and an account past a
  * channel's own cutoff is one the guardian cannot find and no count includes.
  * The fold that decides which addressings are one account needs every address
  * book entire in any case.
+ *
+ * No history is read here — not a mirror's and not the triage record's. This is
+ * what a contacts list needs and the whole of it, so the read that serves one
+ * never reaches a message store. {@link foldAccountRecords} is the fold that
+ * does.
  *
  * `stored` is every address the caller already holds. The channels are read
  * concurrently, and each channel's reads are issued in one batch, because a
@@ -196,13 +228,52 @@ export function newer(a: AccountDynamic | null, b: AccountDynamic | null): Accou
  */
 export async function foldAccounts(
   planes: MirrorPlanes,
-  input: { senders: readonly SentinelSenderActivity[]; stored: readonly StoredAddress[] },
+  input: { stored: readonly StoredAddress[] },
 ): Promise<AccountFold> {
+  const read = await readPlanes(planes, input.stored, { activity: false });
+  return new AccountFold(read.accounts, read.byAddress);
+}
+
+/**
+ * {@link foldAccounts}, joined to what the producers hold for each account.
+ *
+ * Two histories: each mirror's own, and the triage record, which is the only
+ * one Rome keeps for a channel it mirrors no address book for. `senders` is
+ * that record, read by the caller and folded onto accounts here.
+ */
+export async function foldAccountRecords(
+  planes: MirrorPlanes,
+  input: { senders: readonly SentinelSenderActivity[]; stored: readonly StoredAddress[] },
+): Promise<AccountRecords> {
+  const read = await readPlanes(planes, input.stored, { activity: true });
+
+  const bySender = new Map<string, SentinelSenderActivity[]>();
+  for (const sender of input.senders) {
+    const own = read.byAddress.get(addressKey(sender.channel, sender.channelUserId));
+    const key = addressKey(sender.channel, own?.channelUserId ?? sender.channelUserId);
+    const group = bySender.get(key);
+    if (group) group.push(sender);
+    else bySender.set(key, [sender]);
+  }
+  return new AccountRecords(read.accounts, read.byAddress, read.activity, bySender);
+}
+
+/** Every channel read concurrently, and their address books merged into one
+ *  fold. */
+async function readPlanes(
+  planes: MirrorPlanes,
+  storedAddresses: readonly StoredAddress[],
+  options: { activity: boolean },
+): Promise<{
+  accounts: MirrorAccount[];
+  byAddress: Map<string, MirrorAccount>;
+  activity: Map<string, AccountRecord>;
+}> {
   // One entry per (channel, address): the sources overlap — a link and a
   // sentinel row routinely name the same address — and each one asks its
   // channel a question.
   const stored = new Map<string, StoredAddress>();
-  for (const address of input.stored) {
+  for (const address of storedAddresses) {
     stored.set(addressKey(address.channel, address.channelUserId), address);
   }
 
@@ -212,26 +283,20 @@ export async function foldAccounts(
         channel,
         plane,
         [...stored.values()].filter((address) => address.channel === channel),
+        options,
       ),
     ),
   );
 
   const accounts: MirrorAccount[] = [];
   const byAddress = new Map<string, MirrorAccount>();
+  const activity = new Map<string, AccountRecord>();
   for (const read of reads) {
     accounts.push(...read.accounts);
     for (const [address, account] of read.byAddress) byAddress.set(address, account);
+    for (const [address, record] of read.activity) activity.set(address, record);
   }
-
-  const bySender = new Map<string, SentinelSenderActivity[]>();
-  for (const sender of input.senders) {
-    const own = byAddress.get(addressKey(sender.channel, sender.channelUserId));
-    const key = addressKey(sender.channel, own?.channelUserId ?? sender.channelUserId);
-    const group = bySender.get(key);
-    if (group) group.push(sender);
-    else bySender.set(key, [sender]);
-  }
-  return new AccountFold(accounts, byAddress, bySender);
+  return { accounts, byAddress, activity };
 }
 
 /** One channel's address book, projected and indexed under every address its
@@ -240,7 +305,12 @@ async function readPlane(
   channel: string,
   plane: MirrorPlane,
   stored: readonly StoredAddress[],
-): Promise<{ accounts: MirrorAccount[]; byAddress: Map<string, MirrorAccount> }> {
+  options: { activity: boolean },
+): Promise<{
+  accounts: MirrorAccount[];
+  byAddress: Map<string, MirrorAccount>;
+  activity: Map<string, AccountRecord>;
+}> {
   // Every read this channel owes, issued in one batch so the plane serves them
   // all from a single fold of its address book. The stored addresses are
   // resolved without waiting to learn which of them the listing already covers:
@@ -248,17 +318,21 @@ async function readPlane(
   // member id from a profile URL naming it — and asking after the listing
   // arrived would fall outside the shared read and cost a second fold of the
   // whole address book.
-  const [listing, activity, resolved] = await Promise.all([
+  //
+  // The history read is the one thing that is conditional: a caller who only
+  // has to know who is one account skips it, and with it the channel's whole
+  // message store.
+  const [listing, seenBy, resolved] = await Promise.all([
     plane.listAccounts({ limit: WHOLE_LISTING }),
-    plane.listActivity(),
+    options.activity ? plane.listActivity() : null,
     Promise.all(stored.map((address) => plane.resolve(address.channelUserId))),
   ]);
 
   const accounts: MirrorAccount[] = [];
   const byAddress = new Map<string, MirrorAccount>();
   const byId = new Map<string, MirrorAccount>();
+  const activity = new Map<string, AccountRecord>();
   for (const account of listing.accounts) {
-    const seen = activity.get(account.id);
     const mirrored: MirrorAccount = {
       channel,
       channelUserId: account.id,
@@ -270,15 +344,23 @@ async function readPlane(
         compareCodePoints,
       ),
       name: account.name,
-      latest:
-        seen == null
-          ? null
-          : { source: channel, timestamp: seen.lastMessageAt, preview: seen.lastMessagePreview },
-      messageCount: seen?.messageCount ?? 0,
     };
     accounts.push(mirrored);
     byId.set(account.id, mirrored);
     for (const alias of mirrored.aliases) byAddress.set(addressKey(channel, alias), mirrored);
+    if (seenBy) {
+      // An entry for every listed account, activity or not: its presence is
+      // what says the mirror holds this account, which is what decides whose
+      // message count a record reports.
+      const seen = seenBy.get(account.id);
+      activity.set(addressKey(channel, account.id), {
+        latest:
+          seen == null
+            ? null
+            : { source: channel, timestamp: seen.lastMessageAt, preview: seen.lastMessagePreview },
+        messageCount: seen?.messageCount ?? 0,
+      });
+    }
   }
 
   // A stored address no listed account named. Left unfolded, a mapping written
@@ -292,7 +374,7 @@ async function readPlane(
     if (account) byAddress.set(addressKey(channel, address.channelUserId), account);
   });
 
-  return { accounts, byAddress };
+  return { accounts, byAddress, activity };
 }
 
 /**

--- a/packages/core/src/people/account-decisions.ts
+++ b/packages/core/src/people/account-decisions.ts
@@ -180,10 +180,10 @@ async function locate(
  * it now.
  *
  * Patched rather than re-read. A decision moves the link and nothing else — the
- * platform's name for the account, the addresses it answers to, its last
- * message and its count are all untouched — so re-folding every address book to
- * learn what this function already holds would buy nothing but a second chance
- * to disagree with the read that made the decision.
+ * platform's name for the account, the addresses it answers to and whether
+ * anything is on record for it are all untouched — so re-folding every address
+ * book to learn what this function already holds would buy nothing but a second
+ * chance to disagree with the read that made the decision.
  *
  * The link goes through the same presentation seam a directory row does, which
  * is what keeps the sentinel off the wire here.

--- a/packages/core/src/people/account-directory.ts
+++ b/packages/core/src/people/account-directory.ts
@@ -7,12 +7,27 @@
 // reaches them at. Which of them fold together is the channel's own answer,
 // read once through `AccountFold` (../channels/account-fold.ts), so nothing
 // here is channel-specific and adding a mirror changes nothing in this file.
+//
+// Two reads, because the two surfaces ask two questions — "who does Rome know"
+// and "who has something new". They fold the same address books to decide which
+// addressings are one account, and only the stream goes on to read a history.
 
-import { accountPresentation, type DirectoryAccount } from "@rome/api-types/people";
+import {
+  accountPresentation,
+  type DirectoryAccount,
+  type StreamAccount,
+} from "@rome/api-types/people";
 import { compareCodePoints } from "@rome/api-types/identities";
 import { STRANGER_PERSON_ID } from "../constants.js";
 import type { AccountNames } from "../channels/account-names.js";
-import { foldAccounts, mirrorRegistry, type MirrorPlane } from "../channels/account-fold.js";
+import {
+  foldAccountRecords,
+  foldAccounts,
+  mirrorRegistry,
+  type AccountFold,
+  type AccountRecords,
+  type MirrorPlane,
+} from "../channels/account-fold.js";
 import type { PersonMappingRepository } from "../db/repositories/person-mapping.js";
 import type { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
 
@@ -39,11 +54,63 @@ interface AccountLink {
  * account needs every address book entire, and an account past a channel's own
  * cutoff is one the guardian cannot find and no count includes. The cost is one
  * read of each address book for the fold and one more to name what it found.
+ *
+ * A contacts list's rows: who each account is, and nothing about what anyone
+ * said. No message store is read — not a mirror's history and not the triage
+ * record's — because the directory orders by name and previews nothing, so
+ * every message-derived fact would be work no reader of this read ever renders.
+ * {@link readAccountStream} is the read that does.
  */
 export async function readAccountDirectory(
   deps: AccountDirectoryDeps,
 ): Promise<DirectoryAccount[]> {
+  return (await observeAccounts(deps, { activity: false })).accounts;
+}
+
+/**
+ * Every account something has happened on, unordered and unfiltered — the whole
+ * stream a page is cut out of (`sliceAccountStream`).
+ *
+ * The same accounts as {@link readAccountDirectory} over the same sources,
+ * projected the other way: with the dynamic the stream orders and previews by,
+ * and without the accounts that have none. An address-book contact nobody has
+ * ever heard from has no position in an order made of timestamps, so it is
+ * absent rather than listed last.
+ */
+export async function readAccountStream(deps: AccountDirectoryDeps): Promise<StreamAccount[]> {
+  const { accounts, fold } = await observeAccounts(deps, { activity: true });
+  return accounts.flatMap((account) => {
+    const record = fold.recordFor(account.channel, account.channelUserId);
+    return record.latest == null
+      ? []
+      : [{ ...account, latest: record.latest, messageCount: record.messageCount }];
+  });
+}
+
+/**
+ * Which accounts there are, what each is called, and who holds it — the join
+ * both reads share, so the two can never disagree about which accounts exist.
+ *
+ * `activity` decides how much is read, not what is answered: with it the fold
+ * carries each account's history and the caller can ask, without it no message
+ * store is touched at all.
+ */
+async function observeAccounts(
+  deps: AccountDirectoryDeps,
+  options: { activity: true },
+): Promise<{ accounts: DirectoryAccount[]; fold: AccountRecords }>;
+async function observeAccounts(
+  deps: AccountDirectoryDeps,
+  options: { activity: false },
+): Promise<{ accounts: DirectoryAccount[]; fold: AccountFold }>;
+async function observeAccounts(
+  deps: AccountDirectoryDeps,
+  options: { activity: boolean },
+): Promise<{ accounts: DirectoryAccount[]; fold: AccountFold }> {
   const [senders, persons] = await Promise.all([
+    // The triage record, for the senders it is the only source of: a channel
+    // Rome mirrors no address book for has no other row saying the account
+    // exists. What each of them said is read off this only by the stream.
     deps.sentinelLogRepo.listSenderActivity(),
     // One statement, so an account moving between two people mid-read cannot
     // land under both of them.
@@ -53,10 +120,10 @@ export async function readAccountDirectory(
   const mappings = persons.flatMap((person) =>
     person.channelMappings.map((mapping) => ({ ...mapping, person })),
   );
-  const fold = await foldAccounts(mirrorRegistry(deps), {
-    senders,
-    stored: [...senders, ...mappings],
-  });
+  const stored = [...senders, ...mappings];
+  const fold = options.activity
+    ? await foldAccountRecords(mirrorRegistry(deps), { senders, stored })
+    : await foldAccounts(mirrorRegistry(deps), { stored });
 
   /** Who holds each account, decided once before any row is built. */
   const linkOf = new Map<string, AccountLink>();
@@ -99,12 +166,14 @@ export async function readAccountDirectory(
   // and only where a mirror left a name unanswered.
   const names = await deps.accountNames.displayNames(rows.map(([, account]) => account));
 
-  return rows.map(([key, account], i) => ({
-    ...account,
-    displayName: names[i],
-    ...accountPresentation(linkOf.get(key)),
-    ...fold.recordFor(account.channel, account.channelUserId),
-  }));
+  return {
+    fold,
+    accounts: rows.map(([key, account], i) => ({
+      ...account,
+      displayName: names[i],
+      ...accountPresentation(linkOf.get(key)),
+    })),
+  };
 }
 
 /**

--- a/packages/web/mock/handlers/people-proposed.ts
+++ b/packages/web/mock/handlers/people-proposed.ts
@@ -18,19 +18,23 @@ import {
   countPeople,
   parseAccountCursor,
   parseAccountState,
+  parseStreamCursor,
   parseMergeRequest,
   parsePersonFilterLevel,
   parseUpdatePersonRequest,
   personMatchesLevel,
   personMatchesQuery,
   sliceAccountDirectory,
+  sliceAccountStream,
   timelinePageLimit,
   type CreatePersonRequest,
   type DirectoryAccount,
   type LinkAccountRequest,
   type LinkConflict,
+  type AccountState,
   type PeopleList,
   type PersonResource,
+  type StreamAccount,
 } from "@rome/api-types/people";
 import { buildTimeline, proposedApiStore } from "./people";
 
@@ -96,18 +100,60 @@ function personResource(person: PersonFixture): PersonResource {
   };
 }
 
+/** A contacts-list row: who the account is, and nothing about what was said. */
 function directoryRow(ref: AccountRef): DirectoryAccount {
   const owner = ownerOf(ref.channel, ref.channelUserId);
-  const entries = buildTimeline(channelIdentityId(ref.channel, ref.channelUserId)) ?? [];
   return {
     channel: ref.channel,
     channelUserId: ref.channelUserId,
     addresses: [ref.channelUserId],
     displayName: accountDisplayName(ref.channel, ref.channelUserId),
     ...accountPresentation(owner ? { personId: owner.id, displayName: owner.displayName } : null),
-    messageCount: messageCountFor(ref.channel, ref.channelUserId),
-    latest: latestDynamic(entries),
   };
+}
+
+/** The same account on the recents surface, or null when nothing has happened
+ *  on it — the stream carries no such account. */
+function streamRow(ref: AccountRef): StreamAccount | null {
+  const latest = latestDynamic(
+    buildTimeline(channelIdentityId(ref.channel, ref.channelUserId)) ?? [],
+  );
+  return latest == null
+    ? null
+    : {
+        ...directoryRow(ref),
+        latest,
+        messageCount: messageCountFor(ref.channel, ref.channelUserId),
+      };
+}
+
+/** Every account the three sources name, once each — what both account reads
+ *  are cut out of. */
+function observedAccounts(): AccountRef[] {
+  const seen = new Map<string, AccountRef>();
+  const add = (channel: string, channelUserId: string) => {
+    seen.set(`${channel}\n${channelUserId}`, { channel, channelUserId });
+  };
+  for (const p of persons) for (const m of p.channelMappings) add(m.channel, m.channelUserId);
+  for (const s of sentinelSenders) add(s.channel, s.channelUserId);
+  for (const c of whatsappContacts) if (!c.isGroup) add("whatsapp", c.jid);
+  return [...seen.values()];
+}
+
+/** The `?state=` both account reads narrow by, or the 400 a value naming no
+ *  state earns. */
+function readState(params: URLSearchParams): { state: AccountState | null } | { error: Response } {
+  const raw = params.get("state");
+  const state = parseAccountState(raw);
+  if (raw != null && raw !== "" && state === null) {
+    return {
+      error: HttpResponse.json(
+        { error: "state must be unlinked, linked, or dismissed" },
+        { status: 400 },
+      ),
+    };
+  }
+  return { state };
 }
 
 /** The sentinel is structure: no /api/people route resolves it. */
@@ -190,39 +236,52 @@ export const proposedPeopleHandlers = [
   // Every account ever observed — from links, the sentinel log, and channel
   // mirrors — with its derived state. `?state=unlinked` is the discovery queue
   // that replaces /api/persons/unknown and the union's unknown rows.
+  //
+  // The contacts list: every account, by name, carrying nothing about what
+  // anyone said. `/api/accounts/stream` below is the other half.
   http.get("/api/accounts", ({ request }) => {
     const params = new URL(request.url).searchParams;
-    const rawState = params.get("state");
-    const state = parseAccountState(rawState);
-    if (rawState != null && rawState !== "" && state === null) {
-      return HttpResponse.json(
-        { error: "state must be unlinked, linked, or dismissed" },
-        { status: 400 },
-      );
-    }
+    const state = readState(params);
+    if ("error" in state) return state.error;
     const rawCursor = params.get("cursor");
     const cursor = parseAccountCursor(rawCursor);
     if (rawCursor != null && rawCursor !== "" && cursor === null) {
       return HttpResponse.json({ error: "cursor is not an account cursor" }, { status: 400 });
     }
-    const seen = new Map<string, AccountRef>();
-    const add = (channel: string, channelUserId: string) => {
-      seen.set(`${channel}\n${channelUserId}`, { channel, channelUserId });
-    };
-    for (const p of persons) for (const m of p.channelMappings) add(m.channel, m.channelUserId);
-    for (const s of sentinelSenders) add(s.channel, s.channelUserId);
-    for (const c of whatsappContacts) if (!c.isGroup) add("whatsapp", c.jid);
 
-    // Paging, counts, the silent toggle and ordering are the shared rule's job,
-    // so the fixtures cannot drift from the route on any of them.
+    // Paging, counts and ordering are the shared rule's job, so the fixtures
+    // cannot drift from the route on any of them.
     return HttpResponse.json(
-      sliceAccountDirectory([...seen.values()].map(directoryRow), {
+      sliceAccountDirectory(observedAccounts().map(directoryRow), {
         query: params.get("q"),
-        state,
+        state: state.state,
         cursor,
         limit: params.get("limit") ? Number(params.get("limit")) : null,
-        includeSilent: params.get("includeSilent") === "true",
       }),
+    );
+  }),
+
+  // The recents surface: the accounts something has happened on, newest first.
+  http.get("/api/accounts/stream", ({ request }) => {
+    const params = new URL(request.url).searchParams;
+    const state = readState(params);
+    if ("error" in state) return state.error;
+    const rawCursor = params.get("cursor");
+    const cursor = parseStreamCursor(rawCursor);
+    if (rawCursor != null && rawCursor !== "" && cursor === null) {
+      return HttpResponse.json({ error: "cursor is not a stream cursor" }, { status: 400 });
+    }
+
+    return HttpResponse.json(
+      sliceAccountStream(
+        observedAccounts().flatMap((ref) => streamRow(ref) ?? []),
+        {
+          query: params.get("q"),
+          state: state.state,
+          cursor,
+          limit: params.get("limit") ? Number(params.get("limit")) : null,
+        },
+      ),
     );
   }),
 

--- a/packages/web/mock/handlers/people.ts
+++ b/packages/web/mock/handlers/people.ts
@@ -377,9 +377,9 @@ const whatsappContacts: WhatsAppContactRow[] = [
   },
   {
     // Two contacts nobody has ever said anything to, and nobody has ever heard
-    // from: the address book's silent thousands, in miniature. They stay out of
-    // the stream and out of the directory until the toggle asks for them, and
-    // the search box reaches them either way.
+    // from: the address book's quiet thousands, in miniature. They stay out of
+    // the stream, which carries only the accounts something has happened on,
+    // and the contacts list holds them like any other account.
     jid: QUIET_JID,
     phoneNumber: "6598023311",
     name: "Jonas Tan",

--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -48,17 +48,11 @@
   "row": {
     "messageCount_one": "{{count}} message",
     "messageCount_other": "{{count}} messages",
-    "neverMessaged": "No activity yet — synced from your address book",
     "noPreview": "No text in this one",
     "noActivity": "No activity yet"
   },
   "guardian": {
     "meta": "That is you. Full access to every surface."
-  },
-  "unknown": {
-    "includeSilent": "Include never-messaged contacts",
-    "includeSilentCount_one": "Include never-messaged contacts ({{count}})",
-    "includeSilentCount_other": "Include never-messaged contacts ({{count}})"
   },
   "actions": {
     "select": "Select {{name}}",

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -48,17 +48,11 @@
   "row": {
     "messageCount_one": "{{count}} 条消息",
     "messageCount_other": "{{count}} 条消息",
-    "neverMessaged": "暂无动态 — 由通讯录同步而来",
     "noPreview": "这条没有文字内容",
     "noActivity": "暂无动态"
   },
   "guardian": {
     "meta": "这是你本人，拥有所有界面的完整权限。"
-  },
-  "unknown": {
-    "includeSilent": "包含从未联系的联系人",
-    "includeSilentCount_one": "包含从未联系的联系人（{{count}}）",
-    "includeSilentCount_other": "包含从未联系的联系人（{{count}}）"
   },
   "actions": {
     "select": "选择 {{name}}",

--- a/packages/web/src/pages/PeoplePage.test.tsx
+++ b/packages/web/src/pages/PeoplePage.test.tsx
@@ -10,20 +10,25 @@ import {
   parseAccountCursor,
   parseAccountState,
   parsePersonFilterLevel,
+  parseStreamCursor,
   personMatchesLevel,
   personMatchesQuery,
   sliceAccountDirectory,
+  sliceAccountStream,
+  type AccountDynamic,
   type DirectoryAccount,
   type PersonResource,
+  type StreamAccount,
 } from "@rome/api-types/people";
 import i18n from "@/i18n";
 import PeoplePage from "./PeoplePage";
 
 // The People page as the guardian drives it: a stream that routes to whoever
-// has something new, and a directory that reads the roster. The derivations
-// behind grouping and counts are pinned in `people/people-model.test.ts`; what
-// is under test here is the page wiring — which request a control sends, what
-// it shows afterwards, and where a click takes the guardian.
+// has something new, and a directory — a contacts list — that reads the roster.
+// The derivations behind grouping and counts are pinned in
+// `people/people-model.test.ts`; what is under test here is the page wiring —
+// which of the two account reads a view sends, what it shows afterwards, and
+// where a click takes the guardian.
 //
 // The backend is stubbed through the contract's own helpers rather than
 // restated, so a fixture cannot drift from the routes on ordering, filtering,
@@ -91,7 +96,25 @@ const QUIET_PERSON: PersonResource = {
   latest: null,
 };
 
-const UNKNOWN_SENDER: DirectoryAccount = {
+/**
+ * One account as the world holds it: the contacts-list row, plus the activity
+ * the stream read would project. Neither read answers this shape — `directoryRow`
+ * and `streamRow` below cut it down to the one each contract carries.
+ */
+type WorldAccount = DirectoryAccount & {
+  latest: AccountDynamic | null;
+  messageCount: number;
+};
+
+const directoryRow = ({ latest: _l, messageCount: _c, ...row }: WorldAccount): DirectoryAccount =>
+  row;
+
+const streamRow = (account: WorldAccount): StreamAccount | null =>
+  account.latest == null
+    ? null
+    : { ...directoryRow(account), latest: account.latest, messageCount: account.messageCount };
+
+const UNKNOWN_SENDER: WorldAccount = {
   channel: "whatsapp",
   channelUserId: "6591234472@s.whatsapp.net",
   addresses: ["6591234472", "6591234472@s.whatsapp.net"],
@@ -103,7 +126,7 @@ const UNKNOWN_SENDER: DirectoryAccount = {
   messageCount: 12,
 };
 
-const SILENT_CONTACT: DirectoryAccount = {
+const SILENT_CONTACT: WorldAccount = {
   channel: "whatsapp",
   channelUserId: "6588021147@s.whatsapp.net",
   addresses: ["6588021147@s.whatsapp.net"],
@@ -115,7 +138,7 @@ const SILENT_CONTACT: DirectoryAccount = {
   messageCount: 0,
 };
 
-const DISMISSED: DirectoryAccount = {
+const DISMISSED: WorldAccount = {
   channel: "whatsapp",
   channelUserId: "447700900123@s.whatsapp.net",
   addresses: ["447700900123@s.whatsapp.net"],
@@ -127,7 +150,7 @@ const DISMISSED: DirectoryAccount = {
   messageCount: 6,
 };
 
-const LINKED_ACCOUNT: DirectoryAccount = {
+const LINKED_ACCOUNT: WorldAccount = {
   channel: "telegram",
   channelUserId: "418820113",
   addresses: ["418820113"],
@@ -142,7 +165,7 @@ const LINKED_ACCOUNT: DirectoryAccount = {
 /** The world both reads are served from, and every write applies to. */
 interface World {
   people: PersonResource[];
-  accounts: DirectoryAccount[];
+  accounts: WorldAccount[];
   peopleFail: boolean;
   accountsFail: boolean;
 }
@@ -199,7 +222,7 @@ function applyWrite(
   body: WriteBody,
   json: Json,
 ): Response {
-  const holder = (account: DirectoryAccount) => ({
+  const holder = (account: WorldAccount) => ({
     id: account.personId ?? "",
     displayName: account.personName ?? "",
   });
@@ -214,7 +237,7 @@ function applyWrite(
     if (!account) return json({ error: "Unknown account" }, 404);
     if (account.state === "linked") return json(linkConflict(account, holder(account)), 409);
     account.state = verb === "dismiss" ? "dismissed" : "unlinked";
-    return json(account);
+    return json(directoryRow(account));
   }
 
   if (path === "/api/people" && method === "POST") {
@@ -280,7 +303,7 @@ function applyWrite(
  * hands back a different world rather than a patched local state.
  */
 function mockApi(
-  world: { people?: PersonResource[]; accounts?: DirectoryAccount[] } = {},
+  world: { people?: PersonResource[]; accounts?: WorldAccount[] } = {},
   options: {
     limit?: number;
     peopleFail?: boolean;
@@ -321,15 +344,32 @@ function mockApi(
       return applyWrite(state, method, parsed.pathname, body ?? {}, json);
     }
 
+    // The two account reads over one world: the contacts list, and the recents
+    // surface. Which one the page asked for is the view's own answer, so a test
+    // that drove the wrong view reads the wrong rows rather than none.
+    if (parsed.pathname === "/api/accounts/stream") {
+      if (state.accountsFail) return json({ error: "directory unavailable" }, 500);
+      return json(
+        sliceAccountStream(
+          state.accounts.flatMap((account) => streamRow(account) ?? []),
+          {
+            query: params.get("q"),
+            state: parseAccountState(params.get("state")),
+            cursor: parseStreamCursor(params.get("cursor")),
+            limit: options.limit ?? null,
+          },
+        ),
+      );
+    }
+
     if (url.includes("/api/accounts")) {
       if (state.accountsFail) return json({ error: "directory unavailable" }, 500);
       return json(
-        sliceAccountDirectory(state.accounts, {
+        sliceAccountDirectory(state.accounts.map(directoryRow), {
           query: params.get("q"),
           state: parseAccountState(params.get("state")),
           cursor: parseAccountCursor(params.get("cursor")),
           limit: options.limit ?? null,
-          includeSilent: params.get("includeSilent") === "true",
         }),
       );
     }
@@ -433,8 +473,9 @@ describe("PeoplePage stream", () => {
     renderPage();
 
     await screen.findByText("Wei Chen");
-    // The silent contact is not waiting on a decision, so the browsing view's
-    // count leaves it out — and the number is the server's either way.
+    // The stream's read is the accounts something has happened on, so its count
+    // of unlinked ones is the senders waiting on a decision — a contact nobody
+    // has ever heard from is not one, and never reaches this view.
     await waitFor(() => expect(within(chip(/^Unknown/)).getByText("1")).toBeTruthy());
     expect(within(chip(/^All/)).queryByText(/^\d+$/)).toBeNull();
   });
@@ -475,18 +516,19 @@ describe("PeoplePage stream", () => {
     expect(await screen.findByText("person page")).toBeTruthy();
   });
 
-  it("searches the server, reaching contacts no page has loaded", async () => {
+  it("sends the search term to the server rather than filtering what loaded", async () => {
     const user = userEvent.setup();
-    const { calls } = mockApi({ people: [FRIEND], accounts: [SILENT_CONTACT] });
+    const { calls } = mockApi({ people: [FRIEND], accounts: [UNKNOWN_SENDER] });
     renderPage();
 
     await screen.findByText("Wei Chen");
-    await user.type(screen.getByRole("searchbox", { name: /search people/i }), "jonas");
+    await user.type(screen.getByRole("searchbox", { name: /search people/i }), "rachel");
 
-    // A search reaches the address book whatever the toggle says — the
-    // endpoint's rule, and the reason the term goes to the server at all.
-    expect(await screen.findByText("Jonas Tan")).toBeTruthy();
-    await waitFor(() => expect(calls.some((c) => c.url.includes("q=jonas"))).toBe(true));
+    expect(await screen.findByText("Rachel Lim")).toBeTruthy();
+    await waitFor(() => expect(calls.some((c) => c.url.includes("q=rachel"))).toBe(true));
+    // The account read pages, so a filter over the rows that happened to arrive
+    // would answer "no such contact" for someone further down the listing.
+    expect(screen.queryByText("Wei Chen")).toBeNull();
   });
 
   it("sends one request for a typed word rather than one per letter", async () => {
@@ -517,47 +559,56 @@ describe("PeoplePage directory", () => {
     await screen.findByText("Wei Chen");
     await showDirectory(user);
 
-    // Everyone is in a group, the quiet person included — a roster answers
-    // "who does Rome know", not "who said something".
+    // Everyone is in a group, the quiet person and the address-book contact
+    // included — a contacts list answers "who does Rome know", not "who said
+    // something".
     expect(await screen.findByText("Nadia Petrova")).toBeTruthy();
     expect(screen.getByText("Zhangfan Dong")).toBeTruthy();
+    expect(screen.getByText("Jonas Tan")).toBeTruthy();
     // The heading's number is the directory's own, not the rows on screen.
     const unknown = screen.getByRole("heading", { name: "Unknown" }).parentElement!;
-    expect(within(unknown).getByText("1")).toBeTruthy();
+    expect(within(unknown).getByText("2")).toBeTruthy();
   });
 
-  it("offers the silent contacts it is holding back, and asks the server for them", async () => {
+  it("reads the contacts list rather than the stream, and shows no activity in it", async () => {
     const user = userEvent.setup();
-    const { calls } = mockApi({ people: [FRIEND], accounts: [UNKNOWN_SENDER, SILENT_CONTACT] });
+    const { calls } = mockApi({ people: [FRIEND], accounts: [UNKNOWN_SENDER] });
+    renderPage();
+
+    await screen.findByText("Wei Chen");
+    expect(screen.getByText("on my way")).toBeTruthy();
+    await showDirectory(user);
+
+    const accountReads = () =>
+      calls.filter((c) => c.method === "GET" && c.url.startsWith("/api/accounts"));
+    await waitFor(() =>
+      expect(accountReads().some((c) => !c.url.startsWith("/api/accounts/stream"))).toBe(true),
+    );
+    // No preview and no count anywhere in the view — the read carries neither.
+    await waitFor(() => expect(screen.queryByText("on my way")).toBeNull());
+    expect(screen.queryByText("Are you free Saturday?")).toBeNull();
+    expect(screen.queryByText(/\d+ messages?/)).toBeNull();
+  });
+
+  it("still offers the placement gestures on an account nobody has decided about", async () => {
+    const user = userEvent.setup();
+    mockApi({ people: [FRIEND], accounts: [UNKNOWN_SENDER] });
     renderPage();
 
     await screen.findByText("Wei Chen");
     await showDirectory(user);
 
-    // Browsing holds the address book back; the toggle says how many are there.
-    expect(screen.queryByText("Jonas Tan")).toBeNull();
-    await user.click(await screen.findByLabelText(/Include never-messaged contacts \(1\)/));
-
-    expect(await screen.findByText("Jonas Tan")).toBeTruthy();
-    await waitFor(() => expect(calls.some((c) => c.url.includes("includeSilent=true"))).toBe(true));
+    // The contacts row carries the same three verbs the stream's dense row does
+    // — the decision is available wherever the account is.
+    await screen.findByText("Rachel Lim");
+    expect(screen.getByRole("button", { name: "Create" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Link" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Treat as stranger" })).toBeTruthy();
   });
 
-  it("keeps the Unknown heading when the toggle is what emptied it", async () => {
+  it("pages the directory by name, resuming at the cursor the server named", async () => {
     const user = userEvent.setup();
-    mockApi({ people: [FRIEND], accounts: [SILENT_CONTACT] });
-    renderPage();
-
-    await screen.findByText("Wei Chen");
-    await showDirectory(user);
-
-    // The heading carries the toggle, so an address book with no waiting
-    // senders in front of it would otherwise have no way back on screen.
-    expect(await screen.findByRole("heading", { name: "Unknown" })).toBeTruthy();
-  });
-
-  it("pages the directory by the cursor the server named", async () => {
-    const user = userEvent.setup();
-    const second: DirectoryAccount = {
+    const second: WorldAccount = {
       ...UNKNOWN_SENDER,
       channelUserId: "6580001111@s.whatsapp.net",
       addresses: ["6580001111@s.whatsapp.net"],
@@ -567,17 +618,32 @@ describe("PeoplePage directory", () => {
     const { calls } = mockApi({ accounts: [UNKNOWN_SENDER, second] }, { limit: 1 });
     renderPage();
 
-    await user.click(chip(/^Unknown/));
-    // Newest first, so the older sender sits on the page after this one.
-    expect(await screen.findByText("Rachel Lim")).toBeTruthy();
-    expect(screen.queryByText("Priya Nair")).toBeNull();
+    await showDirectory(user);
+    // By name, so Priya comes first however recently Rachel said something.
+    expect(await screen.findByText("Priya Nair")).toBeTruthy();
+    expect(screen.queryByText("Rachel Lim")).toBeNull();
 
     await user.click(screen.getByRole("button", { name: "Show more" }));
 
     // Appended, not swapped in: paging is reading further down a listing.
-    expect(await screen.findByText("Priya Nair")).toBeTruthy();
-    expect(screen.getByText("Rachel Lim")).toBeTruthy();
+    expect(await screen.findByText("Rachel Lim")).toBeTruthy();
+    expect(screen.getByText("Priya Nair")).toBeTruthy();
     expect(calls.some((c) => c.url.includes("cursor="))).toBe(true);
+  });
+
+  it("reaches a contact no page has loaded through the search box", async () => {
+    const user = userEvent.setup();
+    const { calls } = mockApi({ people: [FRIEND], accounts: [SILENT_CONTACT] });
+    renderPage();
+
+    await screen.findByText("Wei Chen");
+    await showDirectory(user);
+    await user.type(screen.getByRole("searchbox", { name: /search people/i }), "jonas");
+
+    // The contacts list is where a lookup lands: every account is in it, and the
+    // term goes to the server rather than filtering whichever page arrived.
+    expect(await screen.findByText("Jonas Tan")).toBeTruthy();
+    await waitFor(() => expect(calls.some((c) => c.url.includes("q=jonas"))).toBe(true));
   });
 });
 

--- a/packages/web/src/pages/PeoplePage.tsx
+++ b/packages/web/src/pages/PeoplePage.tsx
@@ -15,6 +15,7 @@ import {
   FILTER_ORDER,
   levelCounts,
   streamRows,
+  type LevelCounts,
   type PeopleFilter,
   type PeopleRow,
   type PeopleView,
@@ -28,15 +29,17 @@ import { LinkedInSection } from "./people/linkedin";
  *
  * Latest answers "who has something new" — one row per identity with a
  * dynamic, newest first, carrying only what routing needs. Directory answers
- * "who does Rome know" — everyone grouped by bond. Unknown and Stranger are
- * positions on the same ladder as the curated levels, so an account waiting on
- * a decision and a person the guardian placed sit in one list rather than in
- * sections that cannot say where either stands relative to the other.
+ * "who does Rome know" — a contacts list, everyone Rome holds, by name, with no
+ * preview and no count anywhere in it. Unknown and Stranger are positions on
+ * the same ladder as the curated levels, so an account waiting on a decision
+ * and a person the guardian placed sit in one list rather than in sections that
+ * cannot say where either stands relative to the other.
  *
  * The contract is two nouns and this page is one ladder over both: `GET
- * /api/people` for the people, `GET /api/accounts` for every account Rome has
- * observed, joined in `people-model.ts`. A person's history is a third read,
- * `GET /api/people/:id/messages`, and it belongs to the person page.
+ * /api/people` for the people, and the account read the view is about — `GET
+ * /api/accounts` for the contacts list, `GET /api/accounts/stream` for the
+ * recents surface — joined in `people-model.ts`. A person's history is a third
+ * read, `GET /api/people/:id/messages`, and it belongs to the person page.
  *
  * Every number on screen is the server's. The directory pages, so a count taken
  * over the rows that happened to arrive would report no waiting senders as soon
@@ -66,19 +69,17 @@ export default function PeoplePage() {
   const [view, setView] = useState<PeopleView>("latest");
   const [filter, setFilter] = useState<PeopleFilter>("all");
   const [search, setSearch] = useState("");
-  const [showSilent, setShowSilent] = useState(false);
 
-  // The directory shows the address book behind its own toggle; the stream
-  // never does, and a search reaches it either way — the endpoint's own rule.
+  // The view picks the account read: the contacts list, or the recents surface.
   //
   // The chip rides the requests in the stream, where a level is the whole view:
-  // an account state is what the directory read can narrow by, a bond level is
+  // an account state is what the account read can narrow by, a bond level is
   // what the people read can. The directory view renders every group at once,
   // so it sends neither — a level on the request would leave the other headings
   // with nothing to show.
   const roster = usePeopleRoster({
     search,
-    includeSilent: view === "directory" && showSilent,
+    view,
     accountState: view === "directory" ? null : filter === "stranger" ? "dismissed" : "unlinked",
     personLevel: view === "directory" || !PLACED_FILTERS.has(filter) ? null : filter,
   });
@@ -94,20 +95,15 @@ export default function PeoplePage() {
     [rows, settled, filter],
   );
   const groups = useMemo(
-    () => directoryGroups(rows, { filter, search: settled, showSilent }),
-    [rows, filter, settled, showSilent],
+    () => directoryGroups(rows, { filter, search: settled }),
+    [rows, filter, settled],
   );
-  // Two sets of numbers, and they are meant to disagree: a chip counts what is
-  // waiting on a decision, a directory heading counts everyone in the group as
-  // the roster currently stands.
+  // The numbers the chips and the group headings show, from the read the view
+  // is on: what the stream calls Unknown is the senders waiting on a decision,
+  // what the directory calls Unknown is everyone Rome has not placed.
   const counts = useMemo(
-    () =>
-      levelCounts(
-        roster.peopleCounts,
-        { counts: roster.accountCounts, silentTotal: roster.silentTotal },
-        { includeSilent: view === "directory" && showSilent },
-      ),
-    [roster.peopleCounts, roster.accountCounts, roster.silentTotal, view, showSilent],
+    () => levelCounts(roster.peopleCounts, roster.accountCounts),
+    [roster.peopleCounts, roster.accountCounts],
   );
   // A link lands on a person, so the picker offers the people this read
   // returned rather than the accounts beside them.
@@ -136,15 +132,16 @@ export default function PeoplePage() {
   const loading = roster.isPending;
   const loadError = roster.error ? roster.error.message : null;
 
-  // Both unplaced ends of the ladder render dense, with the gesture their
-  // position admits. A restore decides on the same evidence a placement does —
-  // what the sender actually sent — so it gets the same row rather than a
-  // roster line with a button on it.
-  const unplaced = (row: PeopleRow) =>
+  // Both unplaced ends of the ladder carry the gesture their position admits,
+  // on the row their view has. The stream renders them dense — a placement and
+  // a restore both decide on what the sender actually sent, so the evidence is
+  // on the row rather than a click away — and the directory renders them as the
+  // contacts line every other row is, with the buttons at the end of it.
+  const unplaced = (row: PeopleRow, variant: PeopleView) =>
     row.level === "stranger" ? (
-      <DismissedEntry key={row.id} row={row} />
+      <DismissedEntry key={row.id} row={row} variant={variant} />
     ) : (
-      <UnknownEntry key={row.id} row={row} people={linkTargets} />
+      <UnknownEntry key={row.id} row={row} people={linkTargets} variant={variant} />
     );
 
   return (
@@ -189,8 +186,7 @@ export default function PeoplePage() {
               label: option === "all" ? t("filters.all") : t(levelLabelKey(option)),
               // Unknown is the page's one number that asks for a decision, so
               // it carries a count; the other chips are plain labels.
-              count:
-                option === "unknown" && counts.chips.unknown > 0 ? counts.chips.unknown : undefined,
+              count: option === "unknown" && counts.unknown > 0 ? counts.unknown : undefined,
             }))}
           />
         </div>
@@ -239,17 +235,14 @@ export default function PeoplePage() {
             rows={latest}
             searching={settled !== ""}
             onOpen={openRow}
-            renderUnplaced={unplaced}
+            renderUnplaced={(row) => unplaced(row, "latest")}
           />
         ) : (
           <DirectoryView
             groups={groups}
-            counts={counts.totals}
-            showSilent={showSilent}
-            silentTotal={roster.silentTotal}
-            onToggleSilent={setShowSilent}
+            counts={counts}
             onOpen={openRow}
-            renderUnplaced={unplaced}
+            renderUnplaced={(row) => unplaced(row, "directory")}
           />
         )}
 
@@ -330,19 +323,11 @@ function LatestView({
 function DirectoryView({
   groups,
   counts,
-  showSilent,
-  silentTotal,
-  onToggleSilent,
   onOpen,
   renderUnplaced,
 }: {
   groups: { level: RowLevel; rows: PeopleRow[] }[];
-  counts: Record<RowLevel, number>;
-  showSilent: boolean;
-  /** How many silent contacts the directory holds, whether or not this view is
-   *  currently carrying them. */
-  silentTotal: number;
-  onToggleSilent: (value: boolean) => void;
+  counts: LevelCounts;
   onOpen: (row: PeopleRow) => void;
   renderUnplaced: (row: PeopleRow) => React.ReactNode;
 }) {
@@ -369,30 +354,10 @@ function DirectoryView({
             <span className="font-mono text-badge tabular-nums text-subtle-foreground">
               {counts[group.level]}
             </span>
-            {/* The toggle is always on the Unknown heading: the endpoint holds
-                silent contacts back until it is on, so the page cannot count
-                what it has not been sent. */}
-            {group.level === "unknown" ? (
-              <label className="ml-auto flex items-center gap-2 text-badge text-muted-foreground">
-                <input
-                  type="checkbox"
-                  checked={showSilent}
-                  onChange={(e) => onToggleSilent(e.target.checked)}
-                  className="accent-primary"
-                />
-                {/* The number is what the toggle is deciding about, and it is a
-                    directory-wide total rather than a page one — so it reads
-                    the same whether those rows are on screen or held back. */}
-                {silentTotal > 0
-                  ? t("unknown.includeSilentCount", { count: silentTotal })
-                  : t("unknown.includeSilent")}
-              </label>
-            ) : (
-              LEVEL_HINT_KEY[group.level] && (
-                <span className="ml-auto text-badge text-subtle-foreground">
-                  {t(LEVEL_HINT_KEY[group.level]!)}
-                </span>
-              )
+            {LEVEL_HINT_KEY[group.level] && (
+              <span className="ml-auto text-badge text-subtle-foreground">
+                {t(LEVEL_HINT_KEY[group.level]!)}
+              </span>
             )}
           </div>
           <div className="flex flex-col">

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -97,8 +97,6 @@ const UNPLACED: DirectoryAccount = {
   state: "unlinked",
   personId: null,
   personName: null,
-  latest: { source: "whatsapp", timestamp: NOW - 7_200, preview: "Are you free Saturday?" },
-  messageCount: 12,
 };
 
 const HELD_BY_ANOTHER: DirectoryAccount = {
@@ -109,8 +107,6 @@ const HELD_BY_ANOTHER: DirectoryAccount = {
   state: "linked",
   personId: "mira",
   personName: "Mira Chen",
-  latest: { source: "telegram", timestamp: NOW - 3_600, preview: "sent" },
-  messageCount: 4,
 };
 
 /** Whatever a write put on the wire, read back for assertions. */

--- a/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
+++ b/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
@@ -53,7 +53,6 @@ function row(
     addresses: account ? [account.channelUserId] : [],
     latest: null,
     messageCount: 0,
-    silent: false,
     ...over,
   };
 }
@@ -294,10 +293,10 @@ const DIRECTORY: { level: RowLevel; total: number; rows: PeopleRow[] }[] = [
         displayName: "Ana Ruiz",
         level: "acquaintance",
         kind: "account",
+        // Synced from an address book and never messaged. The directory holds
+        // nobody back, and its row says the same thing about them it says about
+        // everyone: who they are, and where to reach them.
         accounts: on("whatsapp", "34600555321@s.whatsapp.net"),
-        // Synced from an address book and never messaged: the row says so
-        // where a handle would otherwise sit.
-        silent: true,
       }),
     ],
   },

--- a/packages/web/src/pages/dev/mdx/docs/people-page.mdx
+++ b/packages/web/src/pages/dev/mdx/docs/people-page.mdx
@@ -56,13 +56,12 @@ Unknown and Stranger are each entered on purpose. The Unknown chip carries a cou
 when senders are waiting.
 
 <Invariant>
-  Every number on screen is the server's. Chips read `counts`, directory headings read
-  `totals`, and neither is derived from the rows that happened to load — the directory
-  is paged, so a count taken over page one would report no waiting senders whenever
-  placed people fill it. The two numbers answer different questions and are meant to
-  disagree: a chip counts what is waiting on a decision, so a contact the address book
-  synced and nobody has ever heard from is not in it, while the heading counts everyone
-  in the group as the roster stands.
+  Every number on screen is the server's `counts`, never derived from the rows that
+  happened to load — the account read is paged, so a count taken over page one would
+  report no waiting senders whenever placed people fill it. Which accounts it counts is
+  the view's own read: the stream counts the ones something has happened on, so its
+  Unknown is the senders waiting on a decision, while the directory counts the whole
+  contacts list, so its Unknown is everyone Rome has not placed.
 </Invariant>
 
 ---
@@ -107,21 +106,25 @@ row rather than a roster line with a button on it.
 
 ---
 
-## Directory — the roster
+## Directory — the contacts list
 
-Everyone grouped by bond with live counts, three columns (avatar, name plus
-identifier, `⋯`), no channel badges. Click a row to open the person, and click the
-avatar to select. A selection raises the bulk bar, whose choices are the **intersection**
-across the selection, since one choice applies to every row in it.
+Everyone Rome knows grouped by bond, ordered by name within each group, with live
+counts and three columns (avatar, name plus identifier, `⋯`) — no channel badges, no
+preview, no message count. The directory read carries none of that, which is what
+makes this a contacts list rather than a second stream. Click a row to open the
+person, and click the avatar to select. A selection raises the bulk bar, whose choices
+are the **intersection** across the selection, since one choice applies to every row in
+it.
 
 <Specimen title="Directory groups, selection, bulk bar">
   <DirectoryDemo />
 </Specimen>
 
-The guardian row is fixed: not moved, not merged, not selected. Never-messaged
-contacts sit behind a toggle in the Unknown group — which is why the Unknown heading
-survives an empty group, since an address book with no waiting senders in front of it
-would otherwise have no way back on screen.
+The guardian row is fixed: not moved, not merged, not selected. Nobody else is held
+back — a contact the address book synced and nobody has ever heard from is in the
+Unknown group like any other account, because looking someone up is what this view is
+for. An account nobody has decided about carries the same three placement gestures
+here that it carries on the stream, at the end of its row.
 
 ---
 

--- a/packages/web/src/pages/people/people-model.test.ts
+++ b/packages/web/src/pages/people/people-model.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { AccountDirectory, DirectoryAccount, PersonResource } from "@rome/api-types/people";
+import type {
+  AccountCounts,
+  DirectoryAccount,
+  PersonResource,
+  StreamAccount,
+} from "@rome/api-types/people";
 import {
   directoryGroups,
   levelCounts,
@@ -12,7 +17,12 @@ import {
 // The People page reads two nouns — a person and the accounts they are reachable
 // at — and renders one ladder over both. What is pinned here is the join: which
 // contract row becomes which ladder position, how the two interleave in the
-// stream, and whose numbers the chips and headings show.
+// stream, how the contacts list orders, and whose numbers the chips and headings
+// show.
+//
+// Two account shapes, because there are two account reads. `contact` is the
+// directory's row — everyone, and nothing about what was said. `spoke` is the
+// stream's — an account something has happened on, with the line to preview.
 
 const now = Math.floor(Date.now() / 1000);
 
@@ -28,7 +38,8 @@ function person(over: Partial<PersonResource> = {}): PersonResource {
   };
 }
 
-function account(over: Partial<DirectoryAccount> = {}): DirectoryAccount {
+/** One row of the contacts list. */
+function contact(over: Partial<DirectoryAccount> = {}): DirectoryAccount {
   const channelUserId = over.channelUserId ?? "883104221";
   return {
     channel: "telegram",
@@ -38,16 +49,18 @@ function account(over: Partial<DirectoryAccount> = {}): DirectoryAccount {
     state: "unlinked",
     personId: null,
     personName: null,
-    latest: { source: "telegram", timestamp: now - 300, preview: "is this the right number?" },
-    messageCount: 1,
     ...over,
   };
 }
 
-function directory(accounts: DirectoryAccount[], over: Partial<AccountDirectory> = {}) {
-  const counts = { unlinked: 0, linked: 0, dismissed: 0 };
-  for (const row of accounts) counts[row.state] += 1;
-  return { accounts, nextCursor: null, counts, silentTotal: 0, ...over } satisfies AccountDirectory;
+/** The same account on the stream, with the dynamic that put it there. */
+function spoke(over: Partial<StreamAccount> = {}): StreamAccount {
+  return {
+    ...contact(over),
+    latest: { source: "telegram", timestamp: now - 300, preview: "is this the right number?" },
+    messageCount: 1,
+    ...over,
+  };
 }
 
 const rowsOf = (rows: PeopleRow[]) => rows.map((row) => row.displayName);
@@ -65,8 +78,8 @@ describe("peopleRows", () => {
     const rows = peopleRows(
       [],
       [
-        account({ channelUserId: "1", state: "unlinked" }),
-        account({ channelUserId: "2", state: "dismissed" }),
+        contact({ channelUserId: "1", state: "unlinked" }),
+        contact({ channelUserId: "2", state: "dismissed" }),
       ],
     );
     expect(rows.map((row) => row.level)).toEqual(["unknown", "stranger"]);
@@ -79,7 +92,7 @@ describe("peopleRows", () => {
     const rows = peopleRows(
       [person()],
       [
-        account({
+        contact({
           channel: "telegram",
           channelUserId: "418820113",
           state: "linked",
@@ -98,7 +111,7 @@ describe("peopleRows", () => {
     const rows = peopleRows(
       [],
       [
-        account({
+        contact({
           channelUserId: "1555@s.whatsapp.net",
           addresses: ["1555", "1555@s.whatsapp.net"],
         }),
@@ -113,7 +126,7 @@ describe("streamRows", () => {
     const rows = peopleRows(
       [person({ latest: { source: "telegram", timestamp: now - 900, preview: "older" } })],
       [
-        account({
+        spoke({
           channelUserId: "new",
           displayName: "Devika",
           latest: { source: "whatsapp", timestamp: now - 60, preview: "newer" },
@@ -134,8 +147,8 @@ describe("streamRows", () => {
     const rows = peopleRows(
       [person()],
       [
-        account({ channelUserId: "waiting", displayName: "Jules" }),
-        account({ channelUserId: "spam", displayName: "Prize", state: "dismissed" }),
+        spoke({ channelUserId: "waiting", displayName: "Jules" }),
+        spoke({ channelUserId: "spam", displayName: "Prize", state: "dismissed" }),
       ],
     );
     expect(rowsOf(streamRows(rows, { search: "", filter: "all" }))).toEqual(["Ray Oster"]);
@@ -149,20 +162,26 @@ describe("streamRows", () => {
         person({ id: "me", displayName: "Mock Guardian", bondLevel: "guardian" }),
         person({ id: "quiet", displayName: "Nadia", latest: null, messageCount: 0 }),
       ],
-      [account({ channelUserId: "silent", displayName: "Jonas", latest: null, messageCount: 0 })],
+      [],
     );
     // A stream row is something that happened, and it is about somebody else.
+    // The read holds back the accounts nothing happened on; a person the
+    // guardian entered by hand is on the people listing either way, so this end
+    // of the rule is the client's.
     expect(rowsOf(streamRows(rows, { search: "", filter: "all" }))).toEqual([]);
   });
 
   it("lets a search reach the quiet ones, whatever chip is lit — guardian excepted", () => {
     const rows = peopleRows(
-      [person({ id: "me", displayName: "Mock Guardian", bondLevel: "guardian" })],
-      [account({ channelUserId: "silent", displayName: "Jonas Tan", latest: null })],
+      [
+        person({ id: "me", displayName: "Mock Guardian", bondLevel: "guardian" }),
+        person({ id: "quiet", displayName: "Nadia Petrova", latest: null, accounts: [] }),
+      ],
+      [],
     );
     // Someone typing a name wants that person wherever they sit on the ladder.
-    expect(rowsOf(streamRows(rows, { search: "jonas", filter: "inner-circle" }))).toEqual([
-      "Jonas Tan",
+    expect(rowsOf(streamRows(rows, { search: "nadia", filter: "inner-circle" }))).toEqual([
+      "Nadia Petrova",
     ]);
     expect(rowsOf(streamRows(rows, { search: "mock", filter: "all" }))).toEqual([]);
   });
@@ -177,9 +196,10 @@ describe("directoryGroups", () => {
         person({ id: "sam", displayName: "Sam Okafor", bondLevel: "colleague" }),
       ],
       [
-        account({ channelUserId: "waiting", displayName: "Jules" }),
-        account({ channelUserId: "spam", displayName: "Prize", state: "dismissed" }),
-        account({ channelUserId: "quiet", displayName: "Jonas Tan", latest: null }),
+        contact({ channelUserId: "waiting", displayName: "Jules" }),
+        contact({ channelUserId: "spam", displayName: "Prize", state: "dismissed" }),
+        contact({ channelUserId: "quiet", displayName: "Jonas Tan" }),
+        contact({ channelUserId: "abby", displayName: "Abby Nunes" }),
       ],
     );
 
@@ -189,68 +209,61 @@ describe("directoryGroups", () => {
       group.rows.map((row) => row.displayName),
     ]);
 
-  it("groups everyone in ladder order, holding the address book back", () => {
-    expect(groupsOf({ filter: "all", search: "", showSilent: false })).toEqual([
-      ["unknown", ["Jules"]],
+  it("groups everyone in ladder order, and orders each group by name", () => {
+    // A contacts list: every account Rome holds is in here, and the order
+    // within a group is the name, not what anyone last said.
+    expect(groupsOf({ filter: "all", search: "" })).toEqual([
+      ["unknown", ["Abby Nunes", "Jonas Tan", "Jules"]],
       ["guardian", ["Mock Guardian"]],
       ["inner-circle", ["Ray Oster"]],
       ["other", ["Sam Okafor"]],
     ]);
   });
 
-  it("keeps the Unknown heading when the toggle is what emptied it", () => {
-    const groups = directoryGroups(
-      peopleRows([person({ id: "ray" })], [account({ channelUserId: "quiet", latest: null })]),
-      { filter: "all", search: "", showSilent: false },
-    );
-    // The heading carries the toggle, so an address book with no waiting
-    // senders in front of it would otherwise have no way back on screen.
-    const unknown = groups.find((group) => group.level === "unknown");
-    expect(unknown?.rows).toEqual([]);
-    expect(unknown).toBeDefined();
-  });
-
-  it("shows the silent contacts once they are asked for", () => {
-    const groups = groupsOf({ filter: "all", search: "", showSilent: true });
-    expect(groups.find(([level]) => level === "unknown")?.[1]).toEqual(["Jules", "Jonas Tan"]);
-  });
-
   it("holds both unplaced ends back from All, and enters each on purpose", () => {
-    // "All" means the placed people plus the senders waiting on a decision;
+    // "All" means the placed people plus the accounts nobody has placed;
     // dismissal is entered deliberately.
-    expect(
-      groupsOf({ filter: "all", search: "", showSilent: false }).map(([level]) => level),
-    ).not.toContain("stranger");
+    expect(groupsOf({ filter: "all", search: "" }).map(([level]) => level)).not.toContain(
+      "stranger",
+    );
     // The guardian rides along, as in every view — see below.
-    expect(groupsOf({ filter: "stranger", search: "", showSilent: false })).toEqual([
+    expect(groupsOf({ filter: "stranger", search: "" })).toEqual([
       ["guardian", ["Mock Guardian"]],
       ["stranger", ["Prize"]],
     ]);
   });
 
   it("keeps the guardian in their own people list, whatever the chip says", () => {
-    const groups = groupsOf({ filter: "inner-circle", search: "", showSilent: false });
+    const groups = groupsOf({ filter: "inner-circle", search: "" });
     expect(groups.map(([level]) => level)).toContain("guardian");
   });
 
-  it("reaches the address book through a search whatever the toggle says", () => {
-    const groups = groupsOf({ filter: "all", search: "jonas", showSilent: false });
-    expect(groups).toEqual([["unknown", ["Jonas Tan"]]]);
+  it("reaches the address book through a search, whatever chip is lit", () => {
+    expect(groupsOf({ filter: "inner-circle", search: "jonas" })).toEqual([
+      ["unknown", ["Jonas Tan"]],
+    ]);
+  });
+
+  it("drops a group nothing sits in rather than heading an empty one", () => {
+    const groups = directoryGroups(peopleRows([person({ id: "ray" })], []), {
+      filter: "all",
+      search: "",
+    });
+    expect(groups.map((group) => group.level)).toEqual(["inner-circle"]);
   });
 });
 
 describe("levelCounts", () => {
-  const directoryCounts = (over = {}) =>
-    directory([], { counts: { unlinked: 6, linked: 12, dismissed: 2 }, silentTotal: 4, ...over });
+  const people = { all: 9, guardian: 1, "inner-circle": 3, acquaintance: 4, other: 1 };
+  const accounts = (over: Partial<AccountCounts> = {}): AccountCounts => ({
+    unlinked: 6,
+    linked: 12,
+    dismissed: 2,
+    ...over,
+  });
 
   it("reads every number off the server, never off the loaded rows", () => {
-    const { totals } = levelCounts(
-      { all: 9, guardian: 1, "inner-circle": 3, acquaintance: 4, other: 1 },
-      directoryCounts(),
-      { includeSilent: false },
-    );
-
-    expect(totals).toEqual({
+    expect(levelCounts(people, accounts())).toEqual({
       unknown: 6,
       guardian: 1,
       "inner-circle": 3,
@@ -260,31 +273,18 @@ describe("levelCounts", () => {
     });
     // Linked accounts are counted under the person they resolve to, never again
     // as accounts — the two nouns describe one roster.
-    expect(Object.values(totals).reduce((a, b) => a + b, 0)).toBe(9 + 6 + 2);
+    expect(Object.values(levelCounts(people, accounts())).reduce((a, b) => a + b, 0)).toBe(
+      9 + 6 + 2,
+    );
   });
 
-  it("counts what is waiting on a decision on the chip, and the group on the heading", () => {
-    const people = { all: 9, guardian: 1, "inner-circle": 3, acquaintance: 4, other: 1 };
-    // Browsing: the directory holds the address book back, so its own count of
-    // unlinked accounts is the waiting ones and nothing else.
-    const browsing = levelCounts(people, directoryCounts(), { includeSilent: false });
-    expect(browsing.chips.unknown).toBe(6);
-    expect(browsing.totals.unknown).toBe(6);
-
-    // The toggle admits four contacts nobody has ever heard from. The heading
-    // counts them — it answers "how many are in here" — and the chip does not:
-    // a contact that has never said anything is not waiting on a decision, and
-    // a chip that grew when the address book came on screen would report ten
-    // senders to triage where there are six.
-    const showing = levelCounts(
-      people,
-      directoryCounts({ counts: { unlinked: 10, linked: 12, dismissed: 2 } }),
-      {
-        includeSilent: true,
-      },
-    );
-    expect(showing.chips.unknown).toBe(6);
-    expect(showing.totals.unknown).toBe(10);
+  it("counts whatever the read the view is on counts under Unknown", () => {
+    // The stream's read is the accounts something has happened on, so its
+    // Unknown is the senders waiting on a decision. The directory's is the whole
+    // contacts list, so its Unknown is everyone Rome has not placed — a bigger
+    // number describing a bigger listing, which is the one on screen.
+    expect(levelCounts(people, accounts({ unlinked: 6 })).unknown).toBe(6);
+    expect(levelCounts(people, accounts({ unlinked: 4_212 })).unknown).toBe(4_212);
   });
 });
 
@@ -292,13 +292,13 @@ describe("rowHandle", () => {
   it("renders a WhatsApp account as its phone number", () => {
     const [row] = peopleRows(
       [],
-      [account({ channel: "whatsapp", channelUserId: "14155550142@s.whatsapp.net" })],
+      [contact({ channel: "whatsapp", channelUserId: "14155550142@s.whatsapp.net" })],
     );
     expect(rowHandle(row)).toBe("+1 (415) 555-0142");
   });
 
   it("falls back to the raw identifier on a channel with no phone shape", () => {
-    const [row] = peopleRows([], [account({ channel: "discord", channelUserId: "6128843201" })]);
+    const [row] = peopleRows([], [contact({ channel: "discord", channelUserId: "6128843201" })]);
     expect(rowHandle(row)).toBe("6128843201");
   });
 });

--- a/packages/web/src/pages/people/people-model.ts
+++ b/packages/web/src/pages/people/people-model.ts
@@ -9,11 +9,12 @@ import {
 } from "@rome/api-types/identities";
 import {
   accountRef,
-  isSilentAccount,
-  type AccountDirectory,
+  compareAccountCursors,
+  type AccountCounts,
   type DirectoryAccount,
   type PersonCounts,
   type PersonResource,
+  type StreamAccount,
 } from "@rome/api-types/people";
 
 // The People page's derivations, kept out of the components so the stream, the
@@ -85,11 +86,30 @@ export interface PeopleRow {
    * than folding a second time and disagreeing.
    */
   addresses: string[];
+  /**
+   * The row's newest dynamic, or null when there is none — and null on every
+   * account row the directory read produced, which carries no activity at all.
+   * Only the stream renders it.
+   */
   latest: IdentityDynamic | null;
+  /** How much is on record for the row. Zero on a directory account row, for
+   *  the reason {@link PeopleRow.latest} is null there. */
   messageCount: number;
-  /** An account with nothing on record that nobody has decided about: a synced
-   *  address-book contact and no more. Never true of a person. */
-  silent: boolean;
+}
+
+/**
+ * What a row says about activity, from whichever account read produced it.
+ *
+ * The directory is a contacts list and its rows carry nothing about what anyone
+ * said, so a row built from one reports none. A stream row is the other way
+ * round: it has a dynamic, which is why it is on the stream at all.
+ */
+function accountActivity(
+  account: DirectoryAccount | StreamAccount,
+): Pick<PeopleRow, "latest" | "messageCount"> {
+  return "latest" in account
+    ? { latest: account.latest, messageCount: account.messageCount }
+    : { latest: null, messageCount: 0 };
 }
 
 /**
@@ -102,7 +122,7 @@ export interface PeopleRow {
  */
 export function peopleRows(
   people: readonly PersonResource[],
-  accounts: readonly DirectoryAccount[],
+  accounts: readonly (DirectoryAccount | StreamAccount)[],
 ): PeopleRow[] {
   const rows: PeopleRow[] = people.map((person) => ({
     kind: "person",
@@ -115,7 +135,6 @@ export function peopleRows(
     addresses: person.accounts.map((account) => account.channelUserId),
     latest: person.latest,
     messageCount: person.messageCount,
-    silent: false,
   }));
 
   for (const account of accounts) {
@@ -133,9 +152,7 @@ export function peopleRows(
         },
       ],
       addresses: account.addresses,
-      latest: account.latest,
-      messageCount: account.messageCount,
-      silent: isSilentAccount(account),
+      ...accountActivity(account),
     });
   }
 
@@ -176,14 +193,28 @@ export function searchRows(rows: readonly PeopleRow[], query: string): PeopleRow
   return rows.filter((row) => rowMatchesQuery(row, q));
 }
 
-/** The stream's order, and the directory's within a group: newest first, rows
- *  that have never done anything last, ties broken by name and then id so the
- *  sequence is total. The identity stream's order rather than a second one that
- *  happens to agree. */
+/** The stream's order: newest first, rows that have never done anything last,
+ *  ties broken by name and then id so the sequence is total. The identity
+ *  stream's order rather than a second one that happens to agree. */
 export function compareRows(a: PeopleRow, b: PeopleRow): number {
   return compareIdentityCursors(
     { timestamp: a.latest?.timestamp ?? null, displayName: a.displayName, id: a.id },
     { timestamp: b.latest?.timestamp ?? null, displayName: b.displayName, id: b.id },
+  );
+}
+
+/**
+ * The directory's order, within a group: by display name, ties broken by id so
+ * the sequence is total.
+ *
+ * The account contract's own directory order, which is what the server pages
+ * by. A second ordering that happened to agree would disagree at a page
+ * boundary, and the guardian would read one contact twice.
+ */
+export function compareRowsByName(a: PeopleRow, b: PeopleRow): number {
+  return compareAccountCursors(
+    { displayName: a.displayName, ref: a.id },
+    { displayName: b.displayName, ref: b.id },
   );
 }
 
@@ -236,35 +267,31 @@ export interface PeopleGroup {
 }
 
 /**
- * The directory's groups, in ladder order, after the chip, the search box and
- * the silent-contact toggle have each had their say.
+ * The directory's groups, in ladder order, after the chip and the search box
+ * have each had their say.
+ *
+ * Every contact Rome holds is in here: a contacts app hides nobody, and a
+ * roster that held the address book back would answer "no such contact" for
+ * someone the mirror has.
  *
  * Guardian survives every filter: a roster that hid it would read as "you are
  * not in your own people list". Empty groups are dropped rather than rendered
- * as headings with nothing under them — except Unknown while the toggle is what
- * emptied it, since that heading is where the toggle lives.
+ * as headings with nothing under them.
  */
 export function directoryGroups(
   rows: readonly PeopleRow[],
-  options: { filter: PeopleFilter; search: string; showSilent: boolean },
+  options: { filter: PeopleFilter; search: string },
 ): PeopleGroup[] {
   const searching = options.search.trim() !== "";
   const matching = searchRows(rows, options.search);
-  // A search reaches the address book whatever the toggle says: a lookup that
-  // answered "no such contact" for someone the mirror holds is a worse answer
-  // than a long list.
-  const visible = matching.filter((row) => options.showSilent || searching || !row.silent);
 
   return GROUP_ORDER.map((level) => ({
     level,
-    rows: visible.filter((row) => row.level === level).sort(compareRows),
+    rows: matching.filter((row) => row.level === level).sort(compareRowsByName),
   })).filter((group) => {
-    const chipShows =
-      options.filter === "all" ? group.level !== "stranger" : group.level === options.filter;
-    if (group.level === "unknown" && !searching && chipShows) return true;
     if (group.rows.length === 0) return false;
     if (searching || group.level === "guardian") return true;
-    return chipShows;
+    return options.filter === "all" ? group.level !== "stranger" : group.level === options.filter;
   });
 }
 
@@ -273,44 +300,30 @@ export function directoryGroups(
 export type LevelCounts = Record<RowLevel, number>;
 
 /**
- * The two sets of numbers this page renders — the server's, from both reads at
- * once, and meant to disagree.
+ * How many rows sit at each ladder position, from both reads at once.
  *
- * `chips` is what a filter chip can show: what is *waiting on a decision*. A
- * contact the address book synced and nobody has ever heard from is not waiting
- * on anything, so it is not counted, whether or not the directory is currently
- * showing it.
+ * Off the reads rather than the loaded rows. The account read pages, so a tally
+ * over what happened to arrive would report no waiting senders whenever placed
+ * people filled page one.
  *
- * `totals` is what a directory heading counts: everyone in the group as the
- * roster currently stands, silent contacts included once the toggle has asked
- * for them — a heading answers "how many are in here".
- *
- * Both come off the reads rather than the loaded rows. The directory pages, so
- * a count taken over what happened to arrive would report no waiting senders
- * whenever placed people filled page one.
+ * What "unknown" counts is the account read's own answer, and the two views
+ * hand this different ones on purpose: the directory's read is the whole
+ * contacts list, so it counts everyone Rome has not placed, while the stream's
+ * is the accounts something has happened on, so it counts the senders actually
+ * waiting on a decision. Each number describes the listing the reader is
+ * looking at.
  *
  * A linked account is never counted twice: it is already counted under the
  * person it resolves to, which is the same rule that keeps it off the roster as
  * a row of its own.
  */
-export function levelCounts(
-  people: PersonCounts,
-  accounts: Pick<AccountDirectory, "counts" | "silentTotal">,
-  options: { includeSilent: boolean },
-): { chips: LevelCounts; totals: LevelCounts } {
-  const placed = {
+export function levelCounts(people: PersonCounts, accounts: AccountCounts): LevelCounts {
+  return {
     guardian: people.guardian,
     "inner-circle": people["inner-circle"],
     acquaintance: people.acquaintance,
     other: people.other,
-    stranger: accounts.counts.dismissed,
-  };
-  // `counts` describes what the request admitted, so the silent contacts are in
-  // it exactly when the toggle asked for them — and taking them back out is
-  // what keeps the chip counting the same thing in both views.
-  const waiting = accounts.counts.unlinked - (options.includeSilent ? accounts.silentTotal : 0);
-  return {
-    chips: { ...placed, unknown: waiting },
-    totals: { ...placed, unknown: accounts.counts.unlinked },
+    stranger: accounts.dismissed,
+    unknown: accounts.unlinked,
   };
 }

--- a/packages/web/src/pages/people/proposed-people-api.test.ts
+++ b/packages/web/src/pages/people/proposed-people-api.test.ts
@@ -63,12 +63,25 @@ test("proposed /people contract walkthrough", async () => {
   const unlinked = r.body.accounts.map((a: { channelUserId: string }) => a.channelUserId);
   expect(unlinked).toContain(DEV_JID);
   expect(unlinked).toContain(JULES_TG);
-  // Silent address-book contacts stay off the default page and are counted
-  // for the toggle; the state counts describe the admitted directory.
-  expect(r.body.silentTotal).toBeGreaterThan(0);
+  // The contacts list carries nothing about what anyone said, and the state
+  // counts describe the whole of it.
+  expect(r.body.accounts.every((a: object) => !("latest" in a))).toBe(true);
   expect(r.body.counts.unlinked).toBeGreaterThanOrEqual(r.body.accounts.length);
   r = await call("GET", "/api/accounts?state=bogus");
   expect(r.status).toBe(400);
+
+  // The stream is the same accounts, narrowed to the ones something happened
+  // on, with the line to preview. A cursor from one names no position in the
+  // other, so each read refuses the other's.
+  r = await call("GET", "/api/accounts/stream?state=unlinked");
+  expect(r.body.accounts.map((a: { channelUserId: string }) => a.channelUserId)).toContain(DEV_JID);
+  expect(r.body.accounts.every((a: { latest: unknown }) => a.latest != null)).toBe(true);
+  expect(r.body.silentTotal).toBeUndefined();
+  const streamPage = await call("GET", "/api/accounts/stream?limit=1");
+  expect(
+    (await call("GET", `/api/accounts?cursor=${encodeURIComponent(streamPage.body.nextCursor)}`))
+      .status,
+  ).toBe(400);
 
   // Atomic create-and-link: promote Devika. One call, person + link together.
   r = await call("POST", "/api/people", {

--- a/packages/web/src/pages/people/rows.test.tsx
+++ b/packages/web/src/pages/people/rows.test.tsx
@@ -30,7 +30,6 @@ function row(over: Partial<PeopleRow> = {}): PeopleRow {
     addresses: ["418820113"],
     latest: null,
     messageCount: 0,
-    silent: false,
     ...over,
   };
 }
@@ -41,10 +40,12 @@ describe("DirectoryRow", () => {
     expect(screen.getByText("418820113")).toBeTruthy();
   });
 
-  it("says an address-book contact has never said anything, where a handle would sit", () => {
-    render(<DirectoryRow row={row({ kind: "account", silent: true })} />);
-    expect(screen.getByText("No activity yet — synced from your address book")).toBeTruthy();
-    expect(screen.queryByText("418820113")).toBeNull();
+  it("says the same thing about a contact nobody has heard from as about anyone else", () => {
+    // The directory read carries nothing about what was said, so there is
+    // nothing to distinguish these rows by — and a contacts list has no reason
+    // to.
+    render(<DirectoryRow row={row({ kind: "account" })} />);
+    expect(screen.getByText("418820113")).toBeTruthy();
   });
 
   it("makes the avatar the selection control, and exposes the state as state", async () => {

--- a/packages/web/src/pages/people/rows.tsx
+++ b/packages/web/src/pages/people/rows.tsx
@@ -122,8 +122,14 @@ export function UnknownRow({ row, actions }: { row: PeopleRow; actions?: React.R
 
 /**
  * A directory row is identity only: avatar, name, and the identifier the person
- * is recognized by. Clicking a person opens their dossier; an account has none
- * to open until it is placed on somebody.
+ * is recognized by. Nothing about what anyone said — the directory read carries
+ * none of it, which is what makes this a contacts list rather than a second
+ * stream. Clicking a person opens their dossier; an account has none to open
+ * until it is placed on somebody.
+ *
+ * `actions` is whatever gesture the row's position admits: placing an account
+ * nobody has decided about, or taking a dismissal back. The gestures themselves
+ * are `people/triage.tsx`; the row only says where they go.
  */
 export function DirectoryRow({
   row,
@@ -152,8 +158,6 @@ export function DirectoryRow({
       <span className="block truncate text-aux text-muted-foreground">
         {fixed ? (
           t("guardian.meta")
-        ) : row.silent ? (
-          <span className="italic">{t("row.neverMessaged")}</span>
         ) : (
           <span className="font-mono tabular-nums">{handle ?? ""}</span>
         )}

--- a/packages/web/src/pages/people/triage.tsx
+++ b/packages/web/src/pages/people/triage.tsx
@@ -19,11 +19,11 @@ import {
 } from "@/components/ui/select";
 import { RomeConfirmDialog } from "@/components/rome-confirm-dialog";
 import { cn } from "@/lib/utils";
-import { UnknownRow } from "./rows";
+import { DirectoryRow, UnknownRow } from "./rows";
 import { levelLabelKey } from "./rows";
 import { TransferConfirm } from "./transfer";
 import { usePeopleWrites } from "./use-writes";
-import type { PeopleRow } from "./people-model";
+import type { PeopleRow, PeopleView } from "./people-model";
 
 // Placing an account that nobody has decided about, and taking one back.
 //
@@ -250,6 +250,18 @@ function LinkForm({
 }
 
 /**
+ * The row an entry's gestures sit on, which is the view's own answer.
+ *
+ * The stream's row is dense: a placement decision runs on the evidence — which
+ * channel, which number, what they last said — so all of it is on the row. The
+ * directory carries none of that, so its row is the contacts line every other
+ * row in that view is, and the buttons sit at the end of it.
+ */
+function entryRow(variant: PeopleView) {
+  return variant === "directory" ? DirectoryRow : UnknownRow;
+}
+
+/**
  * One unplaced account, with the gestures that place it.
  *
  * Nothing is handed back to a parent to refresh: every verb here settles by
@@ -259,10 +271,13 @@ function LinkForm({
 export function UnknownEntry({
   row,
   people,
+  variant,
 }: {
   row: PeopleRow;
   /** The people a link can land on — the listing's own rows. */
   people: PersonResource[];
+  /** Which view this row is in — see {@link entryRow}. */
+  variant: PeopleView;
 }) {
   const { t } = useTranslation("people");
   const writes = usePeopleWrites();
@@ -346,9 +361,10 @@ export function UnknownEntry({
     }
   }
 
+  const Row = entryRow(variant);
   return (
     <div>
-      <UnknownRow
+      <Row
         row={row}
         actions={
           !action && (
@@ -449,12 +465,11 @@ export function UnknownEntry({
 /**
  * An account the guardian dismissed, with the gesture that undoes it.
  *
- * The same dense row the Unknown view uses, because the decision runs on the
- * same evidence: a restore is worth making on what the sender actually sent,
- * not on a name in a roster. No confirmation — a restore only puts the account
- * back where a decision is still owed.
+ * The same row the Unknown view uses in whichever view it is in, because the
+ * decision runs on the same evidence. No confirmation — a restore only puts the
+ * account back where a decision is still owed.
  */
-export function DismissedEntry({ row }: { row: PeopleRow }) {
+export function DismissedEntry({ row, variant }: { row: PeopleRow; variant: PeopleView }) {
   const { t } = useTranslation("people");
   const writes = usePeopleWrites();
   const [acting, setActing] = useState(false);
@@ -473,9 +488,10 @@ export function DismissedEntry({ row }: { row: PeopleRow }) {
     }
   }
 
+  const Row = entryRow(variant);
   return (
     <div>
-      <UnknownRow
+      <Row
         row={row}
         actions={
           <Button

--- a/packages/web/src/pages/people/use-roster.ts
+++ b/packages/web/src/pages/people/use-roster.ts
@@ -4,13 +4,14 @@ import { useTranslation } from "react-i18next";
 import type {
   AccountDirectory,
   AccountState,
+  AccountStream,
   PeopleList,
   PersonResource,
 } from "@rome/api-types/people";
 import type { TimelinePage } from "@rome/api-types/identities";
 import { getApiErrorMessage } from "@/lib/api-error";
 import { fetchJson } from "@/lib/fetch-json";
-import { peopleRows, type PeopleRow } from "./people-model";
+import { peopleRows, type PeopleRow, type PeopleView } from "./people-model";
 
 // The People page's reads, and nothing else — the writes are `./writes.ts`,
 // and `./use-writes.ts` is what settles these queries after one lands.
@@ -20,10 +21,17 @@ import { peopleRows, type PeopleRow } from "./people-model";
 // page's own paged reads. Two hooks with one name would be read as one.
 //
 // Two reads compose the roster: `GET /api/people` for the people the guardian
-// has placed, `GET /api/accounts` for every account Rome has observed. They are
-// separate queries rather than one, because they page differently: curated
-// people are entered one at a time by hand and the listing is bounded, while a
-// synced address book is thousands of rows and pages by cursor.
+// has placed, and one of the two account reads for the accounts beside them.
+// They are separate queries rather than one, because they page differently:
+// curated people are entered one at a time by hand and the listing is bounded,
+// while a synced address book is thousands of rows and pages by cursor.
+//
+// Which account read is the view's own question. The directory is a contacts
+// list and reads `GET /api/accounts`: every account, by name, carrying nothing
+// about what anyone said. The stream is the recents surface and reads `GET
+// /api/accounts/stream`: what happened last, with the line to preview. Neither
+// view pays for the other's fields, and a cursor from one never resumes the
+// other — they are different orders.
 //
 // Every number a chip or a heading shows comes back with these reads and
 // describes the whole roster the query admits. A tally over the rows that
@@ -57,10 +65,9 @@ function useDebounced<T>(value: T, delayMs: number): T {
 
 export interface PeopleRosterParams {
   search: string;
-  /** Whether the account directory carries the contacts nobody has ever
-   *  messaged. The toggle governs browsing; a search reaches them either way,
-   *  which is the endpoint's own rule. */
-  includeSilent: boolean;
+  /** Which account read the view is about — the contacts list, or the recents
+   *  surface. */
+  view: PeopleView;
   /**
    * Which state of account the view is about, when one narrows it.
    *
@@ -118,11 +125,15 @@ export function usePeopleRoster(params: PeopleRosterParams) {
     },
   });
 
-  // The directory pages; the people listing does not. Its cursor is opaque and
-  // names a position rather than a row, so a page boundary survives an account
-  // being linked or dismissed between two requests.
-  const accounts = useInfiniteQuery<AccountDirectory>({
-    queryKey: [ACCOUNTS_KEY, search, params.includeSilent, accountState],
+  // The account read pages; the people listing does not. Its cursor is opaque
+  // and names a position rather than a row, so a page boundary survives an
+  // account being linked or dismissed between two requests.
+  //
+  // The view is part of the key, not just of the URL: the two reads are two
+  // orders with two cursors, and a page of one is not a page of the other.
+  const path = params.view === "directory" ? "/api/accounts" : "/api/accounts/stream";
+  const accounts = useInfiniteQuery<AccountDirectory | AccountStream>({
+    queryKey: [ACCOUNTS_KEY, params.view, search, accountState],
     initialPageParam: null as string | null,
     getNextPageParam: (last) => last.nextCursor,
     refetchInterval: ROSTER_POLL_MS,
@@ -131,10 +142,9 @@ export function usePeopleRoster(params: PeopleRosterParams) {
       const query = new URLSearchParams();
       if (search) query.set("q", search);
       if (accountState) query.set("state", accountState);
-      if (params.includeSilent) query.set("includeSilent", "true");
       if (pageParam) query.set("cursor", String(pageParam));
       const suffix = query.toString();
-      return fetchJson<AccountDirectory>(`/api/accounts${suffix ? `?${suffix}` : ""}`, {
+      return fetchJson<AccountDirectory | AccountStream>(`${path}${suffix ? `?${suffix}` : ""}`, {
         signal,
         fallback,
       });
@@ -161,9 +171,6 @@ export function usePeopleRoster(params: PeopleRosterParams) {
       other: 0,
     },
     accountCounts: head?.counts ?? { unlinked: 0, linked: 0, dismissed: 0 },
-    /** Every matching silent account, whether or not the toggle let them onto
-     *  the page — the number the toggle itself offers. */
-    silentTotal: head?.silentTotal ?? 0,
     /** The term these rows answer. A caller filtering or labelling them reads
      *  this rather than what is in the box, or it applies a term the rows were
      *  not fetched for and empties the view for exactly the quiet contacts only
@@ -185,7 +192,8 @@ export type PeopleRoster = ReturnType<typeof usePeopleRoster>;
 /**
  * The accounts a picker can name, as the server answers the term typed.
  *
- * Every state, not only the unlinked ones. A picker that hid the accounts
+ * The contacts list, so every account Rome has observed is offerable — and
+ * every state, not only the unlinked ones. A picker that hid the accounts
  * another person already holds would hide the one gesture that can take one
  * back, and the contract answers that attempt with a conflict the caller
  * surfaces rather than with a silent re-point.
@@ -203,9 +211,13 @@ export function useAccountSearch(search: string, options: { enabled: boolean }) 
     enabled: options.enabled,
     placeholderData: keepPreviousData,
     queryFn: ({ signal }) => {
-      const query = new URLSearchParams({ includeSilent: "true" });
+      const query = new URLSearchParams();
       if (term) query.set("q", term);
-      return fetchJson<AccountDirectory>(`/api/accounts?${query.toString()}`, { signal, fallback });
+      const suffix = query.toString();
+      return fetchJson<AccountDirectory>(`/api/accounts${suffix ? `?${suffix}` : ""}`, {
+        signal,
+        fallback,
+      });
     },
   });
 }

--- a/packages/web/src/pages/people/writes.test.ts
+++ b/packages/web/src/pages/people/writes.test.ts
@@ -46,8 +46,6 @@ const ACCOUNT: DirectoryAccount = {
   state: "dismissed",
   personId: null,
   personName: null,
-  latest: null,
-  messageCount: 12,
 };
 
 const REF = { channel: "whatsapp", channelUserId: "6591234472@s.whatsapp.net" };


### PR DESCRIPTION
## What this PR does

The People page's Directory view answered "who does Rome know" with the stream's ordering and the stream's row — newest activity first, a preview, a message count, and a toggle holding the synced address book back. That is a second recents surface wearing a roster's name. Looking someone up meant scanning by recency, and the one contact you wanted was the one behind the toggle.

It becomes a contacts list. Every account, always, ordered by display name. No preview, no count, no toggle.

The read splits to match, because the point is what the backend no longer computes. The directory read now touches only the address books and Rome's own links, and performs no message-store read at all.

Closes #113

## Design & Invariants

**Two account reads, because two surfaces ask two questions.**

| | `GET /api/accounts` | `GET /api/accounts/stream` |
|---|---|---|
| Question | who does Rome know | who has something new |
| Rows | every account | only those something happened on |
| Order | `(displayName, ref)` | `(timestamp, displayName, ref)` |
| Carries | identity and link only | `latest`, `messageCount` |

Each has its own row shape (`DirectoryAccount`, `StreamAccount`) and its own cursor (`AccountCursor`, `StreamCursor`), so neither pays for the other's fields and neither order can be resumed with the other's position — a cursor from one is a 400 on the other rather than a page boundary the two ends disagree about.

Invariants that must stay true:

- **No message-derived fact reaches a directory row.** Not a preview, not a count, not a bit saying whether there is anything to count. `DirectoryAccount` has no field one could be written into, so a producer cannot start computing one and a client cannot start rendering one.
- **Every account is on the contacts list.** Nobody is held back. A lookup that answered "no such contact" for someone the mirror holds is a worse answer than a long list, and paging is what a long list is for.
- **Both orders are total**, which is what lets a cursor name a position rather than a row — a row that is linked, dismissed, or renamed between two requests must not truncate the listing.

Underneath, `AccountFold` splits along the same seam. `foldAccounts` reads address books alone; `foldAccountRecords` returns an `AccountRecords` that also joins the histories. The type is what enforces the invariant: a caller holding the base fold has no `recordFor` to call, so "the contacts list reads no message store" is not a rule someone has to remember.

**Alternative rejected.** One endpoint, with the directory row carrying `hasMessages` so the silent toggle could survive. That keeps a per-account activity read alive behind a boolean, and the toggle is exactly what a contacts app should not have — the address book *is* the contacts list.

The vocabulary is [`docs/concepts/identity.md`](docs/concepts/identity.md)'s; the surface is documented in the design note at `/dev/docs/people-page`, updated here.

### Stated consequence

The state chips describe whichever listing the reader is on. In the stream, Unknown counts the senders waiting on a decision; in the directory, it counts everyone Rome has not placed — so the number grows when you switch views. That is the issue's own call, and each number describes the listing on screen.

## Test plan

- [x] `pnpm typecheck` — clean across the workspace
- [x] `pnpm test:unit` — 6119 passing, 2 skipped
- [x] `biome ci` on the touched packages — clean
- [x] Contract and route tests updated: the directory row carries exactly seven keys; the stream refuses a directory cursor and vice versa; the directory pages by name and its pages equal the whole listing in order
- [x] `foldAccounts` asks no channel for a history — pinned by a plane that counts `listActivity` calls
- [x] Browser, `pnpm start:web:mock`: the stream requests `/api/accounts/stream?state=unlinked` and renders previews and relative times unchanged; the Directory requests `/api/accounts`, renders name-ordered with no preview, no count and no toggle, pages by the name cursor, and reaches a never-messaged contact through the search box. The Unknown chip reads 7 in the stream and 10 in the directory.
- [ ] `pnpm dev:all` — port 3200 was already occupied on the dev machine, so the containerized boot was not run. Read-path only, and core's full suite is green.

## Not in this PR

- The Messages interface migration (#94–#101) — this cut works on the interfaces the code has today, and lands before #99 to shrink it.
- The legacy `/api/identities` union keeps its own `neverMessaged` machinery; no surface reads it any more, and it goes with the route.
- Bulk selection on the directory row — the avatar is still an ornament here, as it was before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)