### PR TITLE
feat(skills): add the reconciliation loop skills

### DIFF
--- a/.claude/skills/loop-northstar/SKILL.md
+++ b/.claude/skills/loop-northstar/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: loop-northstar
+description: Hold an interactive session to create or revise an ideal-state doc, or to slice it into approved milestones on the project board.
+disable-model-invocation: true
+---
+
+# Loop: north star
+
+Goal end-state: the ideal state of the target area is written down and agreed — as a doc PR, and when the session slices it, as approved milestones on the board.
+
+This is the interactive half of the reconciliation loop. The autonomous half (`loop-reconcile`) computes the gap between these artifacts and the codebase and files work issues. This session files no work issues.
+
+## The ideal-state doc
+
+The doc lives in `docs/northstars/`, one file per area, named for the area it describes. It describes the ideal present — what should be true. Never how to get there, and never what used to be. Prose follows [WRITING.md](../../../docs/authoring/WRITING.md).
+
+The body takes whatever form fits the subject — contract tables, flow descriptions, diagrams, examples — with one required section: **Statements**, a bullet list of checkable claims. Only the Statements section has authority. `loop-reconcile` computes the gap against it, and everything else is illustration.
+
+Admission rules for every statement:
+
+- Declarative present tense. No "currently", no "we will", no "migrate from", no milestone names.
+- Checkable: an agent can verify compliance by reading the code.
+- Open: more than one implementation can satisfy it. The test: the statement stands without naming a file, function, or type. A statement only one implementation satisfies is code transcribed into prose.
+
+Content that never enters the doc:
+
+- Milestones. They go to the board and die there.
+- Rationale. It goes to [an ADR](../../../docs/authoring/adrs.md).
+- Migration policy. It lives in `loop-reconcile`.
+
+## Milestones
+
+A milestone is an intermediate ideal state. Its description is a Statements list — typically a subset or a weakened version of the north star's statements — plus optional notes. The same admission rules apply: what, never how.
+
+- Slice the end state into pillars or layers. Pillars are independent and build in any order. Layers stack and build bottom up.
+- A milestone must describe a state worth pausing at indefinitely. If pausing there leaves the codebase incoherent, the slice is wrong.
+- Milestones are born approved. Consensus happens in this session, and the record lands on the board. No proposed state exists.
+
+## Flow
+
+1. Orient. Read the existing doc if there is one, the board, and the code the doc covers.
+2. Discuss to consensus. Draft in chat and iterate with the user. Push back on any statement that fails an admission rule.
+3. Check consistency. Walk the full Statements list — new and existing statements together — and surface any two that cannot both hold. A revision session checks against the whole doc, not only the edited part.
+4. Land the artifacts, only after the user's go-ahead in chat:
+   1. The doc: open a branch and a PR. The user merges.
+   2. The milestones: create each on GitHub with `gh api repos/{owner}/{repo}/milestones -f title=... -f description=...` — the title names the slice, the description holds its Statements list. Create layers in build order.
+
+Nothing lands before the go-ahead.

--- a/.claude/skills/loop-northstar/SKILL.md
+++ b/.claude/skills/loop-northstar/SKILL.md
@@ -35,7 +35,8 @@ A milestone is an intermediate ideal state. Its description is a Statements list
 - Slice the end state into pillars or layers. Pillars are independent and build in any order. Layers stack and build bottom up.
 - A milestone must describe a state worth pausing at indefinitely. If pausing there leaves the codebase incoherent, the slice is wrong.
 - Milestones are born approved. Consensus happens in this session, and the record lands as repository milestones. No proposed state exists.
-- A milestone that later contradicts a revised doc gets fixed here too: `loop-reconcile` reports the contradiction and stops, and the next session revises the milestone.
+- A milestone that falls behind a revised doc gets fixed here too: `loop-reconcile` reports the drift and stops, and the next session revises the milestone.
+- A session that revises a doc also walks the open milestones and updates any statement the revision changed or removed, while the human is present to confirm.
 
 ## Flow
 

--- a/.claude/skills/loop-northstar/SKILL.md
+++ b/.claude/skills/loop-northstar/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: loop-northstar
-description: Hold an interactive session to create or revise an ideal-state doc, or to slice it into approved milestones on the project board.
+description: Hold an interactive session to create or revise an ideal-state doc, or to slice it into approved repository milestones.
 disable-model-invocation: true
 ---
 
 # Loop: north star
 
-Goal end-state: the ideal state of the target area is written down and agreed — as a doc PR, and when the session slices it, as approved milestones on the board.
+Goal end-state: the ideal state of the target area is written down and agreed — as a doc PR, and when the session slices it, as approved repository milestones.
 
 This is the interactive half of the reconciliation loop. The autonomous half (`loop-reconcile`) computes the gap between these artifacts and the codebase and files work issues. This session files no work issues.
 
@@ -24,7 +24,7 @@ Admission rules for every statement:
 
 Content that never enters the doc:
 
-- Milestones. They go to the board and die there.
+- Milestones. They go to the repository's milestone list and die there.
 - Rationale. It goes to [an ADR](../../../docs/authoring/adrs.md).
 - Migration policy. It lives in `loop-reconcile`.
 
@@ -34,11 +34,12 @@ A milestone is an intermediate ideal state. Its description is a Statements list
 
 - Slice the end state into pillars or layers. Pillars are independent and build in any order. Layers stack and build bottom up.
 - A milestone must describe a state worth pausing at indefinitely. If pausing there leaves the codebase incoherent, the slice is wrong.
-- Milestones are born approved. Consensus happens in this session, and the record lands on the board. No proposed state exists.
+- Milestones are born approved. Consensus happens in this session, and the record lands as repository milestones. No proposed state exists.
+- A milestone that later contradicts a revised doc gets fixed here too: `loop-reconcile` reports the contradiction and stops, and the next session revises the milestone.
 
 ## Flow
 
-1. Orient. Read the existing doc if there is one, the board, and the code the doc covers.
+1. Orient. Read the existing doc if there is one, the repository's open milestones and `loop-reconcile` issues, and the code the doc covers.
 2. Discuss to consensus. Draft in chat and iterate with the user. Push back on any statement that fails an admission rule.
 3. Check consistency. Walk the full Statements list — new and existing statements together — and surface any two that cannot both hold. A revision session checks against the whole doc, not only the edited part.
 4. Land the artifacts, only after the user's go-ahead in chat:

--- a/.claude/skills/loop-reconcile/SKILL.md
+++ b/.claude/skills/loop-reconcile/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: loop-reconcile
-description: Autonomously compute the gap between an ideal-state doc and the codebase, then file the next work issues — or a milestone-complete or needs-discussion report.
+description: Autonomously compute the gap between an ideal-state doc and the codebase, then file the next work issues — or a loop-complete or loop-needs-discussion report.
 disable-model-invocation: true
 ---
 
 # Loop: reconcile
 
-Goal end-state: the next deliverable chunk of the gap between the doc and the codebase exists as issues on the board, awaiting `ready-for-agent`, or one report explains why not.
+Goal end-state: the next deliverable chunk of the gap between the doc and the codebase exists as issues, awaiting `ready-for-agent`, or one report explains why not.
 
-This is the autonomous half of the reconciliation loop. When launched from a session, run it in a background agent. It runs headless: never ask the user a question mid-run. Every ambiguity resolves to "stop and file a report", never "do something plausible". Every report reads standalone on the board and never depends on chat context.
+This is the autonomous half of the reconciliation loop. When launched from a session, run it in a background agent. It runs headless: never ask the user a question mid-run. Every ambiguity resolves to "stop and file a report", never "do something plausible". Every report reads standalone on GitHub and never depends on chat context.
 
-Args: an ideal-state doc under `docs/northstars/`, and optionally a milestone. Given a milestone, reconcile against the milestone description instead of the full doc. Only the Statements list — the doc's Statements section, or the milestone description's — has authority. The rest of the doc is illustration.
+All work state lives in the GitHub repository itself: issues, labels, and milestones. No project board. Every issue this skill files carries the label `loop-reconcile`, the mark that the loop owns it. Reports carry `loop-complete` or `loop-needs-discussion`. If a label is missing from the repository, create it.
+
+Args: an ideal-state doc under `docs/northstars/`, and optionally a repository milestone.
+
+- Given a milestone, reconcile against the milestone description. First check its statements against the doc: if one contradicts the doc, file a `loop-needs-discussion` report and stop. The doc wins on intent, and a milestone that fell behind it needs a session, not work.
+- Given no milestone, reconcile against the doc's Statements section and file issues attached to no milestone.
+- Only the Statements list has authority. The rest of the doc is illustration.
 
 ## Inputs and precedence
 
@@ -18,28 +24,28 @@ Args: an ideal-state doc under `docs/northstars/`, and optionally a milestone. G
 | --- | --- | --- |
 | Ideal-state doc | What should be | Wins on intent |
 | Codebase | What is | Wins on facts |
-| Board | What is in flight | None — it gates and remembers |
+| Issue tracker | What is in flight | None — it gates and remembers |
 
-- The board never influences what to scope. It only gates whether to scope.
+- The tracker never influences what to scope. It only gates whether to scope.
 - Do not read PR or git history to guess intent. If a gap looks like a deliberate move away from the doc, scope it anyway. The human withholds `ready-for-agent` and fixes the doc.
 - Concurrency belongs to the driver. Assume this run is alone.
 
 ## Authority
 
-- Allowed: create issues, add them to the board, comment, and revise or withdraw this loop's own issues while they carry no `ready-for-agent` label.
-- Never: apply `ready-for-agent`, create or advance milestones, close an issue labeled `ready-for-agent`, or edit the ideal-state doc.
+- Allowed: create issues, comment, and revise or withdraw issues that carry `loop-reconcile` and not `ready-for-agent`.
+- Never: apply `ready-for-agent`, create or advance milestones, close an issue labeled `ready-for-agent`, touch an issue without the `loop-reconcile` label, or edit the ideal-state doc.
 - Anything a human approved is frozen. Issues labeled `ready-for-agent` and milestones change only by human hand.
 
 ## Procedure
 
-1. Guard. Read the board for the given scope.
-   - If an open issue is labeled `ready-for-agent` or is in progress, file nothing. Print a pointer to it and stop.
-   - If the open issues carry no `ready-for-agent` label, re-check each against the gap computed below. If they hold, stop. If they are stale, revise or withdraw them, then continue.
+1. Guard. Read the open `loop-reconcile` issues for the given scope.
+   - If one is labeled `ready-for-agent` or is in progress, file nothing. Print a pointer to it and stop.
+   - If none carries `ready-for-agent`, re-check each against the gap computed below. If they hold, stop. If they are stale, revise or withdraw them, then continue.
 2. Compute the gap. Walk the Statements list one claim at a time against the code. Record each as holds, with evidence, or fails, with the shortest path to make it hold.
 3. Exit by what the walk found.
-   - A statement cannot be checked, or two statements cannot both hold: the doc is broken. File an issue labeled `needs-discussion` naming the statements, and file nothing else. The doc gets fixed in a `loop-northstar` session, never by this run.
-   - Zero gap: file an issue labeled `milestone-complete` walking each statement with its evidence. Never advance to the next milestone.
-   - More than about four chunks, or crossing a contract boundary: file an issue labeled `needs-discussion` calling for a milestone session and sketching a possible slicing. Never scope and plan in the same run.
+   - A statement cannot be checked, or two statements cannot both hold: the doc is broken. File a `loop-needs-discussion` report naming the statements, and file nothing else. The doc gets fixed in a `loop-northstar` session, never by this run.
+   - Zero gap: file a `loop-complete` report walking each statement with its evidence and naming what it checked — the doc, or the milestone. Never advance to the next milestone.
+   - More than about four chunks, or crossing a contract boundary: file a `loop-needs-discussion` report calling for a milestone session and sketching a possible slicing. Never scope and plan in the same run.
    - Otherwise: scope chunks by the rules below and file them as issues.
 
 ## Scoping rules
@@ -49,9 +55,9 @@ Args: an ideal-state doc under `docs/northstars/`, and optionally a milestone. G
 - The chunk that removes the last consumer of a replaced thing also deletes it. Dead code is noise to the next gap computation.
 - When an issue states a fact about the code, it names the file that shows it. The reader verifies by looking, not by searching. This caps nothing — a chunk touches as many files as one reviewable PR allows.
 - File several issues only when the chunks are parallel: disjoint files, no shared contract. Never file a dependency chain — a chained issue is a stored prediction that goes stale.
-- Issues follow [the issue format](../../../docs/authoring/github-issues.md), attach to the given milestone, and stand alone without the doc.
+- Issues follow [the issue format](../../../docs/authoring/github-issues.md), attach to the milestone when one is given, and stand alone without the doc.
 - Never apply `ready-for-agent`.
 
 ## Exits
 
-Every run ends in exactly one: issues filed, a `milestone-complete` report, or a `needs-discussion` report.
+Every run ends in exactly one: issues filed, a `loop-complete` report, or a `loop-needs-discussion` report. A report is an issue carrying its label.

--- a/.claude/skills/loop-reconcile/SKILL.md
+++ b/.claude/skills/loop-reconcile/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: loop-reconcile
+description: Autonomously compute the gap between an ideal-state doc and the codebase, then file the next work issues — or a milestone-complete or needs-discussion report.
+disable-model-invocation: true
+---
+
+# Loop: reconcile
+
+Goal end-state: the next deliverable chunk of the gap between the doc and the codebase exists as issues on the board, awaiting `ready-for-agent`, or one report explains why not.
+
+This is the autonomous half of the reconciliation loop. When launched from a session, run it in a background agent. It runs headless: never ask the user a question mid-run. Every ambiguity resolves to "stop and file a report", never "do something plausible". Every report reads standalone on the board and never depends on chat context.
+
+Args: an ideal-state doc under `docs/northstars/`, and optionally a milestone. Given a milestone, reconcile against the milestone description instead of the full doc. Only the Statements list — the doc's Statements section, or the milestone description's — has authority. The rest of the doc is illustration.
+
+## Inputs and precedence
+
+| Source | Role | Authority |
+| --- | --- | --- |
+| Ideal-state doc | What should be | Wins on intent |
+| Codebase | What is | Wins on facts |
+| Board | What is in flight | None — it gates and remembers |
+
+- The board never influences what to scope. It only gates whether to scope.
+- Do not read PR or git history to guess intent. If a gap looks like a deliberate move away from the doc, scope it anyway. The human withholds `ready-for-agent` and fixes the doc.
+- Concurrency belongs to the driver. Assume this run is alone.
+
+## Authority
+
+- Allowed: create issues, add them to the board, comment, and revise or withdraw this loop's own issues while they carry no `ready-for-agent` label.
+- Never: apply `ready-for-agent`, create or advance milestones, close an issue labeled `ready-for-agent`, or edit the ideal-state doc.
+- Anything a human approved is frozen. Issues labeled `ready-for-agent` and milestones change only by human hand.
+
+## Procedure
+
+1. Guard. Read the board for the given scope.
+   - If an open issue is labeled `ready-for-agent` or is in progress, file nothing. Print a pointer to it and stop.
+   - If the open issues carry no `ready-for-agent` label, re-check each against the gap computed below. If they hold, stop. If they are stale, revise or withdraw them, then continue.
+2. Compute the gap. Walk the Statements list one claim at a time against the code. Record each as holds, with evidence, or fails, with the shortest path to make it hold.
+3. Exit by what the walk found.
+   - A statement cannot be checked, or two statements cannot both hold: the doc is broken. File an issue labeled `needs-discussion` naming the statements, and file nothing else. The doc gets fixed in a `loop-northstar` session, never by this run.
+   - Zero gap: file an issue labeled `milestone-complete` walking each statement with its evidence. Never advance to the next milestone.
+   - More than about four chunks, or crossing a contract boundary: file an issue labeled `needs-discussion` calling for a milestone session and sketching a possible slicing. Never scope and plan in the same run.
+   - Otherwise: scope chunks by the rules below and file them as issues.
+
+## Scoping rules
+
+- A chunk fits one reviewable PR.
+- Change a shared contract by expand and contract: add the new alongside the old, and move consumers in later chunks. If the contract and all its consumers fit one chunk, change it in place.
+- The chunk that removes the last consumer of a replaced thing also deletes it. Dead code is noise to the next gap computation.
+- When an issue states a fact about the code, it names the file that shows it. The reader verifies by looking, not by searching. This caps nothing — a chunk touches as many files as one reviewable PR allows.
+- File several issues only when the chunks are parallel: disjoint files, no shared contract. Never file a dependency chain — a chained issue is a stored prediction that goes stale.
+- Issues follow [the issue format](../../../docs/authoring/github-issues.md), attach to the given milestone, and stand alone without the doc.
+- Never apply `ready-for-agent`.
+
+## Exits
+
+Every run ends in exactly one: issues filed, a `milestone-complete` report, or a `needs-discussion` report.

--- a/.claude/skills/loop-reconcile/SKILL.md
+++ b/.claude/skills/loop-reconcile/SKILL.md
@@ -10,11 +10,11 @@ Goal end-state: the next deliverable chunk of the gap between the doc and the co
 
 This is the autonomous half of the reconciliation loop. When launched from a session, run it in a background agent. It runs headless: never ask the user a question mid-run. Every ambiguity resolves to "stop and file a report", never "do something plausible". Every report reads standalone on GitHub and never depends on chat context.
 
-All work state lives in the GitHub repository itself: issues, labels, and milestones. No project board. Every issue this skill files carries the label `loop-reconcile`, the mark that the loop owns it. Reports carry `loop-complete` or `loop-needs-discussion`. If a label is missing from the repository, create it.
+All work state lives in the GitHub repository itself: issues, labels, and milestones. No project board. Every issue this skill files carries two labels: `loop-reconcile`, the mark that the loop owns it, and a scope label `loop:<doc-stem>` naming its source doc — `loop:people` for `docs/northstars/people.md`. Reports also carry `loop-complete` or `loop-needs-discussion`. If a label is missing from the repository, create it.
 
 Args: an ideal-state doc under `docs/northstars/`, and optionally a repository milestone.
 
-- Given a milestone, reconcile against the milestone description. First check its statements against the doc: if one contradicts the doc, file a `loop-needs-discussion` report and stop. The doc wins on intent, and a milestone that fell behind it needs a session, not work.
+- Given a milestone, reconcile against the milestone description. First check that the doc still backs every milestone statement: if one contradicts the doc, or the doc no longer asks for it at all, file a `loop-needs-discussion` report and stop. The doc wins on intent, and a milestone that fell behind it needs a session, not work.
 - Given no milestone, reconcile against the doc's Statements section and file issues attached to no milestone.
 - Only the Statements list has authority. The rest of the doc is illustration.
 
@@ -32,13 +32,13 @@ Args: an ideal-state doc under `docs/northstars/`, and optionally a repository m
 
 ## Authority
 
-- Allowed: create issues, comment, and revise or withdraw issues that carry `loop-reconcile` and not `ready-for-agent`.
-- Never: apply `ready-for-agent`, create or advance milestones, close an issue labeled `ready-for-agent`, touch an issue without the `loop-reconcile` label, or edit the ideal-state doc.
+- Allowed: create issues, comment, and revise or withdraw issues that carry `loop-reconcile` plus this run's scope label and not `ready-for-agent`.
+- Never: apply `ready-for-agent`, create or advance milestones, close an issue labeled `ready-for-agent`, touch an issue outside this run's scope label, or edit the ideal-state doc.
 - Anything a human approved is frozen. Issues labeled `ready-for-agent` and milestones change only by human hand.
 
 ## Procedure
 
-1. Guard. Read the open `loop-reconcile` issues for the given scope.
+1. Guard. Read the open issues carrying `loop-reconcile` and this run's scope label.
    - If one is labeled `ready-for-agent` or is in progress, file nothing. Print a pointer to it and stop.
    - If none carries `ready-for-agent`, re-check each against the gap computed below. If they hold, stop. If they are stale, revise or withdraw them, then continue.
 2. Compute the gap. Walk the Statements list one claim at a time against the code. Record each as holds, with evidence, or fails, with the shortest path to make it hold.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Durable design documentation for Rome. For the rules used when writing docs, see
 - [`architecture/`](architecture/index.md) — the components on each surface and the invariants binding them.
 - `adrs/` — records of standing decisions, one file per decision keyed by filename. [authoring/adrs.md](authoring/adrs.md) defines the family.
 - [`authoring/`](authoring/authoring.md) — the rulebook for each content type (docs, PRs, issues, ADRs, design tokens, code comments, CLAUDE.md files) plus the cross-cutting prose rules.
+- [`northstars/`](northstars/CLAUDE.md) — ideal-state docs, one per area: what should be true, checked against the codebase by the `loop-reconcile` skill.
 - [`ui/`](ui/CLAUDE.md) — the design token docs, one directory per kind of token. [authoring/ui-tokens.md](authoring/ui-tokens.md) holds the rules they share.
 
 Other top-level files in `docs/` are operational references paired with the surface they document — [`design-system.md`](design-system.md), [`ui-kit.md`](ui-kit.md), [`dashboard-mock-mode.md`](dashboard-mock-mode.md), [`releases.md`](releases.md), [`observability/`](observability/). Rome Cloud deployment operations live in the private [`amantru/rome-cloud`](https://github.com/amantru/rome-cloud) repository.

--- a/docs/northstars/AGENTS.md
+++ b/docs/northstars/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/docs/northstars/CLAUDE.md
+++ b/docs/northstars/CLAUDE.md
@@ -1,0 +1,7 @@
+# docs/northstars/
+
+Each file describes the ideal present of one area — what should be true, never how to get there. The body takes any form. One section, Statements, carries the checkable claims, and only it has authority: the `loop-reconcile` skill computes the gap between a file's Statements and the codebase and files the next work issues.
+
+## Playbook
+
+- Before creating or revising a file here, run the `loop-northstar` skill. It enforces the statement admission rules and lands the change as a PR.


### PR DESCRIPTION
## What this PR does

An upfront issue breakdown goes stale as execution changes the plan. On [project 3](https://github.com/orgs/rome-os/projects/3), the second wave of issues (#94–101) superseded parts of the first (#58–70) while first-wave issues still sat open, and updating downstream issues took deliberate manual effort. The staleness came from storing the plan in the issues: a detailed issue far down the sequence predicts a future codebase state, and the prediction rots.

This PR replaces upfront breakdowns with a reconciliation loop, split into two skills:

- `loop-northstar` — interactive. A working session that creates or revises an ideal-state doc under `docs/northstars/`, or slices it into milestones. Consensus happens in the session; the doc lands as a PR and milestones land on the board already approved.
- `loop-reconcile` — autonomous. Computes the gap between a doc's Statements and the codebase, then files the next chunk of work as issues — or a `milestone-complete` or `needs-discussion` report. It never asks a question mid-run.

It also adds `docs/northstars/` with a CLAUDE.md defining the family, and maps it in `docs/README.md`.

## Design & Invariants

- Only two sources are authoritative: the ideal-state doc for intent, the codebase for facts. The board gates and remembers but never decides — its contents regenerate from a fresh gap computation, so board rot is harmless.
- An ideal-state doc describes the ideal present, never the journey. Only its Statements section carries authority; each statement is declarative present tense, checkable by reading the code, and satisfiable by more than one implementation.
- Issues are a work log, not a plan. A run files several issues only when they are parallel (disjoint files, no shared contract), and never a dependency chain.
- Anything a human approved is frozen for the skill: issues labeled `ready-for-agent` and milestones change only by human hand. Doc content changes only through `loop-northstar` sessions, never through autonomous runs.
- Every ambiguity resolves to "stop and file a report", never "do something plausible".

## Test plan

- [x] Prose pass against `docs/authoring/WRITING.md` and the CLAUDE.md rulebook.
- [x] `scripts/check-pr-title.sh` on this title.
- [ ] First real `loop-northstar` session producing a northstar doc.
- [ ] First `loop-reconcile` run against that doc, verifying the guard, the exits, and the issue format.

## Not in this PR

- The design record that produced these skills (`docs/workstreams/reconciliation-loop.md`) stays uncommitted — scaffolding, fully absorbed into the skill bodies.
- Merge-triggered `loop-reconcile` runs — launches stay manual until the filed issues stop needing rewrites.
- Whole-repo reconciliation across every northstar doc — runs take one doc as the argument for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)