### PR TITLE
fix(agents): make stop reliable and preserve completed work

### DIFF
--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -95,6 +95,7 @@ The caller creating the fork chooses one of two modes:
 
 - In both modes the source conversation is untouched: its next turn never sees the fork's prompt, output, or tool calls.
 - The fork's model is the caller's choice in both modes: it follows the source's live model unless the caller overrides the tier. Exact-mode callers that want provider prompt-cache reuse keep the source's model. Forks never write [model pins](#model-pin).
+- A turn can be forked only after it completes successfully and Rome persists that exact turn's provider checkpoint. Running, stopped, failed, and checkpoint-less turns are not forkable; Rome never substitutes another turn's transcript head or reconstructs provider history from visible output.
 - Every forked turn is recorded as its own fork session, linked back to the parent session and the turn the fork branched from, so its trajectory can be inspected like any other agent run.
 
 **Not to be confused with:**

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -42,6 +42,9 @@ An agent run is one turn of agent work, identified by its turn id — the unit u
 
 - The user inputs, assistant output, and trace evidence produced by the same turn count as one run, not several. A run can consume more than one user input.
 - Failed and interrupted turns still count as runs.
+- Stop targets one run and requests provider cancellation. Until that run ends, Stop can be retried; accepting the request does not mean execution has ended.
+- Stopping preserves received text and tool evidence, including partial replies. It does not roll back changes. A tool call without a received result has an unknown outcome, not a guarantee that nothing ran.
+- Cancelling provider execution does not close the conversation. The next message opens usable execution state and resumes available history without replaying the cancelled message.
 - A run's outcome and wall-clock duration come from the bracket that closes it, and its model attribution and token cost come from the terminal block's accounting. Neither is read from fields mirrored onto individual messages.
 
 **Not to be confused with:**

--- a/packages/api-types/src/trace-segments.ts
+++ b/packages/api-types/src/trace-segments.ts
@@ -256,11 +256,12 @@ export interface TraceSummary {
   /** Wall-clock duration the outermost AgentSession measured for the turn.
    *  Read from the turn's `turn_end` block. */
   totalDurationMs?: number;
+  /** Authoritative outcome from the latest `turn_end` block. Absent while the
+   *  turn is still running and on legacy traces without lifecycle brackets. */
+  turnStatus?: TurnEndBlock["status"];
   /** Per-app invocation totals for the icon-strip tooltip. Keyed by app.id. */
   invocationCounts: Record<string, number>;
-  /** True when the turn was interrupted by the user via Stop. Derived by the
-   *  segment builder from a result/error block whose accounting.stopReason is
-   *  "interrupted" — the AnthropicProvider's signal for a graceful abort. */
+  /** True when the turn was interrupted by the user via Stop. */
   stoppedByUser?: boolean;
   /** Terminal agent error for failed turns. Present only when the trace ended
    *  with an error rather than a user stop. */

--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -2179,6 +2179,130 @@ describe("Webchat API", () => {
     });
   });
 
+  describe("turn cancellation", () => {
+    const setupStop = async (tail: "result" | "partial" | "error" = "result") => {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const interrupt = vi.fn(async () => undefined);
+      const wrongTurnInterrupt = vi.fn(async () => undefined);
+      deps.agentSessionManager = {
+        acquire: vi.fn(async () => ({
+          key: { agentName: "main" },
+          sessionId: "runtime",
+          status: "running",
+          sendTurn: () => ({
+            turnId: "cancel-turn",
+            interrupt,
+            turnContext: otelContext.active(),
+            getSubmittedOutput: () => undefined,
+            events: (async function* () {
+              yield {
+                type: "turn_start",
+                turnId: "cancel-turn",
+                sessionId: "runtime",
+                userPrompt: "work",
+              };
+              yield {
+                type: "tool_use",
+                id: "edit-1",
+                tool: "Edit",
+                input: { file_path: "test.txt" },
+              };
+              yield {
+                type: "tool_result",
+                toolUseId: "edit-1",
+                tool: "Edit",
+                output: "File changed",
+              };
+              if (tail === "partial")
+                yield { type: "text_delta", content: "Already changed the file" };
+              await gate;
+              if (tail === "result") yield { type: "result", content: "Already changed the file" };
+              if (tail === "error") yield { type: "error", error: "Actual provider failure" };
+              yield {
+                type: "turn_end",
+                turnId: "cancel-turn",
+                status: tail === "error" ? "error" : "interrupted",
+                durationMs: 10,
+              };
+            })(),
+          }),
+          subscribe: () => () => undefined,
+          onStatusChange: () => () => undefined,
+          interrupt: wrongTurnInterrupt,
+        })),
+        peek: vi.fn(),
+        shutdown: async () => undefined,
+      } as unknown as typeof deps.agentSessionManager;
+      const sendMessageRun = vi.fn(async () => ({ status: "ok" }));
+      deps.actionEngine = { run: sendMessageRun } as unknown as typeof deps.actionEngine;
+      const app = createWebchatRuntime(deps).routes;
+      const res = await app.request("/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Stop test" }),
+      });
+      const { id: sessionId } = (await res.json()) as { id: string };
+      await app.request(`/chat/sessions/${sessionId}/turns`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "work" }),
+      });
+      return {
+        app,
+        sessionId,
+        interrupt,
+        wrongTurnInterrupt,
+        sendMessageRun,
+        release,
+        stop: () => app.request("/chat/turns/cancel-turn/interrupt", { method: "POST" }),
+        finish: async () => {
+          release();
+          const stream = await app.request("/chat/turns/cancel-turn/stream");
+          return await stream.text();
+        },
+      };
+    };
+
+    it.each([
+      "result",
+      "partial",
+    ] as const)("preserves %s output and tool evidence after repeated Stop", async (tail) => {
+      const h = await setupStop(tail);
+      expect((await h.stop()).status).toBe(202);
+      expect(await (await h.stop()).json()).toEqual({ stopped: false });
+      expect(h.interrupt).toHaveBeenCalledTimes(2);
+      expect(h.wrongTurnInterrupt).not.toHaveBeenCalled();
+      const stream = await h.finish();
+      expect(stream).toContain('"stopped":true');
+      expect(h.sendMessageRun).toHaveBeenCalledWith(
+        "send_message",
+        expect.objectContaining({ text: "Already changed the file" }),
+        expect.anything(),
+      );
+      const trace = await deps.webchatRepo.getTraceContentByTurn(h.sessionId, "cancel-turn");
+      expect(trace!.content).toContain("File changed");
+      expect(trace!.content).toContain("edit-1");
+      if (tail === "partial") expect(trace!.content).toContain("Already changed the file");
+      expect((await h.stop()).status).toBe(404);
+    });
+
+    it("permits retry after cancellation fails and does not hide a later provider error", async () => {
+      const h = await setupStop("error");
+      h.interrupt.mockRejectedValueOnce(new Error("Stop transport failed"));
+      expect((await h.stop()).status).toBe(500);
+      expect((await h.stop()).status).toBe(202);
+      expect(h.interrupt).toHaveBeenCalledTimes(2);
+      const stream = await h.finish();
+      expect(stream).toContain("Actual provider failure");
+      expect(stream).toContain('"success":false');
+      expect(stream).toContain('"stopped":false');
+      expect(h.sendMessageRun).not.toHaveBeenCalled();
+    });
+  });
+
   it("expands a slash-skill command for the model but persists the raw text", async () => {
     let sentTurn: AgentTurnInput | undefined;
     deps.agentSessionManager = {
@@ -3343,6 +3467,55 @@ describe("Webchat API", () => {
   });
 
   describe("session message events", () => {
+    it("retries backend continuation Stop without interrupting a later provider turn", async () => {
+      const sessionId = "sess-backend-stop";
+      await deps.webchatRepo.createSession(sessionId, "Backend stop");
+      const owner = { currentTurnId: "backend-provider-turn", interrupt: vi.fn(async () => {}) };
+      vi.spyOn(deps.agentSessionManager, "peek").mockReturnValue(owner as unknown as AgentSession);
+      const { routes, runtime } = createWebchatRuntime(deps);
+      let finish!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      const task = runtime.enqueueSessionTask(sessionId, async ({ emit }) => {
+        emit({
+          type: "turn_start",
+          turnId: "backend-provider-turn",
+          sessionId: "provider-session",
+          userPrompt: "Continue",
+        });
+        await gate;
+        emit({ type: "result", content: "Already changed the file." });
+        emit({
+          type: "turn_end",
+          turnId: "backend-provider-turn",
+          status: "interrupted",
+          durationMs: 1,
+        });
+      });
+      let turnId = "";
+      await vi.waitFor(async () => {
+        const turns = await (await routes.request(`/chat/sessions/${sessionId}/turns`)).json();
+        turnId = turns[0]?.turnId;
+        expect(turnId).toMatch(/^backend:/);
+      });
+      const stop = () => routes.request(`/chat/turns/${turnId}/interrupt`, { method: "POST" });
+      expect((await stop()).status).toBe(202);
+      expect((await stop()).status).toBe(202);
+      expect(owner.interrupt).toHaveBeenCalledTimes(2);
+      owner.currentTurnId = "later-turn";
+      await stop();
+      expect(owner.interrupt).toHaveBeenCalledTimes(2);
+      finish();
+      await task;
+      expect(
+        (await deps.webchatRepo.getMessages(sessionId)).some((m) =>
+          m.content.includes("Already changed the file."),
+        ),
+      ).toBe(true);
+      await runtime.flushAll();
+    });
+
     it("emits message_insert when a turn recap row is inserted", async () => {
       const sessionId = "sess-recap-events";
       const turnId = "turn-recap-events";

--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -2847,7 +2847,13 @@ describe("Webchat API", () => {
       // check passes; mirrors the real-world state where the feedback footer
       // only renders once the turn's trace row has been written.
       const id = `${sessionId}-${turnId}-anchor`;
-      await deps.webchatRepo.addMessage(id, sessionId, "trace", "[]", turnId);
+      await deps.webchatRepo.addMessage(
+        id,
+        sessionId,
+        "trace",
+        JSON.stringify([{ type: "turn_end", turnId, status: "completed", durationMs: 10 }]),
+        turnId,
+      );
     }
 
     beforeEach(async () => {
@@ -3306,7 +3312,15 @@ describe("Webchat API", () => {
 
     beforeEach(async () => {
       await deps.webchatRepo.createSession(SESSION_ID, "Branch Routes");
-      await deps.webchatRepo.addMessage("branch-anchor", SESSION_ID, "trace", "[]", TURN_ID);
+      await deps.webchatRepo.addMessage(
+        "branch-anchor",
+        SESSION_ID,
+        "trace",
+        JSON.stringify([
+          { type: "turn_end", turnId: TURN_ID, status: "completed", durationMs: 10 },
+        ]),
+        TURN_ID,
+      );
     });
 
     it("resumes the source, runs an exact fork, and shows its Sessions route", async () => {
@@ -3398,6 +3412,57 @@ describe("Webchat API", () => {
           turnId: "branch-fork-turn",
         }),
       );
+    });
+
+    it("refuses a stopped turn before acquiring or reading provider history", async () => {
+      await deps.webchatRepo.addMessage(
+        "branch-user",
+        SESSION_ID,
+        "user",
+        JSON.stringify([{ type: "text", content: "Run the long task" }]),
+        TURN_ID,
+      );
+      await deps.webchatRepo.addMessage(
+        "branch-assistant",
+        SESSION_ID,
+        "assistant",
+        JSON.stringify([{ type: "text", content: "Partial work before Stop" }]),
+        TURN_ID,
+      );
+      await deps.webchatRepo.appendTraceBlocks({
+        messageId: "branch-anchor",
+        sessionId: SESSION_ID,
+        turnId: TURN_ID,
+        startSeq: 0,
+        blocks: [{ type: "turn_end", turnId: TURN_ID, status: "interrupted", durationMs: 10 }],
+      });
+      const runForked = vi.fn(() => (async function* () {})());
+      deps.agentRunner = {
+        run: deps.agentRunner.run.bind(deps.agentRunner),
+        runForked,
+      };
+      const acquireSource = vi.spyOn(deps.agentSessionManager, "acquire").mockResolvedValue({
+        sessionId: "live-source-session",
+      } as AgentSession);
+      const exactCheckpoint = vi.spyOn(deps.sessionManager, "getTurnCheckpoint").mockResolvedValue({
+        sessionId: "live-source-session",
+        turnId: "turn-before-stop",
+        provider: "anthropic",
+        providerThreadId: "claude-thread",
+        checkpointId: "durable-assistant-before-stop",
+      });
+      const app = createWebchatRuntime(deps).routes;
+
+      const res = await app.request(`/chat/sessions/${SESSION_ID}/turns/${TURN_ID}/forks`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: "Explain what happened" }),
+      });
+
+      expect(res.status).toBe(409);
+      expect(acquireSource).not.toHaveBeenCalled();
+      expect(exactCheckpoint).not.toHaveBeenCalled();
+      expect(runForked).not.toHaveBeenCalled();
     });
 
     it("rejects missing turns and invalid prompts", async () => {

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -613,7 +613,7 @@ interface ActiveWebchatStream {
   cleanupTimer: ReturnType<typeof setTimeout> | null;
   onFinish: Promise<void>;
   resolveFinish: () => void;
-  stopRequested: boolean;
+  interrupt?: (reason?: string) => Promise<void>;
   agentName: string;
   channelThreadKey: string | null;
 }
@@ -1619,7 +1619,6 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       cleanupTimer: null,
       onFinish,
       resolveFinish,
-      stopRequested: false,
       agentName,
       channelThreadKey,
     };
@@ -1684,29 +1683,20 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     try {
       const done = await task();
       await safePersistTrace(stream, label);
-      if (stream.stopRequested) {
-        emitToStream(stream, "done", { success: true, stopped: true }, "terminal");
-      } else {
-        emitToStream(stream, "done", done ?? { success: true }, "terminal");
-      }
+      emitToStream(stream, "done", done ?? { success: true }, "terminal");
     } catch (err) {
       await safePersistTrace(stream, label);
-      if (stream.stopRequested) {
-        log.info(`${label} stopped by user`, { sessionId: stream.sessionId });
-        emitToStream(stream, "done", { success: true, stopped: true }, "terminal");
-      } else {
-        const modelError = toModelResolutionErrorPayload(err);
-        log.error(`${label} failed`, {
-          sessionId: stream.sessionId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        emitToStream(
-          stream,
-          "stream_error",
-          modelError ?? { error: err instanceof Error ? err.message : "Internal error" },
-          "terminal",
-        );
-      }
+      const modelError = toModelResolutionErrorPayload(err);
+      log.error(`${label} failed`, {
+        sessionId: stream.sessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      emitToStream(
+        stream,
+        "stream_error",
+        modelError ?? { error: err instanceof Error ? err.message : "Internal error" },
+        "terminal",
+      );
     } finally {
       finishStream(stream);
     }
@@ -2516,32 +2506,25 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
         return c.json({ stopped: false, reason: "turn_not_interruptible" }, 409);
       }
       await agentTurnStream.interrupt("user-stop");
-      return c.json({ stopped: true });
+      return c.json({ stopped: agentTurnStream.finished }, agentTurnStream.finished ? 200 : 202);
     }
     if (!stream) return c.json({ stopped: false, reason: "no_running_turn" }, 404);
-    if (stream.stopRequested) {
-      return c.json({ stopped: true, alreadyRequested: true });
+    log.info("interrupt requested for turn", { turnId, sessionId: stream.sessionId });
+    if (stream.interrupt) {
+      await stream.interrupt("user-stop");
+      return c.json({ stopped: stream.finished }, stream.finished ? 200 : 202);
     }
-    const channelThreadKey = stream.channelThreadKey;
+    // A stream without a turn-bound interrupt can only be cancelled through
+    // its live session owner. Require the exact active turn so a queued turn
+    // cannot cancel the turn currently producing output.
     const agentSess = deps.agentSessionManager.peek({
       agentName: stream.agentName,
-      channelThreadKey: channelThreadKey ?? `webchat:${stream.sessionId}`,
+      channelThreadKey: stream.channelThreadKey ?? `webchat:${stream.sessionId}`,
     });
     if (!agentSess || agentSess.currentTurnId !== turnId) {
-      return c.json({ stopped: false, reason: "turn_not_running" }, 409);
+      return c.json({ stopped: false, reason: "turn_not_interruptible" }, 409);
     }
-    stream.stopRequested = true;
-    log.info("interrupt requested for turn", { turnId, sessionId: stream.sessionId });
-    if (agentSess) {
-      try {
-        await agentSess.interrupt("user-stop", turnId);
-      } catch (err) {
-        log.warn("agentSession.interrupt() rejected", {
-          turnId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
+    await agentSess.interrupt("user-stop", turnId);
     return c.json({ stopped: true });
   });
 
@@ -3076,6 +3059,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       const turnId = handle.turnId;
 
       const stream = await createStream(sessionId, turnId, channelThreadKey, agentName);
+      stream.interrupt = handle.interrupt;
       enqueueStream(sessionId, stream);
       void generateAndPersistConversationTitle(sessionId, session.name, firstMessageForTitle);
 
@@ -3111,7 +3095,6 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
             let resultError: Extract<AgentMessage, { type: "error" }> | undefined;
             for await (const msg of handle.events) {
               if (msg.type === "input_status") continue;
-              if (stream.stopRequested && msg.type === "error") continue;
               // Live preview of the in-flight text block. Transient — never a
               // trace block, never persisted. The replay key is fixed so a
               // late subscriber gets one event with the latest block's
@@ -3176,6 +3159,20 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
                   turnPhase: msg.turnPhase,
                 };
                 if (msg.turnPhase === "final") finalTextBlockIx = blockIx;
+                stream.assistantBlockIx += 1;
+                stream.assistantText = "";
+              }
+              if (msg.type === "turn_end" && stream.assistantText) {
+                const blockIx = stream.assistantBlockIx;
+                const partial = {
+                  type: "text" as const,
+                  content: stream.assistantText,
+                  turnPhase: "final" as const,
+                };
+                lastCompletedText = { blockIx, content: partial.content, turnPhase: "final" };
+                finalTextBlockIx = blockIx;
+                stream.traceBlocks.push(partial);
+                emitTraceBlock(stream, partial);
                 stream.assistantBlockIx += 1;
                 stream.assistantText = "";
               }
@@ -3384,7 +3381,14 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
             // In-turn commentary was already persisted per-block as its own live
             // message; this is the final answer only. `text` is the final answer
             // for non-webchat consumers; webchat persists the tagged part.
-            if (resultContent && !stream.stopRequested) {
+            if (
+              !resultContent &&
+              lastCompletedText &&
+              finalTextBlockIx === lastCompletedText.blockIx
+            ) {
+              resultContent = lastCompletedText.content;
+            }
+            if (resultContent) {
               const reusableResultBlockIx =
                 lastCompletedText?.turnPhase === undefined &&
                 lastCompletedText?.content === resultContent
@@ -3419,7 +3423,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
             }
 
             // Mirror the auto-approved outgoing-message audit record message_handler creates.
-            if (resultContent && !stream.stopRequested && deps.approvalsRepo) {
+            if (resultContent && deps.approvalsRepo) {
               await deps.approvalsRepo
                 .create({
                   type: "outgoing_message",
@@ -3442,9 +3446,11 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
                 });
             }
 
+            const stopped = stream.segmentBuilder.snapshot().summary.stoppedByUser === true;
             return {
               success: !resultError,
-              data: { action: stream.stopRequested ? "stopped" : "sent" },
+              stopped,
+              data: { action: stopped ? "stopped" : "sent" },
               error: resultError?.error,
               code: resultError?.code,
               provider: resultError?.provider,
@@ -3546,7 +3552,10 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     const stream = await createStream(
       sessionId,
       syntheticTurnId,
-      null,
+      buildWebchatChannelThreadKey(
+        sessionId,
+        resolveStoredModelSelection(session.largeModelSelection),
+      ),
       session.agentName ?? "main",
     );
     enqueueStream(sessionId, stream);
@@ -3562,6 +3571,19 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     // in the trace and the model falsely believes the form was shown.
     const builtinQuestionCards: PendingInteractionPart[] = [];
     const emit = (msg: AgentMessage & { agent?: string }) => {
+      if (msg.type === "turn_start" && stream.channelThreadKey) {
+        const owner = deps.agentSessionManager.peek({
+          agentName: msg.agent ?? stream.agentName,
+          channelThreadKey: stream.channelThreadKey,
+        });
+        // The wrapper may outlive its provider turn. Never stop a later turn
+        // merely because it reuses the same runtime session.
+        if (owner?.currentTurnId === msg.turnId) {
+          stream.interrupt = async (reason) => {
+            if (owner.currentTurnId === msg.turnId) await owner.interrupt(reason);
+          };
+        }
+      }
       // Backend turns have no live bubble; drop transient text previews.
       if (msg.type === "text_delta" || msg.type === "input_status") return;
       stream.traceBlocks.push(msg);
@@ -3588,9 +3610,13 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       // late-attached subscriber's reload-on-done also sees it. The push
       // (addBackendReplyMessage → message_inserted) is the primary delivery
       // path since the browser isn't subscribed to this synthetic stream.
-      if (replyText && !stream.stopRequested) {
+      if (replyText) {
         await deps.webchatRepo.addBackendReplyMessage(sessionId, syntheticTurnId, replyText);
       }
+      return {
+        success: true,
+        stopped: stream.segmentBuilder.snapshot().summary.stoppedByUser === true,
+      };
     });
   };
 

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -1147,6 +1147,24 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     let threadContext: ThreadContext;
     let sourceCheckpoint: ForkSourceCheckpoint | null = null;
     try {
+      const traceRow = await deps.webchatRepo.getTraceContentByTurn(input.session.id, input.turnId);
+      const turnStatus = traceRow
+        ? parseStoredTraceBlocks(traceRow.content)
+            .filter(
+              (block): block is Extract<TraceBlockDto, { type: "turn_end" }> =>
+                block.type === "turn_end" && block.turnId === input.turnId,
+            )
+            .at(-1)?.status
+        : undefined;
+      if (turnStatus !== "completed") {
+        log.warn("turn fork skipped: source turn did not complete successfully", {
+          sessionId: input.session.id,
+          turnId: input.turnId,
+          label: input.label,
+          turnStatus,
+        });
+        return null;
+      }
       const projectPath = normalizeSelectedWebchatProjectPath(
         input.session.projectPath ?? input.session.projectName,
       );

--- a/packages/core/src/api/trace-segments.test.ts
+++ b/packages/core/src/api/trace-segments.test.ts
@@ -380,6 +380,7 @@ describe("buildTraceSnapshot — summary", () => {
     expect(snap.summary.distinctApps).toEqual([]);
     expect(snap.summary.stoppedByUser).toBeUndefined();
     expect(snap.summary.terminalError).toBeUndefined();
+    expect(snap.summary.turnStatus).toBeUndefined();
   });
 
   it("error block followed by turn_end flags summary.terminalError for failed turns", () => {
@@ -393,6 +394,7 @@ describe("buildTraceSnapshot — summary", () => {
     });
     expect(snap.summary.terminalError).toBe("Access token expired");
     expect(snap.summary.stoppedByUser).toBeUndefined();
+    expect(snap.summary.turnStatus).toBe("error");
   });
 
   it("interrupted turn with an error terminal is reported as stopped rather than failed", () => {
@@ -409,6 +411,7 @@ describe("buildTraceSnapshot — summary", () => {
     });
     expect(snap.summary.stoppedByUser).toBe(true);
     expect(snap.summary.terminalError).toBeUndefined();
+    expect(snap.summary.turnStatus).toBe("interrupted");
   });
 
   it("turn_end with status 'interrupted' flags summary.stoppedByUser", () => {
@@ -427,6 +430,7 @@ describe("buildTraceSnapshot — summary", () => {
     });
     expect(snap.summary.stoppedByUser).toBe(true);
     expect(snap.summary.totalSteps).toBe(1);
+    expect(snap.summary.turnStatus).toBe("interrupted");
   });
 
   it("turn_start clears the previous turn's terminal summary for the live trace", () => {
@@ -445,6 +449,7 @@ describe("buildTraceSnapshot — summary", () => {
     expect(snap.summary.terminalError).toBeUndefined();
     expect(snap.summary.stoppedByUser).toBeUndefined();
     expect(snap.summary.totalDurationMs).toBeUndefined();
+    expect(snap.summary.turnStatus).toBeUndefined();
   });
 
   it("stoppedByUser resets when a later turn in the same trace completes normally", () => {
@@ -461,6 +466,7 @@ describe("buildTraceSnapshot — summary", () => {
     });
     expect(snap.summary.stoppedByUser).toBeUndefined();
     expect(snap.summary.totalDurationMs).toBe(900);
+    expect(snap.summary.turnStatus).toBe("completed");
   });
 
   it("stoppedByUser resets when a later turn in the same trace fails", () => {
@@ -477,6 +483,7 @@ describe("buildTraceSnapshot — summary", () => {
     });
     expect(snap.summary.stoppedByUser).toBeUndefined();
     expect(snap.summary.terminalError).toBe("boom");
+    expect(snap.summary.turnStatus).toBe("error");
   });
 
   it("result block with a non-interrupted stopReason leaves stoppedByUser unset", () => {

--- a/packages/core/src/api/trace-segments.ts
+++ b/packages/core/src/api/trace-segments.ts
@@ -113,11 +113,7 @@ export function createSegmentBuilder(args: SegmentBuilderArgs): SegmentBuilder {
   const subagents: TraceSummary["subagents"] = [];
   const subagentByUseId = new Map<string, NonNullable<TraceSummary["subagents"]>[number]>();
   let totalDurationMs: number | undefined;
-  // Mirrors `turn_end.status === "interrupted"` — the AgentSession classifies
-  // a user stop (Stop button → `q.interrupt()` → terminal accounting
-  // `stopReason: "interrupted"`) when it emits the bracket, so the builder
-  // reads the outcome off the lifecycle block instead of re-deriving it from
-  // the terminal's accounting.
+  // Turn outcome comes from turn_end, not provider transport completion.
   let stoppedByUser = false;
   let terminalError: string | undefined;
   let latestPlan: TraceSummary["plan"];

--- a/packages/core/src/api/trace-segments.ts
+++ b/packages/core/src/api/trace-segments.ts
@@ -113,6 +113,7 @@ export function createSegmentBuilder(args: SegmentBuilderArgs): SegmentBuilder {
   const subagents: TraceSummary["subagents"] = [];
   const subagentByUseId = new Map<string, NonNullable<TraceSummary["subagents"]>[number]>();
   let totalDurationMs: number | undefined;
+  let turnStatus: TraceSummary["turnStatus"];
   // Turn outcome comes from turn_end, not provider transport completion.
   let stoppedByUser = false;
   let terminalError: string | undefined;
@@ -190,6 +191,7 @@ export function createSegmentBuilder(args: SegmentBuilderArgs): SegmentBuilder {
         // keep reporting the previous turn's error/stopped pill (or its
         // duration) while it is still running.
         totalDurationMs = undefined;
+        turnStatus = undefined;
         stoppedByUser = false;
         terminalError = undefined;
         latestPlan = undefined;
@@ -199,6 +201,7 @@ export function createSegmentBuilder(args: SegmentBuilderArgs): SegmentBuilder {
       if (block.type === "turn_end") {
         activeRunSegId = null;
         totalDurationMs = block.durationMs;
+        turnStatus = block.status;
         // `turn_end.status` is the authoritative turn outcome; the bracketed
         // terminal (most recent same-agent result/error — sub-agent terminals
         // relay tagged with their own agent name) only supplies the error
@@ -341,6 +344,7 @@ export function createSegmentBuilder(args: SegmentBuilderArgs): SegmentBuilder {
             ? { subagents: subagents.map((subagent) => ({ ...subagent })) }
             : {}),
           totalDurationMs,
+          turnStatus,
           invocationCounts: { ...invocationCounts },
           ...(stoppedByUser ? { stoppedByUser: true } : {}),
           ...(terminalError ? { terminalError } : {}),

--- a/packages/core/src/core/agent-runner.test.ts
+++ b/packages/core/src/core/agent-runner.test.ts
@@ -1608,6 +1608,127 @@ describe("AgentRunner", () => {
       await manager.shutdown();
     });
 
+    it("reopens an aborted provider before forking its current checkpoint", async () => {
+      const opens: ModelSessionParams[] = [];
+      let releaseInterrupted!: () => void;
+      const interruptedGate = new Promise<void>((resolve) => {
+        releaseInterrupted = resolve;
+      });
+      let beginInterrupted!: () => void;
+      const interruptedBegun = new Promise<void>((resolve) => {
+        beginInterrupted = resolve;
+      });
+      let providerFork: ModelSessionForkParams | undefined;
+      const provider: ModelProvider = {
+        id: "anthropic",
+        displayName: "Claude",
+        builtinTools: new Set(),
+        async openSession(params) {
+          opens.push(params);
+          const first = opens.length === 1;
+          let disposed = false;
+          const model = createSessionFromRun(
+            "anthropic",
+            async function* () {
+              if (!first) return;
+              beginInterrupted();
+              await interruptedGate;
+              yield { type: "result", content: "Work before cancellation" };
+              await model.close();
+            },
+            params,
+          );
+          return {
+            ...model,
+            providerThreadId: "persisted-claude-thread",
+            get isClosed() {
+              return disposed;
+            },
+            get lastCompletedTurnCheckpoint() {
+              return first ? "assistant-current" : undefined;
+            },
+            async interrupt() {
+              if (!first || disposed) return;
+              disposed = true;
+              releaseInterrupted();
+            },
+            async fork(forkParams) {
+              if (disposed) throw new Error("Cannot fork a closed ModelSession");
+              providerFork = forkParams;
+              return {
+                providerId: "anthropic" as const,
+                sessionId: forkParams.sessionId,
+                sourceSessionId: params.sessionId,
+                sourceProviderThreadId: "persisted-claude-thread",
+                mode: forkParams.mode ?? "ephemeral",
+                providerThreadId: forkParams.sessionId,
+                open: async () =>
+                  forkSessionStub({
+                    providerId: "anthropic",
+                    model: "claude-fork",
+                    events: (async function* (): AsyncIterable<AgentMessage> {
+                      yield { type: "result", content: "Fork complete" };
+                    })(),
+                  }),
+              };
+            },
+            async close() {
+              disposed = true;
+              await model.close();
+            },
+          };
+        },
+      };
+      const manager = createAgentSessionManager(
+        managerDeps(createTestModelResolver({ providers: [provider] })),
+        { keepAliveAcrossTurns: true },
+      );
+      const runner = new AgentRunner(manager);
+      const session = await manager.acquire({
+        agentName: "test-main",
+        channelThreadKey: "webchat:abort-fork",
+      });
+      const interrupted = session.sendTurn({ prompt: "first" });
+      const interruptedMessages = collectMessages(interrupted.events);
+      await interruptedBegun;
+      await interrupted.interrupt!("user-stop");
+      expect(await interruptedMessages).toContainEqual(
+        expect.objectContaining({ type: "turn_end", status: "interrupted" }),
+      );
+
+      const forkMessages = await collectMessages(
+        runner.runForked({
+          agentName: "test-main",
+          sourceSessionId: session.sessionId,
+          channelThreadKey: "webchat:abort-fork",
+          prompt: "fork it",
+          mode: "exact",
+          sourceCheckpoint: {
+            providerId: "anthropic",
+            providerThreadId: "persisted-claude-thread",
+            checkpointId: "assistant-current",
+          },
+        }),
+      );
+
+      expect(forkMessages.map((message) => message.type)).toEqual([
+        "turn_start",
+        "result",
+        "turn_end",
+      ]);
+      expect(forkMessages[1]).toMatchObject({ type: "result", content: "Fork complete" });
+      expect(opens).toHaveLength(2);
+      expect(opens[1]).toMatchObject({
+        isNewSession: false,
+        providerThreadId: "persisted-claude-thread",
+      });
+      expect(providerFork).toMatchObject({
+        configurationMode: "exact",
+        sourceCheckpoint: "assistant-current",
+      });
+      await manager.shutdown();
+    });
+
     it("resumes an explicit sessionId without a caller-provided channelThreadKey", async () => {
       const sendTurn: AgentSession["sendTurn"] = vi.fn(() => ({
         turnId: "turn-1",

--- a/packages/core/src/core/agent-runner.test.ts
+++ b/packages/core/src/core/agent-runner.test.ts
@@ -60,6 +60,7 @@ import {
   type AgentSessionManager,
 } from "./agent-session.js";
 import { createAgentLifecycleDispatcher } from "./agent-lifecycle.js";
+import { createTurnMiddlewareChain } from "./turn-middleware.js";
 import { CapabilityDiscovery } from "./capability-discovery.js";
 import { SkillCatalog } from "./skill-catalog.js";
 import type { AgentLifecycleDispatcher } from "./agent-lifecycle.js";
@@ -1430,6 +1431,165 @@ describe("AgentRunner", () => {
   }
 
   describe("session management", () => {
+    it("waits for cancellation before ending a turn stopped during middleware", async () => {
+      let releaseMiddleware!: () => void;
+      const middlewareGate = new Promise<void>((resolve) => {
+        releaseMiddleware = resolve;
+      });
+      let confirmExit!: () => void;
+      const exit = new Promise<void>((resolve) => {
+        confirmExit = resolve;
+      });
+      const turnMiddleware = createTurnMiddlewareChain();
+      vi.spyOn(turnMiddleware, "run").mockImplementation(async (_ctx, next) => {
+        await middlewareGate;
+        await next();
+      });
+      const interrupt = vi.fn(() => exit);
+      const sendUserInput = vi.fn(async () => {});
+      vi.spyOn(mockProvider, "openSession").mockImplementation(async (params) => ({
+        ...createClosableModelSession(params),
+        interrupt,
+        sendUserInput,
+      }));
+      const manager = createAgentSessionManager(
+        {
+          ...managerDeps(createTestModelResolver({ providers: [mockProvider] })),
+          turnMiddleware,
+        },
+        { keepAliveAcrossTurns: true },
+      );
+      const session = await manager.acquire({
+        agentName: "test-main",
+        channelThreadKey: "webchat:stop-middleware",
+      });
+      const turn = session.sendTurn({ prompt: "Do not dispatch" });
+      let finished = false;
+      const messages = collectMessages(turn.events).then((value) => {
+        finished = true;
+        return value;
+      });
+      await vi.waitFor(() => expect(turnMiddleware.run).toHaveBeenCalled());
+      const stopping = turn.interrupt!("user-stop");
+      releaseMiddleware();
+      await vi.waitFor(() => expect(interrupt).toHaveBeenCalledTimes(2));
+      expect(finished).toBe(false);
+      expect(sendUserInput).not.toHaveBeenCalled();
+      confirmExit();
+      await stopping;
+      expect(await messages).toContainEqual(
+        expect.objectContaining({ type: "turn_end", status: "interrupted" }),
+      );
+      await manager.shutdown();
+    });
+
+    it("cancels a turn before dispatch without sending its input", async () => {
+      const manager = createAgentSessionManager(
+        managerDeps(createTestModelResolver({ providers: [mockProvider] })),
+        { keepAliveAcrossTurns: true },
+      );
+      const session = await manager.acquire({
+        agentName: "test-main",
+        channelThreadKey: "webchat:early-stop",
+      });
+      const turn = session.sendTurn({ prompt: "Do not dispatch" });
+      await turn.interrupt!("user-stop");
+      const messages = await collectMessages(turn.events);
+      expect(mockProvider.calls).toHaveLength(0);
+      expect(messages).toContainEqual(
+        expect.objectContaining({ type: "turn_end", status: "interrupted" }),
+      );
+      await manager.shutdown();
+    });
+
+    it("reopens an aborted provider for the next turn without replaying cancelled input", async () => {
+      const opens: ModelSessionParams[] = [];
+      const prompts: string[] = [];
+      const cancels = vi.fn();
+      let releaseFirst!: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let releaseSecond!: () => void;
+      const secondGate = new Promise<void>((resolve) => {
+        releaseSecond = resolve;
+      });
+      const provider: ModelProvider = {
+        id: "anthropic",
+        displayName: "Claude",
+        builtinTools: new Set(),
+        async openSession(params) {
+          opens.push(params);
+          const first = opens.length === 1;
+          let disposed = false;
+          const model = createSessionFromRun(
+            "anthropic",
+            async function* ({ prompt }) {
+              prompts.push(prompt);
+              if (first) {
+                yield {
+                  type: "tool_use",
+                  id: "edit-1",
+                  tool: "Edit",
+                  input: { file_path: "test.txt" },
+                };
+                await firstGate;
+                yield { type: "result", content: "Work before cancellation" };
+                await model.close();
+              } else {
+                await secondGate;
+                yield { type: "result", content: "Next turn" };
+              }
+            },
+            params,
+          );
+          return {
+            ...model,
+            providerThreadId: "persisted-claude-thread",
+            get isClosed() {
+              return disposed;
+            },
+            async interrupt() {
+              cancels();
+              disposed = true;
+              releaseFirst();
+            },
+          };
+        },
+      };
+      const manager = createAgentSessionManager(
+        managerDeps(createTestModelResolver({ providers: [provider] })),
+        { keepAliveAcrossTurns: true },
+      );
+      const session = await manager.acquire({
+        agentName: "test-main",
+        channelThreadKey: "webchat:abort-resume",
+      });
+      const first = session.sendTurn({ prompt: "first" });
+      const firstMessages = collectMessages(first.events);
+      await vi.waitFor(() => expect(prompts).toEqual(["first"]));
+      const second = session.sendTurn({ prompt: "second" });
+      const secondMessages = collectMessages(second.events);
+      await first.interrupt!("user-stop");
+      expect(await firstMessages).toContainEqual(
+        expect.objectContaining({ type: "turn_end", status: "interrupted" }),
+      );
+      await vi.waitFor(() => expect(prompts).toEqual(["first", "second"]));
+      await first.interrupt!("late-repeat");
+      expect(cancels).toHaveBeenCalledTimes(1);
+      releaseSecond();
+      expect(await secondMessages).toContainEqual(
+        expect.objectContaining({ type: "result", content: "Next turn" }),
+      );
+      expect(opens).toHaveLength(2);
+      expect(opens[1]).toMatchObject({
+        isNewSession: false,
+        providerThreadId: "persisted-claude-thread",
+      });
+      expect(session.status).toBe("idle");
+      await manager.shutdown();
+    });
+
     it("resumes an explicit sessionId without a caller-provided channelThreadKey", async () => {
       const sendTurn: AgentSession["sendTurn"] = vi.fn(() => ({
         turnId: "turn-1",

--- a/packages/core/src/core/agent-runner.test.ts
+++ b/packages/core/src/core/agent-runner.test.ts
@@ -58,6 +58,7 @@ import {
   createAgentSessionManager,
   type AgentSession,
   type AgentSessionManager,
+  type AgentTurnHandle,
 } from "./agent-session.js";
 import { createAgentLifecycleDispatcher } from "./agent-lifecycle.js";
 import { createTurnMiddlewareChain } from "./turn-middleware.js";
@@ -1502,7 +1503,7 @@ describe("AgentRunner", () => {
       await manager.shutdown();
     });
 
-    it("reopens an aborted provider for the next turn without replaying cancelled input", async () => {
+    it("reopens an aborted provider through the conversational input lane", async () => {
       const opens: ModelSessionParams[] = [];
       const prompts: string[] = [];
       const cancels = vi.fn();
@@ -1565,15 +1566,32 @@ describe("AgentRunner", () => {
         agentName: "test-main",
         channelThreadKey: "webchat:abort-resume",
       });
-      const first = session.sendTurn({ prompt: "first" });
+      const submit = (inputId: string, prompt: string) => {
+        let resolveTurn!: (handle: AgentTurnHandle) => void;
+        const turn = new Promise<AgentTurnHandle>((resolve) => {
+          resolveTurn = resolve;
+        });
+        const receipt = session.submitInput!(
+          { inputId, prompt },
+          { onTurn: (handle) => resolveTurn(handle) },
+        );
+        return { receipt, turn };
+      };
+
+      const firstInput = submit("input-first", "first");
+      expect(firstInput.receipt.disposition).toBe("started");
+      const first = await firstInput.turn;
       const firstMessages = collectMessages(first.events);
       await vi.waitFor(() => expect(prompts).toEqual(["first"]));
-      const second = session.sendTurn({ prompt: "second" });
-      const secondMessages = collectMessages(second.events);
       await first.interrupt!("user-stop");
       expect(await firstMessages).toContainEqual(
         expect.objectContaining({ type: "turn_end", status: "interrupted" }),
       );
+
+      const secondInput = submit("input-second", "second");
+      expect(secondInput.receipt.disposition).toBe("started");
+      const second = await secondInput.turn;
+      const secondMessages = collectMessages(second.events);
       await vi.waitFor(() => expect(prompts).toEqual(["first", "second"]));
       await first.interrupt!("late-repeat");
       expect(cancels).toHaveBeenCalledTimes(1);

--- a/packages/core/src/core/agent-runner.test.ts
+++ b/packages/core/src/core/agent-runner.test.ts
@@ -2049,6 +2049,54 @@ describe("AgentRunner", () => {
       });
     });
 
+    it("does not persist a provider checkpoint for an interrupted turn", async () => {
+      const provider: ModelProvider = {
+        id: "anthropic",
+        displayName: "Claude",
+        builtinTools: new Set(),
+        async openSession(params) {
+          const session = createSessionFromRun(
+            "anthropic",
+            async function* () {
+              yield { type: "text", content: "partial output" };
+              yield {
+                type: "result",
+                content: "partial output",
+                accounting: {
+                  provider: "anthropic",
+                  model: params.model,
+                  usage: {
+                    cacheReadTokens: 0,
+                    cacheWriteTokens: 0,
+                    inputTokens: 0,
+                    outputTokens: 0,
+                  },
+                  stopReason: "interrupted",
+                },
+              };
+            },
+            params,
+          );
+          return {
+            ...session,
+            providerThreadId: "claude-thread",
+            lastCompletedTurnCheckpoint: "streamed-but-not-resumable-assistant-uuid",
+          };
+        },
+      };
+      const runner = createRunner(provider);
+
+      const messages = await collectMessages(
+        runner.run({ agentName: "test-main", prompt: "Hello" }),
+      );
+      const start = messages.find((message) => message.type === "turn_start");
+      expect(start).toBeDefined();
+      if (!start || start.type !== "turn_start") return;
+
+      expect(await sessionManager.getTurnCheckpoint(start.sessionId, start.turnId)).toBeNull();
+      expect(messages.at(-1)).toMatchObject({ type: "turn_end", status: "interrupted" });
+    });
+
     it("persists the session model pin for a completed Rome turn", async () => {
       const provider = new MockModelProvider([[{ type: "result", content: "Done" }]]);
       const runner = createRunner(provider);

--- a/packages/core/src/core/agent-runner.ts
+++ b/packages/core/src/core/agent-runner.ts
@@ -156,7 +156,7 @@ export interface ModelSessionParams {
   /**
    * Provider-specific thread/session id from a previous session, used for
    * resume. Codex generates its own opaque thread id that must be passed
-   * back to `resumeThread()`; Anthropic uses Rome's `sessionId` directly.
+   * back to `resumeThread()`; Anthropic captures the SDK transcript's id.
    */
   providerThreadId?: string;
   /** Provider-owned fork source. Normal application code should not set this. */
@@ -256,6 +256,8 @@ export interface ModelSessionFork {
 export interface ModelSession {
   readonly providerId: ProviderId;
   readonly model: string;
+  /** A disposed provider execution must be reopened before another turn. */
+  readonly isClosed?: boolean;
   /** Single, lifetime stream of AgentMessages produced by the provider. */
   readonly events: AsyncIterable<AgentMessage>;
 
@@ -278,7 +280,7 @@ export interface ModelSession {
   /** Create an isolated provider-owned branch from this live session. */
   fork(params: ModelSessionForkParams): Promise<ModelSessionFork>;
 
-  /** Graceful stop of the in-flight turn. */
+  /** Stop the in-flight turn. The provider may dispose of its execution. */
   interrupt(reason?: string): Promise<void>;
 
   /**

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -2655,45 +2655,58 @@ class AgentSessionImpl implements AgentSession {
         agent: this.key.agentName,
       };
       try {
-        if (input.sourceCheckpoint) {
-          if (input.sourceCheckpoint.providerId !== this.modelSession.providerId) {
-            throw new Error(
-              `Fork checkpoint provider ${input.sourceCheckpoint.providerId} does not match live provider ${this.modelSession.providerId}`,
-            );
+        // An interrupt may close the provider query while leaving the Rome
+        // session reusable. Ordinary turns reopen that provider at their mutex
+        // boundary; forks need the same gate before touching the source. Keep
+        // the lock only through descriptor creation so the independent fork
+        // does not block later source turns.
+        const { fork, forkOpen, outbound } = await this.turnMutex.runExclusive(async () => {
+          if (this.status === "closed") {
+            throw new Error(`AgentSession ${this.sessionId} is closed`);
           }
-          const liveProviderThreadId = this.modelSession.providerThreadId;
-          if (
-            liveProviderThreadId &&
-            input.sourceCheckpoint.providerThreadId !== liveProviderThreadId
-          ) {
-            throw new Error("Fork checkpoint belongs to a different provider thread");
+          await this.ensureModelSessionForTurn();
+          const sourceModelSession = this.modelSession;
+          if (input.sourceCheckpoint) {
+            if (input.sourceCheckpoint.providerId !== sourceModelSession.providerId) {
+              throw new Error(
+                `Fork checkpoint provider ${input.sourceCheckpoint.providerId} does not match live provider ${sourceModelSession.providerId}`,
+              );
+            }
+            const liveProviderThreadId = sourceModelSession.providerThreadId;
+            if (
+              liveProviderThreadId &&
+              input.sourceCheckpoint.providerThreadId !== liveProviderThreadId
+            ) {
+              throw new Error("Fork checkpoint belongs to a different provider thread");
+            }
           }
-        }
-        const forkModel = input.tier
-          ? await this.deps.modelResolver.getModelProvider({
-              tier: input.tier,
-              providerId: this.modelSession.providerId,
-            })
-          : undefined;
-        const fork = await this.modelSession.fork({
-          sessionId: forkSessionId,
-          mode: "ephemeral",
-          configurationMode: mode,
-          sourceCheckpoint: input.sourceCheckpoint?.checkpointId,
-        });
-        // One serialized outbound stream for the whole forked turn: the
-        // provider-event pump below and out-of-band emitters (exact-mode
-        // subagent relays, structured_output) push concurrently; the drain
-        // loop yields in arrival order. A provider stream failure becomes the
-        // turn's terminal error block, preserving the bracketing invariant.
-        const outbound = new ForkStreamQueue();
-        const forkOpen = this.buildForkOpenParams({
-          mode,
-          forkSessionId,
-          forkTurnId: turnId,
-          model: forkModel?.model ?? this.modelSession.model,
-          threadContext: input.threadContext,
-          emit: (msg) => outbound.push(msg),
+          const forkModel = input.tier
+            ? await this.deps.modelResolver.getModelProvider({
+                tier: input.tier,
+                providerId: sourceModelSession.providerId,
+              })
+            : undefined;
+          const fork = await sourceModelSession.fork({
+            sessionId: forkSessionId,
+            mode: "ephemeral",
+            configurationMode: mode,
+            sourceCheckpoint: input.sourceCheckpoint?.checkpointId,
+          });
+          // One serialized outbound stream for the whole forked turn: the
+          // provider-event pump below and out-of-band emitters (exact-mode
+          // subagent relays, structured_output) push concurrently; the drain
+          // loop yields in arrival order. A provider stream failure becomes the
+          // turn's terminal error block, preserving the bracketing invariant.
+          const outbound = new ForkStreamQueue();
+          const forkOpen = this.buildForkOpenParams({
+            mode,
+            forkSessionId,
+            forkTurnId: turnId,
+            model: forkModel?.model ?? sourceModelSession.model,
+            threadContext: input.threadContext,
+            emit: (msg) => outbound.push(msg),
+          });
+          return { fork, forkOpen, outbound };
         });
         disposeForkResources = forkOpen.dispose;
         forkSession = await fork.open(forkOpen.params);

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -2174,7 +2174,6 @@ class AgentSessionImpl implements AgentSession {
       });
     } finally {
       if (this.replacingModelSession === session || this.modelSession !== session) return;
-      this.inputs.close();
       const sink = this.currentSink;
       if (session.isClosed) {
         this.modelSessionAvailable = false;
@@ -2190,6 +2189,7 @@ class AgentSessionImpl implements AgentSession {
         }
         return;
       }
+      this.inputs.close();
       if (sink && !sink.done) {
         this.failTurn(sink, "session closed mid-turn");
       }

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -2154,7 +2154,9 @@ class AgentSessionImpl implements AgentSession {
           // Persist the provider-native anchor first so an immediate click can
           // never fall back to (or race with) a later provider-thread head.
           if (outbound.type === "result") {
-            await this.maybePersistTurnCheckpoint(session, sink.turnId);
+            const interrupted =
+              sink.lifecycleInterrupted || outbound.accounting?.stopReason === "interrupted";
+            if (!interrupted) await this.maybePersistTurnCheckpoint(session, sink.turnId);
             await this.maybePersistProviderInfo();
           }
           // Use `outbound` (not `msg`) so error-replacement (when an

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -256,6 +256,8 @@ export type AgentSessionStatus = "idle" | "running" | "closed";
 export interface AgentTurnHandle {
   turnId: string;
   events: AsyncIterable<StreamAgentMessage>;
+  /** Cancel only this turn, including before provider dispatch. */
+  interrupt?(reason?: string): Promise<void>;
   /**
    * OTel context carrying the per-turn `agent:*` span. Callers doing
    * post-turn work outside `runOneTurn` can wrap it in
@@ -1985,6 +1987,7 @@ class AgentSessionImpl implements AgentSession {
     );
     if (
       this.modelSessionAvailable &&
+      !this.modelSession.isClosed &&
       resolution.modelProvider.id === this.modelSession.providerId &&
       resolution.model === this.modelSession.model
     ) {
@@ -2019,6 +2022,7 @@ class AgentSessionImpl implements AgentSession {
   }
 
   private async runEventsLoop(session: ModelSession): Promise<void> {
+    let streamError: unknown;
     try {
       enterSession(this.sessionId);
       for await (const msg of session.events) {
@@ -2162,6 +2166,7 @@ class AgentSessionImpl implements AgentSession {
         }
       }
     } catch (err) {
+      streamError = err;
       log.warn("agent session events loop ended", {
         sessionId: this.sessionId,
         provider: session.providerId,
@@ -2171,6 +2176,20 @@ class AgentSessionImpl implements AgentSession {
       if (this.replacingModelSession === session || this.modelSession !== session) return;
       this.inputs.close();
       const sink = this.currentSink;
+      if (session.isClosed) {
+        this.modelSessionAvailable = false;
+        if (sink && !sink.done) {
+          if (sink.lifecycleInterrupted && !streamError) {
+            this.finalizeTurn(sink, { type: "result", content: "" });
+          } else {
+            this.failTurn(
+              sink,
+              streamError instanceof Error ? streamError.message : "session closed mid-turn",
+            );
+          }
+        }
+        return;
+      }
       if (sink && !sink.done) {
         this.failTurn(sink, "session closed mid-turn");
       }
@@ -2958,6 +2977,11 @@ class AgentSessionImpl implements AgentSession {
     return {
       turnId,
       events,
+      interrupt: async (reason) => {
+        if (sink.done) return;
+        sink.lifecycleInterrupted = true;
+        if (this.currentSink === sink) await this.interrupt(reason);
+      },
       turnContext: turnCtx,
       getSubmittedOutput: () => this.submittedOutputs.get(turnId),
     };
@@ -2981,7 +3005,14 @@ class AgentSessionImpl implements AgentSession {
     // Turns are FIFO-serialized by turnMutex. Resolve exactly once at this
     // boundary, before the sink is attached, so a backend replacement cannot
     // leak close events into the new turn.
-    await this.ensureModelSessionForTurn();
+    if (!sink.lifecycleInterrupted) await this.ensureModelSessionForTurn();
+    if (sink.lifecycleInterrupted) {
+      await this.modelSession.interrupt("user-stop");
+      this.ensureTurnStart(sink);
+      this.finalizeTurn(sink, { type: "result", content: "" });
+      span.end();
+      return;
+    }
     this.currentSink = sink;
     this.currentTurnId = turnId;
     this.status = "running";
@@ -3107,6 +3138,12 @@ class AgentSessionImpl implements AgentSession {
       };
 
       const runModelTerminal = async (): Promise<void> => {
+        if (sink.done) return;
+        if (sink.lifecycleInterrupted) {
+          await this.modelSession.interrupt("user-stop");
+          this.finalizeTurn(sink, { type: "result", content: "" });
+          return;
+        }
         modelRan = true;
         try {
           await context.with(turnCtx, async () => {
@@ -3272,11 +3309,13 @@ class AgentSessionImpl implements AgentSession {
     const sink = this.currentSink;
     if (!sink || sink.done || (expectedTurnId && sink.turnId !== expectedTurnId)) return;
     sink.lifecycleInterrupted = true;
-    // Capture the provider target before awaiting child interruption: the
-    // current turn may finish and another turn may start during that await.
-    await Promise.allSettled([
+    // Cancel the provider before awaiting child cleanup. A slow child must
+    // not keep its parent generating after the user presses Stop.
+    await Promise.all([
       this.modelSession.interrupt(reason),
-      ...[...sink.subagentExecutions.values()].map(({ execution }) => execution.interrupt(reason)),
+      Promise.allSettled(
+        [...sink.subagentExecutions.values()].map(({ execution }) => execution.interrupt(reason)),
+      ),
     ]);
   }
 

--- a/packages/core/src/core/anthropic-provider.test.ts
+++ b/packages/core/src/core/anthropic-provider.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AbortError } from "@anthropic-ai/claude-agent-sdk";
 import { AnthropicProvider } from "./anthropic-provider.js";
 import type { AgentMessage } from "../types.js";
 import type {
@@ -34,7 +35,8 @@ const {
   clearAnthropicAuthRevokedMock: vi.fn(),
 }));
 
-vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@anthropic-ai/claude-agent-sdk")>()),
   query: queryMock,
   createSdkMcpServer: createSdkMcpServerMock,
   tool: sdkToolMock,
@@ -210,6 +212,71 @@ describe("AnthropicProvider", () => {
     const provider = new AnthropicProvider();
 
     expect(provider.builtinTools.has("TodoWrite")).toBe(true);
+  });
+
+  it.each([
+    "startup",
+    "partial",
+    "completed-block",
+  ])("aborts the Query during %s and preserves received output", async (phase) => {
+    let controller!: AbortController;
+    let begin!: () => void;
+    const begun = new Promise<void>((resolve) => {
+      begin = resolve;
+    });
+    const q = {
+      interrupt: vi.fn(),
+      close: vi.fn(),
+      async *[Symbol.asyncIterator]() {
+        if (phase === "partial") {
+          yield {
+            type: "stream_event",
+            parent_tool_use_id: null,
+            event: {
+              type: "content_block_delta",
+              delta: { type: "text_delta", text: "Saved work" },
+            },
+          };
+        }
+        if (phase === "completed-block") {
+          yield {
+            type: "assistant",
+            session_id: "persisted-thread",
+            parent_tool_use_id: null,
+            message: { content: [{ type: "text", text: "Saved work" }] },
+          };
+        }
+        begin();
+        if (!controller.signal.aborted) {
+          await new Promise<void>((resolve) =>
+            controller.signal.addEventListener("abort", () => resolve(), { once: true }),
+          );
+        }
+        throw new AbortError("Cancelled");
+      },
+    };
+    queryMock.mockImplementation(({ options }) => {
+      controller = options.abortController;
+      return q;
+    });
+    const session = await new AnthropicProvider().openSession(buildParams());
+    await session.sendUserInput({ text: "work" });
+    const collected = collectEvents(session);
+    await begun;
+    await session.interrupt("user-stop");
+    const messages = await collected;
+    expect(q.interrupt).not.toHaveBeenCalled();
+    expect(q.close).not.toHaveBeenCalled();
+    expect(controller.signal.aborted).toBe(true);
+    expect(session.isClosed).toBe(true);
+    expect(messages.filter((message) => message.type === "result")).toEqual([
+      { type: "result", content: phase === "startup" ? "" : "Saved work" },
+    ]);
+    if (phase !== "startup") {
+      expect(messages).toContainEqual({ type: "text", content: "Saved work", turnPhase: "final" });
+    }
+    await expect(session.sendUserInput({ text: "next" })).rejects.toThrow("closed");
+    await session.close();
   });
 
   it("projects top-level TodoWrite snapshots while preserving generic tool events", async () => {
@@ -403,7 +470,7 @@ describe("AnthropicProvider", () => {
       await session.close();
     });
 
-    it("does not resume a reused session that never wrote a transcript", async () => {
+    it("uses a fresh SDK id when a reused session has no resumable transcript", async () => {
       // A stored session row with no captured provider thread id — e.g. a turn
       // that short-circuited (the not-logged-in notice) before opening an SDK
       // conversation. Resuming it would fail with "No conversation found".
@@ -416,7 +483,8 @@ describe("AnthropicProvider", () => {
         }),
       );
 
-      expect(queryMock.mock.calls[0]![0].options).toMatchObject({ sessionId: "reused-session" });
+      expect(queryMock.mock.calls[0]![0].options.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(queryMock.mock.calls[0]![0].options.sessionId).not.toBe("reused-session");
       expect(queryMock.mock.calls[0]![0].options.resume).toBeUndefined();
 
       await session.close();

--- a/packages/core/src/core/anthropic-provider.test.ts
+++ b/packages/core/src/core/anthropic-provider.test.ts
@@ -241,6 +241,7 @@ describe("AnthropicProvider", () => {
         if (phase === "completed-block") {
           yield {
             type: "assistant",
+            uuid: "assistant-before-stop",
             session_id: "persisted-thread",
             parent_tool_use_id: null,
             message: { content: [{ type: "text", text: "Saved work" }] },
@@ -252,6 +253,7 @@ describe("AnthropicProvider", () => {
             controller.signal.addEventListener("abort", () => resolve(), { once: true }),
           );
         }
+        if (phase === "completed-block") return;
         throw new AbortError("Cancelled");
       },
     };
@@ -275,7 +277,95 @@ describe("AnthropicProvider", () => {
     if (phase !== "startup") {
       expect(messages).toContainEqual({ type: "text", content: "Saved work", turnPhase: "final" });
     }
+    expect(session.lastCompletedTurnCheckpoint).toBe(
+      phase === "completed-block" ? "assistant-before-stop" : undefined,
+    );
     await expect(session.sendUserInput({ text: "next" })).rejects.toThrow("closed");
+    await session.close();
+  });
+
+  it.each([
+    { label: "the current assistant checkpoint", interruptedCheckpoint: "assistant-current" },
+    { label: "no checkpoint", interruptedCheckpoint: undefined },
+  ])("replaces a prior successful checkpoint with $label when interrupted", async ({
+    interruptedCheckpoint,
+  }) => {
+    let controller!: AbortController;
+    let beginInterruptibleTurn!: () => void;
+    const interruptibleTurnBegun = new Promise<void>((resolve) => {
+      beginInterruptibleTurn = resolve;
+    });
+    queryMock.mockImplementation(({ prompt, options }) => {
+      controller = options.abortController;
+      return {
+        async *[Symbol.asyncIterator]() {
+          const inputs = prompt[Symbol.asyncIterator]();
+          await inputs.next();
+          yield {
+            type: "assistant",
+            uuid: "assistant-previous",
+            session_id: "persisted-thread",
+            parent_tool_use_id: null,
+            message: { content: [{ type: "text", text: "Previous turn" }] },
+          };
+          yield {
+            type: "result",
+            subtype: "success",
+            result: "Previous turn",
+            num_turns: 1,
+            stop_reason: "end_turn",
+            total_cost_usd: 0,
+            duration_ms: 1,
+          };
+
+          await inputs.next();
+          if (interruptedCheckpoint) {
+            yield {
+              type: "assistant",
+              uuid: interruptedCheckpoint,
+              session_id: "persisted-thread",
+              parent_tool_use_id: null,
+              message: { content: [{ type: "text", text: "Current turn" }] },
+            };
+          }
+          beginInterruptibleTurn();
+          if (!controller.signal.aborted) {
+            await new Promise<void>((resolve) =>
+              controller.signal.addEventListener("abort", () => resolve(), { once: true }),
+            );
+          }
+          throw new AbortError("Cancelled");
+        },
+        close: vi.fn(),
+      };
+    });
+
+    const session = await new AnthropicProvider().openSession(buildParams());
+    const events = session.events[Symbol.asyncIterator]();
+    await session.sendUserInput({ text: "first" });
+    expect((await events.next()).value).toMatchObject({
+      type: "text",
+      content: "Previous turn",
+    });
+    expect((await events.next()).value).toMatchObject({ type: "result", content: "Previous turn" });
+    expect(session.lastCompletedTurnCheckpoint).toBe("assistant-previous");
+
+    await session.sendUserInput({ text: "second" });
+    const remaining = (async () => {
+      const messages: AgentMessage[] = [];
+      for (;;) {
+        const next = await events.next();
+        if (next.done) return messages;
+        messages.push(next.value);
+      }
+    })();
+    await interruptibleTurnBegun;
+    await session.interrupt("user-stop");
+    expect(await remaining).toContainEqual({
+      type: "result",
+      content: interruptedCheckpoint ? "Current turn" : "",
+    });
+    expect(session.lastCompletedTurnCheckpoint).toBe(interruptedCheckpoint);
     await session.close();
   });
 

--- a/packages/core/src/core/anthropic-provider.test.ts
+++ b/packages/core/src/core/anthropic-provider.test.ts
@@ -277,9 +277,7 @@ describe("AnthropicProvider", () => {
     if (phase !== "startup") {
       expect(messages).toContainEqual({ type: "text", content: "Saved work", turnPhase: "final" });
     }
-    expect(session.lastCompletedTurnCheckpoint).toBe(
-      phase === "completed-block" ? "assistant-before-stop" : undefined,
-    );
+    expect(session.lastCompletedTurnCheckpoint).toBeUndefined();
     await expect(session.sendUserInput({ text: "next" })).rejects.toThrow("closed");
     await session.close();
   });
@@ -287,7 +285,7 @@ describe("AnthropicProvider", () => {
   it.each([
     { label: "the current assistant checkpoint", interruptedCheckpoint: "assistant-current" },
     { label: "no checkpoint", interruptedCheckpoint: undefined },
-  ])("replaces a prior successful checkpoint with $label when interrupted", async ({
+  ])("does not publish $label when interrupted after a successful turn", async ({
     interruptedCheckpoint,
   }) => {
     let controller!: AbortController;
@@ -365,7 +363,7 @@ describe("AnthropicProvider", () => {
       type: "result",
       content: interruptedCheckpoint ? "Current turn" : "",
     });
-    expect(session.lastCompletedTurnCheckpoint).toBe(interruptedCheckpoint);
+    expect(session.lastCompletedTurnCheckpoint).toBeUndefined();
     await session.close();
   });
 

--- a/packages/core/src/core/anthropic-provider.ts
+++ b/packages/core/src/core/anthropic-provider.ts
@@ -769,7 +769,6 @@ export class AnthropicProvider implements ModelProvider {
           }
           if (partialText) yield { type: "text", content: partialText, turnPhase: "final" };
           running = false;
-          lastCompletedTurnCheckpoint = activeTurnLastAssistantMessageId;
           yield { type: "result", content: partialText || pendingText || "" };
         }
       } catch (err) {
@@ -791,7 +790,6 @@ export class AnthropicProvider implements ModelProvider {
           await queryProcess.abort();
           if (running) {
             running = false;
-            lastCompletedTurnCheckpoint = activeTurnLastAssistantMessageId;
             yield { type: "result", content: partialText || pendingText || "" };
           }
           return;
@@ -843,6 +841,12 @@ export class AnthropicProvider implements ModelProvider {
           throw new Error("ModelSession is closed");
         }
         activeTurnLastAssistantMessageId = undefined;
+        // A checkpoint is publishable only after this turn reaches an SDK
+        // success result. Assistant UUIDs observed before an abort can be
+        // present in the stream without being resumable in Claude's durable
+        // transcript, so never let a prior or partial UUID stand in for the
+        // current turn.
+        lastCompletedTurnCheckpoint = undefined;
         running = true;
         permitPrompt();
         if (input.inputId && deferredInputs.delete(input.inputId)) return;

--- a/packages/core/src/core/anthropic-provider.ts
+++ b/packages/core/src/core/anthropic-provider.ts
@@ -769,6 +769,7 @@ export class AnthropicProvider implements ModelProvider {
           }
           if (partialText) yield { type: "text", content: partialText, turnPhase: "final" };
           running = false;
+          lastCompletedTurnCheckpoint = activeTurnLastAssistantMessageId;
           yield { type: "result", content: partialText || pendingText || "" };
         }
       } catch (err) {
@@ -790,6 +791,7 @@ export class AnthropicProvider implements ModelProvider {
           await queryProcess.abort();
           if (running) {
             running = false;
+            lastCompletedTurnCheckpoint = activeTurnLastAssistantMessageId;
             yield { type: "result", content: partialText || pendingText || "" };
           }
           return;

--- a/packages/core/src/core/anthropic-provider.ts
+++ b/packages/core/src/core/anthropic-provider.ts
@@ -1,4 +1,5 @@
-import { query } from "@anthropic-ai/claude-agent-sdk";
+import { AbortError, query } from "@anthropic-ai/claude-agent-sdk";
+import { randomUUID } from "node:crypto";
 import { DEFAULT_REASONING_EFFORT } from "@rome-os/app-runtime";
 import type {
   EffortLevel,
@@ -49,6 +50,7 @@ import {
 } from "./anthropic-auth-revoked.js";
 import { buildAnthropicMcpServers } from "./anthropic-mcp-servers.js";
 import { isAnthropicUsageLimitError } from "./anthropic-usage-limit.js";
+import { createClaudeQueryProcess } from "./claude-query-process.js";
 
 // Beta content block types are not re-exported from the agent SDK and
 // `@anthropic-ai/sdk` is not a direct dependency, so we derive the shapes
@@ -473,6 +475,8 @@ export class AnthropicProvider implements ModelProvider {
     const onQuotaExhausted = this.options.onQuotaExhausted;
 
     const inputQueue = new AsyncMessageQueue<SDKUserMessage>();
+    const queryProcess = createClaudeQueryProcess();
+    const { abortController } = queryProcess;
     const { sessionId } = params;
     const pendingSteers = new Set<string>();
     const deferredInputs = new Set<string>();
@@ -484,10 +488,16 @@ export class AnthropicProvider implements ModelProvider {
       releasePrompt?.();
       releasePrompt = undefined;
     };
+    // A cancelled first turn can leave a user-only transcript that is not
+    // resumable. Its id is still reserved by the CLI, so don't reuse it.
+    const sdkSessionId =
+      params.isNewSession === false && !params.providerThreadId ? randomUUID() : sessionId;
 
     const q = query({
       prompt: inputQueue.iter(),
       options: {
+        abortController,
+        spawnClaudeCodeProcess: queryProcess.spawn,
         model: effectiveModel,
         effort,
         systemPrompt,
@@ -548,7 +558,7 @@ export class AnthropicProvider implements ModelProvider {
             // "No conversation found with session ID". Start fresh in that case.
             !params.isNewSession && params.providerThreadId
             ? { resume: params.providerThreadId }
-            : { sessionId }),
+            : { sessionId: sdkSessionId }),
       },
     });
 
@@ -562,12 +572,6 @@ export class AnthropicProvider implements ModelProvider {
     let closed = false;
     let queryDisposed = false;
     let running = false;
-    // When interrupt() lands, the SDK aborts the in-flight HTTP
-    // request and emits an `error_during_execution` rather than a clean
-    // `stop_reason: "interrupted"` result. We track that state here so the
-    // events loop can translate the next error into a graceful interrupted
-    // result for the consumer.
-    let interruptRequested = false;
 
     // The SDK's own session id, captured from the first assistant message once a
     // transcript with real content exists. Exposed via `session.providerThreadId`
@@ -593,6 +597,7 @@ export class AnthropicProvider implements ModelProvider {
       // stream in real time; only the completed-block event is deferred by one
       // step (a block isn't truly "done" until the next one starts anyway).
       let pendingText: string | null = null;
+      let partialText = "";
       try {
         for await (const message of q) {
           if (isPartialAssistantMessage(message)) {
@@ -604,6 +609,11 @@ export class AnthropicProvider implements ModelProvider {
             if (message.parent_tool_use_id === null) {
               const evt = message.event;
               if (evt.type === "content_block_delta" && evt.delta.type === "text_delta") {
+                if (partialText === "" && pendingText !== null) {
+                  yield { type: "text", content: pendingText, turnPhase: "commentary" };
+                  pendingText = null;
+                }
+                partialText += evt.delta.text;
                 yield { type: "text_delta", content: evt.delta.text };
               }
             }
@@ -621,6 +631,7 @@ export class AnthropicProvider implements ModelProvider {
             }
             for (const block of message.message.content) {
               if (isTextBlock(block) && block.text) {
+                partialText = "";
                 // A new text block: the previously held one is now confirmed
                 // mid-turn narration. Hold this one until something follows it.
                 if (pendingText !== null) {
@@ -684,7 +695,10 @@ export class AnthropicProvider implements ModelProvider {
               yield { type: "text", content: pendingText, turnPhase: "final" };
               pendingText = null;
             }
-            const contextUsage = await readSdkContextUsage(q);
+            if (abortController.signal.aborted) await queryProcess.abort();
+            const contextUsage = abortController.signal.aborted
+              ? undefined
+              : await readSdkContextUsage(q);
             const accounting = buildAnthropicAccounting(
               message,
               effectiveModel,
@@ -705,7 +719,6 @@ export class AnthropicProvider implements ModelProvider {
                 agentName: params.agentName,
                 appStoreListingId: params.appStoreListingId,
               });
-              interruptRequested = false;
               running = false;
               // A turn that reached the API proves the credential works; drop any
               // lingering revoked marker (covers a Keychain re-login whose file
@@ -716,19 +729,6 @@ export class AnthropicProvider implements ModelProvider {
                 type: "result",
                 content: message.result || "",
                 accounting,
-              };
-            } else if (interruptRequested) {
-              // The user pressed Stop and the SDK aborted the request; emit a
-              // clean interrupted result instead of an error so the trace UI
-              // doesn't surface "Request was aborted." stack traces.
-              log.info("agent SDK result (interrupted)", resultData);
-              interruptRequested = false;
-              running = false;
-              lastCompletedTurnCheckpoint = activeTurnLastAssistantMessageId;
-              yield {
-                type: "result",
-                content: "",
-                accounting: accounting ? { ...accounting, stopReason: "interrupted" } : undefined,
               };
             } else {
               const errors = message.errors ?? [];
@@ -758,6 +758,19 @@ export class AnthropicProvider implements ModelProvider {
             }
           }
         }
+        if (abortController.signal.aborted && running) {
+          await queryProcess.abort();
+          if (pendingText !== null) {
+            yield {
+              type: "text",
+              content: pendingText,
+              turnPhase: partialText ? "commentary" : "final",
+            };
+          }
+          if (partialText) yield { type: "text", content: partialText, turnPhase: "final" };
+          running = false;
+          yield { type: "result", content: partialText || pendingText || "" };
+        }
       } catch (err) {
         // The stream threw without delivering a terminal `result` (raw abort,
         // SDK panic, …). Flush any held text as the closing answer before the
@@ -766,8 +779,20 @@ export class AnthropicProvider implements ModelProvider {
         // purpose: a `yield` in `finally` re-suspends the generator when the
         // consumer abandons iteration via `.return()`, swallowing the close.
         if (pendingText !== null) {
-          yield { type: "text", content: pendingText, turnPhase: "final" };
-          pendingText = null;
+          yield {
+            type: "text",
+            content: pendingText,
+            turnPhase: partialText ? "commentary" : "final",
+          };
+        }
+        if (partialText) yield { type: "text", content: partialText, turnPhase: "final" };
+        if (abortController.signal.aborted && err instanceof AbortError) {
+          await queryProcess.abort();
+          if (running) {
+            running = false;
+            yield { type: "result", content: partialText || pendingText || "" };
+          }
+          return;
         }
         // A 401 can also surface as a thrown stream error rather than a result
         // with `subtype: error`. Convert it to a classified terminal and persist
@@ -801,6 +826,9 @@ export class AnthropicProvider implements ModelProvider {
     const session: ModelSession = {
       providerId,
       model: effectiveModel,
+      get isClosed(): boolean {
+        return closed || abortController.signal.aborted;
+      },
       get providerThreadId(): string | undefined {
         return establishedThreadId;
       },
@@ -809,7 +837,7 @@ export class AnthropicProvider implements ModelProvider {
       },
       events,
       async sendUserInput(input: ModelUserInput): Promise<void> {
-        if (closed) {
+        if (closed || abortController.signal.aborted) {
           throw new Error("ModelSession is closed");
         }
         activeTurnLastAssistantMessageId = undefined;
@@ -836,7 +864,7 @@ export class AnthropicProvider implements ModelProvider {
           ...(input.inputId ? { uuid: input.inputId as SDKUserMessage["uuid"] } : {}),
           priority: "next",
           parent_tool_use_id: null,
-          session_id: sessionId,
+          session_id: sdkSessionId,
           message: {
             role: "user",
             content,
@@ -845,7 +873,9 @@ export class AnthropicProvider implements ModelProvider {
         inputQueue.push(sdkMsg);
       },
       async steerUserInput(input: ModelUserInput): Promise<"accepted" | "deferred"> {
-        if (closed) throw new Error("ModelSession is closed");
+        if (closed || abortController.signal.aborted) {
+          throw new Error("ModelSession is closed");
+        }
         if (!running || !input.inputId || input.injectedToolResult) return "deferred";
         if (input.reasoningEffort && toAnthropicEffort(input.reasoningEffort) !== effort)
           return "deferred";
@@ -855,13 +885,15 @@ export class AnthropicProvider implements ModelProvider {
           uuid: input.inputId as SDKUserMessage["uuid"],
           priority: "next",
           parent_tool_use_id: null,
-          session_id: sessionId,
+          session_id: sdkSessionId,
           message: { role: "user", content: [{ type: "text", text: input.text }] },
         });
         return "accepted";
       },
       async fork(forkParams: ModelSessionForkParams): Promise<ModelSessionFork> {
-        if (closed) throw new Error("Cannot fork a closed ModelSession");
+        if (closed || abortController.signal.aborted) {
+          throw new Error("Cannot fork a closed ModelSession");
+        }
         if (running) throw new Error("Cannot fork while source session is running");
         const mode = forkParams.mode ?? "ephemeral";
         const sourceSessionId = params.sessionId;
@@ -897,16 +929,9 @@ export class AnthropicProvider implements ModelProvider {
         };
       },
       async interrupt(reason?: string): Promise<void> {
-        if (closed) return;
         log.info("ModelSession interrupt requested", { reason });
-        interruptRequested = true;
-        try {
-          await q.interrupt();
-        } catch (err) {
-          log.warn("query.interrupt() rejected", {
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
+        await queryProcess.abort();
+        inputQueue.end();
       },
       async close(): Promise<void> {
         if (queryDisposed) return;

--- a/packages/core/src/core/claude-query-process.test.ts
+++ b/packages/core/src/core/claude-query-process.test.ts
@@ -1,0 +1,81 @@
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createClaudeQueryProcess } from "./claude-query-process.js";
+
+vi.mock("node:child_process", () => ({ spawn: vi.fn() }));
+
+function setup() {
+  const child = Object.assign(new EventEmitter(), {
+    pid: 123,
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    killed: false,
+    exitCode: null,
+    kill: vi.fn((_signal?: NodeJS.Signals) => {
+      child.killed = true;
+      return true;
+    }),
+  });
+  vi.mocked(spawn).mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+  const owner = createClaudeQueryProcess();
+  owner.abortController.signal.addEventListener("abort", () => child.kill("SIGTERM"));
+  owner.spawn({ command: "claude", args: [], env: {}, signal: owner.abortController.signal });
+  return { owner, child };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("Claude Query process cancellation", () => {
+  it("waits for actual exit rather than the killed flag", async () => {
+    const { owner, child } = setup();
+    let finished = false;
+    const abort = owner.abort().then(() => {
+      finished = true;
+    });
+    await Promise.resolve();
+    expect(owner.abortController.signal.aborted).toBe(true);
+    expect(child.killed).toBe(true);
+    expect(finished).toBe(false);
+    child.emit("exit", null, "SIGTERM");
+    await abort;
+    expect(finished).toBe(true);
+    expect(child.kill).toHaveBeenCalledExactlyOnceWith("SIGTERM");
+  });
+
+  it("escalates only the owned process when SIGTERM does not exit", async () => {
+    vi.useFakeTimers();
+    const { owner, child } = setup();
+    const abort = owner.abort();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(child.kill).toHaveBeenLastCalledWith("SIGKILL");
+    child.emit("exit", null, "SIGKILL");
+    await abort;
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(child.kill).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports an unconfirmed exit and permits another cancellation attempt", async () => {
+    vi.useFakeTimers();
+    const { owner, child } = setup();
+    const first = expect(owner.abort()).rejects.toThrow("did not exit");
+    await vi.advanceTimersByTimeAsync(2_000);
+    await first;
+    const second = owner.abort();
+    child.emit("exit", null, "SIGKILL");
+    await second;
+  });
+
+  it("does not signal an exited process again", async () => {
+    const { owner, child } = setup();
+    const abort = owner.abort();
+    child.emit("exit", 0, null);
+    await abort;
+    await owner.abort();
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/core/claude-query-process.ts
+++ b/packages/core/src/core/claude-query-process.ts
@@ -1,0 +1,62 @@
+import { spawn } from "node:child_process";
+import type { SpawnedProcess, SpawnOptions } from "@anthropic-ai/claude-agent-sdk";
+
+const EXIT_GRACE_MS = 1_000;
+
+/** Owns one Query's process. Aborting resolves only after that process exits. */
+export function createClaudeQueryProcess() {
+  const abortController = new AbortController();
+  let child: SpawnedProcess | undefined;
+  let exited = false;
+  let resolveExit!: () => void;
+  const exit = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+  const didExit = () => {
+    exited = true;
+    resolveExit();
+  };
+  const waitForExit = async (): Promise<boolean> => {
+    if (!child || exited) return true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        exit.then(() => true),
+        new Promise<false>((resolve) => {
+          timer = setTimeout(() => resolve(false), EXIT_GRACE_MS);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  };
+
+  return {
+    abortController,
+    spawn(options: SpawnOptions): SpawnedProcess {
+      const process = spawn(options.command, options.args, {
+        cwd: options.cwd,
+        env: options.env,
+        signal: options.signal,
+        stdio: ["pipe", "pipe", "ignore"],
+        windowsHide: true,
+      });
+      child = process;
+      process.once("exit", didExit);
+      process.on("error", () => {
+        if (process.pid === undefined) didExit();
+      });
+      return process;
+    },
+    async abort(): Promise<void> {
+      abortController.abort();
+      if (await waitForExit()) return;
+      // ChildProcess.killed records signal delivery, not exit. The SDK skips
+      // its close-time escalation after abort has already set that flag.
+      child!.kill("SIGKILL");
+      if (!(await waitForExit())) {
+        throw new Error("Claude process did not exit after cancellation");
+      }
+    },
+  };
+}

--- a/packages/web/src/components/chat/Chat.test.tsx
+++ b/packages/web/src/components/chat/Chat.test.tsx
@@ -330,6 +330,32 @@ describe("Chat turn stream lifecycle", () => {
     );
   });
 
+  it("keeps Stop available while the server still reports the turn running", async () => {
+    vi.mocked(interruptTurn).mockResolvedValue(new Response(null, { status: 202 }));
+    vi.mocked(listSessionTurns).mockResolvedValue([{ turnId: "turn-1", status: "running" }]);
+    renderChat(<Chat sessionId="session-1" />);
+    await waitFor(() => expect(screen.getByTestId("stop-button")).toBeTruthy());
+    const signal = vi.mocked(openTurnStream).mock.calls[0]?.[1];
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByTestId("stop-button"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
+    });
+    expect(signal?.aborted).toBe(false);
+    expect(screen.getByTestId("chat-composer").getAttribute("data-streaming")).toBe("true");
+
+    // Retry is real, and a missed done can still be recovered once confirmed.
+    vi.mocked(listSessionTurns).mockResolvedValue([]);
+    fireEvent.click(screen.getByTestId("stop-button"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
+    });
+    expect(interruptTurn).toHaveBeenCalledTimes(2);
+    expect(signal?.aborted).toBe(true);
+    expect(screen.getByTestId("chat-composer").getAttribute("data-streaming")).toBe("false");
+  });
+
   it("does not let a delayed force-release abort a fresh stream for the same turn", async () => {
     const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
     vi.mocked(listSessionTurns).mockResolvedValue([{ turnId: "turn-1", status: "running" }]);

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -1246,23 +1246,19 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
     if (!turnId) return;
     const targetController = turnStreamControllersRef.current.get(turnId);
 
-    // The streaming entry normally clears when the stream delivers `done`.
-    // But if the SSE connection died silently (mobile background/lock, proxy
-    // idle timeout), that `done` never arrives: the entry is stuck on a turn
-    // that is over (interrupt → 404) or unobservable (interrupt → 200 with
-    // no visible effect) — Stop appears dead until the next send resyncs.
-    // Force-release the entry after `delayMs` if it's still pinned to this
-    // turn: aborting the turn's stream controller runs the caller's normal
-    // teardown (inflight bookkeeping + reconnect-revision bump, which also
-    // re-attaches if the turn is somehow still running), endSessionStream is
-    // the direct backstop, and the forced reload shows the turn's real state.
-    const forceReleaseIfStuck = (delayMs: number) => {
-      setTimeout(() => {
-        if (streamingSessionsRef.current.get(sid)?.turnId !== turnId) return;
-        // A dropped stream can reattach to the same turn while this timeout is
-        // pending. Only retire the controller that Stop originally targeted;
-        // a different instance is a healthy replacement and owns the state now.
-        if (turnStreamControllersRef.current.get(turnId) !== targetController) return;
+    // A dead SSE connection can miss `done`. Release it only after the server
+    // confirms this turn ended; accepting Stop is not confirmation of exit.
+    const forceReleaseIfStuck = (delayMs: number, confirmedFinished = false) => {
+      const stillOwnsStream = () =>
+        streamingSessionsRef.current.get(sid)?.turnId === turnId &&
+        turnStreamControllersRef.current.get(turnId) === targetController;
+      setTimeout(async () => {
+        if (!stillOwnsStream()) return;
+        if (!confirmedFinished) {
+          const turns = await listSessionTurns(sid).catch(() => null);
+          if (!turns || turns.some((turn) => turn.turnId === turnId)) return;
+          if (!stillOwnsStream()) return;
+        }
         targetController?.abort();
         endSessionStream(sid, turnId);
         void loadMessages(sid, { force: true, dropLocalOptimistic: true });
@@ -1274,7 +1270,7 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
       if (res.status === 404) {
         // The turn already finished server-side (stop landed late, or the
         // local entry outlived a dead stream) — release the stale entry now.
-        forceReleaseIfStuck(0);
+        forceReleaseIfStuck(0, true);
       } else if (res.ok) {
         // Interrupt accepted. A healthy stream flips the UI via `done`
         // within moments; the grace-period check only fires on a dead one.

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -155,6 +155,7 @@ const traceSummarySchema: z.ZodType<TraceSummary> = z.lazy(() =>
       )
       .optional(),
     totalDurationMs: z.number().optional(),
+    turnStatus: z.enum(["completed", "interrupted", "error"]).optional(),
     invocationCounts: z.record(z.string(), z.number()),
     stoppedByUser: z.boolean().optional(),
     terminalError: z.string().optional(),

--- a/packages/web/src/components/chat/MessageList.test.tsx
+++ b/packages/web/src/components/chat/MessageList.test.tsx
@@ -7,6 +7,12 @@ import { cleanup, fireEvent, render, screen, within } from "@testing-library/rea
 vi.mock("@/components/logo", () => ({
   RomeLogo: (props: Record<string, unknown>) => <div data-testid="rome-logo" {...props} />,
 }));
+vi.mock("@/components/chat/TurnBranchButton", () => ({
+  TurnBranchButton: () => <button type="button">side-chat-branch</button>,
+}));
+vi.mock("@/components/chat/TurnFeedbackButtons", () => ({
+  TurnFeedbackButtons: () => null,
+}));
 import {
   findActiveSubmission,
   findLastSubmission,
@@ -228,6 +234,77 @@ describe("MessageList inline-card state across streaming→settled", () => {
     expect((screen.getByPlaceholderText("Type your answer…") as HTMLTextAreaElement).value).toBe(
       "Alice",
     );
+  });
+});
+
+describe("MessageList side-chat eligibility", () => {
+  const renderSettledTurn = (turnStatus?: "completed" | "interrupted" | "error") => {
+    const messages: ChatMessage[] = [
+      {
+        id: "assistant-side-chat",
+        sessionId: "s-1",
+        turnId: "turn-side-chat",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", content: "Turn output" }]),
+        createdAt: "2026-06-13T00:00:00.000Z",
+      },
+      {
+        id: "trace-side-chat",
+        sessionId: "s-1",
+        turnId: "turn-side-chat",
+        role: "trace",
+        content: "[]",
+        createdAt: "2026-06-13T00:00:01.000Z",
+        traceSummary: {
+          distinctApps: [],
+          totalSteps: 0,
+          invocationCounts: {},
+          turnStatus,
+        },
+      },
+    ];
+    const rows = buildRows(messages, new Map([["s-1", IDENTITY]]), IDENTITY, {
+      runningTurnId: null,
+      isStreaming: false,
+    });
+    render(
+      <ThemeProvider>
+        <MessageList
+          rows={rows}
+          live={{
+            isStreaming: false,
+            runningTurnId: null,
+            snapshot: null,
+            text: "",
+            identity: IDENTITY,
+          }}
+          contentRef={() => {}}
+          onOpenLiveTrace={() => {}}
+          onOpenStoredTrace={() => {}}
+          actions={{
+            onApprovalResolved: () => {},
+            onSubmitAppComponent: () => {},
+            onDismissAppComponent: () => {},
+            interactionResults: new Map(),
+          }}
+          feedback
+        />
+      </ThemeProvider>,
+    );
+  };
+
+  it("shows Side Chat only for completed turns", () => {
+    renderSettledTurn("completed");
+    expect(screen.getByRole("button", { name: "side-chat-branch" })).toBeTruthy();
+  });
+
+  it.each([
+    "interrupted",
+    "error",
+    undefined,
+  ] as const)("hides Side Chat when turn status is %s", (status) => {
+    renderSettledTurn(status);
+    expect(screen.queryByRole("button", { name: "side-chat-branch" })).toBeNull();
   });
 });
 

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -280,6 +280,7 @@ const RowView = memo(function RowView({
   const feedbackTurn = feedback && !live ? rowTurnRef(row) : null;
   const showFeedback = !!feedbackTurn?.turnId && !!feedbackTurn.sessionId;
   const summary = live?.snapshot?.summary ?? row.trace?.traceSummary;
+  const showBranch = showFeedback && summary?.turnStatus === "completed";
   const subagents = summary?.subagents;
   const recapMessageId = row.messages.find((message) =>
     parseMessageBlocks(message).some((block) => block.type === "turn_recap"),
@@ -366,7 +367,7 @@ const RowView = memo(function RowView({
               turnId={feedbackTurn.turnId}
             />
           ) : null}
-          {showFeedback && feedbackTurn?.turnId ? (
+          {showBranch && feedbackTurn?.turnId ? (
             <TurnBranchButton
               key={`branch:${feedbackTurn.sessionId}:${feedbackTurn.turnId}`}
               sessionId={feedbackTurn.sessionId}

--- a/packages/web/src/components/chat/blocks/ToolStepBlock.render.test.tsx
+++ b/packages/web/src/components/chat/blocks/ToolStepBlock.render.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import "@/i18n";
+import { ToolStepBlock } from "./ToolStepBlock";
+
+afterEach(cleanup);
+
+describe("ToolStepBlock incomplete results", () => {
+  it("keeps the input and labels a finished call without a result as unknown", () => {
+    render(
+      <ToolStepBlock
+        tool="Edit"
+        input={{ path: "changed.ts" }}
+        output={undefined}
+        status="running"
+        hasResult={false}
+      />,
+    );
+    expect(screen.getByText("Result unknown")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getAllByText("changed.ts").length).toBeGreaterThan(0);
+    expect(screen.getByText(/The tool may have made changes/)).toBeTruthy();
+  });
+
+  it.each([
+    { live: true, hasResult: false },
+    { live: false, hasResult: true },
+  ])("does not label live or completed calls as unknown: %j", ({ live, hasResult }) => {
+    render(
+      <ToolStepBlock
+        tool="Edit"
+        input={{ path: "changed.ts" }}
+        output="File changed"
+        status={hasResult ? "ok" : "running"}
+        hasResult={hasResult}
+        live={live}
+      />,
+    );
+    expect(screen.queryByText("Result unknown")).toBeNull();
+    fireEvent.click(screen.getByRole("button"));
+    if (hasResult) expect(screen.getByText("File changed")).toBeTruthy();
+  });
+});

--- a/packages/web/src/components/chat/blocks/ToolStepBlock.tsx
+++ b/packages/web/src/components/chat/blocks/ToolStepBlock.tsx
@@ -43,6 +43,7 @@ export function ToolStepBlock({
   const toolLabel = artifactLocalName(rawToolLabel);
   const summary = describeToolSummary(tool, input, output, hasResult, t);
   const duration = formatStepDuration(durationMs);
+  const resultUnknown = !hasResult && !live;
 
   return (
     <div
@@ -80,6 +81,11 @@ export function ToolStepBlock({
           </span>
         )}
         {!summary && <span className="flex-1" />}
+        {resultUnknown && (
+          <span className="flex-none text-aux text-muted-foreground">
+            {t("blocks.resultUnknown")}
+          </span>
+        )}
         {duration && (
           <span className="flex-none font-mono text-aux tracking-wide tabular-nums text-subtle-foreground">
             {duration}
@@ -89,6 +95,9 @@ export function ToolStepBlock({
       {open && (
         <div className="pt-1 pr-3 pb-3 pl-9">
           <ToolStepDetails tool={toolLabel} input={input} output={output} hasResult={hasResult} />
+          {resultUnknown && (
+            <p className="mt-2 text-aux text-muted-foreground">{t("blocks.resultUnknownHint")}</p>
+          )}
         </div>
       )}
     </div>

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -104,6 +104,8 @@
     "showLess": "Show less",
     "input": "Input",
     "output": "Output",
+    "resultUnknown": "Result unknown",
+    "resultUnknownHint": "No result was received. The tool may have made changes before the turn ended.",
     "itemCount_one": "{{count}} item",
     "itemCount_other": "{{count}} items",
     "keyCount_one": "{{count}} key",

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -104,6 +104,8 @@
     "showLess": "收起",
     "input": "输入",
     "output": "输出",
+    "resultUnknown": "结果未知",
+    "resultUnknownHint": "未收到执行结果；工具可能已在本轮结束前产生修改。",
     "itemCount_one": "{{count}} 项",
     "itemCount_other": "{{count}} 项",
     "keyCount_one": "{{count}} 个字段",


### PR DESCRIPTION
## What this PR does

Claude could acknowledge Stop during startup and then begin generating anyway. The shared webchat `stopRequested` latch also blocked subsequent Stop attempts and hid real replies or errors after cancellation.

Stop now aborts the Claude SDK Query, waits for its owned CLI process to exit, and escalates to SIGKILL after a bounded grace period if necessary. The conversation survives: later turns reopen provider execution and resume established history, or use a fresh SDK id when an interrupted first turn left no resumable history.

Webchat no longer latches Stop or suppresses output. Repeated requests target the original turn, accepted cancellation returns 202 while the turn is still open, and the UI checks server state before clearing a stale stream. Received partial replies and tool results remain visible after Stop and reload; a finished tool call without a received result is labelled unknown.

## Design & Invariants

- Stop cancels execution, not evidence or already-applied changes. The durable contract lives in [Sessions / Agent run](docs/concepts/sessions.md#agent-run).
- Only the Query-owned Claude child is signalled. The shared Codex app-server is never killed; it benefits from the common webchat retry/output fixes.
- SDK `AbortController` is the primary cancellation path. Soft `query.interrupt()` can miss startup; `query.close()` remains disposal, not the Stop mechanism. Use the SDK's actual `AbortError` type, whose `name` is `Error` in the pinned release.
- A stale Stop cannot cancel the next turn. Pending middleware must not dispatch a cancelled prompt, and provider exit must precede cancellation completion.
- Cancelling a Query does not close the Rome session or automatically replay its cancelled prompt.

## Test plan

- [x] `pnpm typecheck` across the workspace; repeated Core typecheck after the final cancellation-boundary test.
- [x] `pnpm test:unit:rest` through the top-level unit run.
- [x] Full Core unit suite with `--maxWorkers 4`: 4217 tests passed; final targeted provider/session/process suite: 141 passed, including one additional middleware-cancellation test.
- [x] Full Web unit suite with `--maxWorkers 4`: 1223 passed; shared UI suite: 528 passed.
- [x] Real Claude Agent SDK/CLI against an isolated localhost Anthropic-compatible fixture: startup, waiting, thinking, partial text, and established-history resume. Each cancellation allowed a subsequent new turn; no production model/account was used.
- [x] Browser acceptance using the real dashboard and provider: Stop during Thinking; real Write tool execution followed by partial text and Stop; reload retained the partial reply and Write input/result; the next message completed. Screenshots, video, and HTTP evidence captured locally.
- [x] Biome check on changed source/test files, `git diff --check`, and PR-title validation.
- [ ] `pnpm dev:all` container readiness: image build and source sync succeeded, but dependency installation did not complete while Docker status calls and a bounded daemon `_ping` timed out. This validation run was stopped without restarting shared Docker services; `Rome started` is not confirmed.

The default-concurrency unit runs hit timing-sensitive failures in unrelated file-watcher and channel-settings debounce tests. Both passed in isolation, and the full Core/Web suites passed with four workers. Host validation used Node 24.11.1 / pnpm 11.6.0; Nix is unavailable on this host.

## Not in this PR

- Reducing Claude send-to-agent startup latency: this change makes startup cancellable; it does not optimize MCP/session preparation.
- Rolling back tool side effects or guaranteeing cancellation of external services that already accepted work: Stop preserves the evidence and does not claim those effects were undone.
