### PR TITLE
feat(core): merge the person timeline and people listing over Messages

### DIFF
--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -19,7 +19,7 @@ import { mergePeople } from "../../people/merge.js";
 import { findPerson, readPeople, readPerson } from "../../people/resource.js";
 import { updatePerson } from "../../people/update.js";
 import { readPersonTimeline } from "../../people/timeline.js";
-import { personTimelineSources, timelineAccounts } from "../../people/timeline-sources.js";
+import { personMessageStores, timelineAccounts } from "../../people/timeline-sources.js";
 import type { ApiDeps } from "../deps.js";
 
 // The People surface. What a person and their accounts are, how the listing
@@ -166,7 +166,7 @@ export function peopleRoutes(deps: ApiDeps): Hono {
 
     return c.json(
       await readPersonTimeline(
-        personTimelineSources(deps),
+        personMessageStores(deps),
         accounts.filter((account) => !channel || account.channel === channel),
         { cursor, limit: timelinePageLimit(c.req.query("limit")) },
       ),

--- a/packages/core/src/people/activity.ts
+++ b/packages/core/src/people/activity.ts
@@ -3,20 +3,19 @@
 // shows without opening the dossier.
 //
 // Read from the same stores as the page in timeline.ts, claimed in the order
-// `assignAccounts` defines and for the reason stated there, and summarized in
-// one read per store however many people are asked about.
+// `assignAccounts` defines and for the reason stated there, through the same
+// `Messages` verbs. That is what makes the row and the page one answer: the
+// preview is the store's `latest`, which `Messages` binds to the head of the
+// history its `read` pages, and the number beside it is that history's `count`.
 
 import {
   compareTimelineEntries,
   latestDynamic,
   type IdentityDynamic,
+  type TimelineEntry,
 } from "@rome/api-types/people";
-import {
-  assignAccounts,
-  type AccountDigest,
-  type TimelineAccount,
-  type TimelineSource,
-} from "./timeline.js";
+import type { MessageAccount, Messages } from "../channels/messages.js";
+import { assignAccounts } from "./timeline.js";
 
 /** A person's history at a glance. `latest` is null exactly when
  *  `messageCount` is zero — a person nobody has ever written to. */
@@ -33,25 +32,53 @@ export interface PersonActivity {
  * queries as a single person.
  */
 export async function readPeopleActivity(
-  sources: readonly TimelineSource[],
-  accountsByPerson: readonly (readonly TimelineAccount[])[],
+  stores: readonly Messages[],
+  accountsByPerson: readonly (readonly MessageAccount[])[],
 ): Promise<PersonActivity[]> {
-  const digests = new Map<TimelineAccount, AccountDigest>();
-  for (const [source, held] of await assignAccounts(sources, accountsByPerson.flat())) {
-    for (const digest of await source.digest(held)) digests.set(digest.account, digest);
+  const owner = new Map<MessageAccount, Messages>();
+  for (const [store, held] of await assignAccounts(stores, accountsByPerson.flat())) {
+    for (const account of held) owner.set(account, store);
   }
 
-  return accountsByPerson.map((accounts) => {
-    const held = accounts
-      .map((account) => digests.get(account))
-      .filter((digest) => digest !== undefined);
-    return {
-      // Through `latestDynamic`, over entries in the timeline's own order, so
-      // a person whose two accounts last spoke in the same second previews the
-      // entry their merged timeline opens on rather than whichever account the
-      // fold reached first.
-      latest: latestDynamic(held.map((digest) => digest.latest).sort(compareTimelineEntries)),
-      messageCount: held.reduce((total, digest) => total + digest.messageCount, 0),
-    };
+  // One summary per person per store, over every account of theirs that store
+  // owns — not one per account. A store reads a set of accounts as a single
+  // history, so this is the same read the page makes, and a message that two
+  // addressings of a person both name is one message in both.
+  const summaries = accountsByPerson.flatMap((accounts, person) => {
+    const byStore = new Map<Messages, MessageAccount[]>();
+    for (const account of accounts) {
+      const store = owner.get(account);
+      if (store === undefined) continue;
+      const held = byStore.get(store);
+      if (held) held.push(account);
+      else byStore.set(store, [account]);
+    }
+    return [...byStore].map(([store, held]) => ({ person, store, accounts: held }));
   });
+
+  // Every `count` and every `latest` raised before the first is awaited, so a
+  // store that groups the calls of a tick answers the whole listing in one pass
+  // rather than two per row.
+  const [counts, heads] = await Promise.all([
+    Promise.all(summaries.map((summary) => summary.store.count(summary.accounts))),
+    Promise.all(summaries.map((summary) => summary.store.latest(summary.accounts))),
+  ]);
+
+  const activity = accountsByPerson.map(() => ({ heads: [] as TimelineEntry[], messageCount: 0 }));
+  summaries.forEach((summary, index) => {
+    const person = activity[summary.person];
+    if (!person) return;
+    person.messageCount += counts[index] ?? 0;
+    const head = heads[index];
+    if (head) person.heads.push(head);
+  });
+
+  return activity.map((person) => ({
+    // Through `latestDynamic`, over the stores' heads in the timeline's own
+    // order, so a person whose two accounts last spoke in the same second
+    // previews the entry their merged timeline opens on rather than whichever
+    // store the fold reached first.
+    latest: latestDynamic(person.heads.sort(compareTimelineEntries)),
+    messageCount: person.messageCount,
+  }));
 }

--- a/packages/core/src/people/resource.ts
+++ b/packages/core/src/people/resource.ts
@@ -16,7 +16,7 @@ import type { TalkAccounts } from "../channels/accounts.js";
 import type { DrizzleDb } from "../db/index.js";
 import type { PersonMappingRepository } from "../db/repositories/person-mapping.js";
 import { readPeopleActivity } from "./activity.js";
-import { personTimelineSources, timelineAccounts } from "./timeline-sources.js";
+import { personMessageStores, timelineAccounts } from "./timeline-sources.js";
 
 export interface PeopleReadDeps {
   db: DrizzleDb;
@@ -78,7 +78,7 @@ async function serialize(
     ),
     deps.accountNames.displayNames(refs),
   ]);
-  const activity = await readPeopleActivity(personTimelineSources(deps), accountsByPerson);
+  const activity = await readPeopleActivity(personMessageStores(deps), accountsByPerson);
 
   let next = 0;
   return persons.map((person, i) => ({

--- a/packages/core/src/people/timeline-sources.ts
+++ b/packages/core/src/people/timeline-sources.ts
@@ -1,33 +1,68 @@
-// One adapter per message store a person's history can come from, and the
-// order they claim an account in. The seam and the merge are in timeline.ts;
-// the SQL plumbing every adapter here shares is in timeline-sql.ts.
+// Which stores a person's history comes from, and the order they claim an
+// account in. The stores themselves are the channels' — one `Messages` adapter
+// each, in channels/ — and the merge over them is timeline.ts's.
 //
-// Direct threads only. Each adapter scopes itself by the account's own
-// addresses, so a group conversation — addressed by the group rather than by
-// the person — never reaches a person's timeline.
+// Also the fold from a person's channel mappings to the accounts those stores
+// are read for, since the two are the same question asked of one channel: which
+// addresses are one account, and what was said at them.
+//
+// The `TimelineSource` adapters below the list are the previous shape of the
+// same four stores, and nothing calls them any more; the SQL plumbing they
+// share is in timeline-sql.ts.
+//
+// Direct threads only, on either shape. Each adapter scopes itself by the
+// account's own addresses, so a group conversation — addressed by the group
+// rather than by the person — never reaches a person's timeline.
 
 import { sql } from "drizzle-orm";
 import type { TalkAccounts } from "../channels/accounts.js";
+import { linkedInMessages } from "../channels/linkedin-messages.js";
+import type { Messages } from "../channels/messages.js";
 // How a stored agent message reads — which way it went, and the line it
 // renders as — defined once beside the `Messages` store over the same rows.
-import { agentMessageOutbound, messageContentText } from "../channels/messages-agent.js";
+import {
+  agentMessageOutbound,
+  agentMessages,
+  messageContentText,
+} from "../channels/messages-agent.js";
+import { sentinelLogMessages } from "../channels/messages-sentinel.js";
+import { whatsAppMessages } from "../channels/whatsapp-messages.js";
 import type { DrizzleDb } from "../db/index.js";
 import type { TimelineAccount, TimelineSource } from "./timeline.js";
 import { accountPairs, addressesOn, inList, sqlTimelineSource } from "./timeline-sql.js";
 
 /**
- * The stores a person's timeline is read from, in the order they claim an
- * account.
+ * The stores a person's history is read from, in the order they claim an
+ * account — the list `assignAccounts` walks, for the page and for the listing
+ * row alike.
  *
- * The order is the precedence the seam's {@link TimelineSource} contract
- * describes: a channel mirror holds the conversation as the channel has it, so
- * it outranks Rome's own transcript of the same messages, which in turn
- * outranks the sentinel's triage record. An account only the sentinel saw still
- * gets its exchanges — the sentinel is last, not excluded.
+ * The order is a precedence: a channel mirror holds the conversation as the
+ * channel has it, so it outranks Rome's own transcript of the same messages,
+ * which in turn outranks the sentinel's triage record. An account only the
+ * sentinel saw still gets its exchanges — the sentinel is last, not excluded.
  *
  * The cost of that precedence: an account with a mirrored conversation shows
  * the conversation, and the sentinel's own record of an exchange inside it
  * stays behind Rome's reply as the channel delivered it.
+ *
+ * Adding a store is one more `Messages` adapter appended here. Nothing above
+ * knows how many there are or what they read.
+ */
+export function personMessageStores(deps: { db: DrizzleDb }): Messages[] {
+  return [
+    whatsAppMessages(deps.db),
+    linkedInMessages(deps.db),
+    agentMessages(deps.db),
+    sentinelLogMessages(deps.db),
+  ];
+}
+
+/**
+ * The same four stores as {@link TimelineSource}s.
+ *
+ * @deprecated Nothing reads a person's history through these any more —
+ * {@link personMessageStores} is the list both the timeline and the people
+ * listing walk. Kept only until the account directory moves over too.
  */
 export function personTimelineSources(deps: { db: DrizzleDb }): TimelineSource[] {
   return [

--- a/packages/core/src/people/timeline.test.ts
+++ b/packages/core/src/people/timeline.test.ts
@@ -1,18 +1,16 @@
 import { describe, it, expect } from "vitest";
-import {
-  compareTimelineEntries,
-  isAfterTimelineCursor,
-  parseTimelineCursor,
-  type TimelineEntry,
-} from "@rome/api-types/people";
-import { readPersonTimeline, type TimelineAccount, type TimelineSource } from "./timeline.js";
+import { latestDynamic, parseTimelineCursor, type TimelineEntry } from "@rome/api-types/people";
+import { memoryMessages } from "../channels/messages-memory.js";
+import type { MessageAccount, Messages } from "../channels/messages.js";
+import { readPersonTimeline } from "./timeline.js";
 import { readPeopleActivity } from "./activity.js";
 
 // The merge above the stores: what a page is, how it resumes, and which store
-// owns an account. Every source here is a fake, so nothing below is about SQL —
-// a store that answers the seam's contract is a store this merge can page.
+// owns an account. Every store here is in-memory, so nothing below is about
+// SQL — a store that answers the `Messages` contract is a store this merge can
+// page.
 
-const account = (channel: string, ...addresses: string[]): TimelineAccount => ({
+const account = (channel: string, ...addresses: string[]): MessageAccount => ({
   channel,
   addresses,
 });
@@ -25,52 +23,44 @@ const entry = (
 ): TimelineEntry => ({ source, timestamp, ref, direction, body: `${ref}@${timestamp}` });
 
 /**
- * A store held in memory, answering the seam exactly as its contract asks:
- * only entries strictly after the cursor, in order, at most `limit` of them.
+ * A store holding `held`, keyed by the address each entry arrived at — the
+ * reference `Messages` implementation, which is what makes these fakes prove
+ * something: they answer the contract every real adapter is enrolled in.
+ *
+ * An entry's `source` is the channel it belongs to, so an address on one
+ * channel never answers for an account on another.
  */
-function fakeSource(
+function store(held: Record<string, TimelineEntry[]>): Messages {
+  return memoryMessages(
+    Object.entries(held).flatMap(([address, entries]) =>
+      entries.map((held) => ({ channel: held.source, address, entry: held })),
+    ),
+  );
+}
+
+/** One store, with every verb the merge reaches for written down. The property
+ *  name rather than only the call, so a merge that asked for a verb `Messages`
+ *  does not have is caught here rather than by the type checker alone. */
+function watched(
   name: string,
-  held: Record<string, TimelineEntry[]>,
-  calls: string[] = [],
-): TimelineSource & { calls: string[] } {
-  const addressesHeld = new Set(Object.keys(held));
-  return {
-    name,
-    calls,
-    async holds(accounts) {
-      return accounts.filter((a) => a.addresses.some((address) => addressesHeld.has(address)));
+  messages: Messages,
+  asked: Array<{ store: string; verb: string }>,
+): Messages {
+  return new Proxy(messages, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (typeof property !== "string") return value;
+      asked.push({ store: name, verb: property });
+      return value;
     },
-    async digest(accounts) {
-      return accounts.flatMap((a) => {
-        const entries = a.addresses.flatMap((address) => held[address] ?? []);
-        if (entries.length === 0) return [];
-        return [
-          {
-            account: a,
-            latest: [...entries].sort(compareTimelineEntries)[0],
-            messageCount: entries.length,
-          },
-        ];
-      });
-    },
-    async read(request) {
-      calls.push(name);
-      const entries = request.accounts
-        .flatMap((a) => a.addresses)
-        .flatMap((address) => held[address] ?? []);
-      return entries
-        .filter((e) => request.cursor === null || isAfterTimelineCursor(e, request.cursor))
-        .sort(compareTimelineEntries)
-        .slice(0, request.limit);
-    },
-  };
+  });
 }
 
 describe("readPersonTimeline", () => {
-  const whatsapp = fakeSource("wa", {
+  const whatsapp = store({
     "wa-1": [entry("whatsapp", 300, "wa:c"), entry("whatsapp", 100, "wa:a")],
   });
-  const telegram = fakeSource("tg", {
+  const telegram = store({
     "tg-1": [entry("telegram", 200, "tg:b"), entry("telegram", 400, "tg:d")],
   });
   const accounts = [account("whatsapp", "wa-1"), account("telegram", "tg-1")];
@@ -99,7 +89,7 @@ describe("readPersonTimeline", () => {
   it("resumes inside a second rather than after it", async () => {
     // Four entries share one timestamp, so a cursor carrying the timestamp
     // alone could only resume before or after all of them.
-    const crowded = fakeSource("crowd", {
+    const crowded = store({
       "c-1": [
         entry("whatsapp", 100, "a"),
         entry("whatsapp", 100, "b", "outbound"),
@@ -129,35 +119,40 @@ describe("readPersonTimeline", () => {
     expect(short.nextCursor).not.toBeNull();
   });
 
-  it("gives an account to the first store that holds it and asks no other", async () => {
-    const calls: string[] = [];
-    const mirror = fakeSource("mirror", { "wa-1": [entry("whatsapp", 500, "mirrored")] }, calls);
-    const transcript = fakeSource(
+  it("gives an account to the first store whose latest answers, and asks no other", async () => {
+    // Ownership is derived rather than asked for: the mirror answers a newest
+    // message for the account, so the transcript's copy of the same exchange is
+    // never read — and the transcript is not asked anything at all.
+    const asked: Array<{ store: string; verb: string }> = [];
+    const mirror = watched(
+      "mirror",
+      store({ "wa-1": [entry("whatsapp", 500, "mirrored")] }),
+      asked,
+    );
+    const transcript = watched(
       "transcript",
-      { "wa-1": [entry("whatsapp", 500, "transcribed")] },
-      calls,
+      store({ "wa-1": [entry("whatsapp", 500, "transcribed")] }),
+      asked,
     );
     const page = await readPersonTimeline([mirror, transcript], [account("whatsapp", "wa-1")], {
       limit: 10,
     });
     expect(page.entries.map((e) => e.ref)).toEqual(["mirrored"]);
-    expect(calls).toEqual(["mirror"]);
+    expect(new Set(asked.map((call) => call.store))).toEqual(new Set(["mirror"]));
   });
 
-  it("falls through to a later store for an account the earlier one lacks", async () => {
-    const mirror = fakeSource("mirror", { "wa-1": [entry("whatsapp", 500, "mirrored")] });
-    const transcript = fakeSource("transcript", { "tg-1": [entry("telegram", 400, "typed")] });
+  it("falls through to a later store for an account the earlier one holds nothing for", async () => {
+    const mirror = store({ "wa-1": [entry("whatsapp", 500, "mirrored")] });
+    const transcript = store({ "tg-1": [entry("telegram", 400, "typed")] });
     const page = await readPersonTimeline([mirror, transcript], accounts, { limit: 10 });
     expect(page.entries.map((e) => e.ref)).toEqual(["mirrored", "typed"]);
   });
 
   it("takes a new store as one more adapter, with nothing above it changed", async () => {
-    // What "adding a source is one adapter" means: a store of a kind this file
+    // What "adding a store is one adapter" means: a store of a kind this file
     // has never heard of, appended to the list, and its entries page with the
     // rest through the same cursor.
-    const app = fakeSource("some-rome-app", {
-      "app-1": [entry("bookings", 250, "booking:7", "outbound")],
-    });
+    const app = store({ "app-1": [entry("bookings", 250, "booking:7", "outbound")] });
     const page = await readPersonTimeline(
       [whatsapp, telegram, app],
       [...accounts, account("bookings", "app-1")],
@@ -170,6 +165,18 @@ describe("readPersonTimeline", () => {
     const page = await readPersonTimeline([whatsapp, telegram], [], { limit: 10 });
     expect(page).toEqual({ entries: [], nextCursor: null });
   });
+
+  it("asks a store for nothing but read, count and latest", async () => {
+    // The seam is `Messages` and only `Messages`: `holds` and `digest` were how
+    // the old interface asked a store who it answered for, and a merge still
+    // reaching for either would be reading a store two ways at once.
+    const asked: Array<{ store: string; verb: string }> = [];
+    const only = watched("only", store({ "wa-1": [entry("whatsapp", 500, "mirrored")] }), asked);
+    await readPersonTimeline([only], [account("whatsapp", "wa-1")], { limit: 10 });
+
+    expect(asked.length).toBeGreaterThan(0);
+    expect(new Set(asked.map((call) => call.verb))).toEqual(new Set(["read", "latest"]));
+  });
 });
 
 // The same precedence, read as a summary instead of a page: what a directory
@@ -181,8 +188,8 @@ describe("readPeopleActivity", () => {
   it("summarizes each account from the first store that claims it", async () => {
     // One exchange written down twice, as the real stores overlap. Counting
     // both would report an inbox the dossier does not have.
-    const mirror = fakeSource("mirror", { "wa-1": [entry("whatsapp", 500, "mirrored")] });
-    const transcript = fakeSource("transcript", {
+    const mirror = store({ "wa-1": [entry("whatsapp", 500, "mirrored")] });
+    const transcript = store({
       "wa-1": [entry("whatsapp", 500, "copy"), entry("whatsapp", 200, "older copy")],
       "tg-1": [entry("telegram", 400, "typed")],
     });
@@ -195,16 +202,16 @@ describe("readPeopleActivity", () => {
       messageCount: 1,
       latest: { source: "whatsapp", timestamp: 500, preview: "mirrored@500" },
     });
-    expect(telegram.messageCount).toBe(1);
+    expect(telegram?.messageCount).toBe(1);
   });
 
   it("folds a person's accounts into one history", async () => {
-    const store = fakeSource("store", {
+    const held = store({
       "wa-1": [entry("whatsapp", 300, "wa:c"), entry("whatsapp", 100, "wa:a")],
       "tg-1": [entry("telegram", 400, "tg:d")],
     });
 
-    const [both] = await readPeopleActivity([store], [[waAccount, tgAccount]]);
+    const [both] = await readPeopleActivity([held], [[waAccount, tgAccount]]);
     expect(both).toEqual({
       messageCount: 3,
       // The head of the merged timeline, not of whichever account came first.
@@ -213,11 +220,51 @@ describe("readPeopleActivity", () => {
   });
 
   it("answers one activity per group, in the order given", async () => {
-    const store = fakeSource("store", { "tg-1": [entry("telegram", 400, "tg:d")] });
-    expect(await readPeopleActivity([store], [[waAccount], [], [tgAccount]])).toEqual([
+    const held = store({ "tg-1": [entry("telegram", 400, "tg:d")] });
+    expect(await readPeopleActivity([held], [[waAccount], [], [tgAccount]])).toEqual([
       { latest: null, messageCount: 0 },
       { latest: null, messageCount: 0 },
       { latest: { source: "telegram", timestamp: 400, preview: "tg:d@400" }, messageCount: 1 },
     ]);
+  });
+
+  it("previews the entry the person's own timeline opens on, and counts its length", async () => {
+    // The listing and the page are one read of one set of stores, so the row a
+    // guardian clicks and the history it opens cannot disagree — the preview is
+    // the first entry of the timeline, and the number beside it the length of
+    // exactly that timeline.
+    const mirror = store({
+      "wa-1": [entry("whatsapp", 500, "mirrored"), entry("whatsapp", 300, "earlier")],
+    });
+    const transcript = store({
+      // The same WhatsApp exchange again, and a newer entry on a channel with
+      // no mirror: counting the copy would put a number on the row the page
+      // never reaches.
+      "wa-1": [entry("whatsapp", 500, "copy")],
+      "tg-1": [entry("telegram", 700, "tg:newest"), entry("telegram", 200, "tg:old")],
+    });
+    const stores = [mirror, transcript];
+    const accounts = [waAccount, tgAccount];
+
+    const [activity] = await readPeopleActivity(stores, [accounts]);
+    const timeline = await readPersonTimeline(stores, accounts, { limit: 100 });
+
+    expect(timeline.entries.map((e) => e.ref)).toEqual([
+      "tg:newest",
+      "mirrored",
+      "earlier",
+      "tg:old",
+    ]);
+    expect(activity?.latest).toEqual(latestDynamic(timeline.entries));
+    expect(activity?.messageCount).toBe(timeline.entries.length);
+  });
+
+  it("asks a store for nothing but read, count and latest", async () => {
+    const asked: Array<{ store: string; verb: string }> = [];
+    const only = watched("only", store({ "wa-1": [entry("whatsapp", 500, "mirrored")] }), asked);
+    await readPeopleActivity([only], [[waAccount]]);
+
+    expect(asked.length).toBeGreaterThan(0);
+    expect(new Set(asked.map((call) => call.verb))).toEqual(new Set(["count", "latest"]));
   });
 });

--- a/packages/core/src/people/timeline.ts
+++ b/packages/core/src/people/timeline.ts
@@ -1,7 +1,7 @@
 // A person's history, merged across every account they are linked to. The
 // entry shape, the ordering and the cursor are the contract's
-// (@rome/api-types/people); this module is the seam the stores plug into and
-// the merge above it.
+// (@rome/api-types/people); a store is the channel's (`Messages`, in
+// channels/messages.js); this module is only the merge above them.
 
 import {
   compareTimelineEntries,
@@ -10,6 +10,7 @@ import {
   type TimelineEntry,
   type TimelinePage,
 } from "@rome/api-types/people";
+import type { MessageAccount, Messages } from "../channels/messages.js";
 
 /**
  * One account a person is reachable at, as a timeline read addresses it.
@@ -45,21 +46,14 @@ export interface AccountDigest {
 }
 
 /**
- * One message store, as a person's timeline reads it.
+ * One message store, as a person's timeline used to read it.
  *
- * Adding a store is one implementation of this interface listed alongside the
- * others; nothing above here knows how many there are or what they read.
+ * Superseded by `Messages`: the merge below reads stores through that
+ * interface, and nothing calls `holds`, `digest` or this `read` any more. The
+ * declaration and its SQL implementations survive only until the account
+ * directory moves too, and go with them.
  *
- * The store answers which accounts it holds as well as what it holds for them,
- * because the stores overlap rather than partition. One inbound WhatsApp
- * message is a `wa_messages` row, a `rome_agent_messages` row on the channel
- * session, and — when the sentinel triaged it — a `sentinel_log` row as well.
- * Merging all three renders one message three times, and the copies carry
- * different ids at different timestamps, so no after-the-fact dedupe survives
- * a page boundary. Instead each account's timeline comes from exactly one
- * store: the stores are asked in order, and the first one that holds an
- * account owns it — for the page ({@link holds}, then {@link read}) and for
- * the summary ({@link digest}) alike.
+ * @deprecated Read a store as {@link Messages}.
  */
 export interface TimelineSource {
   /** Stable, for tests and logs. Never {@link TimelineEntry.source}, which
@@ -109,8 +103,8 @@ export interface TimelineSource {
  * the only scope there is.
  */
 export async function readPersonTimeline(
-  sources: readonly TimelineSource[],
-  accounts: readonly TimelineAccount[],
+  stores: readonly Messages[],
+  accounts: readonly MessageAccount[],
   options: { cursor?: TimelineEntry | null; limit: number },
 ): Promise<TimelinePage> {
   const cursor = options.cursor ?? null;
@@ -121,8 +115,8 @@ export async function readPersonTimeline(
     // page of exactly `limit` merged entries is otherwise indistinguishable
     // from an exhausted history, and answering null there truncates the
     // timeline at a boundary the client cannot resume past.
-    (await assignAccounts(sources, accounts)).map(([source, held]) =>
-      source.read({ accounts: held, cursor, limit: limit + 1 }),
+    (await assignAccounts(stores, accounts)).map(([store, held]) =>
+      store.read({ accounts: held, after: cursor, limit: limit + 1 }),
     ),
   );
 
@@ -144,23 +138,42 @@ export async function readPersonTimeline(
  * Each store paired with the accounts it owns: the first store that holds an
  * account takes it, and no later store is offered it.
  *
- * The one place that rule is applied. Every read of a person's history — the
+ * The rule exists because the stores overlap rather than partition. One inbound
+ * WhatsApp message is a `wa_messages` row, a `rome_agent_messages` row on the
+ * channel session, and — when the sentinel triaged it — a `sentinel_log` row as
+ * well. Merging all three renders one message three times, and the copies carry
+ * different ids at different timestamps, so no after-the-fact dedupe survives a
+ * page boundary. Instead each account's history comes from exactly one store.
+ *
+ * Ownership is derived rather than asked for: a store that answers a `latest`
+ * for an account is a store that holds it, and `Messages` states that `latest`
+ * is the head of the very history `read` pages. A separate "do you hold this"
+ * verb would be a second answer to the same question, free to disagree with the
+ * first — a row previewing an entry from one store while the page beneath it
+ * opens on another's.
+ *
+ * The one place the rule is applied. Every read of a person's history — the
  * page here, the summary in activity.ts — goes through this, because a summary
  * that claimed accounts on its own terms could count an exchange the page
  * attributes to a different store.
+ *
+ * One `latest` per account, and the whole store's worth raised before any is
+ * awaited: an adapter that groups the calls of a tick — every SQL one does —
+ * settles a whole directory's ownership in one pass over the store rather than
+ * one per row.
  */
-export async function assignAccounts(
-  sources: readonly TimelineSource[],
-  accounts: readonly TimelineAccount[],
-): Promise<Array<[TimelineSource, TimelineAccount[]]>> {
-  const assigned: Array<[TimelineSource, TimelineAccount[]]> = [];
+export async function assignAccounts<Account extends MessageAccount>(
+  stores: readonly Messages[],
+  accounts: readonly Account[],
+): Promise<Array<[Messages, Account[]]>> {
+  const assigned: Array<[Messages, Account[]]> = [];
   let unclaimed = [...accounts];
-  for (const source of sources) {
+  for (const store of stores) {
     if (unclaimed.length === 0) break;
-    const held = new Set(await source.holds(unclaimed));
-    const taken = unclaimed.filter((account) => held.has(account));
-    if (taken.length > 0) assigned.push([source, taken]);
-    unclaimed = unclaimed.filter((account) => !held.has(account));
+    const heads = await Promise.all(unclaimed.map((account) => store.latest([account])));
+    const taken = unclaimed.filter((_, index) => heads[index] != null);
+    if (taken.length > 0) assigned.push([store, taken]);
+    unclaimed = unclaimed.filter((_, index) => heads[index] == null);
   }
   return assigned;
 }


### PR DESCRIPTION
## Summary

Point `readPersonTimeline` and `readPeopleActivity` at the four `Messages` adapters, in the existing precedence order (WhatsApp mirror, LinkedIn mirror, agent transcript, sentinel log). The merge above the stores no longer reads through `TimelineSource`.

**Ownership is derived, not asked.** `holds` was a second answer to "does this store hold this account", free to differ from what `read` and `digest` went on to say — that is how a directory row could preview one entry while the page beneath it opened on another. A store that answers a `latest` for an account is a store that holds it, and `Messages` binds that `latest` to the head of the very history `read` pages. The precedence is settled once, off one verb, for the preview and the page alike.

**The listing summarizes per person per store**, over every account of theirs that store owns, rather than per account. A store reads a set of accounts as one history, so this is the same read the page makes: a message that two addressings of one person both name counts once in both.

**Batching is preserved.** A store's whole batch of `latest` calls is raised before any is awaited, and so are the listing's `count`/`latest` calls — so `sqlMessages`' tick grouping settles a whole directory in one pass per store rather than one per row.

`holds` and `digest` have no callers left. The `TimelineSource` declaration and its four SQL implementations stay until the account directory moves too (#99, #100), marked `@deprecated`.

## Acceptance

- [x] `GET /api/people/:id/messages` pages exactly as before — the 66 route tests in `api/routes/people.test.ts` pass unchanged, including paging, cursor-inside-a-second, `?channel=`, group/reaction exclusion and the `@lid` fold.
- [x] A person's listing preview equals the first entry their timeline answers — the existing route test "previews the head of the person's own timeline and counts its entries" still holds, and a new seam test asserts it directly against a merged timeline over overlapping stores.
- [x] No call to `holds` or `digest` remains on the timeline or people-listing path — enforced by the type change, and by a test on each of `readPersonTimeline` and `readPeopleActivity` that records every verb a store is asked for.

## Test plan

Tests were written first, against the seam, and were red before the implementation landed (13 failing).

- [x] `packages/core/src/people/timeline.test.ts` rewritten to drive `Messages` stores through `memoryMessages` — the reference implementation the contract suite is proved against — so what it asserts about the merge is asserted over a store every real adapter is enrolled alongside. New cases: ownership derived from `latest` and no later store asked anything; the preview equals the timeline's first entry and the count its length; each entry point asks for nothing but `read`/`count`/`latest`.
- [x] `pnpm --filter @rome/core test:unit` — 4228 passed. (Two suites fail to load in my sandbox on a `node-pty` native binding, unrelated to this change.)
- [x] `tsc --noEmit` clean, `biome check src` clean.

Closes rome-os/rome#97

🤖 Generated with [Claude Code](https://claude.com/claude-code)