### PR TITLE
feat: add streaming input to WebChat

### DIFF
--- a/docs/adrs/provider-native-conversational-steering.md
+++ b/docs/adrs/provider-native-conversational-steering.md
@@ -1,0 +1,32 @@
+# Conversational input uses provider-native, non-interrupting steering
+
+- **Status**: Accepted
+- **Date**: 2026-08-27
+- **Concept**: [conversational inputs](../concepts/sessions.md#conversational-inputs)
+
+## Context
+
+Serializing every user message as a new turn prevents a guardian's correction from reaching an agent that is still using tools. Interrupting the agent cannot undo those tools' effects. Codex app-server and Claude Agent SDK both accept additional input during execution, but their acknowledgement and turn-boundary behavior differ.
+
+## Decision
+
+WebChat submits independently identified inputs to a session-owned input lane that attempts provider-native, non-interrupting steering. The lane starts follow-up turns for undispatched or definitively deferred inputs, never for unknown deliveries.
+
+## Alternatives
+
+- Keep all user messages in the turn FIFO: safe but cannot correct ongoing work.
+- Interrupt and replace: interrupts useful work without retracting side effects.
+- Retry every unconfirmed steer: can duplicate an input that the provider already accepted.
+- Keep a late Claude loop inside the old Rome turn: obscures run boundaries and tool attribution.
+
+## Consequences
+
+A run may consume multiple independently persisted user messages. Receiving a message does not promise immediate consumption. An idle lane reserves a turn synchronously. Only one unconsumed steering input is dispatched at a time, preserving the order of a burst of messages.
+
+Codex uses `turn/steer` with the expected native turn id and `clientUserMessageId`. A completed user-message item confirms consumption. The initial user-message confirmation gates steering because a `turn/start` acknowledgement can arrive before the native turn accepts additional inputs.
+
+Claude uses the existing streaming prompt with a UUID and `priority: next`. Replayed user messages confirm inclusion. An input retained beyond a result starts a separate Rome turn. A `UserPromptSubmit` gate prevents that native loop from executing before its new Rome owner exists. Adoption does not enqueue the input again.
+
+Provider-retained continuations precede independent queued work so an SDK cannot execute that continuation under another caller's turn. Independent `sendTurn` callers remain FIFO relative to one another and keep one result per call. External-channel handlers do not opt into streaming until their reply ownership can follow the same run-based contract.
+
+Unknown deliveries, including unfinished inputs after a backend restart, remain visible and are not automatically replayed. Stop targets one active turn and leaves later inputs intact. Provider upgrades must revalidate consumption events and the native startup gates.

--- a/docs/adrs/queued-turns-over-interrupt-and-replace.md
+++ b/docs/adrs/queued-turns-over-interrupt-and-replace.md
@@ -1,6 +1,6 @@
 # A concurrent turn queues behind the running turn instead of interrupting it
 
-- **Status**: Accepted
+- **Status**: Superseded for WebChat inputs by [provider-native conversational steering](provider-native-conversational-steering.md). Retained for independent turn callers.
 - **Date**: 2026-08-11
 - **Concept**: [sessions](../concepts/sessions.md)
 

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -40,13 +40,31 @@ An agent run is one turn of agent work, identified by its turn id — the unit u
 
 **Contracts:**
 
-- The user message, assistant output, and trace evidence produced by the same turn count as one run, not several.
+- The user inputs, assistant output, and trace evidence produced by the same turn count as one run, not several. A run can consume more than one user input.
 - Failed and interrupted turns still count as runs.
 - A run's outcome and wall-clock duration come from the bracket that closes it, and its model attribution and token cost come from the terminal block's accounting. Neither is read from fields mirrored onto individual messages.
 
 **Not to be confused with:**
 
 - **[Session](#sessions)** — a session accumulates many runs. A run is a single turn.
+
+## Conversational inputs
+
+A conversational input is one independently submitted user message. Its identity remains the same whether it starts a run or joins one already in progress.
+
+**Contracts:**
+
+- WebChat persists an input before dispatch. Sending during a run attempts non-interrupting provider steering; it does not start a concurrent run or replace the active output stream.
+- Provider acceptance and consumption are distinct. An accepted input is not shown as consumed until the provider includes it in context.
+- A definitely unconsumed input can start the next run. If the provider already holds it, the next run adopts it without sending another copy.
+- An uncertain delivery is not automatically retried. After a backend restart, unfinished inputs remain visible with unconfirmed delivery; they are not silently replayed.
+- Stop targets the specified running turn. It cannot stop another turn, and it does not cancel separately queued inputs.
+- Independent action, approval, and external-channel callers retain their serial, one-result-per-call turn contract. They do not implicitly opt into the WebChat input lane.
+
+**Not to be confused with:**
+
+- **Output streaming** — incremental assistant output says nothing about whether new input can join an active run.
+- **Interrupting** — steering changes a later model step without cancelling an in-flight tool or model request.
 
 ## Owning app
 

--- a/packages/api-types/src/trace-segments.ts
+++ b/packages/api-types/src/trace-segments.ts
@@ -2,6 +2,8 @@
 
 import type { AgentPlan, RomeSessionRef } from "@rome-os/app-runtime";
 export type {
+  AgentInputState,
+  InputStatusMessage,
   AgentPlan,
   AgentPlanStep,
   AgentPlanStepStatus,

--- a/packages/app-runtime-sdk/src/index.ts
+++ b/packages/app-runtime-sdk/src/index.ts
@@ -1168,6 +1168,11 @@ export type MessagePart =
        *  (Anthropic `stop_reason`; Codex app-server `phase`). Absent on legacy
        *  rows (and channels that don't split turns) → treated as `final`. */
       turnPhase?: "commentary" | "final";
+      /** Zero-based identity of this WebChat assistant text block within its turn.
+       *  Assigned by the WebChat projection and persisted so the live SSE
+       *  block and transcript block share the same `(turnId, blockIx)` key.
+       *  Absent on legacy rows and channels that do not stream text blocks. */
+      blockIx?: number;
     }
   | {
       type: "turn_recap";

--- a/packages/app-runtime-sdk/src/index.ts
+++ b/packages/app-runtime-sdk/src/index.ts
@@ -821,7 +821,24 @@ export interface PlanUpdateMessage {
   plan: AgentPlan;
 }
 
+export type AgentInputState =
+  | "queued"
+  | "submitted"
+  | "accepted"
+  | "consumed"
+  | "unknown"
+  | "cancelled"
+  | "failed";
+
+export interface InputStatusMessage {
+  type: "input_status";
+  inputId: string;
+  state: AgentInputState;
+  turnId?: string;
+}
+
 export type AgentMessage =
+  | InputStatusMessage
   | TurnStartMessage
   | TurnEndMessage
   | TextMessage

--- a/packages/core/drizzle/system/0061_nervous_human_fly.sql
+++ b/packages/core/drizzle/system/0061_nervous_human_fly.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `rome_agent_messages` ADD `input_state` text;

--- a/packages/core/drizzle/system/meta/0061_snapshot.json
+++ b/packages/core/drizzle/system/meta/0061_snapshot.json
@@ -1,0 +1,3089 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c4381e36-83b2-43e7-8bab-c5475b54e30a",
+  "prevId": "878b427b-06bb-4f40-8b38-c6780bb59129",
+  "tables": {
+    "action_executions": {
+      "name": "action_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initiator": {
+          "name": "initiator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_keys": {
+      "name": "app_keys",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "approvals": {
+      "name": "approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_state": {
+          "name": "execution_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_error": {
+          "name": "execution_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_mappings": {
+      "name": "channel_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_channel_mappings_identity": {
+          "name": "idx_channel_mappings_identity",
+          "columns": [
+            "channel",
+            "channel_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_mappings_person_id_persons_id_fk": {
+          "name": "channel_mappings_person_id_persons_id_fk",
+          "tableFrom": "channel_mappings",
+          "tableTo": "persons",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connection_grants": {
+      "name": "connection_grants",
+      "columns": {
+        "custody": {
+          "name": "custody",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential": {
+          "name": "credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conferred_at": {
+          "name": "conferred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_at": {
+          "name": "degraded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_reason": {
+          "name": "degraded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connection_grants_custody_name_pk": {
+          "columns": [
+            "custody",
+            "name"
+          ],
+          "name": "connection_grants_custody_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connections": {
+      "name": "connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connections_service_unique": {
+          "name": "connections_service_unique",
+          "columns": [
+            "service"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tzid": {
+          "name": "tzid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_time": {
+          "name": "local_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rrule": {
+          "name": "rrule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "execution_journal": {
+      "name": "execution_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_hash": {
+          "name": "args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expected_action_name": {
+          "name": "expected_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expected_args_hash": {
+          "name": "expected_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_action_name": {
+          "name": "actual_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_args_hash": {
+          "name": "actual_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ej_root_execution_id": {
+          "name": "idx_ej_root_execution_id",
+          "columns": [
+            "root_execution_id"
+          ],
+          "isUnique": false
+        },
+        "idx_ej_created_at": {
+          "name": "idx_ej_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardian_auth": {
+      "name": "guardian_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guardian_auth_user_id_unique": {
+          "name": "guardian_auth_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_messages": {
+      "name": "linkedin_messages",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_profile_url": {
+          "name": "sender_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_headline": {
+          "name": "sender_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_is_self": {
+          "name": "sender_is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_messages_thread_sent": {
+          "name": "idx_linkedin_messages_thread_sent",
+          "columns": [
+            "thread_id",
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_messages_thread_id_message_id_pk": {
+          "columns": [
+            "thread_id",
+            "message_id"
+          ],
+          "name": "linkedin_messages_thread_id_message_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_participants": {
+      "name": "linkedin_participants",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_self": {
+          "name": "is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_thread_participants": {
+      "name": "linkedin_thread_participants",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_thread_participants_participant": {
+          "name": "idx_linkedin_thread_participants_participant",
+          "columns": [
+            "participant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_thread_participants_thread_id_participant_id_pk": {
+          "columns": [
+            "thread_id",
+            "participant_id"
+          ],
+          "name": "linkedin_thread_participants_thread_id_participant_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_threads": {
+      "name": "linkedin_threads",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_url": {
+          "name": "thread_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_name": {
+          "name": "person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_name": {
+          "name": "conversation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread": {
+          "name": "unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "counterparty_type": {
+          "name": "counterparty_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "participants_last_read_at": {
+          "name": "participants_last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_pending_attempts": {
+      "name": "oauth_pending_attempts",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_origin": {
+          "name": "callback_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_pending_attempts_expires_at": {
+          "name": "idx_oauth_pending_attempts_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persons": {
+      "name": "persons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bond_level": {
+          "name": "bond_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_path": {
+          "name": "profile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_value": {
+          "name": "scope_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sync_links": {
+      "name": "project_sync_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_type": {
+          "name": "project_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_extra": {
+          "name": "project_link_extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sync_links_project_path_unique": {
+          "name": "project_sync_links_project_path_unique",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_accounts": {
+      "name": "provider_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "provider_accounts_provider_unique": {
+          "name": "provider_accounts_provider_unique",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_messages": {
+      "name": "rome_agent_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_state": {
+          "name": "input_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_platform_message_id": {
+          "name": "reply_to_platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_injected_turn_id": {
+          "name": "context_injected_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_messages_session_id": {
+          "name": "idx_rome_agent_messages_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_turn_id": {
+          "name": "idx_rome_agent_messages_turn_id",
+          "columns": [
+            "turn_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_role_created_at": {
+          "name": "idx_rome_agent_messages_role_created_at",
+          "columns": [
+            "role",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_platform_message": {
+          "name": "idx_rome_agent_messages_platform_message",
+          "columns": [
+            "session_id",
+            "platform_message_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_agent_messages\".\"platform_message_id\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_trace_blocks": {
+      "name": "rome_agent_trace_blocks",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_trace_blocks_session_id": {
+          "name": "idx_rome_agent_trace_blocks_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_trace_blocks_terminal_message": {
+          "name": "idx_rome_agent_trace_blocks_terminal_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') IN ('result', 'error')"
+        },
+        "idx_rome_agent_trace_blocks_turn_end_message": {
+          "name": "idx_rome_agent_trace_blocks_turn_end_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') = 'turn_end'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rome_agent_trace_blocks_message_id_seq_pk": {
+          "columns": [
+            "message_id",
+            "seq"
+          ],
+          "name": "rome_agent_trace_blocks_message_id_seq_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_sessions": {
+      "name": "rome_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "large_model_selection": {
+          "name": "large_model_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webchat'"
+        },
+        "source_channel": {
+          "name": "source_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_name": {
+          "name": "source_thread_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_type": {
+          "name": "source_thread_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_settings": {
+          "name": "channel_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_turn_id": {
+          "name": "parent_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handoff_spec": {
+          "name": "handoff_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_activity_at": {
+          "name": "last_seen_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_sessions_project_path": {
+          "name": "idx_rome_sessions_project_path",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_sidebar_activity": {
+          "name": "idx_rome_sessions_sidebar_activity",
+          "columns": [
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_project_activity": {
+          "name": "idx_rome_sessions_project_activity",
+          "columns": [
+            "project_path",
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_channel": {
+          "name": "idx_rome_sessions_source_channel",
+          "columns": [
+            "source_channel"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_thread": {
+          "name": "idx_rome_sessions_source_thread",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_channel_address": {
+          "name": "idx_rome_sessions_channel_address",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_sessions\".\"type\" = 'channel' AND \"rome_sessions\".\"source_channel\" IS NOT NULL AND \"rome_sessions\".\"source_thread_id\" IS NOT NULL"
+        },
+        "idx_rome_sessions_parent_session": {
+          "name": "idx_rome_sessions_parent_session",
+          "columns": [
+            "parent_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routine_runs": {
+      "name": "routine_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_routine_runs_routine_id": {
+          "name": "idx_routine_runs_routine_id",
+          "columns": [
+            "routine_id"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_fired_at": {
+          "name": "idx_routine_runs_fired_at",
+          "columns": [
+            "fired_at"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_status": {
+          "name": "idx_routine_runs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "routine_runs_routine_id_routines_id_fk": {
+          "name": "routine_runs_routine_id_routines_id_fk",
+          "tableFrom": "routine_runs",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routines": {
+      "name": "routines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed_by": {
+          "name": "managed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "routines_key_unique": {
+          "name": "routines_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sentinel_log": {
+      "name": "sentinel_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_turn_checkpoints": {
+      "name": "session_turn_checkpoints",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_turn_checkpoints_session_id_sessions_id_fk": {
+          "name": "session_turn_checkpoints_session_id_sessions_id_fk",
+          "tableFrom": "session_turn_checkpoints",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_turn_checkpoints_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "session_turn_checkpoints_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_thread_key": {
+          "name": "channel_thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shared_chats": {
+      "name": "shared_chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_shared_chats_session_id": {
+          "name": "idx_shared_chats_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_chats": {
+      "name": "wa_chats",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_contacts": {
+      "name": "wa_contacts",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify": {
+          "name": "notify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "img_url": {
+          "name": "img_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_messages": {
+      "name": "wa_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_jid": {
+          "name": "chat_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_jid": {
+          "name": "sender_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_me": {
+          "name": "from_me",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_media": {
+          "name": "has_media",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "push_name": {
+          "name": "push_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reacts_to_id": {
+          "name": "reacts_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_chat_ts": {
+          "name": "idx_wa_messages_chat_ts",
+          "columns": [
+            "chat_jid",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wa_messages_chat_jid_id_pk": {
+          "columns": [
+            "chat_jid",
+            "id"
+          ],
+          "name": "wa_messages_chat_jid_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_projects": {
+      "name": "webchat_projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webchat_projects_path_unique": {
+          "name": "webchat_projects_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_turn_feedback": {
+      "name": "webchat_turn_feedback",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webchat_turn_feedback_session_id": {
+          "name": "idx_webchat_turn_feedback_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webchat_turn_feedback_session_id_rome_sessions_id_fk": {
+          "name": "webchat_turn_feedback_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_turn_feedback",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webchat_turn_feedback_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "webchat_turn_feedback_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_workspace_layouts": {
+      "name": "webchat_workspace_layouts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webchat_workspace_layouts_session_id_rome_sessions_id_fk": {
+          "name": "webchat_workspace_layouts_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_workspace_layouts",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_invocations": {
+      "name": "webhook_invocations",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_url": {
+          "name": "callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_status": {
+          "name": "callback_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_attempted_at": {
+          "name": "callback_attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_delivered_at": {
+          "name": "callback_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_response_status": {
+          "name": "callback_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_error": {
+          "name": "callback_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webhook_invocations_created_at": {
+          "name": "idx_webhook_invocations_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_webhook_invocations_action_name": {
+          "name": "idx_webhook_invocations_action_name",
+          "columns": [
+            "action_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/system/meta/_journal.json
+++ b/packages/core/drizzle/system/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1787866308438,
       "tag": "0060_serious_adam_destine",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "6",
+      "when": 1787898378247,
+      "tag": "0061_nervous_human_fly",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/api/helpers.ts
+++ b/packages/core/src/api/helpers.ts
@@ -154,7 +154,7 @@ function timestampToIso(value: Date | number): string {
  * never persisted, so callers must filter deltas out before reaching here —
  * the compiler enforces it instead of a runtime throw.
  */
-export type TraceableAgentMessage = Exclude<AgentMessage, { type: "text_delta" }>;
+export type TraceableAgentMessage = Exclude<AgentMessage, { type: "text_delta" | "input_status" }>;
 
 export function toTraceBlock(msg: TraceableAgentMessage & { agent?: string }): TraceBlockDto {
   switch (msg.type) {

--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -1912,7 +1912,7 @@ describe("Webchat API", () => {
       expect(sendMessageRun).toHaveBeenCalledWith(
         "send_message",
         expect.objectContaining({
-          parts: [{ type: "text", content: "It's sunny.", turnPhase: "final" }],
+          parts: [{ type: "text", content: "It's sunny.", turnPhase: "final", blockIx: 1 }],
         }),
         expect.anything(),
       );
@@ -1925,7 +1925,12 @@ describe("Webchat API", () => {
       );
       expect(commentary).toHaveLength(1);
       expect(JSON.parse(commentary[0].content)).toEqual([
-        { type: "text", content: "Let me check the weather.", turnPhase: "commentary" },
+        {
+          type: "text",
+          content: "Let me check the weather.",
+          turnPhase: "commentary",
+          blockIx: 0,
+        },
       ]);
     });
 
@@ -1938,7 +1943,7 @@ describe("Webchat API", () => {
       let releaseResult!: () => void;
       const resultGate = new Promise<void>((resolve) => (releaseResult = resolve));
       let released = false;
-      const { events } = await runScriptedStream(
+      const { events, sendMessageRun } = await runScriptedStream(
         () =>
           (async function* () {
             yield { type: "text", content: "Whole block" };
@@ -1953,6 +1958,48 @@ describe("Webchat API", () => {
         },
       );
       expect(assistantTexts(events)).toContainEqual({ blockIx: 0, text: "Whole block" });
+      expect(sendMessageRun).toHaveBeenCalledWith(
+        "send_message",
+        expect.objectContaining({
+          parts: [{ type: "text", content: "Whole block", turnPhase: "final", blockIx: 0 }],
+        }),
+        expect.anything(),
+      );
+    });
+
+    it("allocates a new final block after commentary even when the text is identical", async () => {
+      const { sendMessageRun } = await runScriptedStream(
+        () =>
+          (async function* () {
+            yield { type: "text", content: "Same text", turnPhase: "commentary" };
+            yield { type: "result", content: "Same text" };
+          })() as AsyncGenerator<never>,
+      );
+
+      expect(sendMessageRun).toHaveBeenCalledWith(
+        "send_message",
+        expect.objectContaining({
+          parts: [{ type: "text", content: "Same text", turnPhase: "final", blockIx: 1 }],
+        }),
+        expect.anything(),
+      );
+    });
+
+    it("assigns block zero when a provider returns only a final result", async () => {
+      const { sendMessageRun } = await runScriptedStream(
+        () =>
+          (async function* () {
+            yield { type: "result", content: "Result only" };
+          })() as AsyncGenerator<never>,
+      );
+
+      expect(sendMessageRun).toHaveBeenCalledWith(
+        "send_message",
+        expect.objectContaining({
+          parts: [{ type: "text", content: "Result only", turnPhase: "final", blockIx: 0 }],
+        }),
+        expect.anything(),
+      );
     });
 
     it("streams Plan-only summary updates and reconstructs the latest Plan after settlement", async () => {

--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -11,12 +11,14 @@ import {
 import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWebchatRuntime } from "./webchat.js";
+import { AgentInputQueue } from "../../core/agent-input-queue.js";
 import { runWithSessionActor } from "../../lib/session-actor.js";
 import { createTestDb, buildTestDeps, type TestDb, type TestDeps } from "../../test/helpers.js";
 import { seedBaseline, type BaselineIds } from "../../test/seeds.js";
 import type {
   AgentSession,
   AgentSessionInit,
+  AgentTurnHandle,
   AgentTurnInput,
   SendTurnOptions,
 } from "../../core/agent-session.js";
@@ -49,6 +51,154 @@ describe("Webchat API", () => {
       delete process.env.ROME_PROJECTS_ROOT;
     } else {
       process.env.ROME_PROJECTS_ROOT = originalProjectsRoot;
+    }
+  });
+
+  it("persists appended inputs once and keeps one stream owner", async () => {
+    let finish!: () => void;
+    const terminal = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const steerUserInput = vi.fn().mockResolvedValue("accepted" as const);
+    const start = vi.fn(
+      (): AgentTurnHandle => ({
+        turnId: "input-turn",
+        turnContext: otelContext.active(),
+        getSubmittedOutput: () => undefined,
+        events: (async function* () {
+          await terminal;
+          yield { type: "result" as const, content: "" };
+        })(),
+      }),
+    );
+    const queue = new AgentInputQueue(
+      start,
+      () => ({ steerUserInput }),
+      (error) => {
+        throw error;
+      },
+    );
+    const agent: AgentSession = {
+      key: { agentName: "main", channelThreadKey: "webchat:test" },
+      sessionId: "agent-session",
+      status: "running",
+      currentTurnId: "input-turn",
+      sendTurn: start,
+      submitInput: (input, options) => queue.submit(input, options),
+      subscribe: () => () => {},
+      onStatusChange: () => () => {},
+      interrupt: async () => {},
+      close: async () => {},
+      getSubmittedOutput: () => undefined,
+    };
+    deps.agentSessionManager = {
+      acquire: vi.fn(async () => agent),
+      peek: () => agent,
+      shutdown: async () => {},
+    };
+    const app = createWebchatRuntime(deps).routes;
+    const created = await app.request("/chat/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Inputs" }),
+    });
+    const { id } = (await created.json()) as { id: string };
+    const post = (inputId: string, text: string) =>
+      app.request(`/chat/sessions/${id}/turns`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ inputId, text }),
+      });
+    const a = "00000000-0000-4000-8000-000000000001";
+    const b = "00000000-0000-4000-8000-000000000002";
+    try {
+      const firstSubmissions = await Promise.all([post(a, "first"), post(a, "first")]);
+      expect(firstSubmissions.map((response) => response.status)).toEqual([200, 200]);
+      expect(start).toHaveBeenCalledOnce();
+      queue.ready("input-turn");
+      expect(await (await post(b, "second")).json()).toMatchObject({
+        inputId: b,
+        turnId: "input-turn",
+        disposition: "steering",
+      });
+      await vi.waitFor(() => expect(steerUserInput).toHaveBeenCalledOnce());
+      await queue.observe({ type: "input_status", inputId: b, state: "consumed" }, "input-turn");
+      expect((await post(b, "second")).status).toBe(200);
+      expect(steerUserInput).toHaveBeenCalledOnce();
+      expect(start).toHaveBeenCalledOnce();
+      const inputs = (await deps.webchatRepo.getMessages(id)).filter(
+        (message) => message.role === "user",
+      );
+      expect(inputs).toHaveLength(2);
+      expect(inputs.find((message) => message.id === b)).toMatchObject({
+        inputState: "consumed",
+        turnId: "input-turn",
+      });
+      expect(await (await app.request(`/chat/sessions/${id}/turns`)).json()).toHaveLength(1);
+    } finally {
+      finish();
+    }
+  });
+
+  it("refuses a queued turn's Stop without interrupting the active turn", async () => {
+    const finishers: (() => void)[] = [];
+    let sequence = 0;
+    const interrupt = vi.fn(async () => {});
+    const agent: AgentSession = {
+      key: { agentName: "main", channelThreadKey: "webchat:test" },
+      sessionId: "agent-session",
+      status: "running",
+      currentTurnId: "stop-1",
+      sendTurn: () => {
+        const turnId = `stop-${++sequence}`;
+        const terminal = new Promise<void>((resolve) => {
+          finishers.push(resolve);
+        });
+        return {
+          turnId,
+          turnContext: otelContext.active(),
+          getSubmittedOutput: () => undefined,
+          events: (async function* () {
+            await terminal;
+            yield { type: "result" as const, content: "" };
+          })(),
+        };
+      },
+      subscribe: () => () => {},
+      onStatusChange: () => () => {},
+      interrupt,
+      close: async () => {},
+      getSubmittedOutput: () => undefined,
+    };
+    deps.agentSessionManager = {
+      acquire: vi.fn(async () => agent),
+      peek: () => agent,
+      shutdown: async () => {},
+    };
+    const app = createWebchatRuntime(deps).routes;
+    const created = await app.request("/chat/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Stop" }),
+    });
+    const { id } = (await created.json()) as { id: string };
+    try {
+      for (const text of ["first", "second"])
+        await app.request(`/chat/sessions/${id}/turns`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ text }),
+        });
+      expect((await app.request("/chat/turns/stop-2/interrupt", { method: "POST" })).status).toBe(
+        409,
+      );
+      expect(interrupt).not.toHaveBeenCalled();
+      expect((await app.request("/chat/turns/stop-1/interrupt", { method: "POST" })).status).toBe(
+        200,
+      );
+      expect(interrupt).toHaveBeenCalledWith("user-stop", "stop-1");
+    } finally {
+      for (const finish of finishers) finish();
     }
   });
 

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -3100,6 +3100,14 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
         runOnStream(stream, "webchat send", async () => {
           try {
             let resultContent = "";
+            let lastCompletedText:
+              | {
+                  blockIx: number;
+                  content: string;
+                  turnPhase?: "commentary" | "final";
+                }
+              | undefined;
+            let finalTextBlockIx: number | undefined;
             let resultError: Extract<AgentMessage, { type: "error" }> | undefined;
             for await (const msg of handle.events) {
               if (msg.type === "input_status") continue;
@@ -3126,8 +3134,9 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
               // fresh index; the client keeps showing this block until that
               // block's first delta arrives (delayed fold).
               if (msg.type === "text") {
-                // Keeps the live tail's text exactly matching the row the
-                // client dedups against (below).
+                const blockIx = stream.assistantBlockIx;
+                // Keeps the live preview and its persisted replacement on the
+                // same complete block content during their handoff.
                 if (stream.assistantText !== msg.content) {
                   stream.assistantText = msg.content;
                   emitToStream(
@@ -3139,15 +3148,19 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
                 }
                 // Model M: a completed in-turn narration block becomes its own
                 // live message, pushed so it appears in the transcript (time-
-                // ordered with any cards) as the turn streams. The client hides
-                // the matching live-tail copy by content. The final answer is not
-                // persisted here — it goes out once at turn end via send_message.
+                // ordered with any cards) as the turn streams. The final answer
+                // goes out once at turn end via send_message.
                 const isCommentary =
                   msg.turnPhase === "commentary" && msg.content.trim().length > 0;
                 if (isCommentary) {
                   try {
                     await deps.webchatRepo.addBackendMessage(sessionId, turnId, [
-                      { type: "text", content: msg.content, turnPhase: "commentary" },
+                      {
+                        type: "text",
+                        content: msg.content,
+                        turnPhase: "commentary",
+                        blockIx,
+                      },
                     ]);
                   } catch (err) {
                     log.warn("failed to persist commentary message", {
@@ -3157,6 +3170,12 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
                     });
                   }
                 }
+                lastCompletedText = {
+                  blockIx,
+                  content: msg.content,
+                  turnPhase: msg.turnPhase,
+                };
+                if (msg.turnPhase === "final") finalTextBlockIx = blockIx;
                 stream.assistantBlockIx += 1;
                 stream.assistantText = "";
               }
@@ -3366,6 +3385,13 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
             // message; this is the final answer only. `text` is the final answer
             // for non-webchat consumers; webchat persists the tagged part.
             if (resultContent && !stream.stopRequested) {
+              const reusableResultBlockIx =
+                lastCompletedText?.turnPhase === undefined &&
+                lastCompletedText?.content === resultContent
+                  ? lastCompletedText.blockIx
+                  : undefined;
+              const resultBlockIx =
+                finalTextBlockIx ?? reusableResultBlockIx ?? stream.assistantBlockIx;
               await deps.actionEngine.run(
                 "send_message",
                 {
@@ -3373,7 +3399,12 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
                   threadId: sessionId,
                   text: resultContent,
                   parts: [
-                    { type: "text" as const, content: resultContent, turnPhase: "final" as const },
+                    {
+                      type: "text" as const,
+                      content: resultContent,
+                      turnPhase: "final" as const,
+                      blockIx: resultBlockIx,
+                    },
                   ],
                   channelUserId,
                   displayName,

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -50,6 +50,7 @@ import {
 import type { TurnFeedback } from "@rome/api-types/trace-segments";
 import type { StoredTurnFeedback } from "../../db/repositories/webchat.js";
 import type { AgentMessage, MessagePart } from "../../types.js";
+import type { AgentTurnHandle } from "../../core/agent-session.js";
 import type { RomeSessionType, StreamAgentMessage } from "@rome-os/app-runtime";
 import type { ApiDeps } from "../deps.js";
 import {
@@ -183,6 +184,7 @@ function formatFeedback(row: StoredTurnFeedback | null): TurnFeedback | null {
 }
 
 type WebchatEventName =
+  | "input_status"
   | "segment_upsert"
   | "summary_update"
   | "session_status"
@@ -2520,16 +2522,19 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     if (stream.stopRequested) {
       return c.json({ stopped: true, alreadyRequested: true });
     }
-    stream.stopRequested = true;
-    log.info("interrupt requested for turn", { turnId, sessionId: stream.sessionId });
     const channelThreadKey = stream.channelThreadKey;
     const agentSess = deps.agentSessionManager.peek({
       agentName: stream.agentName,
       channelThreadKey: channelThreadKey ?? `webchat:${stream.sessionId}`,
     });
+    if (!agentSess || agentSess.currentTurnId !== turnId) {
+      return c.json({ stopped: false, reason: "turn_not_running" }, 409);
+    }
+    stream.stopRequested = true;
+    log.info("interrupt requested for turn", { turnId, sessionId: stream.sessionId });
     if (agentSess) {
       try {
-        await agentSess.interrupt("user-stop");
+        await agentSess.interrupt("user-stop", turnId);
       } catch (err) {
         log.warn("agentSession.interrupt() rejected", {
           turnId,
@@ -2590,6 +2595,10 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
           queue = queue.then(() => sse.writeSSE({ event, data: JSON.stringify(data) }));
         };
         const project = (message: StreamAgentMessage) => {
+          if (message.type === "input_status") {
+            write("input_status", message);
+            return;
+          }
           if (message.type === "text_delta") {
             assistantText += message.content;
             write("assistant_text", {
@@ -2665,6 +2674,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
   });
 
   type SendBody = {
+    inputId?: string;
     threadId?: string;
     text?: string;
     personaId?: string;
@@ -2727,6 +2737,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
         } catch {}
       }
       return {
+        inputId: getString("inputId"),
         threadId: getString("threadId"),
         text: getString("text"),
         personaId: getString("personaId"),
@@ -2745,6 +2756,13 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     sessionId: string | undefined,
     body: SendBody,
   ): Promise<Response> => {
+    if (
+      body.inputId &&
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(body.inputId)
+    ) {
+      return c.json({ error: "inputId must be a UUID" }, 400);
+    }
+    const inputId = body.inputId ?? randomUUID();
     const uploadedFiles = Array.isArray(body.files) ? body.files : [];
 
     // A resolution from an app interaction surface is a valid turn trigger even
@@ -2890,10 +2908,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       }
     }
 
-    // WebChat bypasses message_handler. Acquire the AgentSession
-    // synchronously, call sendTurn synchronously to allocate turnId at the
-    // bottom of the stack, and return turnId in the POST JSON response.
-    // The actual agent run drains in the background.
+    // WebChat owns input admission and one output drain per actual run.
     const threadContext = {
       channel: "webchat",
       threadId: sessionId,
@@ -2953,20 +2968,32 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
         : [{ type: "text", content: displayText }];
     const userContent = JSON.stringify(userParts);
     const persistUserMessage = (turnId: string) => {
-      const messageId = randomUUID();
-      // Routes webchat around ProviderAdapter.onMessage, so the shared
-      // inbound-message log (see wrapProviderAdaptersWithSpans) must be emitted
-      // here, at the accepted-turn boundary. The active POST span context
-      // links the record to the request trace.
-      logInboundChannelMessage({
-        channel: "webchat",
-        threadId: sessionId,
-        channelUserId,
-        messageId,
-        text: displayText,
+      return deps.webchatRepo.updateUserInput(sessionId, {
+        type: "input_status",
+        inputId,
+        turnId,
+        state: "failed",
       });
-      return deps.webchatRepo.addMessage(messageId, sessionId, "user", userContent, turnId);
     };
+
+    if (!(await deps.webchatRepo.recordUserInput(inputId, sessionId, userContent))) {
+      const existing = await deps.webchatRepo.getUserInput(sessionId, inputId);
+      if (!existing) return c.json({ error: "inputId is already in use" }, 409);
+      return c.json({
+        inputId,
+        turnId: existing.turnId,
+        sessionId,
+        disposition: "queued",
+        inputState: existing.inputState,
+      });
+    }
+    logInboundChannelMessage({
+      channel: "webchat",
+      threadId: sessionId,
+      channelUserId,
+      messageId: inputId,
+      text: displayText,
+    });
 
     let agentSess;
     try {
@@ -3045,393 +3072,410 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       ? [{ context: activePostSpan.spanContext() }]
       : undefined;
 
-    // sendTurn is synchronous — turnId is allocated by AgentSession and
-    // returned immediately. turn-lock makes this safe even
-    // while a previous turn is still running on the same session.
-    const handle = agentSess.sendTurn(
-      { prompt: promptText, reasoningEffort },
-      {
-        links: turnLinks,
-        threadContext,
-        romeSessionId: sessionId,
-        romeSessionType: session.type as RomeSessionType,
-      },
-    );
-    const turnId = handle.turnId;
+    const attachTurn = async (handle: AgentTurnHandle) => {
+      const turnId = handle.turnId;
 
-    // Persist the user message tagged with the turnId so reads can group
-    // user/assistant/trace rows for the same turn together (see
-    // webchatRepo.getMessages). Without this, two POSTs racing on the same
-    // session interleave as user-A / user-B / reply-A / reply-B in the UI.
-    // Caller may supply `parts` (e.g. an `app_component_result` from a resolved
-    // inline component) — when present we trust it as the persisted content and
-    // skip the default text-only part. The model already gets `promptText` via
-    // sendTurn.
-    // persist `displayText`, not `promptText` — the per-turn
-    // `<workspace_context>` block goes to the model only.
-    await persistUserMessage(turnId);
+      const stream = await createStream(sessionId, turnId, channelThreadKey, agentName);
+      enqueueStream(sessionId, stream);
+      void generateAndPersistConversationTitle(sessionId, session.name, firstMessageForTitle);
 
-    const stream = await createStream(sessionId, turnId, channelThreadKey, agentName);
-    enqueueStream(sessionId, stream);
-    void generateAndPersistConversationTitle(sessionId, session.name, firstMessageForTitle);
-
-    const unsubscribeStatus = agentSess.onStatusChange((evt) => {
-      emitToStream(
-        stream,
-        "session_status",
-        { status: evt.status, turnId: evt.turnId, sessionId: evt.sessionId },
-        "session_status",
-      );
-    });
-    // Background: drain the per-turn events into the SSE stream, persist the
-    // trace, then send the assistant's reply via the webchat channel adapter.
-    // AgentSession.turnMutex serializes execution at the SDK layer; ordering
-    // in the UI comes from the (turn_id group anchor, createdAt) sort in
-    // webchatRepo.getMessages — we forward turnId on send_message so the
-    // adapter stamps it onto the persisted assistant row.
-    //
-    // Wrap the drain in the turn's OTel context so any post-turn spans
-    // parent under the agent's trace instead of landing on a stale one.
-    void otelContext.with(handle.turnContext, () =>
-      runOnStream(stream, "webchat send", async () => {
-        try {
-          let resultContent = "";
-          let resultError: Extract<AgentMessage, { type: "error" }> | undefined;
-          for await (const msg of handle.events) {
-            if (stream.stopRequested && msg.type === "error") continue;
-            // Live preview of the in-flight text block. Transient — never a
-            // trace block, never persisted. The replay key is fixed so a
-            // late subscriber gets one event with the latest block's
-            // accumulated text.
-            if (msg.type === "text_delta") {
-              stream.assistantText += msg.content;
-              emitToStream(
-                stream,
-                "assistant_text",
-                { turnId, blockIx: stream.assistantBlockIx, text: stream.assistantText },
-                "assistant_text",
-              );
-              continue;
-            }
-            // Block boundary: a complete `text` block closes the in-flight
-            // preview. If the deltas didn't cover the block (non-streaming
-            // provider, or a dropped frame), emit a corrective event with the
-            // full text — this is what gives block-level previews on
-            // providers that never stream deltas. The next text block gets a
-            // fresh index; the client keeps showing this block until that
-            // block's first delta arrives (delayed fold).
-            if (msg.type === "text") {
-              // Keeps the live tail's text exactly matching the row the
-              // client dedups against (below).
-              if (stream.assistantText !== msg.content) {
-                stream.assistantText = msg.content;
+      const unsubscribeStatus = agentSess.onStatusChange((evt) => {
+        emitToStream(
+          stream,
+          "session_status",
+          { status: evt.status, turnId: evt.turnId, sessionId: evt.sessionId },
+          "session_status",
+        );
+      });
+      // Background: drain the per-turn events into the SSE stream, persist the
+      // trace, then send the assistant's reply via the webchat channel adapter.
+      // AgentSession.turnMutex serializes execution at the SDK layer; ordering
+      // in the UI comes from the (turn_id group anchor, createdAt) sort in
+      // webchatRepo.getMessages — we forward turnId on send_message so the
+      // adapter stamps it onto the persisted assistant row.
+      //
+      // Wrap the drain in the turn's OTel context so any post-turn spans
+      // parent under the agent's trace instead of landing on a stale one.
+      void otelContext.with(handle.turnContext, () =>
+        runOnStream(stream, "webchat send", async () => {
+          try {
+            let resultContent = "";
+            let resultError: Extract<AgentMessage, { type: "error" }> | undefined;
+            for await (const msg of handle.events) {
+              if (msg.type === "input_status") continue;
+              if (stream.stopRequested && msg.type === "error") continue;
+              // Live preview of the in-flight text block. Transient — never a
+              // trace block, never persisted. The replay key is fixed so a
+              // late subscriber gets one event with the latest block's
+              // accumulated text.
+              if (msg.type === "text_delta") {
+                stream.assistantText += msg.content;
                 emitToStream(
                   stream,
                   "assistant_text",
                   { turnId, blockIx: stream.assistantBlockIx, text: stream.assistantText },
                   "assistant_text",
                 );
+                continue;
               }
-              // Model M: a completed in-turn narration block becomes its own
-              // live message, pushed so it appears in the transcript (time-
-              // ordered with any cards) as the turn streams. The client hides
-              // the matching live-tail copy by content. The final answer is not
-              // persisted here — it goes out once at turn end via send_message.
-              const isCommentary = msg.turnPhase === "commentary" && msg.content.trim().length > 0;
-              if (isCommentary) {
+              // Block boundary: a complete `text` block closes the in-flight
+              // preview. If the deltas didn't cover the block (non-streaming
+              // provider, or a dropped frame), emit a corrective event with the
+              // full text — this is what gives block-level previews on
+              // providers that never stream deltas. The next text block gets a
+              // fresh index; the client keeps showing this block until that
+              // block's first delta arrives (delayed fold).
+              if (msg.type === "text") {
+                // Keeps the live tail's text exactly matching the row the
+                // client dedups against (below).
+                if (stream.assistantText !== msg.content) {
+                  stream.assistantText = msg.content;
+                  emitToStream(
+                    stream,
+                    "assistant_text",
+                    { turnId, blockIx: stream.assistantBlockIx, text: stream.assistantText },
+                    "assistant_text",
+                  );
+                }
+                // Model M: a completed in-turn narration block becomes its own
+                // live message, pushed so it appears in the transcript (time-
+                // ordered with any cards) as the turn streams. The client hides
+                // the matching live-tail copy by content. The final answer is not
+                // persisted here — it goes out once at turn end via send_message.
+                const isCommentary =
+                  msg.turnPhase === "commentary" && msg.content.trim().length > 0;
+                if (isCommentary) {
+                  try {
+                    await deps.webchatRepo.addBackendMessage(sessionId, turnId, [
+                      { type: "text", content: msg.content, turnPhase: "commentary" },
+                    ]);
+                  } catch (err) {
+                    log.warn("failed to persist commentary message", {
+                      sessionId,
+                      turnId,
+                      error: err instanceof Error ? err.message : String(err),
+                    });
+                  }
+                }
+                stream.assistantBlockIx += 1;
+                stream.assistantText = "";
+              }
+              stream.traceBlocks.push(msg);
+              emitTraceBlock(stream, msg);
+              if (msg.type === "subagent_result") {
+                const parentRef = { sessionId, turnId, toolUseId: msg.toolUseId };
+                if (deps.activeSubagentRegistry.getLinkByParent(parentRef)) {
+                  await safePersistTrace(stream, "subagent result");
+                  deps.activeSubagentRegistry.clearByParent(parentRef);
+                }
+              }
+              if (msg.type === "result") resultContent = msg.content;
+              if (msg.type === "error") resultError = msg;
+              // Out-of-band snapshot for the routine draft card.
+              if (
+                msg.type === "tool_use" &&
+                (msg.tool === "propose_routine" || msg.tool.endsWith("__propose_routine"))
+              ) {
+                await persistRoutineDraftCard(
+                  deps.webchatRepo,
+                  deps.actionRegistry,
+                  sessionId,
+                  turnId,
+                  msg.id,
+                  msg.input,
+                );
+              }
+              // The borrowed agent relayed the guardian's verbal approval: snapshot
+              // a marker the client picks up to resolve the handback with the
+              // standing submission — the same outcome as clicking Approve. No
+              // payload travels here; the client ships the last submitted payload,
+              // so a stray confirm with nothing submitted is a client-side no-op.
+              if (
+                msg.type === "tool_use" &&
+                session.type === "webchat_handoff" &&
+                (msg.tool === "confirm_output" || msg.tool.endsWith("__confirm_output"))
+              ) {
                 try {
-                  await deps.webchatRepo.addBackendMessage(sessionId, turnId, [
-                    { type: "text", content: msg.content, turnPhase: "commentary" },
-                  ]);
+                  await deps.webchatRepo.addMessage(
+                    randomUUID(),
+                    sessionId,
+                    "assistant",
+                    JSON.stringify([{ type: "handback_approved" }]),
+                    turnId,
+                  );
                 } catch (err) {
-                  log.warn("failed to persist commentary message", {
+                  log.warn("failed to persist handback_approved", {
                     sessionId,
                     turnId,
                     error: err instanceof Error ? err.message : String(err),
                   });
                 }
               }
-              stream.assistantBlockIx += 1;
-              stream.assistantText = "";
-            }
-            stream.traceBlocks.push(msg);
-            emitTraceBlock(stream, msg);
-            if (msg.type === "subagent_result") {
-              const parentRef = { sessionId, turnId, toolUseId: msg.toolUseId };
-              if (deps.activeSubagentRegistry.getLinkByParent(parentRef)) {
-                await safePersistTrace(stream, "subagent result");
-                deps.activeSubagentRegistry.clearByParent(parentRef);
-              }
-            }
-            if (msg.type === "result") resultContent = msg.content;
-            if (msg.type === "error") resultError = msg;
-            // Out-of-band snapshot for the routine draft card.
-            if (
-              msg.type === "tool_use" &&
-              (msg.tool === "propose_routine" || msg.tool.endsWith("__propose_routine"))
-            ) {
-              await persistRoutineDraftCard(
-                deps.webchatRepo,
-                deps.actionRegistry,
-                sessionId,
-                turnId,
-                msg.id,
-                msg.input,
-              );
-            }
-            // The borrowed agent relayed the guardian's verbal approval: snapshot
-            // a marker the client picks up to resolve the handback with the
-            // standing submission — the same outcome as clicking Approve. No
-            // payload travels here; the client ships the last submitted payload,
-            // so a stray confirm with nothing submitted is a client-side no-op.
-            if (
-              msg.type === "tool_use" &&
-              session.type === "webchat_handoff" &&
-              (msg.tool === "confirm_output" || msg.tool.endsWith("__confirm_output"))
-            ) {
-              try {
-                await deps.webchatRepo.addMessage(
-                  randomUUID(),
-                  sessionId,
-                  "assistant",
-                  JSON.stringify([{ type: "handback_approved" }]),
-                  turnId,
-                );
-              } catch (err) {
-                log.warn("failed to persist handback_approved", {
-                  sessionId,
-                  turnId,
-                  error: err instanceof Error ? err.message : String(err),
-                });
-              }
-            }
-            // A valid submission in a handoff child conversation: snapshot it
-            // as a submission_card so the host renders the Approve /
-            // Keep-editing gate. The payload IS the candidate handback —
-            // Approve posts it verbatim as the parent's interaction_result; a
-            // later submission supersedes this card (the client treats only the
-            // newest card as active).
-            if (msg.type === "structured_output" && session.type === "webchat_handoff") {
-              const payload =
-                msg.payload && typeof msg.payload === "object" && !Array.isArray(msg.payload)
-                  ? (msg.payload as Record<string, unknown>)
-                  : { value: msg.payload };
-              try {
-                await deps.webchatRepo.addMessage(
-                  randomUUID(),
-                  sessionId,
-                  "assistant",
-                  JSON.stringify([{ type: "submission_card", payload }]),
-                  turnId,
-                );
-              } catch (err) {
-                log.warn("failed to persist submission_card", {
-                  sessionId,
-                  turnId,
-                  error: err instanceof Error ? err.message : String(err),
-                });
-              }
-            }
-            // Parked suspension: any action that returned a pending_interaction
-            // or handoff result surfaces it on its tool_result. Snapshot a card
-            // keyed by toolUseId so the host renders it and can match the later
-            // interaction_result back to this call. Fail closed on both kinds —
-            // the owning app must actually be installed, and an inline
-            // component must be declared in its app.yaml `components:` list. A
-            // handoff additionally mints a dedicated child session for its
-            // design conversation so it never interleaves with this (parent)
-            // thread.
-            if (msg.type === "tool_result") {
-              const suspension = readSuspensionFromOutput(msg.output);
-              if (suspension && suspension.kind === "inline" && suspension.builtin) {
-                // Host built-in inline card (the ask_question question-card):
-                // rendered by rome-web, so there is no owning app to validate.
-                const card = buildBuiltinQuestionCard(msg, suspension, sessionId);
-                if (card) {
-                  await persistSuspensionCard(deps.webchatRepo, sessionId, turnId, card);
+              // A valid submission in a handoff child conversation: snapshot it
+              // as a submission_card so the host renders the Approve /
+              // Keep-editing gate. The payload IS the candidate handback —
+              // Approve posts it verbatim as the parent's interaction_result; a
+              // later submission supersedes this card (the client treats only the
+              // newest card as active).
+              if (msg.type === "structured_output" && session.type === "webchat_handoff") {
+                const payload =
+                  msg.payload && typeof msg.payload === "object" && !Array.isArray(msg.payload)
+                    ? (msg.payload as Record<string, unknown>)
+                    : { value: msg.payload };
+                try {
+                  await deps.webchatRepo.addMessage(
+                    randomUUID(),
+                    sessionId,
+                    "assistant",
+                    JSON.stringify([{ type: "submission_card", payload }]),
+                    turnId,
+                  );
+                } catch (err) {
+                  log.warn("failed to persist submission_card", {
+                    sessionId,
+                    turnId,
+                    error: err instanceof Error ? err.message : String(err),
+                  });
                 }
-              } else if (suspension) {
-                const resolvedApp = deps.appCatalog
-                  ?.listResolved()
-                  .find((a) => a.appId === suspension.appId);
-                if (!resolvedApp) {
-                  log.warn("rejected suspension: app not installed", {
-                    sessionId,
-                    appId: suspension.appId,
-                  });
-                } else if (
-                  suspension.kind === "inline" &&
-                  !(resolvedApp.manifest.components ?? []).includes(suspension.componentId)
-                ) {
-                  log.warn("rejected suspension: component not declared by app", {
-                    sessionId,
-                    appId: suspension.appId,
-                    componentId: suspension.componentId,
-                  });
-                } else if (suspension.kind === "handoff") {
-                  const handoffAgentName = suspension.agentName;
-                  const childSessionId = randomUUID();
-                  const summary =
-                    typeof suspension.payload?.summary === "string"
-                      ? suspension.payload.summary
-                      : undefined;
-                  const childName = summary?.trim()
-                    ? summary.trim().slice(0, 50)
-                    : `${suspension.appId} design`;
-                  try {
-                    await deps.webchatRepo.createSession(
-                      childSessionId,
-                      childName,
-                      undefined,
-                      sessionProjectName,
-                      null,
-                      sessionProjectPath,
-                      handoffAgentName ?? null,
-                      "webchat_handoff",
-                      // The handback contract rides on the child row, so every
-                      // turn of the child conversation (including after a
-                      // backend restart) re-derives its submit_output tool.
-                      suspension.handback ? JSON.stringify(suspension.handback) : null,
-                    );
-                  } catch (err) {
-                    log.warn("failed to mint handoff child session", {
+              }
+              // Parked suspension: any action that returned a pending_interaction
+              // or handoff result surfaces it on its tool_result. Snapshot a card
+              // keyed by toolUseId so the host renders it and can match the later
+              // interaction_result back to this call. Fail closed on both kinds —
+              // the owning app must actually be installed, and an inline
+              // component must be declared in its app.yaml `components:` list. A
+              // handoff additionally mints a dedicated child session for its
+              // design conversation so it never interleaves with this (parent)
+              // thread.
+              if (msg.type === "tool_result") {
+                const suspension = readSuspensionFromOutput(msg.output);
+                if (suspension && suspension.kind === "inline" && suspension.builtin) {
+                  // Host built-in inline card (the ask_question question-card):
+                  // rendered by rome-web, so there is no owning app to validate.
+                  const card = buildBuiltinQuestionCard(msg, suspension, sessionId);
+                  if (card) {
+                    await persistSuspensionCard(deps.webchatRepo, sessionId, turnId, card);
+                  }
+                } else if (suspension) {
+                  const resolvedApp = deps.appCatalog
+                    ?.listResolved()
+                    .find((a) => a.appId === suspension.appId);
+                  if (!resolvedApp) {
+                    log.warn("rejected suspension: app not installed", {
                       sessionId,
+                      appId: suspension.appId,
+                    });
+                  } else if (
+                    suspension.kind === "inline" &&
+                    !(resolvedApp.manifest.components ?? []).includes(suspension.componentId)
+                  ) {
+                    log.warn("rejected suspension: component not declared by app", {
+                      sessionId,
+                      appId: suspension.appId,
+                      componentId: suspension.componentId,
+                    });
+                  } else if (suspension.kind === "handoff") {
+                    const handoffAgentName = suspension.agentName;
+                    const childSessionId = randomUUID();
+                    const summary =
+                      typeof suspension.payload?.summary === "string"
+                        ? suspension.payload.summary
+                        : undefined;
+                    const childName = summary?.trim()
+                      ? summary.trim().slice(0, 50)
+                      : `${suspension.appId} design`;
+                    try {
+                      await deps.webchatRepo.createSession(
+                        childSessionId,
+                        childName,
+                        undefined,
+                        sessionProjectName,
+                        null,
+                        sessionProjectPath,
+                        handoffAgentName ?? null,
+                        "webchat_handoff",
+                        // The handback contract rides on the child row, so every
+                        // turn of the child conversation (including after a
+                        // backend restart) re-derives its submit_output tool.
+                        suspension.handback ? JSON.stringify(suspension.handback) : null,
+                      );
+                    } catch (err) {
+                      log.warn("failed to mint handoff child session", {
+                        sessionId,
+                        childSessionId,
+                        error: err instanceof Error ? err.message : String(err),
+                      });
+                    }
+                    await persistSuspensionCard(deps.webchatRepo, sessionId, turnId, {
+                      type: "handoff",
+                      toolUseId: msg.toolUseId,
+                      appId: suspension.appId,
+                      agentName: handoffAgentName,
+                      payload: suspension.payload,
                       childSessionId,
-                      error: err instanceof Error ? err.message : String(err),
+                      handbackHint: suspension.handbackHint,
+                    });
+                  } else {
+                    await persistSuspensionCard(deps.webchatRepo, sessionId, turnId, {
+                      type: "pending_interaction",
+                      toolUseId: msg.toolUseId,
+                      appId: suspension.appId,
+                      render: {
+                        kind: "inline",
+                        componentId: suspension.componentId,
+                        props: suspension.props,
+                      },
                     });
                   }
-                  await persistSuspensionCard(deps.webchatRepo, sessionId, turnId, {
-                    type: "handoff",
-                    toolUseId: msg.toolUseId,
-                    appId: suspension.appId,
-                    agentName: handoffAgentName,
-                    payload: suspension.payload,
-                    childSessionId,
-                    handbackHint: suspension.handbackHint,
-                  });
-                } else {
-                  await persistSuspensionCard(deps.webchatRepo, sessionId, turnId, {
-                    type: "pending_interaction",
-                    toolUseId: msg.toolUseId,
-                    appId: suspension.appId,
-                    render: {
-                      kind: "inline",
-                      componentId: suspension.componentId,
-                      props: suspension.props,
-                    },
-                  });
                 }
-              }
-              // Fire-and-forget widget placement: an action that returned
-              // `place_widget` surfaces it on its tool_result. Emit a transient
-              // `widget_placement` event so the live client mounts the widget on
-              // the freegrid (no card, no child session, no parked turn). The
-              // replay key is per-app so a reconnecting client re-mounts it once.
-              // Fail closed: the owning app must actually be installed.
-              const place = readPlaceWidgetFromOutput(msg.output);
-              if (place) {
-                const resolvedApp = deps.appCatalog
-                  ?.listResolved()
-                  .find((a) => a.appId === place.appId);
-                const isHostApp = place.appId === SESSIONS_HOST_APP_ID;
-                if (!resolvedApp && !isHostApp) {
-                  log.warn("rejected place_widget: app not installed", {
-                    sessionId,
-                    appId: place.appId,
-                  });
-                } else {
-                  emitToStream(
-                    stream,
-                    "widget_placement",
-                    {
+                // Fire-and-forget widget placement: an action that returned
+                // `place_widget` surfaces it on its tool_result. Emit a transient
+                // `widget_placement` event so the live client mounts the widget on
+                // the freegrid (no card, no child session, no parked turn). The
+                // replay key is per-app so a reconnecting client re-mounts it once.
+                // Fail closed: the owning app must actually be installed.
+                const place = readPlaceWidgetFromOutput(msg.output);
+                if (place) {
+                  const resolvedApp = deps.appCatalog
+                    ?.listResolved()
+                    .find((a) => a.appId === place.appId);
+                  const isHostApp = place.appId === SESSIONS_HOST_APP_ID;
+                  if (!resolvedApp && !isHostApp) {
+                    log.warn("rejected place_widget: app not installed", {
+                      sessionId,
                       appId: place.appId,
-                      ...(place.route !== undefined ? { route: place.route } : {}),
-                      ...(place.params !== undefined ? { params: place.params } : {}),
-                    },
-                    `widget:${place.appId}`,
-                  );
+                    });
+                  } else {
+                    emitToStream(
+                      stream,
+                      "widget_placement",
+                      {
+                        appId: place.appId,
+                        ...(place.route !== undefined ? { route: place.route } : {}),
+                        ...(place.params !== undefined ? { params: place.params } : {}),
+                      },
+                      `widget:${place.appId}`,
+                    );
+                  }
                 }
               }
             }
-          }
 
-          // Send the agent's reply via webchat channel adapter (guardian path).
-          // In-turn commentary was already persisted per-block as its own live
-          // message; this is the final answer only. `text` is the final answer
-          // for non-webchat consumers; webchat persists the tagged part.
-          if (resultContent && !stream.stopRequested) {
-            await deps.actionEngine.run(
-              "send_message",
-              {
-                channel: "webchat",
-                threadId: sessionId,
-                text: resultContent,
-                parts: [
-                  { type: "text" as const, content: resultContent, turnPhase: "final" as const },
-                ],
-                channelUserId,
-                displayName,
-                replyToMessageId: randomUUID(),
-                turnId,
-              },
-              {
-                initiator: "channel:webchat",
-                channelContext: threadContext,
-              },
-            );
-          }
-
-          // Mirror the auto-approved outgoing-message audit record message_handler creates.
-          if (resultContent && !stream.stopRequested && deps.approvalsRepo) {
-            await deps.approvalsRepo
-              .create({
-                type: "outgoing_message",
-                requestedBy: "main",
-                description: "WebChat guardian send (envoy skipped)",
-                payload: {
-                  response: resultContent,
+            // Send the agent's reply via webchat channel adapter (guardian path).
+            // In-turn commentary was already persisted per-block as its own live
+            // message; this is the final answer only. `text` is the final answer
+            // for non-webchat consumers; webchat persists the tagged part.
+            if (resultContent && !stream.stopRequested) {
+              await deps.actionEngine.run(
+                "send_message",
+                {
                   channel: "webchat",
                   threadId: sessionId,
+                  text: resultContent,
+                  parts: [
+                    { type: "text" as const, content: resultContent, turnPhase: "final" as const },
+                  ],
                   channelUserId,
-                },
-                status: "auto_approved",
-              })
-              .catch((err) => {
-                log.warn("failed to record auto-approved outgoing message", {
-                  sessionId,
+                  displayName,
+                  replyToMessageId: randomUUID(),
                   turnId,
-                  error: err instanceof Error ? err.message : String(err),
+                },
+                {
+                  initiator: "channel:webchat",
+                  channelContext: threadContext,
+                },
+              );
+            }
+
+            // Mirror the auto-approved outgoing-message audit record message_handler creates.
+            if (resultContent && !stream.stopRequested && deps.approvalsRepo) {
+              await deps.approvalsRepo
+                .create({
+                  type: "outgoing_message",
+                  requestedBy: "main",
+                  description: "WebChat guardian send (envoy skipped)",
+                  payload: {
+                    response: resultContent,
+                    channel: "webchat",
+                    threadId: sessionId,
+                    channelUserId,
+                  },
+                  status: "auto_approved",
+                })
+                .catch((err) => {
+                  log.warn("failed to record auto-approved outgoing message", {
+                    sessionId,
+                    turnId,
+                    error: err instanceof Error ? err.message : String(err),
+                  });
                 });
-              });
+            }
+
+            return {
+              success: !resultError,
+              data: { action: stream.stopRequested ? "stopped" : "sent" },
+              error: resultError?.error,
+              code: resultError?.code,
+              provider: resultError?.provider,
+              reason: resultError?.reason,
+            };
+          } finally {
+            unsubscribeStatus();
           }
+        }),
+      );
 
-          return {
-            success: !resultError,
-            data: { action: stream.stopRequested ? "stopped" : "sent" },
-            error: resultError?.error,
-            code: resultError?.code,
-            provider: resultError?.provider,
-            reason: resultError?.reason,
-          };
-        } finally {
-          unsubscribeStatus();
-        }
-      }),
-    );
+      return stream;
+    };
 
+    let started: ReturnType<typeof attachTurn> | undefined;
+    const options = {
+      links: turnLinks,
+      threadContext,
+      romeSessionId: sessionId,
+      romeSessionType: session.type as RomeSessionType,
+      onTurn: (handle: AgentTurnHandle) => {
+        started = attachTurn(handle);
+        void started.catch((error) =>
+          log.error("failed to attach input turn", {
+            turnId: handle.turnId,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+      },
+      onInputStatus: async (status: import("@rome-os/app-runtime").InputStatusMessage) => {
+        await deps.webchatRepo.updateUserInput(sessionId, status);
+        const stream = status.turnId ? streamsByTurnId.get(status.turnId) : undefined;
+        if (stream) emitToStream(stream, "input_status", status, `input:${status.inputId}`);
+      },
+    };
+    const input = { inputId, prompt: promptText, reasoningEffort };
+    let receipt;
+    if (agentSess.submitInput) {
+      receipt = agentSess.submitInput(input, options);
+    } else {
+      const handle = agentSess.sendTurn(input, options);
+      options.onTurn(handle);
+      await options.onInputStatus({
+        type: "input_status",
+        inputId,
+        turnId: handle.turnId,
+        state: "submitted",
+      });
+      receipt = { inputId, turnId: handle.turnId, disposition: "started" as const };
+    }
+    const stream = started ? await started : streamsByTurnId.get(receipt.turnId);
     return c.json({
-      turnId,
+      ...receipt,
       sessionId,
-      startedAt: stream.startedAt,
+      startedAt: stream?.startedAt ?? new Date().toISOString(),
     });
   };
 
-  // Canonical resource-shaped endpoint. Returns JSON
-  // `{ turnId, sessionId, startedAt }` synchronously; the SSE stream lives
-  // at GET /chat/turns/:turnId/stream.
   app.post("/chat/sessions/:id/turns", async (c) => {
     const body = await parseChatSendBody(c);
-    return handleChatSend(c, c.req.param("id"), body);
+    const id = c.req.param("id");
+    return handleChatSend(c, id, body);
   });
 
   const runEnqueuedTask = async (
@@ -3488,7 +3532,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     const builtinQuestionCards: PendingInteractionPart[] = [];
     const emit = (msg: AgentMessage & { agent?: string }) => {
       // Backend turns have no live bubble; drop transient text previews.
-      if (msg.type === "text_delta") return;
+      if (msg.type === "text_delta" || msg.type === "input_status") return;
       stream.traceBlocks.push(msg);
       emitTraceBlock(stream, msg);
       if (msg.type === "result") replyText = msg.content;

--- a/packages/core/src/channels/webchat.test.ts
+++ b/packages/core/src/channels/webchat.test.ts
@@ -168,4 +168,37 @@ describe("WebChatAdapter", () => {
 
     await expect(adapter.fetchHistory("sess-1", Number.NaN)).resolves.toHaveLength(1);
   });
+
+  it("persists the WebChat text-block identity in transcript content", async () => {
+    await repo.createSession("sess-block", "Block identity");
+
+    await adapter.sendMessage("guardian", "sess-block", {
+      text: "Final answer",
+      parts: [
+        {
+          type: "text",
+          content: "Final answer",
+          turnPhase: "final",
+          blockIx: 2,
+        },
+      ],
+      turnId: "turn-block",
+    });
+
+    const messages = await repo.getMessages("sess-block");
+    expect(messages).toEqual([
+      expect.objectContaining({
+        turnId: "turn-block",
+        role: "assistant",
+        content: JSON.stringify([
+          {
+            type: "text",
+            content: "Final answer",
+            turnPhase: "final",
+            blockIx: 2,
+          },
+        ]),
+      }),
+    ]);
+  });
 });

--- a/packages/core/src/core/agent-input-queue.test.ts
+++ b/packages/core/src/core/agent-input-queue.test.ts
@@ -1,0 +1,138 @@
+import { context } from "@opentelemetry/api";
+import { describe, expect, it, vi } from "vitest";
+import type { InputStatusMessage } from "@rome-os/app-runtime";
+import type { AgentTurnHandle, AgentTurnInput } from "./agent-session.js";
+import type { ModelSession } from "./agent-runner.js";
+import { AgentInputQueue } from "./agent-input-queue.js";
+
+const tick = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+function setup(steer = vi.fn<ModelSession["steerUserInput"] & {}>().mockResolvedValue("accepted")) {
+  const started: AgentTurnInput[] = [];
+  const statuses: InputStatusMessage[] = [];
+  const handles: AgentTurnHandle[] = [];
+  const errors = vi.fn();
+  const queue = new AgentInputQueue(
+    (input) => {
+      started.push(input);
+      return {
+        turnId: `turn-${started.length}`,
+        events: { async *[Symbol.asyncIterator]() {} },
+        turnContext: context.active(),
+        getSubmittedOutput: () => undefined,
+      };
+    },
+    () => ({ steerUserInput: steer }),
+    errors,
+  );
+  const submit = (inputId: string) =>
+    queue.submit(
+      { inputId, prompt: inputId },
+      {
+        onTurn: (handle) => handles.push(handle),
+        onInputStatus: (status) => {
+          statuses.push(status);
+        },
+      },
+    );
+  return { queue, submit, started, statuses, handles, steer, errors };
+}
+
+describe("conversational input lane", () => {
+  it("reserves one turn before async startup, then steers in submission order", async () => {
+    const s = setup();
+    const a = s.submit("a");
+    const b = s.submit("b");
+    s.submit("c");
+    expect(b.turnId).toBe(a.turnId);
+    expect(s.started).toHaveLength(1);
+    expect(s.steer).not.toHaveBeenCalled();
+    await s.queue.beforeSend(a.turnId);
+    s.queue.ready(a.turnId);
+    await tick();
+    expect(s.steer.mock.calls.map(([input]) => input.inputId)).toEqual(["b"]);
+    await s.queue.observe({ type: "input_status", inputId: "b", state: "consumed" }, a.turnId);
+    await tick();
+    expect(s.steer.mock.calls.map(([input]) => input.inputId)).toEqual(["b", "c"]);
+    expect(s.handles).toHaveLength(1);
+  });
+
+  it("adopts a provider-retained late input under a new turn and the same input id", async () => {
+    const s = setup();
+    s.submit("a");
+    s.queue.ready("turn-1");
+    s.submit("b");
+    await tick();
+    await s.queue.observe({ type: "input_status", inputId: "b", state: "queued" }, "turn-1");
+    await s.queue.seal("turn-1");
+    s.queue.finish("turn-1");
+    expect(s.started.map((input) => input.inputId)).toEqual(["a", "b"]);
+    expect(s.handles.map((handle) => handle.turnId)).toEqual(["turn-1", "turn-2"]);
+    await tick();
+    expect(s.statuses.at(-1)).toMatchObject({ inputId: "b", turnId: "turn-2", state: "queued" });
+  });
+
+  it("does not replay an accepted but unconfirmed input at the terminal boundary", async () => {
+    const s = setup();
+    s.submit("a");
+    s.queue.ready("turn-1");
+    s.submit("b");
+    await tick();
+    await s.queue.seal("turn-1");
+    s.queue.finish("turn-1");
+    await tick();
+    expect(s.started).toHaveLength(1);
+    expect(s.statuses.filter((status) => status.inputId === "b").at(-1)).toMatchObject({
+      inputId: "b",
+      state: "unknown",
+    });
+  });
+
+  it("falls back only on definite rejection, including rejection racing completion", async () => {
+    let reject!: (value: "deferred") => void;
+    const s = setup(
+      vi.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            reject = resolve;
+          }),
+      ),
+    );
+    s.submit("a");
+    s.queue.ready("turn-1");
+    s.submit("b");
+    s.submit("c");
+    await tick();
+    const seal = s.queue.seal("turn-1");
+    reject("deferred");
+    await seal;
+    s.queue.finish("turn-1");
+    expect(s.started.map((input) => input.inputId)).toEqual(["a", "b"]);
+  });
+
+  it("does not replay a transport failure whose delivery is unknown", async () => {
+    const s = setup(vi.fn().mockRejectedValue(new Error("timeout")));
+    s.submit("a");
+    s.queue.ready("turn-1");
+    s.submit("b");
+    await tick();
+    await s.queue.seal("turn-1");
+    s.queue.finish("turn-1");
+    expect(s.started).toHaveLength(1);
+    expect(s.errors).toHaveBeenCalledOnce();
+    expect(s.statuses.at(-1)).toMatchObject({ inputId: "b", state: "unknown" });
+  });
+
+  it("deduplicates repeated submissions and closes without launching queued work", async () => {
+    const s = setup();
+    s.submit("a");
+    s.submit("a");
+    s.submit("b");
+    s.queue.close();
+    s.queue.finish("turn-1");
+    await tick();
+    expect(s.started).toHaveLength(1);
+    expect(s.statuses.at(-1)).toMatchObject({ inputId: "b", state: "cancelled" });
+    expect(() => s.submit("c")).toThrow("closed");
+  });
+});

--- a/packages/core/src/core/agent-input-queue.ts
+++ b/packages/core/src/core/agent-input-queue.ts
@@ -1,0 +1,222 @@
+import type { AgentInputState, InputStatusMessage } from "@rome-os/app-runtime";
+import type { AgentTurnHandle, AgentTurnInput, SendTurnOptions } from "./agent-session.js";
+import type { ModelSession } from "./agent-runner.js";
+
+export interface SubmitInputOptions extends SendTurnOptions {
+  /** Called once per actual run, including a late input's follow-up run. */
+  onTurn(handle: AgentTurnHandle): void;
+  onInputStatus?(status: InputStatusMessage): Promise<void> | void;
+}
+
+export interface AgentInputReceipt {
+  inputId: string;
+  turnId: string;
+  disposition: "started" | "queued" | "steering";
+}
+
+interface Entry {
+  input: AgentTurnInput & { inputId: string };
+  options: SubmitInputOptions;
+  state: AgentInputState;
+  turnId: string;
+  writes: Promise<void>;
+}
+
+interface ActiveInputTurn {
+  handle: AgentTurnHandle;
+  first: Entry;
+  ready: boolean;
+  pending?: Entry;
+  sealed: boolean;
+  dispatch?: Promise<void>;
+}
+
+/** Chat's input lane is separate from the one-result-per-caller task FIFO. */
+export class AgentInputQueue {
+  private active?: ActiveInputTurn;
+  private queued: Entry[] = [];
+  private entries = new Map<string, Entry>();
+  private closed = false;
+
+  constructor(
+    private readonly startTurn: (
+      input: AgentTurnInput,
+      options: SendTurnOptions,
+    ) => AgentTurnHandle,
+    private readonly provider: () => Pick<ModelSession, "steerUserInput">,
+    private readonly reportError: (error: unknown) => void,
+  ) {}
+
+  get busy(): boolean {
+    return !!this.active || this.queued.length > 0;
+  }
+
+  submit(
+    input: AgentTurnInput & { inputId: string },
+    options: SubmitInputOptions,
+  ): AgentInputReceipt {
+    if (this.closed) throw new Error("Input queue is closed");
+    const existing = this.entries.get(input.inputId);
+    if (existing) return { inputId: input.inputId, turnId: existing.turnId, disposition: "queued" };
+    const entry: Entry = { input, options, state: "queued", turnId: "", writes: Promise.resolve() };
+    this.entries.set(input.inputId, entry);
+    if (!this.active) {
+      this.start(entry);
+      return { inputId: input.inputId, turnId: entry.turnId, disposition: "started" };
+    }
+    entry.turnId = this.active.handle.turnId;
+    this.queued.push(entry);
+    void this.update(entry, "queued").catch(this.reportError);
+    const disposition = this.active.ready && !this.active.sealed ? "steering" : "queued";
+    this.flush();
+    return { inputId: input.inputId, turnId: entry.turnId, disposition };
+  }
+
+  private start(entry: Entry): void {
+    const handle = this.startTurn(entry.input, entry.options);
+    entry.turnId = handle.turnId;
+    this.active = { handle, first: entry, ready: false, sealed: false };
+    void this.update(entry, "queued").catch(this.reportError);
+    entry.options.onTurn(handle);
+  }
+
+  async beforeSend(turnId: string): Promise<void> {
+    const active = this.active;
+    if (active?.handle.turnId === turnId) await this.update(active.first, "submitted");
+  }
+
+  ready(turnId: string): void {
+    if (this.active?.handle.turnId !== turnId) return;
+    this.active.ready = true;
+    this.flush();
+  }
+
+  async observe(event: InputStatusMessage, turnId: string): Promise<void> {
+    const entry = this.entries.get(event.inputId);
+    if (!entry) return;
+    entry.turnId = turnId;
+    await this.update(entry, event.state);
+    const active = this.active;
+    if (active?.handle.turnId !== turnId) return;
+    if (event.state === "queued") {
+      // The provider retained this input across its native turn boundary.
+      // sendUserInput(inputId) will adopt it, never enqueue a second copy.
+      active.sealed = true;
+      if (!this.queued.includes(entry)) this.queued.unshift(entry);
+      if (active.pending === entry) active.pending = undefined;
+    } else if (event.state === "consumed" && active.pending === entry) {
+      active.pending = undefined;
+      this.flush();
+    }
+  }
+
+  private flush(): void {
+    const active = this.active;
+    const provider = this.provider();
+    if (!active?.ready || active.pending || active.sealed || !provider.steerUserInput) return;
+    const entry = this.queued.shift();
+    if (!entry) return;
+    active.pending = entry;
+    entry.turnId = active.handle.turnId;
+    active.dispatch = (async () => {
+      try {
+        // Persist the dispatch boundary before a provider can observe input.
+        await this.update(entry, "submitted");
+        if (this.active !== active || active.sealed) {
+          if (entry.state !== "cancelled") {
+            this.queued.unshift(entry);
+            await this.update(entry, "queued");
+            this.startNext();
+          }
+          return;
+        }
+        const result = await provider.steerUserInput!({
+          inputId: entry.input.inputId,
+          text: entry.input.prompt,
+          images: entry.input.images,
+          reasoningEffort: entry.input.reasoningEffort,
+        });
+        if (entry.state === "consumed" || entry.state === "cancelled" || entry.state === "queued")
+          return;
+        if (result === "deferred") {
+          active.sealed = true;
+          active.pending = undefined;
+          this.queued.unshift(entry);
+          await this.update(entry, "queued");
+          if (this.active !== active && !this.active && !this.closed) this.startNext();
+        } else {
+          await this.update(entry, "accepted");
+        }
+      } catch (error) {
+        // A timeout may have happened after acceptance. Never auto-replay it.
+        if (entry.state !== "consumed" && entry.state !== "cancelled")
+          await this.update(entry, "unknown");
+        this.reportError(error);
+      }
+    })().catch(this.reportError);
+  }
+
+  async seal(turnId: string): Promise<void> {
+    const active = this.active;
+    if (active?.handle.turnId !== turnId) return;
+    active.sealed = true;
+    await active.dispatch;
+  }
+
+  finish(turnId: string): void {
+    const active = this.active;
+    if (active?.handle.turnId !== turnId) return;
+    active.sealed = true;
+    this.active = undefined;
+    for (const entry of [active.first, active.pending]) {
+      if (entry && (entry.state === "accepted" || entry.state === "submitted")) {
+        void this.update(entry, "unknown").catch(this.reportError);
+      }
+    }
+    if (active.first.state === "queued" && !this.queued.includes(active.first)) {
+      void this.update(active.first, "failed").catch(this.reportError);
+    }
+    this.startNext();
+    // Retain a bounded deduplication window; durable identities live in the repository.
+    if (this.entries.size > 256) {
+      for (const [id, entry] of this.entries) {
+        if (["consumed", "unknown", "failed", "cancelled"].includes(entry.state))
+          this.entries.delete(id);
+        if (this.entries.size <= 256) break;
+      }
+    }
+  }
+
+  private startNext(): void {
+    if (this.active || this.closed) return;
+    const next = this.queued.shift();
+    if (next) this.start(next);
+  }
+
+  cancel(turnId: string): void {
+    const active = this.active;
+    if (active?.handle.turnId !== turnId) return;
+    active.sealed = true;
+    for (const entry of [active.pending, ...this.queued]) {
+      if (entry) void this.update(entry, "cancelled").catch(this.reportError);
+    }
+    this.queued = [];
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.active) this.cancel(this.active.handle.turnId);
+  }
+
+  private update(entry: Entry, state: AgentInputState): Promise<void> {
+    entry.state = state;
+    const event: InputStatusMessage = {
+      type: "input_status",
+      inputId: entry.input.inputId,
+      turnId: entry.turnId,
+      state,
+    };
+    entry.writes = entry.writes.then(() => entry.options.onInputStatus?.(event));
+    return entry.writes;
+  }
+}

--- a/packages/core/src/core/agent-runner.ts
+++ b/packages/core/src/core/agent-runner.ts
@@ -203,6 +203,8 @@ export interface ModelSessionParams {
 }
 
 export interface ModelUserInput {
+  /** Stable identity of an independently submitted conversational input. */
+  inputId?: string;
   text: string;
   /** Absolute local paths of images attached to the turn (providers without image-input support ignore them). */
   images?: string[];
@@ -269,6 +271,9 @@ export interface ModelSession {
 
   /** Push a new user turn. Resolves once the provider accepts it. */
   sendUserInput(input: ModelUserInput): Promise<void>;
+
+  /** Append without interrupting. Only `deferred` is safe to submit again. */
+  steerUserInput?(input: ModelUserInput): Promise<"accepted" | "deferred">;
 
   /** Create an isolated provider-owned branch from this live session. */
   fork(params: ModelSessionForkParams): Promise<ModelSessionFork>;

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -2,6 +2,11 @@
 
 import { createHash } from "node:crypto";
 import { Mutex } from "async-mutex";
+import {
+  AgentInputQueue,
+  type AgentInputReceipt,
+  type SubmitInputOptions,
+} from "./agent-input-queue.js";
 import { v4 as uuidv4 } from "uuid";
 import type { AgentLoader } from "./agent-loader.js";
 import type { AppCatalog } from "../apps/catalog.js";
@@ -222,6 +227,7 @@ export interface AgentSessionInit {
 }
 
 export interface AgentTurnInput {
+  inputId?: string;
   prompt: string;
   /** Absolute local paths of images attached to the turn (providers without image-input support ignore them). */
   images?: string[];
@@ -311,10 +317,14 @@ export interface AgentSession {
    * turn actually begins running turn-lock semantics).
    */
   sendTurn(input: AgentTurnInput, options?: SendTurnOptions): AgentTurnHandle;
+  submitInput?(
+    input: AgentTurnInput & { inputId: string },
+    options: SubmitInputOptions,
+  ): AgentInputReceipt;
   runForkedTurn?(input: ForkedAgentTurnInput): AsyncIterable<StreamAgentMessage>;
   subscribe(handler: AgentSessionSubscriber): () => void;
   onStatusChange(listener: AgentSessionStatusListener): () => void;
-  interrupt(reason?: string): Promise<void>;
+  interrupt(reason?: string, expectedTurnId?: string): Promise<void>;
   close(reason: "idle" | "shutdown" | "error" | "user"): Promise<void>;
   /**
    * Read the structured payload that the agent submitted via `submit_output`
@@ -1859,6 +1869,15 @@ class AgentSessionImpl implements AgentSession {
   private toolCount: number;
   private subagentToolNames: Set<string>;
   private readonly turnMutex = new Mutex();
+  private readonly inputs = new AgentInputQueue(
+    (input, options) => this.sendTurn(input, options),
+    () => this.modelSession,
+    (error) =>
+      log.warn("conversational input dispatch failed", {
+        sessionId: this.sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+  );
   private keepAlive: boolean;
   private onClosed: () => void;
   private closingPromise?: Promise<void>;
@@ -1918,7 +1937,12 @@ class AgentSessionImpl implements AgentSession {
   }
 
   get isQuiescentForRotation(): boolean {
-    return this.status === "idle" && !this.turnMutex.isLocked() && !this.hasActiveForkedTurns;
+    return (
+      this.status === "idle" &&
+      !this.turnMutex.isLocked() &&
+      !this.hasActiveForkedTurns &&
+      !this.inputs.busy
+    );
   }
 
   get childManager(): AgentSessionManager {
@@ -2008,6 +2032,12 @@ class AgentSessionImpl implements AgentSession {
           });
           continue;
         }
+        if (msg.type === "input_status") {
+          await this.inputs.observe(msg, sink.turnId);
+          this.publishOutbound(sink, { ...msg, turnId: sink.turnId });
+          continue;
+        }
+        if (msg.type === "result" || msg.type === "error") await this.inputs.seal(sink.turnId);
         // Time-to-first-token: the first *text* event of the turn (a text_delta
         // preview or a completed text block) marks when the model started
         // producing visible output. Gate strictly to text — thinking/tool_use
@@ -2139,6 +2169,7 @@ class AgentSessionImpl implements AgentSession {
       });
     } finally {
       if (this.replacingModelSession === session || this.modelSession !== session) return;
+      this.inputs.close();
       const sink = this.currentSink;
       if (sink && !sink.done) {
         this.failTurn(sink, "session closed mid-turn");
@@ -2413,6 +2444,7 @@ class AgentSessionImpl implements AgentSession {
     this.status = "idle";
     this.currentTurnId = undefined;
     this.emitStatus();
+    this.inputs.finish(sink.turnId);
   }
 
   private clearSubagentLinks(sink: TurnSink): void {
@@ -2803,6 +2835,14 @@ class AgentSessionImpl implements AgentSession {
 
   // sendTurn — FIFO-serialized via turnMutex
 
+  submitInput(
+    input: AgentTurnInput & { inputId: string },
+    options: SubmitInputOptions,
+  ): AgentInputReceipt {
+    if (this.status === "closed") throw new Error(`AgentSession ${this.sessionId} is closed`);
+    return this.inputs.submit(input, options);
+  }
+
   sendTurn(input: AgentTurnInput, options?: SendTurnOptions): AgentTurnHandle {
     if (this.status === "closed") {
       throw new Error(`AgentSession ${this.sessionId} is closed`);
@@ -2887,29 +2927,32 @@ class AgentSessionImpl implements AgentSession {
     // swallows its own failures, so `runExclusive` never rejects here — the
     // fire-and-forget promise is intentionally discarded.
     void this.turnMutex
-      .runExclusive(async () => {
-        try {
-          await context.with(turnCtx, () => this.runOneTurn(turnId, input, sink, turnCtx));
-        } catch (err) {
-          // Safety net: if runOneTurn threw before reaching its own finally
-          // (e.g. synchronous failure before the modelSession call), the
-          // agent span may still be open. End it so the trace closes.
-          if (!span.isRecording || span.isRecording()) {
-            span.setStatus({
-              code: SpanStatusCode.ERROR,
-              message: err instanceof Error ? err.message : String(err),
-            });
-            if (err instanceof Error) span.recordException(err);
-            span.end();
+      .runExclusive(
+        async () => {
+          try {
+            await context.with(turnCtx, () => this.runOneTurn(turnId, input, sink, turnCtx));
+          } catch (err) {
+            // Safety net: if runOneTurn threw before reaching its own finally
+            // (e.g. synchronous failure before the modelSession call), the
+            // agent span may still be open. End it so the trace closes.
+            if (!span.isRecording || span.isRecording()) {
+              span.setStatus({
+                code: SpanStatusCode.ERROR,
+                message: err instanceof Error ? err.message : String(err),
+              });
+              if (err instanceof Error) span.recordException(err);
+              span.end();
+            }
+            // Surface failure on the sink so consumers' for-await ends cleanly.
+            this.failTurn(
+              sink,
+              toModelResolutionErrorPayload(err) ??
+                (err instanceof Error ? err.message : String(err)),
+            );
           }
-          // Surface failure on the sink so consumers' for-await ends cleanly.
-          this.failTurn(
-            sink,
-            toModelResolutionErrorPayload(err) ??
-              (err instanceof Error ? err.message : String(err)),
-          );
-        }
-      })
+        },
+        input.inputId ? 1 : 0,
+      )
       .finally(() => this.emitStatus());
 
     return {
@@ -3045,6 +3088,7 @@ class AgentSessionImpl implements AgentSession {
       // pipeline can't tell them apart.
       const mwInput = { prompt: userPrompt, reasoningEffort: input.reasoningEffort };
       let emittedTerminal: ResultMessage | ErrorMessage | undefined;
+      let modelRan = false;
       const mwCtx: TurnMiddlewareContext = {
         input: mwInput,
         session: {
@@ -3063,14 +3107,18 @@ class AgentSessionImpl implements AgentSession {
       };
 
       const runModelTerminal = async (): Promise<void> => {
+        modelRan = true;
         try {
           await context.with(turnCtx, async () => {
+            await this.inputs.beforeSend(turnId);
             await this.modelSession.sendUserInput({
+              inputId: input.inputId,
               text: mwInput.prompt,
               images: input.images,
               reasoningEffort: mwInput.reasoningEffort,
               injectedToolResult: input.injectedToolResult,
             });
+            this.inputs.ready(turnId);
             if (this.deps.webchatRepo && pendingConversationMessageIds.length > 0) {
               try {
                 await this.deps.webchatRepo.markConversationContextInjected(
@@ -3114,6 +3162,16 @@ class AgentSessionImpl implements AgentSession {
       }
 
       if (!sink.done) {
+        if (!modelRan && input.inputId) {
+          await this.inputs.observe(
+            {
+              type: "input_status",
+              inputId: input.inputId,
+              state: emittedTerminal?.type === "error" ? "failed" : "consumed",
+            },
+            turnId,
+          );
+        }
         this.finalizeTurn(sink, emittedTerminal ?? { type: "result", content: "" });
       }
 
@@ -3210,21 +3268,22 @@ class AgentSessionImpl implements AgentSession {
     }
   }
 
-  async interrupt(reason?: string): Promise<void> {
-    if (this.currentSink && !this.currentSink.done) {
-      this.currentSink.lifecycleInterrupted = true;
-      await Promise.allSettled(
-        [...this.currentSink.subagentExecutions.values()].map(({ execution }) =>
-          execution.interrupt(reason),
-        ),
-      );
-    }
-    await this.modelSession.interrupt(reason);
+  async interrupt(reason?: string, expectedTurnId?: string): Promise<void> {
+    const sink = this.currentSink;
+    if (!sink || sink.done || (expectedTurnId && sink.turnId !== expectedTurnId)) return;
+    sink.lifecycleInterrupted = true;
+    // Capture the provider target before awaiting child interruption: the
+    // current turn may finish and another turn may start during that await.
+    await Promise.allSettled([
+      this.modelSession.interrupt(reason),
+      ...[...sink.subagentExecutions.values()].map(({ execution }) => execution.interrupt(reason)),
+    ]);
   }
 
   async close(reason: "idle" | "shutdown" | "error" | "user"): Promise<void> {
     if (this.closingPromise) return await this.closingPromise;
     if (this.status === "closed") return;
+    this.inputs.close();
     this.closingPromise = (async () => {
       log.info("agent session closing", {
         sessionId: this.sessionId,

--- a/packages/core/src/core/agent-trace-recorder.ts
+++ b/packages/core/src/core/agent-trace-recorder.ts
@@ -93,7 +93,7 @@ export class AgentTraceRecorder {
     startSeq = this.seq,
   ): Promise<void> {
     const blocks = messages.flatMap((msg) =>
-      msg.type === "text_delta"
+      msg.type === "text_delta" || msg.type === "input_status"
         ? []
         : [toTraceBlock(msg as TraceableAgentMessage & { agent?: string })],
     );

--- a/packages/core/src/core/anthropic-provider.test.ts
+++ b/packages/core/src/core/anthropic-provider.test.ts
@@ -122,6 +122,73 @@ function buildForkOpenParams(
 }
 
 describe("AnthropicProvider", () => {
+  it("adopts a late SDK-queued input exactly once and gates the next native loop", async () => {
+    const a = "00000000-0000-4000-8000-000000000001";
+    const b = "00000000-0000-4000-8000-000000000002";
+    const prompts: { uuid: string; priority: string }[] = [];
+    let enteredSecondLoop = false;
+    queryMock.mockImplementation(({ prompt, options }) => ({
+      async *[Symbol.asyncIterator]() {
+        const inputs = prompt[Symbol.asyncIterator]();
+        const hook = options.hooks.UserPromptSubmit[0].hooks[0];
+        const first = (await inputs.next()).value;
+        prompts.push(first);
+        await hook({}, undefined, { signal: new AbortController().signal });
+        yield { ...first, isReplay: true };
+        const second = (await inputs.next()).value;
+        prompts.push(second);
+        yield { type: "result", subtype: "success", result: "first", num_turns: 1 };
+        await hook({}, undefined, { signal: new AbortController().signal });
+        enteredSecondLoop = true;
+        yield { ...second, isReplay: true };
+        yield { type: "result", subtype: "success", result: "second", num_turns: 1 };
+      },
+      close: vi.fn(),
+    }));
+    const session = await new AnthropicProvider().openSession(buildParams());
+    const events = session.events[Symbol.asyncIterator]();
+    await session.sendUserInput({ text: "first", inputId: a });
+    expect((await events.next()).value).toMatchObject({ inputId: a, state: "consumed" });
+    expect(await session.steerUserInput!({ text: "second", inputId: b })).toBe("accepted");
+    expect((await events.next()).value).toMatchObject({ inputId: b, state: "queued" });
+    expect((await events.next()).value).toMatchObject({ type: "result", content: "first" });
+    const next = events.next();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(enteredSecondLoop).toBe(false);
+    await session.sendUserInput({ text: "second", inputId: b });
+    expect((await next).value).toMatchObject({ inputId: b, state: "consumed" });
+    expect(prompts.map((input) => input.uuid)).toEqual([a, b]);
+    expect(prompts.map((input) => input.priority)).toEqual(["next", "next"]);
+    expect((await events.next()).value).toMatchObject({ type: "result", content: "second" });
+    await session.close();
+  });
+
+  it("marks a boundary-consumed steer without creating another native turn", async () => {
+    const a = "00000000-0000-4000-8000-000000000001";
+    const b = "00000000-0000-4000-8000-000000000002";
+    queryMock.mockImplementation(({ prompt, options }) => ({
+      async *[Symbol.asyncIterator]() {
+        const inputs = prompt[Symbol.asyncIterator]();
+        const first = (await inputs.next()).value;
+        await options.hooks.UserPromptSubmit[0].hooks[0]({}, undefined, {
+          signal: new AbortController().signal,
+        });
+        yield { ...first, isReplay: true };
+        yield { ...(await inputs.next()).value, isReplay: true };
+        yield { type: "result", subtype: "success", result: "both", num_turns: 2 };
+      },
+      close: vi.fn(),
+    }));
+    const session = await new AnthropicProvider().openSession(buildParams());
+    const events = session.events[Symbol.asyncIterator]();
+    await session.sendUserInput({ text: "first", inputId: a });
+    await events.next();
+    await session.steerUserInput!({ text: "second", inputId: b });
+    expect((await events.next()).value).toMatchObject({ inputId: b, state: "consumed" });
+    expect((await events.next()).value).toMatchObject({ type: "result", content: "both" });
+    await session.close();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     markAnthropicAuthRevokedMock.mockResolvedValue(undefined);

--- a/packages/core/src/core/anthropic-provider.ts
+++ b/packages/core/src/core/anthropic-provider.ts
@@ -474,6 +474,16 @@ export class AnthropicProvider implements ModelProvider {
 
     const inputQueue = new AsyncMessageQueue<SDKUserMessage>();
     const { sessionId } = params;
+    const pendingSteers = new Set<string>();
+    const deferredInputs = new Set<string>();
+    let promptPermits = 0;
+    let releasePrompt: (() => void) | undefined;
+    let gateClosed = false;
+    const permitPrompt = () => {
+      promptPermits++;
+      releasePrompt?.();
+      releasePrompt = undefined;
+    };
 
     const q = query({
       prompt: inputQueue.iter(),
@@ -489,6 +499,33 @@ export class AnthropicProvider implements ModelProvider {
         // Surface raw API stream events so the events loop below can yield
         // `text_delta` previews while a text block is still being generated.
         includePartialMessages: true,
+        extraArgs: { "replay-user-messages": null },
+        hooks: {
+          UserPromptSubmit: [
+            {
+              timeout: 600,
+              hooks: [
+                async (_input, _toolUseId, { signal }) => {
+                  // Same-loop steering skips this hook. A late SDK-queued input
+                  // starts a new loop, which must wait for Rome's next turn owner.
+                  while (!promptPermits && !gateClosed && !signal.aborted) {
+                    await new Promise<void>((resolve) => {
+                      const wake = () => {
+                        signal.removeEventListener("abort", wake);
+                        resolve();
+                      };
+                      releasePrompt = wake;
+                      signal.addEventListener("abort", wake, { once: true });
+                    });
+                  }
+                  if (gateClosed || signal.aborted) return { continue: false };
+                  promptPermits--;
+                  return {};
+                },
+              ],
+            },
+          ],
+        },
         permissionMode: "bypassPermissions",
         allowDangerouslySkipPermissions: true,
         settingSources: ["project"],
@@ -626,10 +663,22 @@ export class AnthropicProvider implements ModelProvider {
               }
             }
           } else if (isUserMessage(message)) {
+            if ("isReplay" in message && message.isReplay && message.uuid) {
+              pendingSteers.delete(message.uuid);
+              yield { type: "input_status", inputId: message.uuid, state: "consumed" };
+            }
             for (const toolResult of extractToolResultMessages(message, toolUseNames)) {
               yield toolResult;
             }
           } else if (isResultMessage(message)) {
+            running = false;
+            // The SDK owns these queued messages already. Rebind them to a
+            // new Rome turn before allowing its next UserPromptSubmit hook.
+            for (const inputId of pendingSteers) {
+              deferredInputs.add(inputId);
+              yield { type: "input_status", inputId, state: "queued" };
+            }
+            pendingSteers.clear();
             // The turn is ending: any text still held was the closing answer.
             if (pendingText !== null) {
               yield { type: "text", content: pendingText, turnPhase: "final" };
@@ -763,6 +812,10 @@ export class AnthropicProvider implements ModelProvider {
         if (closed) {
           throw new Error("ModelSession is closed");
         }
+        activeTurnLastAssistantMessageId = undefined;
+        running = true;
+        permitPrompt();
+        if (input.inputId && deferredInputs.delete(input.inputId)) return;
         const content: NonNullable<SDKUserMessage["message"]["content"]> = [];
         if (input.injectedToolResult) {
           content.push({
@@ -780,6 +833,8 @@ export class AnthropicProvider implements ModelProvider {
         }
         const sdkMsg: SDKUserMessage = {
           type: "user",
+          ...(input.inputId ? { uuid: input.inputId as SDKUserMessage["uuid"] } : {}),
+          priority: "next",
           parent_tool_use_id: null,
           session_id: sessionId,
           message: {
@@ -788,6 +843,22 @@ export class AnthropicProvider implements ModelProvider {
           },
         };
         inputQueue.push(sdkMsg);
+      },
+      async steerUserInput(input: ModelUserInput): Promise<"accepted" | "deferred"> {
+        if (closed) throw new Error("ModelSession is closed");
+        if (!running || !input.inputId || input.injectedToolResult) return "deferred";
+        if (input.reasoningEffort && toAnthropicEffort(input.reasoningEffort) !== effort)
+          return "deferred";
+        pendingSteers.add(input.inputId);
+        inputQueue.push({
+          type: "user",
+          uuid: input.inputId as SDKUserMessage["uuid"],
+          priority: "next",
+          parent_tool_use_id: null,
+          session_id: sessionId,
+          message: { role: "user", content: [{ type: "text", text: input.text }] },
+        });
+        return "accepted";
       },
       async fork(forkParams: ModelSessionForkParams): Promise<ModelSessionFork> {
         if (closed) throw new Error("Cannot fork a closed ModelSession");
@@ -840,6 +911,8 @@ export class AnthropicProvider implements ModelProvider {
       async close(): Promise<void> {
         if (queryDisposed) return;
         queryDisposed = true;
+        gateClosed = true;
+        releasePrompt?.();
         try {
           inputQueue.end();
         } catch {

--- a/packages/core/src/core/codex-app-server-provider.test.ts
+++ b/packages/core/src/core/codex-app-server-provider.test.ts
@@ -137,6 +137,79 @@ async function collectUntilTerminal(session: ModelSession): Promise<AgentMessage
 }
 
 describe("CodexAppServerProvider", () => {
+  it("steers the owned native turn, correlating consumption separately from RPC acceptance", async () => {
+    requestMock.mockImplementation(async (method: string) => {
+      if (method === "thread/start") return { thread: { id: "thr-1" } };
+      if (method === "turn/start") {
+        captured.onNotification?.("turn/started", { threadId: "thr-1", turn: { id: "native-a" } });
+        return { turn: { id: "native-a" } };
+      }
+      if (method === "turn/steer") return { turnId: "native-a" };
+      return {};
+    });
+    const session = await new CodexAppServerProvider().openSession(buildParams());
+    await session.sendUserInput({ text: "first", inputId: "a" });
+    const steering = session.steerUserInput!({ text: "second", inputId: "b" });
+    await vi.waitFor(() =>
+      expect(requestMock).toHaveBeenCalledWith("turn/start", expect.anything()),
+    );
+    expect(requestMock).not.toHaveBeenCalledWith("turn/steer", expect.anything());
+    captured.onNotification?.("item/completed", {
+      threadId: "thr-1",
+      turnId: "native-a",
+      item: { type: "userMessage", id: "native-input-a", clientId: "a", content: [] },
+    });
+    expect(await steering).toBe("accepted");
+    expect(requestMock).toHaveBeenCalledWith("turn/steer", {
+      threadId: "thr-1",
+      expectedTurnId: "native-a",
+      clientUserMessageId: "b",
+      input: [{ type: "text", text: "second", text_elements: [] }],
+    });
+    expect(requestMock.mock.calls.filter(([method]) => method === "turn/start")).toHaveLength(1);
+    expect(requestMock.mock.calls.filter(([method]) => method === "turn/interrupt")).toHaveLength(
+      0,
+    );
+    captured.onNotification?.("item/completed", {
+      threadId: "thr-1",
+      turnId: "native-a",
+      item: { type: "userMessage", id: "native-b", clientId: "b", content: [] },
+    });
+    captured.onNotification?.("turn/completed", {
+      threadId: "thr-1",
+      turn: { id: "native-a", status: "completed" },
+    });
+    const messages = await collectUntilTerminal(session);
+    expect(messages.filter((message) => message.type === "input_status")).toEqual([
+      { type: "input_status", inputId: "a", state: "consumed" },
+      { type: "input_status", inputId: "b", state: "consumed" },
+    ]);
+    expect(await session.steerUserInput!({ text: "late", inputId: "c" })).toBe("deferred");
+    await session.close();
+  });
+
+  it("releases a buffered steer when startup ends without confirming the first input", async () => {
+    requestMock.mockImplementation(async (method: string) => {
+      if (method === "thread/start") return { thread: { id: "thr-1" } };
+      if (method === "turn/start") return { turn: { id: "native-a" } };
+      return {};
+    });
+    const session = await new CodexAppServerProvider().openSession(buildParams());
+    await session.sendUserInput({ text: "first", inputId: "a" });
+    const steering = session.steerUserInput!({ text: "second", inputId: "b" });
+    await vi.waitFor(() =>
+      expect(requestMock).toHaveBeenCalledWith("turn/start", expect.anything()),
+    );
+    captured.onNotification?.("turn/completed", {
+      threadId: "thr-1",
+      turn: { id: "native-a", status: "completed" },
+    });
+    expect(await steering).toBe("deferred");
+    expect(requestMock).not.toHaveBeenCalledWith("turn/steer", expect.anything());
+    await collectUntilTerminal(session);
+    await session.close();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     getCodexCliStatusMock.mockResolvedValue({ loggedIn: true });
@@ -852,6 +925,12 @@ describe("CodexAppServerProvider", () => {
     await vi.waitFor(() =>
       expect(requestMock).toHaveBeenCalledWith("turn/start", expect.anything()),
     );
+    expect(
+      await source.steerUserInput!({ text: "not for the fork", inputId: "source-input" }),
+    ).toBe("deferred");
+    await source.interrupt("source-only");
+    expect(requestMock).not.toHaveBeenCalledWith("turn/steer", expect.anything());
+    expect(requestMock).not.toHaveBeenCalledWith("turn/interrupt", expect.anything());
 
     // A model-changing fork (e.g. a recap turn on a smaller tier) arrives
     // while the borrowed turn holds the thread.

--- a/packages/core/src/core/codex-app-server-provider.ts
+++ b/packages/core/src/core/codex-app-server-provider.ts
@@ -255,6 +255,8 @@ interface ActiveTurn {
   imageTracker: GeneratedImageTracker;
   romeTools: RomeDynamicTools;
   turnId: string | null;
+  initialInputId?: string;
+  completed: boolean;
   /** Usage accumulated across every model request in this Rome turn. */
   usage?: TokenUsageBreakdown;
   /** Per-request usage retained so non-linear pricing is applied correctly. */
@@ -404,6 +406,8 @@ export class CodexAppServerProvider implements ModelProvider {
     // be replaced.
     let contaminatedReason: string | null = null;
     let activeTurn: ActiveTurn | null = null;
+    let sourceStarted: Promise<void> = Promise.resolve();
+    let resolveSourceStarted: (() => void) | undefined;
     let lastCompletedTurnCheckpoint: string | undefined;
     const dynamicToolOutputs = new Map<string, unknown>();
     const usageByTurnId = new Map<
@@ -424,6 +428,18 @@ export class CodexAppServerProvider implements ModelProvider {
 
     const onItem = (item: ThreadItem, lifecycle: "started" | "completed"): void => {
       const turnSink = activeTurn?.sink ?? sink;
+      if (item.type === "userMessage" && lifecycle === "completed") {
+        const clientId = (item as { clientId?: unknown }).clientId;
+        if (typeof clientId === "string") {
+          if (
+            activeTurn?.ownerSessionId === params.sessionId &&
+            clientId === activeTurn.initialInputId
+          )
+            resolveSourceStarted?.();
+          turnSink.push({ type: "input_status", inputId: clientId, state: "consumed" });
+        }
+        return;
+      }
       const turnImageTraceCtx = activeTurn?.imageTraceCtx ?? imageTraceCtx;
       if (isAgentMessageItem(item)) {
         if (lifecycle !== "completed") return;
@@ -595,6 +611,7 @@ export class CodexAppServerProvider implements ModelProvider {
           const p = params2 as TurnCompletedNotification;
           if (activeTurn) {
             if (activeTurn.turnId && activeTurn.turnId !== p.turn?.id) return;
+            activeTurn.completed = true;
             if (p.turn?.status === "failed") {
               // `turn.error` is a structured `TurnError` object (camelCase),
               // not a string — extract the human message and classify quota
@@ -623,6 +640,7 @@ export class CodexAppServerProvider implements ModelProvider {
           const code = classification.code;
           if (activeTurn) {
             // Route the terminal through runOne (see turn/completed).
+            activeTurn.completed = true;
             activeTurn.failed = true;
             activeTurn.errorMessage = message;
             activeTurn.errorCode = code;
@@ -750,6 +768,8 @@ export class CodexAppServerProvider implements ModelProvider {
         imageTracker: runtime.imageTracker,
         romeTools: runtime.romeTools,
         turnId: null,
+        initialInputId: inputs[0]?.inputId,
+        completed: false,
         requestUsages: [],
         finalText: "",
         startedAt: Date.now(),
@@ -764,11 +784,16 @@ export class CodexAppServerProvider implements ModelProvider {
       activeTurn = turn;
       const effort = normalizeEffort(inputs.at(-1)?.reasoningEffort ?? params.reasoningEffort);
       try {
-        await this.appServerManager.requestForThread(tid, Method.turnStart, {
+        const started = (await this.appServerManager.requestForThread(tid, Method.turnStart, {
           threadId: tid,
           input: turnInput,
           effort,
-        });
+          ...(inputs[0]?.inputId ? { clientUserMessageId: inputs[0].inputId } : {}),
+        })) as { turn?: { id?: string } } | undefined;
+        turn.turnId ??= started?.turn?.id ?? null;
+        // turn/start can acknowledge before the native input becomes steerable.
+        // Identified chat inputs wait for their user-message confirmation.
+        if (runtime === sourceRuntime && !turn.initialInputId) resolveSourceStarted?.();
         await done;
         // Turn finished. Drain deferred image-generation trace work and the
         // filesystem backstop BEFORE the terminal block — the agent session
@@ -826,20 +851,83 @@ export class CodexAppServerProvider implements ModelProvider {
           );
         }
       } finally {
+        if (runtime === sourceRuntime) resolveSourceStarted?.();
         if (turn.turnId) usageByTurnId.delete(turn.turnId);
         activeTurn = null;
       }
     };
 
     const dispatcher = new TurnDispatcher<ModelUserInput>({
-      runOne: async (inputs) =>
-        await turnCoordinator.run(async () => await runOne(inputs, sourceRuntime)),
+      runOne: async (inputs) => {
+        try {
+          await turnCoordinator.run(async () => await runOne(inputs, sourceRuntime));
+        } finally {
+          resolveSourceStarted?.();
+        }
+      },
     });
 
     session.sendUserInput = async (input: ModelUserInput) => {
       if (closed || closing) throw new Error("ModelSession is closed");
       if (contaminatedReason) throw new Error(contaminatedReason);
-      if (input.text) dispatcher.enqueue(input);
+      if (input.text) {
+        sourceStarted = new Promise<void>((resolve) => {
+          resolveSourceStarted = resolve;
+        });
+        dispatcher.enqueue(input);
+      }
+    };
+
+    session.steerUserInput = async (input) => {
+      await sourceStarted;
+      const turn = activeTurn;
+      if (!turn || turn.completed || turn.ownerSessionId !== params.sessionId || !turn.turnId)
+        return "deferred";
+      if (closed || closing) throw new Error("ModelSession is closed");
+      if (input.injectedToolResult) return "deferred";
+      if (
+        input.reasoningEffort &&
+        normalizeEffort(input.reasoningEffort) !== normalizeEffort(params.reasoningEffort)
+      )
+        return "deferred";
+      const nativeInput = await buildTurnInput(input.text, input.images ?? []);
+      if (activeTurn !== turn || turn.completed) return "deferred";
+      const response = this.appServerManager.requestForThread(threadId!, Method.turnSteer, {
+        threadId,
+        expectedTurnId: turn.turnId,
+        clientUserMessageId: input.inputId,
+        input: nativeInput,
+      });
+      let timeout: ReturnType<typeof setTimeout>;
+      const request = Promise.race([
+        response,
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("Steering acknowledgement timed out; delivery is unknown")),
+            10_000,
+          );
+          timeout.unref?.();
+        }),
+      ]).finally(() => clearTimeout(timeout));
+      // A terminal must not overtake a steering RPC's definitive rejection.
+      turn.pending.push(
+        request.then(
+          () => {},
+          () => {},
+        ),
+      );
+      try {
+        await request;
+        return "accepted";
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.name === "AppServerRpcError" &&
+          /no active turn|expected.*turn|turn.*mismatch/i.test(error.message)
+        )
+          return "deferred";
+        throw error;
+      }
     };
 
     const interruptOwnerTurn = async (ownerSessionId: string, reason?: string): Promise<void> => {

--- a/packages/core/src/core/codex/app-server-client.ts
+++ b/packages/core/src/core/codex/app-server-client.ts
@@ -37,6 +37,16 @@ interface Pending {
   reject: (err: Error) => void;
 }
 
+export class AppServerRpcError extends Error {
+  constructor(
+    message: string,
+    readonly code: number,
+  ) {
+    super(message);
+    this.name = "AppServerRpcError";
+  }
+}
+
 export class AppServerClient {
   private proc: ChildProcessWithoutNullStreams | null = null;
   private nextId = 1;
@@ -158,7 +168,10 @@ export class AppServerClient {
       const pending = this.pending.get(msg.id);
       if (!pending) return;
       this.pending.delete(msg.id);
-      if (msg.error) pending.reject(new Error(msg.error.message || "app-server error"));
+      if (msg.error)
+        pending.reject(
+          new AppServerRpcError(msg.error.message || "app-server error", msg.error.code),
+        );
       else pending.resolve(msg.result);
       return;
     }

--- a/packages/core/src/core/codex/app-server-protocol.ts
+++ b/packages/core/src/core/codex/app-server-protocol.ts
@@ -225,10 +225,18 @@ export type UserInput =
 
 export interface TurnStartParams {
   threadId: string;
+  clientUserMessageId?: string | null;
   input: UserInput[];
   model?: string | null;
   effort?: ReasoningEffort | null;
   approvalPolicy?: AskForApproval | null;
+}
+
+export interface TurnSteerParams {
+  threadId: string;
+  expectedTurnId: string;
+  clientUserMessageId?: string | null;
+  input: UserInput[];
 }
 
 export interface TurnInterruptParams {
@@ -250,6 +258,7 @@ export const Method = {
   threadRollback: "thread/rollback",
   threadUnsubscribe: "thread/unsubscribe",
   turnStart: "turn/start",
+  turnSteer: "turn/steer",
   turnInterrupt: "turn/interrupt",
 } as const;
 

--- a/packages/core/src/db/repositories/webchat.test.ts
+++ b/packages/core/src/db/repositories/webchat.test.ts
@@ -44,6 +44,46 @@ describe("WebChatRepository", () => {
     testDb.close();
   });
 
+  it("persists input identity, consumption binding, and uncertain recovery without replay", async () => {
+    await repo.createSession("input-session", "Inputs");
+    expect(await repo.recordUserInput("first", "input-session", "[]")).toBe(true);
+    expect(await repo.recordUserInput("first", "input-session", "[]")).toBe(false);
+    await repo.recordUserInput("second", "input-session", "[]");
+    await repo.updateUserInput("input-session", {
+      type: "input_status",
+      inputId: "first",
+      turnId: "turn-a",
+      state: "consumed",
+    });
+    await repo.updateUserInput("input-session", {
+      type: "input_status",
+      inputId: "second",
+      turnId: "turn-a",
+      state: "accepted",
+    });
+    await repo.recoverInterruptedInputs();
+    expect(await repo.getUserInput("input-session", "first")).toEqual({
+      turnId: "turn-a",
+      inputState: "consumed",
+    });
+    expect(await repo.getUserInput("input-session", "second")).toEqual({
+      turnId: "turn-a",
+      inputState: "unknown",
+    });
+    await repo.updateUserInput("input-session", {
+      type: "input_status",
+      inputId: "second",
+      turnId: "turn-b",
+      state: "consumed",
+    });
+    expect(
+      (await repo.getMessages("input-session")).map(({ id, turnId }) => ({ id, turnId })),
+    ).toEqual([
+      { id: "first", turnId: "turn-a" },
+      { id: "second", turnId: "turn-b" },
+    ]);
+  });
+
   it("lists sessions with message counts and project names", async () => {
     await repo.createSession("sess-1", "Chat A", "guardian-1");
     await repo.createSession("sess-2", "Chat B");

--- a/packages/core/src/db/repositories/webchat.ts
+++ b/packages/core/src/db/repositories/webchat.ts
@@ -40,6 +40,7 @@ export interface StoredWebchatMessage {
   id: string;
   sessionId: string;
   turnId: string | null;
+  inputState?: import("@rome-os/app-runtime").AgentInputState | null;
   role: string;
   content: string;
   platformMessageId?: string | null;
@@ -1465,6 +1466,70 @@ export class WebChatRepository {
     return rows[0]?.count ?? 0;
   }
 
+  async recordUserInput(id: string, sessionId: string, content: string): Promise<boolean> {
+    return this.db.transaction((tx) => {
+      const createdAt = new Date();
+      const inserted = tx
+        .insert(romeAgentMessages)
+        .values({
+          id,
+          sessionId,
+          content,
+          role: "user",
+          inputState: "queued",
+          createdAt,
+        })
+        .onConflictDoNothing()
+        .returning({ id: romeAgentMessages.id })
+        .all();
+      if (inserted.length)
+        tx.update(romeSessions)
+          .set(advanceSessionActivitySet(createdAt))
+          .where(eq(romeSessions.id, sessionId))
+          .run();
+      return inserted.length > 0;
+    });
+  }
+
+  async recoverInterruptedInputs(): Promise<void> {
+    // A process crash can occur between the durable dispatch marker and the
+    // provider acknowledgement. Preserve the message without replaying it.
+    await this.db
+      .update(romeAgentMessages)
+      .set({ inputState: "unknown" })
+      .where(inArray(romeAgentMessages.inputState, ["queued", "submitted", "accepted"]));
+  }
+
+  async getUserInput(sessionId: string, inputId: string) {
+    return this.db
+      .select({ turnId: romeAgentMessages.turnId, inputState: romeAgentMessages.inputState })
+      .from(romeAgentMessages)
+      .where(
+        and(
+          eq(romeAgentMessages.id, inputId),
+          eq(romeAgentMessages.sessionId, sessionId),
+          eq(romeAgentMessages.role, "user"),
+        ),
+      )
+      .get();
+  }
+
+  async updateUserInput(
+    sessionId: string,
+    status: import("@rome-os/app-runtime").InputStatusMessage,
+  ): Promise<void> {
+    await this.db
+      .update(romeAgentMessages)
+      .set({ inputState: status.state, turnId: status.turnId ?? null })
+      .where(
+        and(
+          eq(romeAgentMessages.id, status.inputId),
+          eq(romeAgentMessages.sessionId, sessionId),
+          eq(romeAgentMessages.role, "user"),
+        ),
+      );
+  }
+
   async addMessage(
     id: string,
     sessionId: string,
@@ -1788,6 +1853,7 @@ export class WebChatRepository {
         id: romeAgentMessages.id,
         sessionId: romeAgentMessages.sessionId,
         turnId: romeAgentMessages.turnId,
+        inputState: romeAgentMessages.inputState,
         role: romeAgentMessages.role,
         content:
           sql<string>`CASE WHEN ${romeAgentMessages.role} = 'trace' THEN '[]' ELSE ${romeAgentMessages.content} END`.as(

--- a/packages/core/src/db/schema/system.ts
+++ b/packages/core/src/db/schema/system.ts
@@ -8,6 +8,7 @@ import {
   primaryKey,
 } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
+import type { AgentInputState } from "@rome-os/app-runtime";
 import { TURN_FEEDBACK_RATINGS } from "@rome/api-types/trace-segments";
 import {
   APPROVAL_EXECUTION_STATES,
@@ -601,6 +602,7 @@ export const romeAgentMessages = sqliteTable(
     id: text("id").primaryKey(),
     sessionId: text("session_id").notNull(),
     turnId: text("turn_id"),
+    inputState: text("input_state").$type<AgentInputState>(),
     role: text("role").notNull(), // 'user' | 'assistant' | 'notification' | 'trace'
     content: text("content").notNull(), // JSON array of blocks
     platformMessageId: text("platform_message_id"),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -264,6 +264,7 @@ async function main() {
 
   const policiesRepo = new PoliciesRepository(db);
   const webchatRepo = new WebChatRepository(db);
+  await webchatRepo.recoverInterruptedInputs();
   const appRuntimeRepositories = createAppRuntimeRepositories({ settingsRepo, webchatRepo });
   const actionExecutionsRepo = new ActionExecutionsRepository(db);
   const executionJournalRepo = new ExecutionJournalRepository(db);

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -1618,6 +1618,8 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
                 runningTurnId,
                 snapshot: currentSnapshot,
                 text: liveAssistantText,
+                blockIx: floorSessionStream?.assistantBlockIx,
+                sourceText: floorSessionStream?.assistantText,
                 identity: floorIdentity,
               }}
               selection={

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -814,6 +814,28 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
             }
             continue;
           }
+          if (evt.event === "input_status") {
+            try {
+              const status = JSON.parse(
+                evt.data,
+              ) as import("@rome/api-types/trace-segments").InputStatusMessage;
+              setMessages((prev) => {
+                const next = new Map(prev);
+                next.set(
+                  sessionId,
+                  (prev.get(sessionId) ?? []).map((message) =>
+                    message.id === status.inputId
+                      ? { ...message, inputState: status.state, turnId: status.turnId }
+                      : message,
+                  ),
+                );
+                return next;
+              });
+            } catch {
+              /* Reconnection reloads the durable input state. */
+            }
+            continue;
+          }
           if (evt.event === "session_status") {
             // SSE-driven status lets the UI flip the
             // Send/Stop button without polling /stream-status.
@@ -956,6 +978,7 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
       // Sending re-engages stickiness so the user follows their own message and
       // the reply, even if they'd scrolled up to read history.
       scrollToBottom("auto");
+      const wasLocallyStreaming = locallyStreamingSessionIdsRef.current.has(sendingSessionId);
       locallyStreamingSessionIdsRef.current.add(sendingSessionId);
 
       // The POST result is the acceptance boundary. Whether the composer clears
@@ -967,13 +990,13 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
       // dropped stream never does.
       const result = await postTurn().catch((err: unknown) => {
         // Transport failure posting the turn — a genuine failed submit.
-        locallyStreamingSessionIdsRef.current.delete(sendingSessionId);
+        if (!wasLocallyStreaming) locallyStreamingSessionIdsRef.current.delete(sendingSessionId);
         setStreamReconnectRevision((revision) => revision + 1);
         setStreamError(t("stream.errors.sendInvalidResponse"));
         throw err;
       });
       if (!result.ok) {
-        locallyStreamingSessionIdsRef.current.delete(sendingSessionId);
+        if (!wasLocallyStreaming) locallyStreamingSessionIdsRef.current.delete(sendingSessionId);
         setStreamReconnectRevision((revision) => revision + 1);
         const message =
           result.message ||
@@ -992,13 +1015,12 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
       const createResp: CreateTurnResponse = result.data;
       const pendingTurnId = createResp.turnId;
       const turnsForSession = inflightTurnsRef.current.get(sendingSessionId) ?? new Set<string>();
-      turnsForSession.add(pendingTurnId);
-      inflightTurnsRef.current.set(sendingSessionId, turnsForSession);
-      startSessionStream(sendingSessionId, pendingTurnId);
 
       const userMsg: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: createResp.inputId ?? crypto.randomUUID(),
         sessionId: sendingSessionId,
+        turnId: pendingTurnId,
+        inputState: createResp.inputState ?? (createResp.inputId ? "queued" : undefined),
         role: "user",
         content: optimisticUserContent,
         createdAt: new Date().toISOString(),
@@ -1013,6 +1035,21 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
         next.set(sendingSessionId, mergeChatMessage(existing, userMsg));
         return next;
       });
+
+      // Appending input does not own a second stream or replace the live tail.
+      // Late follow-up turns are discovered by the existing reattach loop.
+      if (turnsForSession.size || streamingSessionsRef.current.has(sendingSessionId)) {
+        if (!turnsForSession.size) locallyStreamingSessionIdsRef.current.delete(sendingSessionId);
+        return;
+      }
+      if (!pendingTurnId) {
+        locallyStreamingSessionIdsRef.current.delete(sendingSessionId);
+        setStreamReconnectRevision((revision) => revision + 1);
+        return;
+      }
+      turnsForSession.add(pendingTurnId);
+      inflightTurnsRef.current.set(sendingSessionId, turnsForSession);
+      startSessionStream(sendingSessionId, pendingTurnId);
 
       // turn is already submitted, so a failed attach or a mid-stream drop must
       // never reject this function — that rejection is what used to restore the
@@ -1075,8 +1112,7 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
   // (text/uploads/options); this handler builds the POST and delegates the
   // turn lifecycle to runTurnLifecycle.
   //
-  // A new turn while a previous one is still streaming is
-  // queued FIFO at the AgentSession layer — no client-side block needed.
+  // The session decides whether input joins the active run or starts the next.
   const handleComposerSend = useCallback(
     async (snapshot: ChatComposerSnapshot) => {
       // The single composer talks to whoever holds the floor — the open

--- a/packages/web/src/components/chat/ChatComposer.tsx
+++ b/packages/web/src/components/chat/ChatComposer.tsx
@@ -1052,8 +1052,10 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
               disabled={
                 isComposerBusy || (!inputText.trim() && pendingUploads.length === 0 && !draftSkill)
               }
-              title={isStreaming ? t("composer.queueTurnTitle") : t("composer.sendTitle")}
-              aria-label={isStreaming ? t("composer.queueTurnTitle") : t("composer.sendTitle")}
+              title={isStreaming ? t("composer.sendWhileRunningTitle") : t("composer.sendTitle")}
+              aria-label={
+                isStreaming ? t("composer.sendWhileRunningTitle") : t("composer.sendTitle")
+              }
               className="touch-target"
             >
               <ArrowUp aria-hidden />

--- a/packages/web/src/components/chat/MessageList.test.tsx
+++ b/packages/web/src/components/chat/MessageList.test.tsx
@@ -231,6 +231,172 @@ describe("MessageList inline-card state across streaming→settled", () => {
   });
 });
 
+function commentary(text: string, id = "a-text", blockIx: number | null = 0): ChatMessage {
+  return {
+    id,
+    sessionId: "s-1",
+    turnId: "turn-1",
+    role: "assistant",
+    content: JSON.stringify([
+      {
+        type: "text",
+        content: text,
+        turnPhase: "commentary",
+        ...(blockIx !== null ? { blockIx } : {}),
+      },
+    ]),
+    createdAt: "2026-06-13T00:00:01.000Z",
+  };
+}
+
+function streamingList(messages: ChatMessage[], text: string, blockIx = 0, sourceText = text) {
+  const { live, actions } = renderList(true);
+  return (
+    <ThemeProvider>
+      <MessageList
+        rows={buildRows(messages, new Map([["s-1", IDENTITY]]), IDENTITY, {
+          runningTurnId: live.runningTurnId,
+          isStreaming: true,
+        })}
+        live={{ ...live, text, blockIx, sourceText }}
+        contentRef={() => {}}
+        onOpenLiveTrace={() => {}}
+        onOpenStoredTrace={() => {}}
+        actions={actions}
+      />
+    </ThemeProvider>
+  );
+}
+
+function expectBefore(earlier: HTMLElement, later: HTMLElement) {
+  expect(earlier.compareDocumentPosition(later) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+}
+
+describe("MessageList streaming input", () => {
+  it("does not repeat persisted commentary after a follow-up input", () => {
+    const original = commentary("I am checking the implementation.");
+    const followup = humanReply("Please include pseudocode.");
+    const { rerender } = render(streamingList([original], "I am checking the implementation."));
+
+    rerender(streamingList([original, followup], "I am checking the implementation."));
+
+    expect(screen.getAllByText("I am checking the implementation.")).toHaveLength(1);
+    expectBefore(screen.getByLabelText("Working"), screen.getByText("Please include pseudocode."));
+  });
+
+  it("keeps a live block in its row when follow-up inputs arrive", () => {
+    const original = commentary("The first step is complete.");
+    const followup = humanReply("Please include pseudocode.");
+    const another = humanReply("Use TypeScript.");
+    const { rerender } = render(streamingList([original], "Now checking", 1));
+    const liveText = screen.getByText("Now checking");
+
+    rerender(streamingList([original, followup, another], "Now checking the next step.", 1));
+
+    expect(screen.getByText("Now checking the next step.")).toBe(liveText);
+    expectBefore(liveText, screen.getByText("Please include pseudocode."));
+    expectBefore(liveText, screen.getByText("Use TypeScript."));
+  });
+
+  it("keeps the first unpersisted block before a follow-up input", () => {
+    const initial = humanReply("Explain the implementation.");
+    const followup = humanReply("Please include pseudocode.");
+    const { rerender } = render(streamingList([initial], "I am checking"));
+    const liveText = screen.getByText("I am checking");
+
+    rerender(streamingList([initial, followup], "I am checking the implementation."));
+
+    expect(screen.getByText("I am checking the implementation.")).toBe(liveText);
+    expectBefore(liveText, screen.getByText("Please include pseudocode."));
+  });
+
+  it("places the next block after the follow-up without replaying the previous block", () => {
+    const original = commentary("The first step is complete.");
+    const followup = humanReply("Please include pseudocode.");
+    const { rerender } = render(streamingList([original], "The first step is complete."));
+    rerender(streamingList([original, followup], "The first step is complete."));
+
+    rerender(streamingList([original, followup], "Here is the pseudocode.", 1));
+
+    expect(screen.getAllByText("The first step is complete.")).toHaveLength(1);
+    expectBefore(
+      screen.getByText("Please include pseudocode."),
+      screen.getByText("Here is the pseudocode."),
+    );
+  });
+
+  it("deduplicates a replayed block when the last row is a follow-up input", () => {
+    render(
+      streamingList(
+        [commentary("I am checking the implementation."), humanReply("Please include pseudocode.")],
+        "I am checking the implementation.",
+      ),
+    );
+
+    expect(screen.getAllByText("I am checking the implementation.")).toHaveLength(1);
+    expectBefore(screen.getByLabelText("Working"), screen.getByText("Please include pseudocode."));
+  });
+
+  it("uses the source text to suppress a persisted block while typing catches up", () => {
+    render(
+      streamingList(
+        [commentary("I am checking the implementation."), humanReply("Please include pseudocode.")],
+        "I am checking",
+        0,
+        "I am checking the implementation.",
+      ),
+    );
+
+    expect(screen.queryByText("I am checking", { exact: true })).toBeNull();
+    expect(screen.getAllByText("I am checking the implementation.")).toHaveLength(1);
+  });
+
+  it("does not mistake a new block with identical text for an old persisted block", () => {
+    const original = commentary("Checking the implementation.");
+    const followup = humanReply("Check once more.");
+    const { rerender } = render(
+      streamingList([original, followup], "Checking the implementation.", 0),
+    );
+
+    rerender(streamingList([original, followup], "Checking the implementation.", 1));
+
+    const copies = screen.getAllByText("Checking the implementation.");
+    expect(copies).toHaveLength(2);
+    expectBefore(screen.getByText("Check once more."), copies[1]);
+  });
+
+  it("renders legacy commentary without blockIx without matching it to a live block", () => {
+    render(
+      streamingList(
+        [commentary("Historical commentary.", "legacy", null), humanReply("Continue from here.")],
+        "Current live block.",
+        0,
+      ),
+    );
+
+    expect(screen.getByText("Historical commentary.")).toBeTruthy();
+    expect(screen.getByText("Current live block.")).toBeTruthy();
+  });
+
+  it("does not move the previous typewriter frame below the follow-up at a block boundary", () => {
+    const original = commentary("The first step is complete.");
+    const followup = humanReply("Please include pseudocode.");
+    const { rerender } = render(streamingList([original], "The first step is complete."));
+
+    rerender(
+      streamingList(
+        [original, followup],
+        "The first step is complete.",
+        1,
+        "Here is the pseudocode.",
+      ),
+    );
+
+    expect(screen.getAllByText("The first step is complete.")).toHaveLength(1);
+    expectBefore(screen.getByText("Please include pseudocode."), screen.getByLabelText("Working"));
+  });
+});
+
 describe("MessageList Plan placement", () => {
   it("groups a collapsed completed Plan and collapsed Recap after turn text", () => {
     const messages: ChatMessage[] = [

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -506,18 +506,20 @@ export function MessageList({
   // settled row bails on memo. A turn with nothing persisted yet has no row, so
   // the tail stands alone until its first message lands.
   const runningTurnId = live.isStreaming ? live.runningTurnId : null;
-  const hasRunningRow =
-    runningTurnId != null &&
-    rows.some((r) => r.kind === "agent" && r.messages.some((m) => m.turnId === runningTurnId));
+  const lastRow = rows.at(-1);
+  const runningRow =
+    runningTurnId &&
+    lastRow?.kind === "agent" &&
+    lastRow.messages.some((m) => m.turnId === runningTurnId)
+      ? lastRow
+      : undefined;
+  const hasRunningRow = !!runningRow;
 
   return (
     <div className="flex-1">
       <div ref={contentRef} className="mx-auto max-w-5xl px-4 pt-4 md:px-6">
         {rows.map((row) => {
-          const isRunning =
-            runningTurnId != null &&
-            row.kind === "agent" &&
-            row.messages.some((m) => m.turnId === runningTurnId);
+          const isRunning = row === runningRow;
           const view = (
             <RowView
               key={row.key}

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactNode } from "react";
+import { memo, type ReactNode, useMemo, useState } from "react";
 import { Check } from "lucide-react";
 import type { TraceSnapshot } from "@rome/api-types/trace-segments";
 import { CollapsedTraceButton } from "@/components/agent-trace/AgentTrace";
@@ -42,6 +42,9 @@ export interface LivePreview {
   runningTurnId: string | null;
   snapshot: TraceSnapshot | null;
   text: string;
+  blockIx?: number;
+  /** The full SSE text, which may be ahead of the typewriter preview. */
+  sourceText?: string;
   identity: AgentIdentity;
 }
 
@@ -167,19 +170,22 @@ function renderSubagents(
   );
 }
 
-// True if the live tail's text already exists as a persisted commentary block in
-// this turn — the persisted copy landed just ahead of the tail, so the tail copy
-// is a duplicate to hide. Only commentary counts: the final answer is persisted
-// into the row too (via send_message) and, if textually identical to an earlier
-// commentary block, must NOT suppress the live tail before stream close.
-function hasPersistedCommentary(messages: ChatMessage[], liveText: string): boolean {
-  for (const m of messages) {
-    for (const part of parseMessageBlocks(m)) {
-      if (part.type === "text" && part.turnPhase === "commentary" && part.content === liveText)
-        return true;
+// Persisted WebChat text blocks retain the same identity as their live SSE
+// preview. Build the lookup once per transcript change; token frames then use
+// a direct `(turnId, blockIx)` lookup instead of reconstructing block order.
+function indexPersistedTextRows(rows: ChatRow[]): Map<string, ChatRow> {
+  const index = new Map<string, ChatRow>();
+  for (const row of rows) {
+    if (row.kind !== "agent") continue;
+    for (const message of row.messages) {
+      if (!message.turnId) continue;
+      for (const part of parseMessageBlocks(message)) {
+        if (part.type !== "text" || part.blockIx === undefined) continue;
+        index.set(`${message.turnId}:${part.blockIx}`, row);
+      }
     }
   }
-  return false;
+  return index;
 }
 
 // The raw text a copy button puts on the clipboard for an agent turn: every
@@ -209,13 +215,8 @@ function LiveActivityDot() {
   );
 }
 
-// One transcript row. Memoized so a streaming turn re-renders ONLY its running
-// row — every settled row bails on its stable props, so renderFlatBlocks never
-// re-runs for the history. `live` is non-null for exactly the running turn's row
-// and carries the live trace + streaming-text tail INTO that row. Crucially the
-// running row stays at its final transcript position the whole turn: when the
-// turn finalizes, `live` flips to null and the row re-renders in place (NOT a
-// remount), so an inline card's local input state — typed mid-stream — survives.
+// Stable row keys preserve inline-card drafts when the live block moves on or
+// the turn ends. Memoization keeps token updates out of the historical rows.
 const RowView = memo(function RowView({
   row,
   live,
@@ -272,7 +273,6 @@ const RowView = memo(function RowView({
   ) : row.trace ? (
     renderTrace(row.trace, onOpenStoredTrace)
   ) : undefined;
-  const suppressText = !!live?.text && hasPersistedCommentary(row.messages, live.text);
   // Copy appears once the turn settles (`live` gone) and only when it produced
   // text — a card-only turn has nothing raw to copy.
   const copyText = live ? "" : turnCopyText(row.messages);
@@ -334,7 +334,7 @@ const RowView = memo(function RowView({
           </div>
         );
       })}
-      {live?.text && !suppressText ? (
+      {live?.text ? (
         // rome-live-caret appends the pulsing live dot after the last rendered
         // character (see globals.css).
         <div className="rome-live-caret">
@@ -379,12 +379,8 @@ const RowView = memo(function RowView({
   );
 });
 
-// The live tail for a running turn that has not persisted ANY message yet —
-// there's no row to attach to, so it stands alone (avatar + live trace +
-// streaming text). The moment its first message persists, a running agent row
-// appears in `rows` and owns the tail instead (RowView). No inline card can
-// exist before that first persist — cards come from persisted blocks, never the
-// raw text tail — so nothing with local state remounts when the tail moves in.
+// A block without an agent row at its transcript position carries its own header.
+// Persisted cards stay in RowView so their local state survives the handoff.
 function StandaloneLiveTail({
   live,
   actions,
@@ -499,32 +495,55 @@ export function MessageList({
   actions,
   feedback,
 }: MessageListProps) {
-  // The running turn's row is NOT pulled out of the transcript — it renders in
-  // its final position and receives `live` so it carries the trace + text tail
-  // in place (RowView). This keeps the row (and any inline card in it) mounted
-  // across the streaming→settled transition; only it re-renders per token, every
-  // settled row bails on memo. A turn with nothing persisted yet has no row, so
-  // the tail stands alone until its first message lands.
   const runningTurnId = live.isStreaming ? live.runningTurnId : null;
-  const lastRow = rows.at(-1);
+  const blockKey = runningTurnId ? `${runningTurnId}:${live.blockIx ?? 0}` : null;
+  const sourceText = live.sourceText ?? live.text;
+  const persistedTextRows = useMemo(() => indexPersistedTextRows(rows), [rows]);
+  const persistedRow = blockKey ? persistedTextRows.get(blockKey) : undefined;
+  const nextAnchor = { blockKey, afterRowKey: persistedRow?.key ?? rows.at(-1)?.key ?? null };
+  const [anchor, setAnchor] = useState(nextAnchor);
+  // A user input cannot relocate an output block already on screen. Only a
+  // new block picks a new position. A persisted copy takes over the live text.
+  let currentAnchor = anchor;
+  if (anchor.blockKey !== blockKey) {
+    currentAnchor = nextAnchor;
+    setAnchor(nextAnchor);
+  }
+  const anchorRow = rows.find(
+    (row) => row.key === (persistedRow?.key ?? currentAnchor.afterRowKey),
+  );
   const runningRow =
     runningTurnId &&
-    lastRow?.kind === "agent" &&
-    lastRow.messages.some((m) => m.turnId === runningTurnId)
-      ? lastRow
+    anchorRow?.kind === "agent" &&
+    anchorRow.messages.some((m) => m.turnId === runningTurnId)
+      ? anchorRow
       : undefined;
-  const hasRunningRow = !!runningRow;
+  // useSmoothText resets after render. Do not place the old block's last frame
+  // at the new block's position while that effect catches up.
+  const preview = !persistedRow && sourceText.startsWith(live.text) ? live : { ...live, text: "" };
+  const standalone =
+    live.isStreaming && !runningRow ? (
+      <StandaloneLiveTail
+        key={`live:${blockKey}`}
+        live={preview}
+        actions={actions}
+        onOpenLiveTrace={onOpenLiveTrace}
+        onOpenSubagentTrace={onOpenSubagentTrace}
+        activeTraceTarget={activeTraceTarget}
+        subagentIconByName={subagentIconByName}
+      />
+    ) : null;
 
   return (
     <div className="flex-1">
       <div ref={contentRef} className="mx-auto max-w-5xl px-4 pt-4 md:px-6">
-        {rows.map((row) => {
+        {rows.flatMap((row) => {
           const isRunning = row === runningRow;
           const view = (
             <RowView
               key={row.key}
               row={row}
-              live={isRunning ? live : null}
+              live={isRunning ? preview : null}
               actions={actions}
               onOpenLiveTrace={onOpenLiveTrace}
               onOpenStoredTrace={onOpenStoredTrace}
@@ -534,18 +553,20 @@ export function MessageList({
               feedback={feedback}
             />
           );
-          if (!selection?.active) return view;
+          const tail = row === anchorRow ? standalone : null;
+          if (!selection?.active) return [view, tail];
           const { turnId, sessionId } = rowTurnRef(row);
           if (!turnId || sessionId !== selection.selectableSessionId) {
             // Not selectable (child-session row, or no turn): still dim it so the
             // selection state reads clearly across the whole transcript.
-            return (
+            return [
               <div key={row.key} className="pl-9 opacity-60">
                 {view}
-              </div>
-            );
+              </div>,
+              tail,
+            ];
           }
-          return (
+          return [
             <SelectableRow
               key={row.key}
               selected={selection.selectedTurns.has(turnId)}
@@ -553,19 +574,11 @@ export function MessageList({
               label={selection.selectedTurns.has(turnId) ? "Deselect message" : "Select message"}
             >
               {view}
-            </SelectableRow>
-          );
+            </SelectableRow>,
+            tail,
+          ];
         })}
-        {live.isStreaming && !hasRunningRow ? (
-          <StandaloneLiveTail
-            live={live}
-            actions={actions}
-            onOpenLiveTrace={onOpenLiveTrace}
-            onOpenSubagentTrace={onOpenSubagentTrace}
-            activeTraceTarget={activeTraceTarget}
-            subagentIconByName={subagentIconByName}
-          />
-        ) : null}
+        {!anchorRow ? standalone : null}
       </div>
     </div>
   );

--- a/packages/web/src/components/chat/UserMessage.test.tsx
+++ b/packages/web/src/components/chat/UserMessage.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@/hooks/use-theme";
+import type { ChatMessage } from "@/lib/chat-types";
+import { UserMessage } from "./UserMessage";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+afterEach(() => cleanup());
+
+const message: ChatMessage = {
+  id: "input-1",
+  sessionId: "session-1",
+  role: "user",
+  content: "Also include pseudocode.",
+  createdAt: "2026-08-28T00:00:00.000Z",
+};
+
+function userMessage(inputState?: ChatMessage["inputState"]) {
+  return (
+    <ThemeProvider>
+      <UserMessage msg={{ ...message, inputState }} />
+    </ThemeProvider>
+  );
+}
+
+describe("UserMessage input state", () => {
+  it.each([
+    "queued",
+    "submitted",
+    "accepted",
+  ] as const)("uses a visibly pending bubble for %s without a status line", (state) => {
+    render(userMessage(state));
+
+    const bubble = screen.getByTitle(`inputState.${state}`);
+    expect(bubble.classList.contains("bg-transparent")).toBe(true);
+    expect(bubble.classList.contains("border-dashed")).toBe(true);
+    expect(bubble.classList.contains("border-border-strong")).toBe(true);
+    expect(bubble.classList.contains("opacity-60")).toBe(false);
+    expect(bubble.getAttribute("aria-busy")).toBe("true");
+    expect(bubble.textContent).toBe(message.content);
+    const status = screen.getByRole("status");
+    expect(status.className).toBe("sr-only");
+    expect(status.textContent).toBe(`inputState.${state}`);
+  });
+
+  it("restores the same bubble when the provider consumes the input", () => {
+    const { rerender } = render(userMessage("queued"));
+    const bubble = screen.getByTitle("inputState.queued");
+
+    for (const state of ["submitted", "accepted"] as const) {
+      rerender(userMessage(state));
+      expect(screen.getByTitle(`inputState.${state}`)).toBe(bubble);
+      expect(bubble.classList.contains("border-dashed")).toBe(true);
+    }
+    rerender(userMessage("consumed"));
+
+    expect(bubble.isConnected).toBe(true);
+    expect(bubble.classList.contains("bg-surface-muted")).toBe(true);
+    expect(bubble.classList.contains("border-dashed")).toBe(false);
+    expect(bubble.hasAttribute("title")).toBe(false);
+    expect(bubble.hasAttribute("aria-busy")).toBe(false);
+    expect(screen.getByRole("status").textContent).toBe("");
+  });
+
+  it.each([
+    ["failed", "border-destructive/50", "text-destructive"],
+    ["unknown", "border-warning/50", "text-warning"],
+    ["cancelled", "bg-transparent", "text-muted-foreground"],
+  ] as const)("keeps %s distinct from pending delivery", (state, bubbleClass, iconClass) => {
+    render(userMessage(state));
+
+    const bubble = screen.getByTitle(`inputState.${state}`);
+    expect(bubble.classList.contains(bubbleClass)).toBe(true);
+    expect(bubble.classList.contains("bg-transparent")).toBe(state === "cancelled");
+    expect(bubble.querySelector("svg")?.classList.contains(iconClass)).toBe(true);
+    expect(bubble.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+    expect(screen.getByRole("status").className).toBe("sr-only");
+  });
+
+  it.each([
+    undefined,
+    null,
+    "consumed",
+  ] as const)("leaves a normal bubble for input state %s", (state) => {
+    const { container } = render(userMessage(state));
+
+    expect(screen.getByText(message.content)).toBeTruthy();
+    expect(container.querySelector(".bg-surface-muted")).not.toBeNull();
+    expect(container.querySelector(".border-dashed")).toBeNull();
+    expect(screen.getByRole("status").textContent).toBe("");
+  });
+
+  it("copies only the message, not its delivery status", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(userMessage("submitted"));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "message.copy" }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith(message.content);
+  });
+
+  it("does not add a status-only bubble for a structured input without text", () => {
+    const { container } = render(
+      <UserMessage
+        msg={{
+          ...message,
+          content: JSON.stringify([{ type: "interaction_result", toolUseId: "tool-1" }]),
+          inputState: "queued",
+        }}
+      />,
+    );
+
+    expect(container.textContent).toBe("");
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/packages/web/src/components/chat/UserMessage.tsx
+++ b/packages/web/src/components/chat/UserMessage.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import Markdown from "@/components/chat/ChatMarkdown";
 import { CopyMessageButton } from "@/components/chat/CopyMessageButton";
 import type { ChatMessage, StreamBlock } from "@/lib/chat-types";
@@ -10,6 +11,7 @@ import { formatMessageTimestamp } from "@/lib/message-timestamp";
 // ChatMessage object identities even though id+content are unchanged.
 export const UserMessage = memo(
   function UserMessage({ msg }: { msg: ChatMessage }) {
+    const { t } = useTranslation("chat");
     const text = useMemo(() => {
       let blocks: StreamBlock[];
       try {
@@ -40,6 +42,11 @@ export const UserMessage = memo(
             {text}
           </Markdown>
         </div>
+        {msg.inputState && msg.inputState !== "consumed" ? (
+          <span className="mt-1 text-aux text-muted-foreground" role="status">
+            {t(`inputState.${msg.inputState}`)}
+          </span>
+        ) : null}
         {/* Timestamp + copy under the bubble. Hover-revealed on pointer
             devices, always visible on touch. Precision tracks recency: time
             of day today, month + day this year, full date for older years. */}
@@ -50,5 +57,8 @@ export const UserMessage = memo(
       </div>
     );
   },
-  (prev, next) => prev.msg.id === next.msg.id && prev.msg.content === next.msg.content,
+  (prev, next) =>
+    prev.msg.id === next.msg.id &&
+    prev.msg.content === next.msg.content &&
+    prev.msg.inputState === next.msg.inputState,
 );

--- a/packages/web/src/components/chat/UserMessage.tsx
+++ b/packages/web/src/components/chat/UserMessage.tsx
@@ -1,9 +1,11 @@
 import { memo, useMemo } from "react";
+import { CircleAlert, CircleHelp, CircleSlash } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import Markdown from "@/components/chat/ChatMarkdown";
 import { CopyMessageButton } from "@/components/chat/CopyMessageButton";
 import type { ChatMessage, StreamBlock } from "@/lib/chat-types";
 import { formatMessageTimestamp } from "@/lib/message-timestamp";
+import { cn } from "@/lib/utils";
 
 // Isolated so that streaming-driven re-renders of ChatPage do not re-parse
 // every historical user message through ReactMarkdown on every snapshot tick.
@@ -26,6 +28,14 @@ export const UserMessage = memo(
         .join("\n");
     }, [msg.content]);
     const timestamp = useMemo(() => formatMessageTimestamp(msg.createdAt), [msg.createdAt]);
+    const pending =
+      msg.inputState === "queued" ||
+      msg.inputState === "submitted" ||
+      msg.inputState === "accepted";
+    const statusLabel =
+      msg.inputState && msg.inputState !== "consumed"
+        ? t(`inputState.${msg.inputState}`)
+        : undefined;
     // Some user turns carry only a structured part with no text (e.g. an
     // interaction_result, whose inline component re-renders its own read-only
     // state), so suppress the empty bubble.
@@ -37,16 +47,34 @@ export const UserMessage = memo(
         {/* One inset on every side, equal to `--markdown-block-space-between`
             at this density. A rim narrower than the space the renderer puts
             between two paragraphs reads as content spilling out of the box. */}
-        <div className="max-w-[70%] break-words rounded-12 bg-surface-muted p-4">
-          <Markdown className="text-foreground" compact={false} preserveSoftBreaks>
+        <div
+          className={cn(
+            "flex max-w-[70%] items-start gap-2 break-words rounded-12 border border-transparent bg-surface-muted p-4 transition-colors motion-reduce:transition-none",
+            pending && "border-dashed border-border-strong bg-transparent",
+            msg.inputState === "cancelled" && "border-dashed border-border bg-transparent",
+            msg.inputState === "failed" && "border-destructive/50",
+            msg.inputState === "unknown" && "border-warning/50",
+          )}
+          title={statusLabel}
+          aria-busy={pending || undefined}
+        >
+          {msg.inputState === "failed" ? (
+            <CircleAlert className="mt-1 size-4 shrink-0 text-destructive" aria-hidden="true" />
+          ) : msg.inputState === "unknown" ? (
+            <CircleHelp className="mt-1 size-4 shrink-0 text-warning" aria-hidden="true" />
+          ) : msg.inputState === "cancelled" ? (
+            <CircleSlash
+              className="mt-1 size-4 shrink-0 text-muted-foreground"
+              aria-hidden="true"
+            />
+          ) : null}
+          <Markdown className="min-w-0 text-foreground" compact={false} preserveSoftBreaks>
             {text}
           </Markdown>
         </div>
-        {msg.inputState && msg.inputState !== "consumed" ? (
-          <span className="mt-1 text-aux text-muted-foreground" role="status">
-            {t(`inputState.${msg.inputState}`)}
-          </span>
-        ) : null}
+        <span className="sr-only" role="status">
+          {statusLabel}
+        </span>
         {/* Timestamp + copy under the bubble. Hover-revealed on pointer
             devices, always visible on touch. Precision tracks recency: time
             of day today, month + day this year, full date for older years. */}

--- a/packages/web/src/hooks/use-streaming-sessions.test.ts
+++ b/packages/web/src/hooks/use-streaming-sessions.test.ts
@@ -19,6 +19,13 @@ const segmentIdAt = (state: StreamingSessionMap, sessionId: string): string | un
 };
 
 describe("streaming-sessions state", () => {
+  it("preserves the live tail and trace when another input joins the same turn", () => {
+    let state = startStream(new Map(), "session", "turn");
+    state = updateSnapshot(state, "session", "turn", snapshotFor("trace"));
+    state = updateAssistantText(state, "session", "turn", 0, "Still working");
+    expect(startStream(state, "session", "turn")).toBe(state);
+    expect(state.get("session")?.assistantText).toBe("Still working");
+  });
   it("isolates per-session snapshots when concurrent streams update each other", () => {
     let state: StreamingSessionMap = new Map();
     state = startStream(state, "A", "turn-A");

--- a/packages/web/src/hooks/use-streaming-sessions.ts
+++ b/packages/web/src/hooks/use-streaming-sessions.ts
@@ -21,6 +21,7 @@ export function startStream(
   sessionId: string,
   turnId: string,
 ): StreamingSessionMap {
+  if (prev.get(sessionId)?.turnId === turnId) return prev;
   const next = new Map(prev);
   next.set(sessionId, { turnId, snapshot: null, assistantText: "", assistantBlockIx: 0 });
   return next;

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -1,5 +1,13 @@
 {
   "title": "Rome",
+  "inputState": {
+    "queued": "Waiting to be included",
+    "submitted": "Sending to agent",
+    "accepted": "Received by agent · awaiting inclusion",
+    "unknown": "Delivery unconfirmed · not sent again",
+    "cancelled": "Cancelled",
+    "failed": "Not delivered"
+  },
   "documentTitle": "{{guardian}} & {{agent}} | Rome",
   "sidebar": {
     "newChat": "New Chat",
@@ -205,7 +213,7 @@
     "filePill": "#File {{index}}",
     "send": "Send",
     "sendTitle": "Send",
-    "queueTurnTitle": "Queue a new turn",
+    "sendWhileRunningTitle": "Send while agent is working",
     "stopGenerating": "Stop generating"
   },
   "questionCard": {

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -1,5 +1,13 @@
 {
   "title": "Rome",
+  "inputState": {
+    "queued": "等待加入对话",
+    "submitted": "正在发送给 Agent",
+    "accepted": "Agent 已接收，等待纳入上下文",
+    "unknown": "未确认送达，未自动重发",
+    "cancelled": "已取消",
+    "failed": "未送达"
+  },
   "documentTitle": "{{guardian}} 与 {{agent}} | Rome",
   "sidebar": {
     "newChat": "新对话",
@@ -205,7 +213,7 @@
     "filePill": "#文件 {{index}}",
     "send": "发送",
     "sendTitle": "发送",
-    "queueTurnTitle": "排队新一轮对话",
+    "sendWhileRunningTitle": "在 Agent 运行中发送消息",
     "stopGenerating": "停止生成"
   },
   "questionCard": {

--- a/packages/web/src/lib/chat-api.ts
+++ b/packages/web/src/lib/chat-api.ts
@@ -371,7 +371,7 @@ export async function postSessionTurnJson(
     method: "POST",
     credentials: "include",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
+    body: JSON.stringify({ inputId: crypto.randomUUID(), ...body }),
   });
   return parseTurnResponse(res);
 }
@@ -422,6 +422,7 @@ async function parseTurnResponse(res: Response): Promise<PostTurnResult> {
 }
 
 export async function postSessionTurn(sessionId: string, body: FormData): Promise<PostTurnResult> {
+  if (!body.has("inputId")) body.set("inputId", crypto.randomUUID());
   const res = await fetch(`/api/chat/sessions/${sessionId}/turns`, {
     method: "POST",
     credentials: "include",

--- a/packages/web/src/lib/chat-types.ts
+++ b/packages/web/src/lib/chat-types.ts
@@ -258,7 +258,10 @@ export interface TurnInfo {
 
 // Shape of POST /chat/sessions/:id/turns response.
 export interface CreateTurnResponse {
-  turnId: string;
+  turnId: string | null;
+  inputId?: string;
+  disposition?: "started" | "queued" | "steering";
+  inputState?: import("@rome/api-types/trace-segments").AgentInputState | null;
   sessionId: string;
   startedAt: string;
 }
@@ -267,6 +270,7 @@ export interface ChatMessage {
   id: string;
   sessionId: string;
   turnId?: string | null;
+  inputState?: import("@rome/api-types/trace-segments").AgentInputState | null;
   role: "user" | "assistant" | "notification" | "trace";
   content: string; // JSON array of blocks
   createdAt: string;

--- a/packages/web/src/lib/chat-types.ts
+++ b/packages/web/src/lib/chat-types.ts
@@ -122,6 +122,8 @@ export interface StreamBlock {
    *  `commentary` = in-turn narration (rendered muted), `final`/absent = the
    *  turn's answer. */
   turnPhase?: "commentary" | "final";
+  /** Zero-based WebChat assistant text-block identity within the agent turn. */
+  blockIx?: number;
   error?: string | { message: string; code?: string };
   code?: ChatErrorCode;
   provider?: ChatErrorProvider;

--- a/rome_apps/system/src/actions/send-message/send-message.test.ts
+++ b/rome_apps/system/src/actions/send-message/send-message.test.ts
@@ -154,6 +154,34 @@ describe("send_message email union", () => {
 });
 
 describe("send_message chat recipient aliases", () => {
+  it("forwards WebChat text-block identity unchanged", async () => {
+    const adapter = makeAdapter("webchat");
+    const parts = [
+      {
+        type: "text" as const,
+        content: "Final answer",
+        turnPhase: "final" as const,
+        blockIx: 2,
+      },
+    ];
+
+    await executeSendMessage(adapter, {
+      channel: "webchat",
+      threadId: "session-1",
+      text: "Final answer",
+      parts,
+      turnId: "turn-1",
+    });
+
+    expect(adapter.send).toHaveBeenCalledWith("test:webchat", "session-1", {
+      text: "Final answer",
+      parts,
+      attachments: undefined,
+      replyToMessageId: undefined,
+      turnId: "turn-1",
+    });
+  });
+
   it("resolves WhatsApp to: guardian through the guardian channel mapping", async () => {
     const adapter = makeAdapter("whatsapp");
     const personMappingRepo = {

--- a/rome_apps/system/src/actions/send-message/types.d.ts
+++ b/rome_apps/system/src/actions/send-message/types.d.ts
@@ -62,7 +62,7 @@ interface SendMessageBase {
    */
   turnId?: string;
   /**
-   * Structured message parts (text with optional turnPhase, cards, …). When
+   * Structured message parts (text with optional turnPhase/blockIx, cards, …). When
    * provided, rich-content channels (webchat) render/persist these instead of
    * the plain `text` path; other channels ignore them and fall back to `text`.
    * Supplied by the orchestrating route (e.g. the webchat turn finalizer that


### PR DESCRIPTION
## What this PR does

WebChat queues each message as a separate turn, so a correction cannot reach an agent while it works. This PR lets a message join the active turn through provider-native steering without interrupting ongoing work.

An input keeps its identity across turn boundaries. The UI shows its delivery state and keeps the active output stream intact when the guardian sends another message.

## Design & Invariants

- The [conversational input contract](https://github.com/rome-os/rome/blob/feat/streaming-input/docs/concepts/sessions.md#conversational-inputs) separates input identity from run identity. The session owns admission and dispatch, while the message repository stores the input and its delivery state.
- Codex uses `turn/steer` with the expected native turn ID and a client message ID. Steering waits for confirmation of the initial user message.
- Claude Agent SDK uses its streaming prompt and replayed user messages. A prompt gate lets a later Rome turn adopt an input the SDK already holds without resending it.
- Definite deferrals can start a follow-up turn. Unknown deliveries are not replayed automatically, including unfinished inputs found after a restart.
- Each run owns one output stream and one final reply. Stop targets a specific running turn and leaves separately queued inputs intact.
- Independent `sendTurn` callers retain their one-result-per-call FIFO contract. The [steering ADR](https://github.com/rome-os/rome/blob/feat/streaming-input/docs/adrs/provider-native-conversational-steering.md) records why steering is separate from that queue.

The migration adds one nullable `input_state` column to `rome_agent_messages`. It adds no table or index. Existing rows remain valid with a null state.

## Test plan

- [x] Run `pnpm typecheck` on the host.
- [x] Run the complete `pnpm test:unit` command.
- [x] Check that migration 0061 adds only `input_state` and links to snapshot 0060.
- [x] Run `git diff --check` and scan the changed files for credential patterns.
- [x] Run `FEATURE_GATE_ROME_CLOUD_AUTH=off pnpm dev:all` and confirm `Rome started` plus a healthy API response.
- [x] Earlier live Claude Agent SDK acceptance on this branch: steer during tool execution, hand off late input, stop a specific turn, and refresh then send. The test used an Anthropic-compatible API with `ark-code-latest`.
- [x] Earlier live Codex acceptance on this branch: send immediately after startup, steer during text and tool execution, start a later turn, stop a specific turn, and refresh then send. The trace identified `gpt-5.6-sol`.
- [ ] CI checks after publication.

Host checks use Node 24.11.1 because Nix is unavailable on this machine. Earlier browser acceptance used the isolated development stack. Its app installation used locally packed SDKs because the required app-web-sdk version was unavailable from the public registry. No dependency manifest or lockfile changes are included.

The startup check also logged a `sentinel_review` routine validation warning about `trigger.tzMode`. The server still reached readiness. That scheduling path is outside this change.

## Not in this PR

- WeChat and Discord streaming input. Their handlers retain the existing FIFO contract until reply ownership supports multiple inputs per run.
- Recovery from a rejected `onInputStatus` callback. The current per-input promise chain stays rejected, so later status writes can be skipped while in-memory state advances. This is a known review finding, not a covered guarantee.
- A stricter input-state model. `queued` covers both Rome-held and provider-retained input, and `accepted` represents different acknowledgement strengths in the two adapters. Those semantics remain a review follow-up.
