### PR TITLE
chore(release): declare each published package's repository

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -95,11 +95,12 @@ jobs:
       # OIDC: the `id-token: write` job permission lets npm exchange the
       # GitHub token for an npm publish credential via the Trusted
       # Publisher mapping (no NPM_TOKEN).
-      # `--provenance` is intentionally NOT set: npm rejects provenance
-      # attestations from private source repositories (HTTP 422
-      # "Unsupported GitHub Actions source repository visibility:
-      # private"), and rome-internal is private. Re-enable if/when the
-      # repo goes public.
+      # `--provenance` is not set because it does not need to be: this
+      # repository is public, so publishing through the Trusted Publisher
+      # attaches a provenance attestation on its own. npm then checks the
+      # packed manifest against it and rejects the upload with HTTP 422
+      # unless `repository.url` resolves to this repository, so every
+      # package here declares `repository` with its workspace `directory`.
       - name: Publish to npm
         working-directory: ${{ matrix.path }}
         run: pnpm publish --access public --no-git-checks${{ inputs.dry_run && ' --dry-run' || '' }}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -114,6 +114,27 @@ There is no PR-time "did you add a changeset?" check. The merge commit is the so
 
 The publish step is the merge of the release PR, not your original PR — so contributors don't have to worry about "every small fix becomes its own release". Multiple commits ship together.
 
+### Every published package declares `repository`
+
+This repository is public and publishes through an npm Trusted Publisher, so npm
+attaches a provenance attestation to each upload on its own — `sdk-publish.yml`
+never passes `--provenance`. npm then compares the packed manifest against that
+attestation and rejects the upload with HTTP 422 when `repository.url` does not
+resolve to `https://github.com/rome-os/rome`:
+
+```
+[E422] 422 Unprocessable Entity - PUT https://registry.npmjs.org/@rome-os%2fui
+Error verifying sigstore provenance bundle: Failed to validate repository
+information: package.json: "repository.url" is "", expected to match
+"https://github.com/rome-os/rome" from provenance
+```
+
+So every entry in `release-please-config.json` also carries `repository` in its
+`package.json`, with `directory` set to its own workspace path. A new releasable
+package without it builds, packs, and then fails at the upload — after
+release-please has already cut the tag and the GitHub release, which is the
+expensive place to find out.
+
 ## Manual npm publish retry
 
 Use `.github/workflows/release.yml` as the single npm publish entrypoint, even

--- a/packages/app-runtime-sdk/package.json
+++ b/packages/app-runtime-sdk/package.json
@@ -2,6 +2,11 @@
   "name": "@rome-os/app-runtime",
   "version": "0.6.1",
   "description": "Runtime SDK for Rome apps",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rome-os/rome.git",
+    "directory": "packages/app-runtime-sdk"
+  },
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/app-web-sdk/package.json
+++ b/packages/app-web-sdk/package.json
@@ -2,6 +2,11 @@
   "name": "@rome-os/app-web-sdk",
   "version": "0.3.0",
   "description": "Web runtime and CLI SDK for Rome apps",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rome-os/rome.git",
+    "directory": "packages/app-web-sdk"
+  },
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -2,6 +2,11 @@
   "name": "@rome-os/libs",
   "version": "0.0.2",
   "description": "Shared runtime primitives used by Rome services",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rome-os/rome.git",
+    "directory": "packages/lib"
+  },
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,11 @@
   "name": "@rome-os/ui",
   "version": "0.2.2",
   "description": "Shared React component kit for the Rome dashboard and Rome apps",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rome-os/rome.git",
+    "directory": "packages/ui"
+  },
   "license": "MIT",
   "type": "module",
   "sideEffects": [

--- a/packages/web-content/package.json
+++ b/packages/web-content/package.json
@@ -2,6 +2,11 @@
   "name": "@rome-os/rome-web-components",
   "version": "0.1.9",
   "description": "Shared Markdown and Rome News components for Rome web surfaces",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rome-os/rome.git",
+    "directory": "packages/web-content"
+  },
   "license": "MIT",
   "type": "module",
   "sideEffects": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
   "include-component-in-tag": true,
   "separate-pull-requests": false,
   "pull-request-title-pattern": "chore: release ${component} ${version}",
-  "bootstrap-sha": "ff79f40",
   "plugins": ["node-workspace"],
   "packages": {
     "packages/app-runtime-sdk": {
@@ -16,8 +15,7 @@
       "package-name": "@rome-os/app-web-sdk"
     },
     "packages/ui": {
-      "package-name": "@rome-os/ui",
-      "release-as": "0.2.2"
+      "package-name": "@rome-os/ui"
     },
     "packages/lib": {
       "package-name": "@rome-os/libs"


### PR DESCRIPTION
## What this PR does

Every npm publish since the move to `rome-os/rome` has failed. The last successful upload for all five packages was 2026-08-19; the two release-PR merges since ([#92](https://github.com/rome-os/rome/actions/runs/33135050890), [#106](https://github.com/rome-os/rome/actions/runs/33139147746)) built and packed fine, then died at the registry:

```
[E422] 422 Unprocessable Entity - PUT https://registry.npmjs.org/@rome-os%2fapp-web-sdk
Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is "", expected to match
"https://github.com/rome-os/rome" from provenance
```

`sdk-publish.yml` deliberately omits `--provenance`, on the reasoning that npm rejects attestations from private source repositories. That reasoning was written for `rome-internal`. This repository is public, so the Trusted Publisher attaches provenance on its own, and npm then checks the packed manifest against it. None of the five packages declared `repository` at all, so the check compared against an empty string and refused every upload.

release-please, meanwhile, kept working. It cut tags and GitHub releases for versions that never reached npm, so the two now disagree:

| package | tagged | on npm |
| --- | --- | --- |
| `@rome-os/app-runtime` | 0.6.1 | 0.6.0 |
| `@rome-os/app-web-sdk` | 0.3.0 | 0.2.21 |
| `@rome-os/libs` | 0.0.2 | 0.0.1 |
| `@rome-os/rome-web-components` | 0.1.9 | 0.1.7 |

Two unrelated landmines found while tracing this, fixed here because they block the recovery:

- `release-as: "0.2.2"` pinned `@rome-os/ui` to one version permanently. Open release PR #109 proposes `ui: 0.2.2 → 0.2.2` against an already-published version and an existing `ui-v0.2.2` tag, so merging it would fail on a duplicate tag even after the 422 is gone.
- `bootstrap-sha: "ff79f40"` names a commit that does not exist in this repository's history (`fatal: Not a valid object name`) — left over from before the migration squashed history to a single initial commit.

## Design & Invariants

Every path in `release-please-config.json` declares `repository` in its `package.json`, with `directory` set to its own workspace path. That is the invariant, and it now has a durable home in [`docs/releases.md`](docs/releases.md). A releasable package that omits it type-checks, builds, and packs, and only fails at the upload — after release-please has already cut the tag and the GitHub release, which is the expensive place to discover it.

`--provenance` stays off the command line. Adding it would be redundant rather than wrong: the Trusted Publisher already attaches the attestation. The workflow comment now says that instead of the stale private-repo claim, so the next reader does not "fix" it by adding the flag.

Removing `bootstrap-sha` changes what bounds release-please's commit scan — the per-component tags now do, and every released package has one. The alternative was to repoint it at this repository's initial commit, which buys nothing the tags don't already give.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 36 files, 528 tests passed
- [x] `pnpm install --frozen-lockfile` — resolves, so the publish job's install step is unaffected
- [x] `pnpm pack` in `packages/lib`, then read `package/package.json` out of the tarball, confirming `repository` survives into the packed manifest that npm validates
- [ ] The real proof is an upload. After merge: run `Release` → `workflow_dispatch` for `packages/app-runtime-sdk`, `packages/app-web-sdk`, `packages/web-content`, and `packages/lib` to fill the four gaps above. Not `packages/ui` — main and npm are both at 0.2.2, so it would 403.

## Not in this PR

- **The npm Trusted Publisher for `@rome-os/libs`.** A registry setting, not a repository change. The 422s prove `app-web-sdk` and `rome-web-components` already authenticate against `rome-os/rome`, since a provenance check only runs post-auth; `libs` has never published from here and is unverified. Confirm before dispatching its catch-up publish.
- **Adding `packages/lib` and `packages/web-content` to the `all` list** in `sdk-publish.yml`. Deferred until the `libs` publisher above is confirmed — landing it early makes every future `all` dispatch fail on a package that cannot authenticate, which is what the current exclusion exists to prevent.
- **`@rome-os/ui` 0.2.3.** Falls out of the pending `fix(ui):` once the `release-as` pin is gone; no manual step needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
