### PR TITLE
refactor: sweep identifiers and prose to the people nouns

### DIFF
--- a/docs/architecture/access-control.md
+++ b/docs/architecture/access-control.md
@@ -1,6 +1,6 @@
 # Access Control
 
-How a Rome instance decides who is on the other end of a request and what that request may reach. The surface has four components: the edge proxy, the verify probe behind it, the policies the probe reads, and the app-API dispatch. The identities themselves are concepts vocabulary — the [guardian](../concepts/identity.md#guardian) and the [visitor](../concepts/identity.md#visitor) — and the [single HTTP listener](api.md#http-surface) behind the edge is owned by `api.md`.
+How a Rome instance decides who is on the other end of a request and what that request may reach. The surface has four components: the edge proxy, the verify probe behind it, the policies the probe reads, and the app-API dispatch. The callers themselves are concepts vocabulary — the [guardian](../concepts/people.md#guardian) and the [visitor](../concepts/people.md#visitor) — and the [single HTTP listener](api.md#http-surface) behind the edge is owned by `api.md`.
 
 ## Policies
 
@@ -25,7 +25,7 @@ browser ──every request──► edge proxy ──consults──► verify p
                        backend route ──app-API dispatch──► app handler (caller re-derived)
 ```
 
-The edge consults the probe on every proxied request and forwards or rejects on its answer. For a gated path, the probe passes a guardian session or an allow-listed [visitor](../concepts/identity.md#visitor) and rejects everything else.
+The edge consults the probe on every proxied request and forwards or rejects on its answer. For a gated path, the probe passes a guardian session or an allow-listed [visitor](../concepts/people.md#visitor) and rejects everything else.
 
 ### Invariants
 

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -9,7 +9,7 @@ action worker ──fork IPC──► main ──spawn──► delegated worker
 
 ## HTTP surface
 
-A single server hosts every HTTP route behind the [edge](access-control.md#request-flow). Four categories share the listener: the dashboard API with its websockets, the access-gated [app surfaces](access-control.md#policies), the [public allow-list](access-control.md#request-flow), and the webhook ingress. [`access-control.md`](access-control.md) owns the per-category auth and the fail-closed default. The identities are concepts entries — [guardian](../concepts/identity.md#guardian) and [visitor](../concepts/identity.md#visitor).
+A single server hosts every HTTP route behind the [edge](access-control.md#request-flow). Four categories share the listener: the dashboard API with its websockets, the access-gated [app surfaces](access-control.md#policies), the [public allow-list](access-control.md#request-flow), and the webhook ingress. [`access-control.md`](access-control.md) owns the per-category auth and the fail-closed default. The callers are concepts entries — [guardian](../concepts/people.md#guardian) and [visitor](../concepts/people.md#visitor).
 
 ### Invariants
 

--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -60,7 +60,7 @@ The actor is the authenticated session identity accountable for an action execut
 
 **Contracts:**
 
-- The actor is the [guardian](identity.md#guardian), a [visitor](identity.md#visitor), or anonymous. Anonymous means the chain entered a session-capable surface (the API surface, the app WebSocket server) with no session. An absent actor means no accountable session could exist anywhere in the chain — agent-autonomous work, routines, startup, and machine-credential surfaces such as webhooks.
+- The actor is the [guardian](people.md#guardian), a [visitor](people.md#visitor), or anonymous. Anonymous means the chain entered a session-capable surface (the API surface, the app WebSocket server) with no session. An absent actor means no accountable session could exist anywhere in the chain — agent-autonomous work, routines, startup, and machine-credential surfaces such as webhooks.
 - Capture is ambient, not per-route. Identity is established once where a request enters and flows to every action run during it, so a newly added route is attributed without doing anything.
 - The whole execution chain inherits the root's actor — sub-actions, detached runs, and worker-process hops — no matter how many apps or agents sit in between.
 - The trust boundary resolves the actor from primary session material, never from forwarded headers or app-supplied input ([access control](../architecture/access-control.md)).

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -14,7 +14,7 @@ An agent is an LLM-backed runtime entity: a named configuration that sets a mode
 
 - **[Action](actions.md)** — an action is code that runs. An agent is the LLM-backed entity that decides to run it.
 - **[Session](sessions.md)** — the session is the durable boundary around a body of agent work. The agent is the configured entity doing the work.
-- **[Guardian](identity.md#guardian)** — the agent has its own identity (name, personality), separate from the human it serves.
+- **[Guardian](people.md#guardian)** — the agent has its own identity (name, personality), separate from the human it serves.
 
 ## Agent hierarchy
 

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -85,7 +85,7 @@ Apps consume three supported packages published under the `@rome-os/` scope: `@r
 
 ## Caller identity
 
-The caller is the request identity an app observes: the [guardian](identity.md#guardian), a [visitor](identity.md#visitor), or anonymous. The host resolves it before an app handler runs and hands the same shape to server code and web code.
+The caller is the request identity an app observes: the [guardian](people.md#guardian), a [visitor](people.md#visitor), or anonymous. The host resolves it before an app handler runs and hands the same shape to server code and web code.
 
 **Contracts:**
 

--- a/docs/concepts/data.md
+++ b/docs/concepts/data.md
@@ -2,11 +2,11 @@
 
 ## Memory
 
-The memory system provides persistent, git-tracked knowledge that survives across agent [sessions](sessions.md). It holds general memory (preferences, key facts, privacy boundaries), the agent's identity, a daily journal, relationship profiles for [persons](identity.md#persons), and summaries of the guardian's [projects](#projects).
+The memory system provides persistent, git-tracked knowledge that survives across agent [sessions](sessions.md). It holds general memory (preferences, key facts, privacy boundaries), the agent's identity, a daily journal, relationship profiles for [persons](people.md#person), and summaries of the guardian's [projects](#projects).
 
 **Contracts:**
 
-- The entire memory directory is a git repository: every change (by agents or the [guardian](identity.md#guardian)) is tracked with full commit history and can be reverted.
+- The entire memory directory is a git repository: every change (by agents or the [guardian](people.md#guardian)) is tracked with full commit history and can be reverted.
 - Key files load into agent context at session start. Person profiles and journal entries load on demand when relevant.
 - Privacy boundaries are part of memory itself: topics marked off-limits must not be remembered.
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -4,7 +4,7 @@ This is the concepts index — the single source of truth for entity definitions
 
 Browse by domain:
 
-- [`identity.md`](identity.md) — Guardian, Visitor, Persons, Accounts, Links, Bond levels. *Who Rome serves and who it interacts with.*
+- [`people.md`](people.md) — Guardian, Visitor, Persons, Accounts, Addresses, Links, Bond levels. *Who Rome serves and who it interacts with.*
 - [`deployment.md`](deployment.md) — Profiles, Instances. *How a deployment names itself for data isolation and for telemetry.*
 - [`rome-cloud.md`](rome-cloud.md) — Rome Cloud, Instance sign-in, OAuth handoff. *The operator-run service in front of all instances.*
 - [`agents.md`](agents.md) — Agents (incl. the agent hierarchy). *The LLM-backed runtime entities.*
@@ -23,7 +23,7 @@ Terms used on multiple surfaces with no entry yet. Each needs a full pass throug
 - **Setup (conferral setup)** — connection setup runtime, dashboard setup renderer, [`architecture/channels.md`](../architecture/channels.md) — a server-owned resumable connect protocol with a closed verb set. Any surface can render any setup.
 - **Turn (agent turn)** — turn lifecycle hooks, trace surfaces, `sessions.md` prose, [`architecture/suspensions.md`](../architecture/suspensions.md) — the atomic unit of agent work: carries a turn id, a lifecycle hook pair, and is the granularity of model-pin and fork rules.
 - **Trace** — per-turn evidence storage, dashboard trace drawer, replay app agent prompt — append-only per-turn evidence stream, distinct from OTEL spans, which docs never disambiguate.
-- **Seat (guardian seat)** — guardian auth state, [`actions.md#actor`](actions.md#actor), [`architecture/access-control.md`](../architecture/access-control.md) — the single per-instance guardian record, stable across login methods. [`identity.md#guardian`](identity.md#guardian) covers the role, not the record.
+- **Seat (guardian seat)** — guardian auth state, [`actions.md#actor`](actions.md#actor), [`architecture/access-control.md`](../architecture/access-control.md) — the single per-instance guardian record, stable across login methods. [`people.md#guardian`](people.md#guardian) covers the role, not the record.
 - **Webchat** — webchat runtime, dashboard chat, agent prompts, several concepts entries use it undefined — the dashboard-native channel and the only interactive surface.
 - **Webhook** — webhook API surface, [`architecture/api.md`](../architecture/api.md) — machine-credential, actor-less async action entry point.
 - **Settings (instance KV vs conversation settings)** — settings APIs and UI, [`architecture/notification-delivery.md`](../architecture/notification-delivery.md) — two distinct things sharing one word. The ambiguity is the reason to document.

--- a/docs/concepts/messaging.md
+++ b/docs/concepts/messaging.md
@@ -2,7 +2,7 @@
 
 ## Channels
 
-Channels are messaging platform integrations — external platforms like Telegram, WhatsApp, and Discord, plus the webchat built into the dashboard. Each channel has an adapter that normalizes platform-specific messages into a common shape carrying the channel, the sender's [account](identity.md#account), thread addressing, content, and the raw platform event.
+Channels are messaging platform integrations — external platforms like Telegram, WhatsApp, and Discord, plus the webchat built into the dashboard. Each channel has an adapter that normalizes platform-specific messages into a common shape carrying the channel, the sender's [account](people.md#account), thread addressing, content, and the raw platform event.
 
 **Contracts:**
 
@@ -12,7 +12,7 @@ Channels are messaging platform integrations — external platforms like Telegra
 
 **Not to be confused with:**
 
-- **[Person](identity.md#persons)** — a channel is where a message arrives. The person is who sent it, resolved across channels.
+- **[Person](people.md#person)** — a channel is where a message arrives. The person is who sent it, resolved across channels.
 - **[Hook](apps.md#hooks)** — the `channel-message` hook is how an inbound message enters app code. The channel is the integration that produced it.
 
 ## Policies
@@ -20,9 +20,9 @@ Channels are messaging platform integrations — external platforms like Telegra
 The policy engine decides how to handle each incoming message based on who sent it and where.
 
 Evaluation order (first match wins):
-1. **Sender-specific** — exact [person](identity.md#persons) match
+1. **Sender-specific** — exact [person](people.md#person) match
 2. **Thread-specific** — thread name + type match
-3. **Sender tier** — [bond level](identity.md#bond-levels) match
+3. **Sender tier** — [bond level](people.md#bond-levels) match
 4. **Channel-specific** — [channel](#channels) match
 5. **Global** — catch-all
 
@@ -38,14 +38,14 @@ Policy actions:
 
 **Not to be confused with:**
 
-- **[Bond level](identity.md#bond-levels)** — a bond level is an attribute of a person. A policy is a routing rule that may key on it.
+- **[Bond level](people.md#bond-levels)** — a bond level is an attribute of a person. A policy is a routing rule that may key on it.
 - **[Approvals](#approvals)** — a policy routes inbound messages. An approval gates a sensitive action before it executes.
 
 ## Sentinel
 
 The sentinel is a lightweight [agent](agents.md) that triages messages from untrusted senders. When the [policy engine](#policies) routes a message to sentinel review, the sentinel decides:
 
-- **Reply** — respond directly (logged for [guardian](identity.md#guardian) review)
+- **Reply** — respond directly (logged for [guardian](people.md#guardian) review)
 - **Escalate** — forward to the [main agent](agents.md#agent-hierarchy)
 - **Ignore** — drop the message (logged)
 
@@ -61,7 +61,7 @@ The sentinel is a lightweight [agent](agents.md) that triages messages from untr
 
 ## Approvals
 
-The approval system gates sensitive [actions](actions.md) behind [guardian](identity.md#guardian) sign-off. When a gated action is triggered, execution pauses and Rome records an approval. The guardian approves or rejects it from the web dashboard.
+The approval system gates sensitive [actions](actions.md) behind [guardian](people.md#guardian) sign-off. When a gated action is triggered, execution pauses and Rome records an approval. The guardian approves or rejects it from the web dashboard.
 
 **Contracts:**
 

--- a/docs/concepts/people.md
+++ b/docs/concepts/people.md
@@ -1,4 +1,4 @@
-# Identity: Guardian, Visitor, Persons, Accounts & Links
+# People: Guardian, Visitor, Persons, Accounts, Addresses & Links
 
 ## Guardian
 
@@ -9,11 +9,11 @@ The guardian is the single human user that a Rome instance serves. They control 
 - One Rome instance serves exactly one guardian. There is no multi-guardian mode.
 - The guardian is always the highest-trust [bond level](#bond-levels). No person can outrank them.
 - Only the guardian can approve or reject an [approval-gated action](messaging.md#approvals).
-- The guardian's full access is inherent. Every other authenticated identity is a [visitor](#visitor) whose access is granted and revocable.
+- The guardian's full access is inherent. Every other authenticated caller is a [visitor](#visitor) whose access is granted and revocable.
 
 **Not to be confused with:**
 
-- **[Person](#persons)** — a person is someone the guardian knows. The guardian is the one the instance serves.
+- **[Person](#person)** — a person is someone the guardian knows. The guardian is the one the instance serves.
 - **[Visitor](#visitor)** — a visitor holds scoped access the guardian granted. The guardian owns the instance and can never be outranked by one.
 - **The agent's identity** — the agent has its own name and personality, stored separately from the guardian's profile.
 
@@ -30,44 +30,61 @@ A visitor is the holder of a [Rome Cloud](rome-cloud.md) account that the guardi
 **Not to be confused with:**
 
 - **[Guardian](#guardian)** — the guardian owns the instance and holds full access. A visitor holds scoped access the guardian granted.
-- **[Person](#persons)** — a person is someone the guardian knows, carrying a bond level. A visitor is an authenticated caller, and the two are orthogonal — a visitor need not be a tracked person.
+- **[Person](#person)** — a person is someone the guardian knows, carrying a bond level. A visitor is an authenticated caller, and the two are orthogonal — a visitor need not be a tracked person.
 
-## Persons
+## Person
 
 Rome tracks people the guardian knows. Each person carries a [bond level](#bond-levels) that determines how the system interacts with them. [Links](#link) to multiple [accounts](#account) let the system recognize the same person across [channels](messaging.md#channels).
 
 **Contracts:**
 
-- A person's identity is channel-independent: multiple linked accounts resolve to the same person, and what the system knows about someone travels with the person, not with any account.
+- A person is channel-independent: multiple linked accounts resolve to the same person, and what the system knows about someone travels with the person, not with any account.
 - Every person carries exactly one [bond level](#bond-levels).
 
 **Not to be confused with:**
 
 - **[Guardian](#guardian)** — the guardian is served by the instance. Persons are known to it.
-- **[Account](#account)** — an account is an identity on one platform. A person aggregates the accounts linked to them.
+- **[Account](#account)** — an account is a party on one platform. A person aggregates the accounts linked to them.
 
 ## Account
 
-An account is an identity on an external messaging platform — a Telegram user ID, a WhatsApp number, a LinkedIn profile. The platform owns the account, and Rome only observes it. Deprecated alias: *platform identity*.
+An account is a party on an external messaging platform — a Telegram user, a WhatsApp number, a LinkedIn profile. The platform owns the account, and Rome only observes it. Deprecated alias: *platform identity*.
 
 **Contracts:**
 
-- An account is identified by its [channel](messaging.md#channels) plus its platform user ID. The same pair always names the same account.
+- An account is identified by its [channel](messaging.md#channels) plus its own [address](#address). The same pair always names the same account.
 - Rome never creates or deletes an account. Platforms own the account lifecycle, and Rome learns of accounts from inbound messages.
 - An account resolves to a person only through its [link](#link). An account with no link resolves to no one.
 - An account is in exactly one of three states: unlinked, linked, or dismissed. Dismissal records that the account belongs to no one the guardian tracks. A dismissed account stays out of discovery until the guardian restores or links it.
 - The state is derived from the account's link. No surface stores or reports a state that can disagree with the link behind it.
-- The guardian's own platform identities are accounts like any other, linked to the guardian.
+- The guardian's own accounts on a platform are accounts like any other, linked to the guardian.
 
 **Not to be confused with:**
 
-- **[Person](#persons)** — Rome owns persons, and platforms own accounts. A person aggregates the accounts linked to them.
-- **[Channel](messaging.md#channels)** — a channel is the platform integration messages arrive through. An account is one identity on that platform.
+- **[Person](#person)** — Rome owns persons, and platforms own accounts. A person aggregates the accounts linked to them.
+- **[Address](#address)** — an account is the party. An address is one of the forms it is reachable at.
+- **[Channel](messaging.md#channels)** — a channel is the platform integration messages arrive through. An account is one party on that platform.
 - **Connection** — a connection joins the Rome instance to a service. An account belongs to a party on that service.
+
+## Address
+
+An address is a form an [account](#account) is reachable at on its [channel](messaging.md#channels) — a phone number, a member id, a mailbox. The platform owns the form and Rome carries it whole. Deprecated alias: *channel user id*.
+
+**Contracts:**
+
+- An address is opaque. No surface parses, constructs, or compares parts of one, so a platform can change the form it hands out without any reader changing.
+- Every address a channel can receive a message on resolves to exactly one account. One account reachable under several addresses is one account, never two.
+- Exactly one of an account's addresses is the account's own — the one a [link](#link), a dismissal, or a stored message names it by. Which one is the channel's answer, not a rule any reader derives.
+- An address names an account, never a person. Who is behind it is the account's [link](#link).
+
+**Not to be confused with:**
+
+- **[Account](#account)** — the account is the party, stable across every address it answers to. An address is one form of reach.
+- **Identifier** — an identifier is a searchable fact about an account, such as an email or a profile URL. An address is what a message is addressed to, and a searchable fact is not one.
 
 ## Link
 
-A link is the recorded fact that an [account](#account) belongs to a [person](#persons). It is the only identity fact Rome adds to what the platforms provide. Deprecated alias: *channel mapping*.
+A link is the recorded fact that an [account](#account) belongs to a [person](#person). It is the only fact about who is who that Rome adds to what the platforms provide. Deprecated alias: *channel mapping*.
 
 **Contracts:**
 
@@ -83,7 +100,7 @@ A link is the recorded fact that an [account](#account) belongs to a [person](#p
 
 ## Bond levels
 
-A bond level is the trust tier assigned to a [person](#persons). It determines how deeply the system remembers them and whether their messages are trusted by default.
+A bond level is the trust tier assigned to a [person](#person). It determines how deeply the system remembers them and whether their messages are trusted by default.
 
 | Level | Examples | Memory depth |
 |---|---|---|

--- a/docs/concepts/rome-cloud.md
+++ b/docs/concepts/rome-cloud.md
@@ -1,6 +1,6 @@
 # Rome Cloud
 
-Rome Cloud is the operator-run service that complements Rome instances. Where each Rome instance serves a single [guardian](identity.md#guardian), Rome Cloud is the shared piece of infrastructure that sits in front of all of them.
+Rome Cloud is the operator-run service that complements Rome instances. Where each Rome instance serves a single [guardian](people.md#guardian), Rome Cloud is the shared piece of infrastructure that sits in front of all of them.
 
 It plays four roles:
 

--- a/packages/api-types/src/approvals.ts
+++ b/packages/api-types/src/approvals.ts
@@ -5,6 +5,10 @@
 // `outgoing_message` and `person_mapping`. Leaving the column a bare string
 // invited callers — and fixtures — to invent kinds nothing downstream knows how
 // to resolve.
+//
+// `person_mapping` is the lifecycle for approving a link (docs/concepts/
+// people.md#link). It keeps its name because it is a persisted column value: a
+// rename would strand every stored row.
 
 // Defined in @rome-os/app-runtime — the SDK apps compile against, and therefore
 // the only place that can constrain the two lifecycles apps create. Re-exported

--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -18,19 +18,17 @@
 //   POST   /api/accounts/:channel/:channelUserId/dismiss  -> DirectoryAccount
 //   POST   /api/accounts/:channel/:channelUserId/restore  -> DirectoryAccount
 //
-// The vocabulary is docs/concepts/identity.md's. Rome never mints an account:
-// an account is platform-owned, named by the pair (channel, channelUserId),
-// and the only identity fact Rome contributes is which person it belongs to.
-// So the writes here move a link between people; none of them creates or
-// destroys the account under it.
+// The vocabulary is docs/concepts/people.md's. Rome never mints an account:
+// an account is platform-owned, named by the pair (channel, channelUserId) —
+// its channel and its own address — and the only fact about who is who that
+// Rome contributes is which person it belongs to. So the writes here move a
+// link between people; none of them creates or destroys the account under it.
 //
 // The bond ladder, the merged timeline and the activity order both the person
-// listing and the account stream run on live here too. They outlived the
-// identity union that first defined them — the flattened row shape this
-// two-noun contract replaced — and they are the pieces both nouns still share:
-// a row's `latest` is the head of the timeline the same row opens, and a
-// cursor written against one activity listing has to name a position in the
-// other. A second definition of any of them is a page boundary the two ends
+// listing and the account stream run on live here too. They are the pieces both
+// nouns share: a row's `latest` is the head of the timeline the same row opens,
+// and a cursor written against one activity listing has to name a position in
+// the other. A second definition of any of them is a page boundary the two ends
 // disagree about, so they are stated once, here.
 //
 // The account read is two reads, because two surfaces ask two questions. The
@@ -402,8 +400,9 @@ export function accountPresentation(
  * One account in the directory: one person on one channel, however many
  * addresses that channel reaches them at.
  *
- * `channel` and `channelUserId` are its identity — the pair a link, a dismissal
- * or a timeline read names. {@link accountRef} renders the pair as the single
+ * `channel` and `channelUserId` name it — the pair a link, a dismissal or a
+ * timeline read carries. `channelUserId` is the account's own address, kept
+ * under its wire name here. {@link accountRef} renders the pair as the single
  * token a key or a path segment needs.
  *
  * A contacts list's row, so it carries who the account is and nothing about
@@ -413,8 +412,8 @@ export function accountPresentation(
  */
 export interface DirectoryAccount {
   channel: string;
-  /** The address the channel folds its other addressings of this account onto.
-   *  Stable across a re-sync and across which addressing a message arrives on. */
+  /** The address the channel folds its other addresses of this account onto.
+   *  Stable across a re-sync and across which address a message arrives on. */
   channelUserId: string;
   /**
    * Every address the channel can reach the account at, `channelUserId`
@@ -501,8 +500,8 @@ export interface AccountStream {
 }
 
 /**
- * Render an account's identity as one token, for a client's row key and for the
- * position a cursor names.
+ * Render the pair naming an account as one token, for a client's row key and
+ * for the position a cursor names.
  *
  * Only the first colon is structural, so a channel carrying one would make the
  * token ambiguous. Channel names are short slugs, so refusing the separator
@@ -810,11 +809,12 @@ export function sliceAccountStream(
 /**
  * One account as it appears under the person linked to it.
  *
- * `(channel, channelUserId)` is the account's identity — Rome never mints one,
- * every pair here is observed from a message or an address-book mirror — and
- * `displayName` is what the platform calls it, the raw identifier being only
- * the last resort. The directory's {@link DirectoryAccount} is the same
- * account seen from the other side, with what Rome decided about it.
+ * `(channel, channelUserId)` names the account — its channel and its own
+ * address. Rome never mints one: every pair here is observed from a message or
+ * from a channel's address book. `displayName` is what the platform calls it,
+ * the raw identifier being only the last resort. The directory's
+ * {@link DirectoryAccount} is the same account seen from the other side, with
+ * what Rome decided about it.
  */
 export interface LinkedAccount {
   channel: string;

--- a/packages/app-runtime-sdk/src/index.ts
+++ b/packages/app-runtime-sdk/src/index.ts
@@ -1947,6 +1947,13 @@ export function upgradeWebSocket(
   return accept(handlers);
 }
 
+/**
+ * One account linked to a person.
+ *
+ * A channel mapping is a link and `channelUserId` is the account's own address
+ * (docs/concepts/people.md). The names here are the published wire contract and
+ * the database's, so they stay as they are.
+ */
 export interface ChannelMappingRecord {
   channel: string;
   channelUserId: string;
@@ -1963,6 +1970,8 @@ export interface PersonRecord {
   [key: string]: unknown;
 }
 
+/** The people the host knows and the accounts linked to each. Named for the
+ *  `channel_mappings` table it reads; see {@link ChannelMappingRecord}. */
 export interface PersonMappingRepository {
   findByChannelUser(channel: string, channelUserId: string): Promise<PersonRecord | null>;
   findByName(displayName: string): Promise<PersonRecord[]>;

--- a/packages/core/src/api/deps.ts
+++ b/packages/core/src/api/deps.ts
@@ -75,10 +75,10 @@ export interface ApiDeps {
   personMappingRepo: PersonMappingRepository;
   /** Durable mirror of the WhatsApp address book + message history (People tab). */
   whatsAppStoreRepo: WhatsAppStoreRepository;
-  /** WhatsApp's account plane over that mirror — who it can reach, folded onto
+  /** WhatsApp's address book over that mirror — who it can reach, folded onto
    *  one account per person, and what was last said to each. */
   whatsAppAccounts: WhatsAppAccounts;
-  /** LinkedIn's account plane over its own inbox mirror — the same shape
+  /** LinkedIn's address book over its own inbox mirror — the same shape
    *  WhatsApp's is, and all the API needs of LinkedIn. The mirror behind it is
    *  the poller's and the timeline's; no route reads it directly. */
   linkedInAccounts: LinkedInAccounts;

--- a/packages/core/src/api/routes/account-decisions.test.ts
+++ b/packages/core/src/api/routes/account-decisions.test.ts
@@ -46,7 +46,7 @@ describe("Account dismiss and restore", () => {
       { jid: TALKING_JID, notify: "Talky Tina" },
       { jid: LINKED_JID, name: "Alice WA" },
       // One contact the address book reaches two ways, so a write has to land
-      // on the account rather than on the addressing it was named by.
+      // on the account rather than on the address it was named by.
       { jid: PHONE_JID, name: "Split Contact" },
       { jid: LID_JID, phoneNumber: "15550009999" },
     ]);

--- a/packages/core/src/api/routes/account-decisions.ts
+++ b/packages/core/src/api/routes/account-decisions.ts
@@ -14,10 +14,10 @@ import type { ApiDeps } from "../deps.js";
 // (@rome/api-types/people). This route is the join between a path and those,
 // and holds no rule of its own beyond which status each outcome is.
 //
-// The account is named by a pair in the path, not by a body: it is the
-// account's identity rather than an argument of the write, so the same account
-// is addressed the same way by every verb, and a retry of a POST is a retry of
-// the same decision.
+// The account is named by a pair in the path, not by a body: the pair names the
+// account rather than arguing the write, so the same account is addressed the
+// same way by every verb, and a retry of a POST is a retry of the same
+// decision.
 //
 // The identifier takes the rest of the path before the verb, separators
 // included, the way the unlink route takes the rest of its own. A channel mints

--- a/packages/core/src/api/routes/people.test.ts
+++ b/packages/core/src/api/routes/people.test.ts
@@ -607,7 +607,7 @@ describe("People API", () => {
     ]);
   });
 
-  it("names an account as its platform does, over every addressing of it", async () => {
+  it("names an account as its platform does, over every address of it", async () => {
     const nadia = await fetchPerson(nadiaId);
     // One account, two mappings: a client addresses the link it stored, and
     // both carry the mirror's name for the account rather than the raw jid.
@@ -681,7 +681,7 @@ describe("People API", () => {
   it("counts one account's history once, whatever it is addressed by", async () => {
     const nadia = await fetchPerson(nadiaId);
     // Two mappings onto one mirrored account, and one conversation on it: the
-    // reaction and the group message are not entries, and the two addressings
+    // reaction and the group message are not entries, and the two addresses
     // are not two histories.
     expect(nadia.messageCount).toBe(2);
     expect(nadia.latest).toEqual({

--- a/packages/core/src/channels/account-fold.test.ts
+++ b/packages/core/src/channels/account-fold.test.ts
@@ -11,7 +11,7 @@ const account = (id: string, addresses: string[] = [id], name: string | null = n
 
 /**
  * A channel answering the whole of what a fold may ask it: a listing whose
- * accounts carry their own addressing sets, and `resolve` for an address the
+ * accounts carry their own address sets, and `resolve` for an address the
  * listing does not carry.
  *
  * It is an `Accounts` and nothing more — no address map and no history — so a
@@ -50,7 +50,7 @@ const adaLid = "77770001@lid";
 const grace = "12025550111@s.whatsapp.net";
 
 describe("foldAccounts", () => {
-  it("takes an account's addressing set from the account itself", async () => {
+  it("takes an account's address set from the account itself", async () => {
     const whatsapp = new FakePlane([account(ada, [ada, adaLid], "Ada")]);
 
     const fold = await foldAccounts({ whatsapp }, { stored: [] });
@@ -63,10 +63,10 @@ describe("foldAccounts", () => {
         name: "Ada",
       },
     ]);
-    // Both addressings name the one account, whichever one a caller holds.
+    // Both addresses name the one account, whichever one a caller holds.
     expect(fold.canonical("whatsapp", adaLid)).toBe(ada);
     expect(fold.canonical("whatsapp", ada)).toBe(ada);
-    expect(fold.mirrorFor("whatsapp", adaLid)?.name).toBe("Ada");
+    expect(fold.accountFor("whatsapp", adaLid)?.name).toBe("Ada");
     expect(whatsapp.listings).toBe(1);
   });
 
@@ -91,7 +91,7 @@ describe("foldAccounts", () => {
 
     expect(linkedin.resolved).toEqual([profileUrl]);
     expect(fold.canonical("linkedin", profileUrl)).toBe("ACoAAAda0001");
-    expect(fold.mirrorFor("linkedin", profileUrl)?.channelUserId).toBe("ACoAAAda0001");
+    expect(fold.accountFor("linkedin", profileUrl)?.channelUserId).toBe("ACoAAAda0001");
     // The stored form stays the caller's: the fold reads it, it does not
     // publish it as an address of the account.
     expect(fold.accounts[0]?.aliases).toEqual(["ACoAAAda0001"]);

--- a/packages/core/src/channels/account-fold.ts
+++ b/packages/core/src/channels/account-fold.ts
@@ -1,9 +1,9 @@
-// Who is one account — every address book Rome mirrors folded onto accounts.
+// Who is one account — every address book Rome reads, folded onto accounts.
 //
 // `Accounts` (accounts.ts) is one channel's address book and `AccountNames`
 // (account-names.ts) is the display-name half of all of them. This is the fold
 // underneath both reads that have to show every account there is: which
-// addressings are one account.
+// addresses are one account. Vocabulary: docs/concepts/people.md.
 //
 // Nothing here reads a history. What an account last did is a `Messages` store's
 // answer (messages.ts), read by the callers that show it, so the contacts list
@@ -14,18 +14,23 @@ import type { Accounts } from "./accounts.js";
 
 /**
  * One account a channel's address book holds, in the shape every caller reads
- * every mirror through.
+ * every channel through.
  *
  * The projection is `Account` as the fold reads it, and nothing channel-specific
- * survives it: which addressings a channel hands out, which of them is
+ * survives it: which addresses a channel hands out, which of them is
  * canonical, and what counts as an account at all are the channel's answers,
  * given once behind {@link Accounts}. So a caller's rules stay
- * channel-agnostic, and adding a mirror is an entry in {@link mirrorRegistry}
- * rather than another special case above.
+ * channel-agnostic, and adding a channel is an entry in
+ * {@link addressBookRegistry} rather than another special case above.
  */
-export interface MirrorAccount {
+export interface FoldedAccount {
   channel: string;
-  /** The account's own address — what a mapping or a placement should name. */
+  /**
+   * The account's own address — what a link or a stored row should name.
+   *
+   * Named `channelUserId` because that is the wire field and the database
+   * column; the noun is the account's own address (docs/concepts/people.md).
+   */
   channelUserId: string;
   /** Every address the account answers to, `channelUserId` included. */
   aliases: string[];
@@ -38,14 +43,14 @@ export const addressKey = (channel: string, channelUserId: string) =>
   `${channel}\n${channelUserId}`;
 
 /**
- * The channels Rome mirrors an address book for. A provider joins every fold
+ * The channels Rome reads an address book for. A provider joins every fold
  * and every naming read at once by taking an entry here.
  *
- * The plane type is the caller's: a fold needs the whole of {@link Accounts}
- * and a naming read needs only `resolve`, and neither should have to name the
- * channels a second time to say so.
+ * The address book type is the caller's: a fold needs the whole of
+ * {@link Accounts} and a naming read needs only `resolve`, and neither should
+ * have to name the channels a second time to say so.
  */
-export function mirrorRegistry<T>(deps: {
+export function addressBookRegistry<T>(deps: {
   whatsAppAccounts: T;
   linkedInAccounts: T;
 }): Readonly<Record<string, T>> {
@@ -55,23 +60,23 @@ export function mirrorRegistry<T>(deps: {
 /**
  * The channels a fold reads, each behind its own address book.
  *
- * A plane is read as its listing gives it — each account carrying its own
- * addressing set — so the whole address book arrives as accounts rather than as
- * a map of addresses a caller has to invert back into them.
+ * An address book is read as its listing gives it — each account carrying its
+ * own address set — so the whole book arrives as accounts rather than as a map
+ * of addresses a caller has to invert back into them.
  */
-export type MirrorPlanes = Readonly<Record<string, Accounts>>;
+export type AddressBooks = Readonly<Record<string, Accounts>>;
 
-/** An identifier a caller already holds, wherever it holds it — a link, a
- *  sentinel row — so a channel can be asked about the ones its address map does
- *  not cover. */
+/** An address a caller already holds, wherever it holds it — a link, a
+ *  sentinel row — so a channel can be asked about the ones its address book
+ *  does not cover. */
 export interface StoredAddress {
   channel: string;
   channelUserId: string;
 }
 
 /**
- * Every account the mirrors hold, folded so that one account answers under
- * every address it is reachable at.
+ * Every account the address books hold, folded so that one account answers
+ * under every address it is reachable at.
  *
  * Built by {@link foldAccounts}. A caller asks it questions about a (channel,
  * address) pair and never has to know which of them the channel considers
@@ -80,9 +85,9 @@ export interface StoredAddress {
  */
 export class AccountFold {
   constructor(
-    /** Every account the mirrors hold. */
-    readonly accounts: readonly MirrorAccount[],
-    protected readonly byAddress: ReadonlyMap<string, MirrorAccount>,
+    /** Every account the address books hold. */
+    readonly accounts: readonly FoldedAccount[],
+    protected readonly byAddress: ReadonlyMap<string, FoldedAccount>,
   ) {}
 
   /**
@@ -90,60 +95,60 @@ export class AccountFold {
    * channel that holds no address book.
    *
    * Which addresses fold together is the channel's answer, not a rule derived
-   * here: it is the address map read as given. Without it the same person is
-   * both a linked account (under the addressing a mapping named) and an
-   * unplaced sender (a sentinel row under another) — two rows a caller cannot
-   * merge and the guardian cannot tell apart.
+   * here: it is the address book read as given. Without it the same person is
+   * both a linked account (under the address a link named) and an unplaced
+   * sender (a sentinel row under another) — two rows a caller cannot merge and
+   * the guardian cannot tell apart.
    */
   canonical(channel: string, channelUserId: string): string {
     return this.byAddress.get(addressKey(channel, channelUserId))?.channelUserId ?? channelUserId;
   }
 
-  /** The key every map in a fold is keyed by: the account, not the addressing
-   *  the caller happened to name. */
+  /** The key every map in a fold is keyed by: the account, not the address the
+   *  caller happened to name. */
   key(channel: string, channelUserId: string): string {
     return addressKey(channel, this.canonical(channel, channelUserId));
   }
 
-  /** The mirror's account for an address, or undefined on a channel that holds
+  /** The channel's account for an address, or undefined on a channel that holds
    *  no address book. */
-  mirrorFor(channel: string, channelUserId: string): MirrorAccount | undefined {
+  accountFor(channel: string, channelUserId: string): FoldedAccount | undefined {
     return this.byAddress.get(this.key(channel, channelUserId));
   }
 }
 
 /**
- * Read every mirror's address book whole and fold it.
+ * Read every address book whole and fold it.
  *
  * Whole rather than paged: a caller pages its own answer, and an account past a
  * channel's own cutoff is one the guardian cannot find and no count includes.
- * The fold that decides which addressings are one account needs every address
+ * The fold that decides which addresses are one account needs every address
  * book entire in any case.
  *
- * No history is read here — not a mirror's and not the triage record's. This is
+ * No history is read here — not a channel's and not the triage record's. This is
  * what a contacts list needs and the whole of it, so the read that serves one
  * never reaches a message store.
  *
  * `stored` is every address the caller already holds. The channels are read
- * concurrently, and each channel's reads are issued in one batch, because a
- * plane that folds its whole address book per call shares the read already in
+ * concurrently, and each channel's reads are issued in one batch, because an
+ * address book that folds itself whole per call shares the read already in
  * flight — so the whole fold costs one read per channel rather than one per
  * call made against it.
  */
 export async function foldAccounts(
-  planes: MirrorPlanes,
+  books: AddressBooks,
   input: { stored: readonly StoredAddress[] },
 ): Promise<AccountFold> {
-  const read = await readPlanes(planes, input.stored);
+  const read = await readAddressBooks(books, input.stored);
   return new AccountFold(read.accounts, read.byAddress);
 }
 
 /** Every channel read concurrently, and their address books merged into one
  *  fold. */
-async function readPlanes(
-  planes: MirrorPlanes,
+async function readAddressBooks(
+  books: AddressBooks,
   storedAddresses: readonly StoredAddress[],
-): Promise<{ accounts: MirrorAccount[]; byAddress: Map<string, MirrorAccount> }> {
+): Promise<{ accounts: FoldedAccount[]; byAddress: Map<string, FoldedAccount> }> {
   // One entry per (channel, address): the sources overlap — a link and a
   // sentinel row routinely name the same address — and each one asks its
   // channel a question.
@@ -153,17 +158,17 @@ async function readPlanes(
   }
 
   const reads = await Promise.all(
-    Object.entries(planes).map(([channel, plane]) =>
-      readPlane(
+    Object.entries(books).map(([channel, book]) =>
+      readAddressBook(
         channel,
-        plane,
+        book,
         [...stored.values()].filter((address) => address.channel === channel),
       ),
     ),
   );
 
-  const accounts: MirrorAccount[] = [];
-  const byAddress = new Map<string, MirrorAccount>();
+  const accounts: FoldedAccount[] = [];
+  const byAddress = new Map<string, FoldedAccount>();
   for (const read of reads) {
     accounts.push(...read.accounts);
     for (const [address, account] of read.byAddress) byAddress.set(address, account);
@@ -173,31 +178,31 @@ async function readPlanes(
 
 /** One channel's address book, projected and indexed under every address its
  *  accounts answer to. */
-async function readPlane(
+async function readAddressBook(
   channel: string,
-  plane: Accounts,
+  book: Accounts,
   stored: readonly StoredAddress[],
-): Promise<{ accounts: MirrorAccount[]; byAddress: Map<string, MirrorAccount> }> {
-  // Every read this channel owes, issued in one batch so the plane serves them
-  // all from a single fold of its address book. The stored addresses are
+): Promise<{ accounts: FoldedAccount[]; byAddress: Map<string, FoldedAccount> }> {
+  // Every read this channel owes, issued in one batch so the address book
+  // serves them all from a single fold of itself. The stored addresses are
   // resolved without waiting to learn which of them the listing already covers:
   // a channel can accept an address it stores no row for — LinkedIn derives a
   // member id from a profile URL naming it — and asking after the listing
   // arrived would fall outside the shared read and cost a second fold of the
   // whole address book.
   const [listing, resolved] = await Promise.all([
-    plane.listAccounts({ limit: WHOLE_LISTING }),
-    Promise.all(stored.map((address) => plane.resolve(address.channelUserId))),
+    book.listAccounts({ limit: WHOLE_LISTING }),
+    Promise.all(stored.map((address) => book.resolve(address.channelUserId))),
   ]);
 
-  const accounts: MirrorAccount[] = [];
-  const byAddress = new Map<string, MirrorAccount>();
-  const byId = new Map<string, MirrorAccount>();
+  const accounts: FoldedAccount[] = [];
+  const byAddress = new Map<string, FoldedAccount>();
+  const byId = new Map<string, FoldedAccount>();
   for (const account of listing.accounts) {
-    const mirrored: MirrorAccount = {
+    const folded: FoldedAccount = {
       channel,
       channelUserId: account.id,
-      // The account's own addressing set, as the channel gave it. An account
+      // The account's own address set, as the channel gave it. An account
       // carries all of them because a search reads them: an omitted address is
       // a contact the guardian cannot reach by the phone number they know. An
       // account the channel holds no address for still answers to its id.
@@ -206,13 +211,13 @@ async function readPlane(
       ),
       name: account.name,
     };
-    accounts.push(mirrored);
-    byId.set(account.id, mirrored);
-    for (const alias of mirrored.aliases) byAddress.set(addressKey(channel, alias), mirrored);
+    accounts.push(folded);
+    byId.set(account.id, folded);
+    for (const alias of folded.aliases) byAddress.set(addressKey(channel, alias), folded);
   }
 
-  // A stored address no listed account named. Left unfolded, a mapping written
-  // in that form is a second account for someone the caller already lists, and
+  // A stored address no listed account named. Left unfolded, a link written in
+  // that form is a second account for someone the caller already lists, and
   // half their history hangs off it. The address stays as the caller gave it:
   // this is the fold, not a new alias to publish.
   stored.forEach((address, i) => {
@@ -229,6 +234,7 @@ async function readPlane(
  * One page big enough to hold any listing — what `Accounts.listAccounts`
  * says to ask for when a caller needs every account exactly once. Its order is
  * stable but the listing under it is not, so walking cursors across a live
- * mirror would skip or repeat an account as an inbound message reordered it.
+ * address book would skip or repeat an account as an inbound message reordered
+ * it.
  */
 const WHOLE_LISTING = Number.MAX_SAFE_INTEGER;

--- a/packages/core/src/channels/account-names.test.ts
+++ b/packages/core/src/channels/account-names.test.ts
@@ -77,7 +77,7 @@ describe("AccountNames", () => {
     expect(await names.displayName("telegram", "5512345")).toBe("Alan T");
   });
 
-  it("answers the same name to every addressing the channel folds together", async () => {
+  it("answers the same name to every address the channel folds together", async () => {
     expect(await names.displayName("whatsapp", LID)).toBe("Ada Lovelace");
   });
 
@@ -113,7 +113,7 @@ describe("AccountNames", () => {
     ).toEqual(["Alan T", "Ada Lovelace", NAMELESS]);
   });
 
-  it("takes a new provider as one account plane, with no change to the call", async () => {
+  it("takes a new provider as one address book, with no change to the call", async () => {
     const matrix = {
       resolve: async (identifier: string) =>
         identifier === "@ada:matrix.org"

--- a/packages/core/src/channels/account-names.ts
+++ b/packages/core/src/channels/account-names.ts
@@ -1,12 +1,13 @@
 // What every platform calls its accounts, behind one call. `Accounts`
 // (accounts.ts) is one channel's address book; this is the display-name half of
 // all of them folded together, so a caller holding a (channel, channelUserId)
-// pair — the identity of an account, per docs/concepts/identity.md — never
+// pair — the channel and the account's own address, per
+// docs/concepts/people.md — never
 // learns which address book answers for which channel, nor that some channels
 // have none at all.
 
 import type { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
-import { mirrorRegistry } from "./account-fold.js";
+import { addressBookRegistry } from "./account-fold.js";
 import type { Accounts } from "./accounts.js";
 
 /**
@@ -29,8 +30,8 @@ export class AccountNames {
    *
    * A channel that addresses one account several ways answers its platform's
    * name to every one of them. Neither fallback can: a sender's own name is
-   * filed under the addressing its message arrived on, and the last resort only
-   * echoes what it was asked. A caller that folds addressings itself asks with
+   * filed under the address its message arrived on, and the last resort only
+   * echoes what it was asked. A caller that folds addresses itself asks with
    * the account's own address.
    */
   async displayName(channel: string, channelUserId: string): Promise<string> {
@@ -71,14 +72,14 @@ export class AccountNames {
   }
 }
 
-/** A provider joins the directory by taking an entry in {@link mirrorRegistry},
+/** A provider joins the directory by taking an entry in {@link addressBookRegistry},
  *  and every caller keeps asking the same one question. */
 export function createAccountNames(deps: {
   whatsAppAccounts: Accounts;
   linkedInAccounts: Accounts;
   sentinelLogRepo: SentinelLogRepository;
 }): AccountNames {
-  return new AccountNames(mirrorRegistry<Accounts>(deps), deps.sentinelLogRepo);
+  return new AccountNames(addressBookRegistry<Accounts>(deps), deps.sentinelLogRepo);
 }
 
 const key = (account: { channel: string; channelUserId: string }) =>

--- a/packages/core/src/channels/account-snapshot.ts
+++ b/packages/core/src/channels/account-snapshot.ts
@@ -1,6 +1,6 @@
 /**
- * The read-sharing half of a mirrored account plane, for a channel that folds
- * its whole address book on every call.
+ * The read-sharing half of an address book, for a channel that folds its
+ * whole address book on every call.
  *
  * An `Accounts` consumer usually needs several answers about the same mirror
  * at once — a listing, and a `resolve` for each address it already holds — and

--- a/packages/core/src/channels/accounts.ts
+++ b/packages/core/src/channels/accounts.ts
@@ -1,8 +1,7 @@
 /**
- * The account plane of a channel. `ProviderAdapter` (adapter.ts) is the
- * message plane — it moves text. This is the address book behind it: who a
- * channel can reach, and which of the identifiers a channel hands out name one
- * and the same account.
+ * A channel's address book. `ProviderAdapter` (adapter.ts) moves text; this
+ * is who a channel can reach, and which of the identifiers a channel hands out
+ * name one and the same account. Vocabulary: docs/concepts/people.md.
  *
  * An account answers *who*. What was said to it — a last message, a count, a
  * preview — is a separate read over the same addresses, and it belongs to
@@ -18,7 +17,7 @@ export interface Account {
   /**
    * Every address the account answers to, `id` among them.
    *
-   * The addressing set a channel folds onto one account: a WhatsApp contact
+   * The address set a channel folds onto one account: a WhatsApp contact
    * answers to both a phone JID and a `@lid` JID, and history hangs off
    * either. A caller that has to show or match every form an account can be
    * reached at reads them here rather than asking the channel a second time.
@@ -57,7 +56,7 @@ export interface Account {
  * - **I1 Uniqueness.** Exactly one {@link Account} per real account. The same
  *   `id` means the same account. Callers never fold aliases themselves.
  * - **I2 Stability.** `id` does not change for the life of the account — not
- *   across a restart, a re-sync, a message arriving on a different addressing,
+ *   across a restart, a re-sync, a message arriving on a different address,
  *   or a change to any identifier the account is reachable on.
  * - **I3 Opacity.** Callers never parse or construct an `id`. This is what lets
  *   a channel change its canonical form later without touching a consumer.
@@ -76,7 +75,7 @@ export interface Accounts {
    * large enough to hold the listing.
    *
    * Each account carries its own {@link Account.addresses}, so this is also how
-   * a caller learns which addressings fold together. There is no separate
+   * a caller learns which addresses fold together. There is no separate
    * address map to ask for: a second answer to a question the listing already
    * answers is a second answer to disagree with.
    */

--- a/packages/core/src/channels/adapter.ts
+++ b/packages/core/src/channels/adapter.ts
@@ -2,7 +2,7 @@ import type { NormalizedMessage, OutgoingMessage } from "./types.js";
 import type { ChannelSendResult } from "@rome-os/app-runtime";
 
 /**
- * The message-plane port resolved by the rest of Rome. Concrete channel
+ * The message-moving port resolved by the rest of Rome. Concrete channel
  * adapters retain their lifecycle methods for registry integrations, but the
  * registry exclusively owns starting and stopping transports.
  */

--- a/packages/core/src/channels/guardian-mapping.test.ts
+++ b/packages/core/src/channels/guardian-mapping.test.ts
@@ -22,8 +22,8 @@ describe("guardian channel mapping", () => {
     testDb.close();
   });
 
-  /** The guardian's identities on `channel`, sorted so the assertion is order-free. */
-  async function identities(channel: string): Promise<string[]> {
+  /** The guardian's accounts on `channel`, sorted so the assertion is order-free. */
+  async function accounts(channel: string): Promise<string[]> {
     const guardian = await repo.findById("guardian");
     return guardian!.channelMappings
       .filter((m) => m.channel === channel)
@@ -31,27 +31,27 @@ describe("guardian channel mapping", () => {
       .sort();
   }
 
-  it("re-canonicalizes the guardian's only identity on the channel", async () => {
+  it("re-canonicalizes the guardian's only account on the channel", async () => {
     await repo.addChannelMapping("guardian", "whatsapp", "15551234567:8@s.whatsapp.net");
 
     expect(await mapGuardianToChannel(repo, "whatsapp", "15551234567@s.whatsapp.net")).toBe(true);
-    expect(await identities("whatsapp")).toEqual(["15551234567@s.whatsapp.net"]);
+    expect(await accounts("whatsapp")).toEqual(["15551234567@s.whatsapp.net"]);
   });
 
-  it("leaves an identity on another channel alone when it re-canonicalizes", async () => {
+  it("leaves an account on another channel alone when it re-canonicalizes", async () => {
     await repo.addChannelMapping("guardian", "whatsapp", "15551234567:8@s.whatsapp.net");
     await repo.addChannelMapping("guardian", "telegram", "tg-guardian");
 
     await mapGuardianToChannel(repo, "whatsapp", "15551234567@s.whatsapp.net");
-    expect(await identities("telegram")).toEqual(["tg-guardian"]);
+    expect(await accounts("telegram")).toEqual(["tg-guardian"]);
   });
 
-  it("adds a further identity when the guardian already holds several on the channel", async () => {
+  it("adds a further account when the guardian already holds several on the channel", async () => {
     await repo.addChannelMapping("guardian", "telegram", "tg-work");
     await repo.addChannelMapping("guardian", "telegram", "tg-personal");
 
     expect(await mapGuardianToChannel(repo, "telegram", "tg-third")).toBe(true);
-    expect(await identities("telegram")).toEqual(["tg-personal", "tg-third", "tg-work"]);
+    expect(await accounts("telegram")).toEqual(["tg-personal", "tg-third", "tg-work"]);
   });
 
   it("plans an add when the guardian already holds several on the channel", async () => {
@@ -64,16 +64,16 @@ describe("guardian channel mapping", () => {
     testDb.db.transaction((tx) => {
       applyGuardianMappingWithinTx(tx, repo, "telegram", "tg-third", plan);
     });
-    expect(await identities("telegram")).toEqual(["tg-personal", "tg-third", "tg-work"]);
+    expect(await accounts("telegram")).toEqual(["tg-personal", "tg-third", "tg-work"]);
   });
 
-  it("applies a planned re-point to the planned identity only", async () => {
+  it("applies a planned re-point to the planned account only", async () => {
     await repo.addChannelMapping("guardian", "telegram", "tg-work");
 
     const plan = await planGuardianMapping(repo, "telegram", "tg-work-canonical");
     expect(plan).toEqual({ op: "update", guardianId: "guardian", from: "tg-work" });
 
-    // A second identity lands between the plan and its application: the grant
+    // A second account lands between the plan and its application: the grant
     // section the conferral holds keeps competing conferrals out, not
     // a link write.
     await repo.addChannelMapping("guardian", "telegram", "tg-personal");
@@ -81,21 +81,21 @@ describe("guardian channel mapping", () => {
     testDb.db.transaction((tx) => {
       applyGuardianMappingWithinTx(tx, repo, "telegram", "tg-work-canonical", plan);
     });
-    expect(await identities("telegram")).toEqual(["tg-personal", "tg-work-canonical"]);
+    expect(await accounts("telegram")).toEqual(["tg-personal", "tg-work-canonical"]);
   });
 
-  it("maps the incoming identity when the one it would re-canonicalize is gone", async () => {
-    // The guardian read reports an identity the database no longer holds — the
+  it("maps the incoming account when the one it would re-canonicalize is gone", async () => {
+    // The guardian read reports an account the database no longer holds — the
     // window between that read and the write, where a link write runs.
     vi.spyOn(repo, "findByBondLevel").mockResolvedValue([
       { id: "guardian", channelMappings: [{ channel: "telegram", channelUserId: "tg-gone" }] },
     ] as unknown as Awaited<ReturnType<PersonMappingRepository["findByBondLevel"]>>);
 
     expect(await mapGuardianToChannel(repo, "telegram", "tg-new")).toBe(true);
-    expect(await identities("telegram")).toEqual(["tg-new"]);
+    expect(await accounts("telegram")).toEqual(["tg-new"]);
   });
 
-  it("writes nothing when the planned identity is gone by the time it applies", async () => {
+  it("writes nothing when the planned account is gone by the time it applies", async () => {
     await repo.addChannelMapping("guardian", "telegram", "tg-work");
 
     const plan = await planGuardianMapping(repo, "telegram", "tg-work-canonical");
@@ -104,10 +104,10 @@ describe("guardian channel mapping", () => {
     testDb.db.transaction((tx) => {
       applyGuardianMappingWithinTx(tx, repo, "telegram", "tg-work-canonical", plan);
     });
-    expect(await identities("telegram")).toEqual([]);
+    expect(await accounts("telegram")).toEqual([]);
   });
 
-  it("re-points an identity another writer claimed between the plan and the apply", async () => {
+  it("re-points an account another writer claimed between the plan and the apply", async () => {
     const alice = await repo.create({ displayName: "Alice", bondLevel: "acquaintance" });
 
     const plan = await planGuardianMapping(repo, "telegram", "tg-guardian");
@@ -122,11 +122,11 @@ describe("guardian channel mapping", () => {
       applyGuardianMappingWithinTx(tx, repo, "telegram", "tg-guardian", plan);
     });
 
-    expect(await identities("telegram")).toEqual(["tg-guardian"]);
+    expect(await accounts("telegram")).toEqual(["tg-guardian"]);
     expect((await repo.findByChannelUser("telegram", "tg-guardian"))!.id).toBe("guardian");
   });
 
-  it("commits a planned re-point onto an identity another writer claimed", async () => {
+  it("commits a planned re-point onto an account another writer claimed", async () => {
     await repo.addChannelMapping("guardian", "whatsapp", "15551234567:8@s.whatsapp.net");
     const alice = await repo.create({ displayName: "Alice", bondLevel: "acquaintance" });
 
@@ -137,7 +137,7 @@ describe("guardian channel mapping", () => {
       from: "15551234567:8@s.whatsapp.net",
     });
 
-    // The canonical identity is claimed in the window the plan cannot hold. The
+    // The canonical account is claimed in the window the plan cannot hold. The
     // conferral must not abort over it — the credential rides the same
     // transaction.
     await repo.addChannelMapping(alice, "whatsapp", "15551234567@s.whatsapp.net");
@@ -146,7 +146,7 @@ describe("guardian channel mapping", () => {
       applyGuardianMappingWithinTx(tx, repo, "whatsapp", "15551234567@s.whatsapp.net", plan);
     });
 
-    expect(await identities("whatsapp")).toEqual(["15551234567@s.whatsapp.net"]);
+    expect(await accounts("whatsapp")).toEqual(["15551234567@s.whatsapp.net"]);
     expect((await repo.findById(alice))!.channelMappings).toEqual([]);
   });
 
@@ -156,6 +156,6 @@ describe("guardian channel mapping", () => {
 
     expect(await mapGuardianToChannel(repo, "telegram", "tg-alice")).toBe(false);
     expect(await planGuardianMapping(repo, "telegram", "tg-alice")).toEqual({ op: "noop" });
-    expect(await identities("telegram")).toEqual([]);
+    expect(await accounts("telegram")).toEqual([]);
   });
 });

--- a/packages/core/src/channels/guardian-mapping.ts
+++ b/packages/core/src/channels/guardian-mapping.ts
@@ -5,9 +5,9 @@ import { createLogger } from "../logger.js";
 const log = createLogger("guardian-mapping");
 
 /**
- * Auto-map the guardian person onto their own identity on a channel.
+ * Auto-map the guardian person onto their own account on a channel.
  *
- * Called on connect for channels that surface the guardian's self identity
+ * Called on connect for channels that surface the guardian's self address
  * (WhatsApp pairing today) and by the channels routes/descriptors. Returns
  * `true` when a mapping was created or re-canonicalized, `false` when the
  * channel user was already mapped or no guardian person exists.
@@ -31,7 +31,7 @@ export async function mapGuardianToChannel(
 
   const guardian = guardians[0];
 
-  const stale = staleIdentity(guardian.channelMappings, channel);
+  const stale = staleAddress(guardian.channelMappings, channel);
   if (stale) {
     if (await repo.updateChannelUserId(guardian.id, channel, stale, channelUserId)) {
       log.info("re-canonicalized guardian channel mapping", {
@@ -43,10 +43,10 @@ export async function mapGuardianToChannel(
       return true;
     }
     // Nothing holds the guardian read above against the write, so a link write
-    // can retire that identity in between. Fall through and map the incoming one
+    // can retire that account in between. Fall through and map the incoming one
     // rather than report a heal that did not happen. The transactional path
     // cannot: its write is one statement settled before the transaction opened.
-    log.info("guardian identity to re-canonicalize is gone", {
+    log.info("guardian account to re-canonicalize is gone", {
       channel,
       from: stale,
       personId: guardian.id,
@@ -59,23 +59,23 @@ export async function mapGuardianToChannel(
 }
 
 /**
- * The identity on `channel` that the incoming one supersedes, or undefined when
+ * The address on `channel` that the incoming one supersedes, or undefined when
  * the incoming one is a further account rather than a canonicalization.
  *
- * A single held identity is stale by definition here: the connect callback only
- * ever hands over the guardian's *current* self identity, the caller has already
+ * A single held address is stale by definition here: the connect callback only
+ * ever hands over the guardian's *current* self address, the caller has already
  * established that nobody holds it, and what remains is the same account under a
  * superseded identifier — e.g. a device-suffixed WhatsApp self JID
  * (`<pn>:8@s.whatsapp.net`) captured before canonicalization. Re-pointing it
  * keeps the mapping joinable to the canonicalized contacts mirror.
  *
- * Several held identities are several accounts (a person may hold more than one
+ * Several held addresses are several accounts (a person may hold more than one
  * per channel, and the link verb places them), and nothing distinguishes a
- * superseded one from a live one. Adding the incoming identity leaves a stale
+ * superseded one from a live one. Adding the incoming address leaves a stale
  * identifier behind at worst; re-pointing an arbitrary one would take an account
  * away from the guardian.
  */
-function staleIdentity(
+function staleAddress(
   mappings: readonly { channel: string; channelUserId: string }[],
   channel: string,
 ): string | undefined {
@@ -104,10 +104,10 @@ export type GuardianMappingPlan =
  * per-(service, grant) section, so no competing conferral can change the guardian
  * between plan and apply.
  *
- * An identity another writer claimed in that window does not abort the conferral,
+ * An account another writer claimed in that window does not abort the conferral,
  * on either branch: the add upserts and the re-point takes `to` from its holder,
  * so both commit. That settles the right way round here — the channel handed this
- * identity over as the guardian's own, so a competing claim on it is the one
+ * account over as the guardian's own, so a competing claim on it is the one
  * mistaken about whose it is. The conferral aborting would cost the guardian the
  * credential in the same transaction, to preserve a claim that is wrong.
  */
@@ -123,8 +123,8 @@ export async function planGuardianMapping(
   if (guardians.length === 0) return { op: "noop" };
 
   const guardian = guardians[0];
-  const stale = staleIdentity(guardian.channelMappings, channel);
-  // The plan names the row it re-points, so an identity placed between this read
+  const stale = staleAddress(guardian.channelMappings, channel);
+  // The plan names the row it re-points, so an account placed between this read
   // and the apply — a link write runs outside the grant section that holds
   // competing conferrals off — is left where it is rather than swept onto
   // `channelUserId` with it.
@@ -140,11 +140,11 @@ export async function planGuardianMapping(
  * zero residual state.
  *
  * A planned re-point whose `from` is gone by now — a link write moved or
- * removed that identity in the window — writes nothing and leaves the incoming
- * identity unmapped, which the log below records. Deliberate: the guardian
- * decided where that identity belongs more recently than the plan did, and
+ * removed that account in the window — writes nothing and leaves the incoming
+ * account unmapped, which the log below records. Deliberate: the guardian
+ * decided where that account belongs more recently than the plan did, and
  * failing the conferral over it would cost them the credential too. The next
- * connect maps the incoming identity.
+ * connect maps the incoming account.
  */
 export function applyGuardianMappingWithinTx(
   tx: DrizzleTx,
@@ -157,7 +157,7 @@ export function applyGuardianMappingWithinTx(
   if (plan.op === "update") {
     const moved = repo.writeChannelUserId(tx, plan.guardianId, channel, plan.from, channelUserId);
     if (!moved) {
-      log.info("planned guardian re-point found no identity to move", {
+      log.info("planned guardian re-point found no account to move", {
         channel,
         from: plan.from,
         to: channelUserId,

--- a/packages/core/src/channels/linkedin-cli.test.ts
+++ b/packages/core/src/channels/linkedin-cli.test.ts
@@ -15,7 +15,7 @@ function ok(stdout: string): OpencliResult {
 }
 
 describe("parseWhoami", () => {
-  it("returns the identity of a signed-in session", () => {
+  it("returns the account of a signed-in session", () => {
     const identity = parseWhoami(
       ok(
         JSON.stringify({
@@ -259,7 +259,7 @@ describe("parseThreadParticipants", () => {
     expect(participants.map((p) => p.participantId)).toEqual(["ACoAAAda0001", "ACoAALurk0002"]);
   });
 
-  it("drops rows with no member id rather than storing a blank identity", () => {
+  it("drops rows with no member id rather than storing a blank account", () => {
     const participants = parseThreadParticipants(
       ok(JSON.stringify([row(), row({ participant_index: 2, participant_id: "" })])),
     );

--- a/packages/core/src/channels/linkedin-cli.ts
+++ b/packages/core/src/channels/linkedin-cli.ts
@@ -158,7 +158,7 @@ const whoamiSchema = z.object({
   name: z.string().optional(),
 });
 
-export interface LinkedInIdentity {
+export interface LinkedInWhoami {
   publicId?: string;
   plainId?: string;
   name?: string;
@@ -166,7 +166,7 @@ export interface LinkedInIdentity {
 
 /** Parse `linkedin whoami`. A clean `logged_in: false` is an auth error — the
  *  command ran fine, the session is simply signed out. */
-export function parseWhoami(result: OpencliResult): LinkedInIdentity {
+export function parseWhoami(result: OpencliResult): LinkedInWhoami {
   const parsed = whoamiSchema.safeParse(parseJsonOutput("linkedin whoami", result));
   if (!parsed.success) {
     throw new OpencliCommandError("linkedin whoami", "unexpected output shape");
@@ -343,7 +343,7 @@ function emptyToNull(value: string | null | undefined): string | null {
 
 /**
  * Parse `linkedin thread-participants`. Rows without a member id are dropped
- * rather than stored as a blank identity — `participant_id` is the primary key
+ * rather than stored as a blank account — `participant_id` is the primary key
  * of `linkedin_participants` and has to match `channel_mappings.channel_user_id`.
  *
  * An empty result is a failure, not an empty thread: the store reads an empty

--- a/packages/core/src/channels/linkedin-sync.ts
+++ b/packages/core/src/channels/linkedin-sync.ts
@@ -52,7 +52,7 @@ export function linkedInMemberIdFromProfileUrl(url: string | null | undefined): 
   return MEMBER_ID_IN_PROFILE_URL.exec(url)?.[1] ?? null;
 }
 
-/** One identity in a thread's participant list, per the thread snapshot. */
+/** One account in a thread's participant list, per the thread snapshot. */
 export interface LinkedInParticipantInput {
   /**
    * LinkedIn member id, bare (`ACoAA…`) — not a urn or a profile URL — so it

--- a/packages/core/src/channels/linkedin.test.ts
+++ b/packages/core/src/channels/linkedin.test.ts
@@ -435,7 +435,7 @@ describe("LinkedInInboxPoller fault handling", () => {
 
 /**
  * Promotion is a guardian action, never a consequence of syncing. A LinkedIn
- * inbox holds many identities — recruiters, newsletters, strangers — that must
+ * inbox holds many accounts — recruiters, newsletters, strangers — that must
  * not walk into the curated person graph on their own.
  *
  * The sink contract is the guarantee: it exposes no way to write `persons`. This

--- a/packages/core/src/channels/messages-agent.test.ts
+++ b/packages/core/src/channels/messages-agent.test.ts
@@ -15,7 +15,7 @@ import { agentMessages } from "./messages-agent.js";
 // channel sessions the account itself addresses.
 
 const CHANNEL = "telegram";
-/** The two addressings of the one account the fixtures speak to. */
+/** The two addresses of the one account the fixtures speak to. */
 const DIRECT = "tg-777";
 const DIRECT_ALT = "tg-777-alt";
 const GROUP = "tg-group-1";
@@ -80,7 +80,7 @@ async function seed(db: DrizzleDb) {
   // A message that did not wake the agent is still something the person said.
   await message(db, "m-note", { sessionId: "s-direct", role: "notification", at: 200 });
   await message(db, "m-later", { sessionId: "s-direct", role: "user", at: 300 });
-  // The account's other addressing: one history, not two halves of one.
+  // The account's other address: one history, not two halves of one.
   await message(db, "m-alt", { sessionId: "s-direct-alt", role: "user", at: 250 });
 
   // Out of scope, each for its own reason.

--- a/packages/core/src/channels/messages-memory.test.ts
+++ b/packages/core/src/channels/messages-memory.test.ts
@@ -20,7 +20,7 @@ const entry = (
 const held: HeldMessage[] = [
   { channel: "whatsapp", address: PHONE, entry: entry("whatsapp", 100, "wa:a") },
   { channel: "whatsapp", address: PHONE, entry: entry("whatsapp", 300, "wa:c", "outbound") },
-  // The same second as wa:c, on the account's other addressing: the direction
+  // The same second as wa:c, on the account's other address: the direction
   // settles the tie, and both have to survive a page boundary.
   { channel: "whatsapp", address: LID, entry: entry("whatsapp", 300, "wa:d") },
   { channel: "whatsapp", address: PHONE, entry: entry("whatsapp", 500, "wa:e") },

--- a/packages/core/src/channels/messages-sentinel.test.ts
+++ b/packages/core/src/channels/messages-sentinel.test.ts
@@ -66,7 +66,7 @@ async function seed(db: DrizzleDb) {
   await groupSession(db, "s-group-elsewhere", { channel: "discord", threadId: "tg-quiet-thread" });
 
   await row(db, "answered", { at: 1000, text: "ping", response: "pong", threadId: DIRECT });
-  // The account's other addressing: one history, not two halves of one.
+  // The account's other address: one history, not two halves of one.
   await row(db, "alt", { at: 1050, text: "over here", channelUserId: DIRECT_ALT });
   // A thread no session covers is a direct exchange until something says so.
   await row(db, "unheard", { at: 1100, text: "solo", threadId: "tg-unknown-thread" });
@@ -124,7 +124,7 @@ describe("sentinelLogMessages", () => {
     expect(await refs()).toContain("sentinel:quiet");
   });
 
-  it("merges every addressing of the account into one newest-first history", async () => {
+  it("merges every address of the account into one newest-first history", async () => {
     expect(await refs()).toEqual([
       "sentinel:quiet",
       "sentinel:unheard",

--- a/packages/core/src/channels/messages-sql.ts
+++ b/packages/core/src/channels/messages-sql.ts
@@ -6,7 +6,7 @@
 // Grouping is the point. The People surface reads a whole directory at once:
 // one `latest` and one `count` per row, all issued together. Served one query
 // each, a directory of a thousand people is a thousand passes over the same
-// mirror. Served here, it is one, the way the WhatsApp account plane already
+// mirror. Served here, it is one, the way the WhatsApp address book already
 // answers concurrent `resolve` calls from a single shared load.
 
 import { sql, type SQL } from "drizzle-orm";

--- a/packages/core/src/channels/messages.ts
+++ b/packages/core/src/channels/messages.ts
@@ -1,6 +1,5 @@
 /**
- * The message plane behind a channel's accounts: what was said, as one store
- * holds it. `Accounts` (accounts.ts) answers who a channel can reach, and this
+ * What was said to a channel's accounts, as one store holds it. `Accounts` (accounts.ts) answers who a channel can reach, and this
  * answers what passed between Rome and them.
  *
  * A message is a {@link TimelineEntry}. The shape, the ordering and the cursor
@@ -13,7 +12,7 @@ import type { TimelineEntry } from "@rome/api-types/people";
 
 /**
  * One account a store reads for, named by every address it answers to —
- * `Account.addresses` on the channel's own account plane.
+ * `Account.addresses` on the channel's own address book.
  *
  * The addresses rather than the id, because a store keys its rows by whichever
  * address a message arrived on. A read that named only the address a person

--- a/packages/core/src/channels/whatsapp-accounts.test.ts
+++ b/packages/core/src/channels/whatsapp-accounts.test.ts
@@ -34,7 +34,7 @@ describe("WhatsAppAccounts", () => {
 
   afterEach(() => close());
 
-  it("keeps one id when a message lands on the other addressing", async () => {
+  it("keeps one id when a message lands on the other address", async () => {
     await repo.upsertContacts([
       { jid: PHONE, phoneNumber: "15550007777", name: "One Contact" },
       { jid: LID, phoneNumber: "15550007777", name: "One Contact" },
@@ -49,7 +49,7 @@ describe("WhatsAppAccounts", () => {
     expect((await accounts.resolve(before))!.id).toBe(before);
   });
 
-  it("folds both addressings into a single account", async () => {
+  it("folds both addresses into a single account", async () => {
     await repo.upsertContacts([
       { jid: PHONE, phoneNumber: "15550007777", name: "One Contact" },
       { jid: LID, phoneNumber: "15550007777" },
@@ -85,7 +85,7 @@ describe("WhatsAppAccounts", () => {
       { jid: "99900099999@lid", phoneNumber: "15550009999" },
     ]);
 
-    // The listing is where a caller learns which addressings fold together, so
+    // The listing is where a caller learns which addresses fold together, so
     // the account has to carry all of them — the derived id among them, whether
     // or not a row spelled it out.
     const page = await accounts.listAccounts({ limit: 50 });

--- a/packages/core/src/channels/whatsapp-accounts.ts
+++ b/packages/core/src/channels/whatsapp-accounts.ts
@@ -47,8 +47,8 @@ function firstNonEmpty(...values: Array<string | null>): string | null {
  * (`<pn>@s.whatsapp.net`) and the privacy LID (`<lid>@lid`) — and the mirror
  * holds a row for each. The canonical form is the phone-number JID, and it is
  * built from the account's digits rather than picked from whichever row exists,
- * so learning the second addressing later never moves the id (I2) while either
- * addressing still resolves to it (I4). Preferring the LID would invert that: a
+ * so learning the second address later never moves the id (I2) while either
+ * address still resolves to it (I4). Preferring the LID would invert that: a
  * LID can only be found, never derived, so every account's id would move the
  * first time a conversation arrived.
  *
@@ -56,14 +56,14 @@ function firstNonEmpty(...values: Array<string | null>): string | null {
  *
  * Two gaps stay open, both because the mirror stores no key that outlives the
  * digits an id is built from. Closing either needs a durable stored account
- * key, not a different choice of addressing, and code that persists an
+ * key, not a different choice of address, and code that persists an
  * `AccountId` has to survive both:
  *
  * - An account that changes its phone number gets a new id (I2).
  * - A named LID row carrying no phone number addresses itself. Its id moves to
  *   the phone-number form once the mirror learns the number (I2), and until
  *   then a phone-number row for the same person is a second `Account` (I1).
- *   Nothing links the two but the name, and names are not identity.
+ *   Nothing links the two but the name, and a name does not name an account.
  */
 export class WhatsAppAccounts implements Accounts {
   constructor(private readonly store: WhatsAppStoreRepository) {}
@@ -99,7 +99,7 @@ export class WhatsAppAccounts implements Accounts {
   private readonly load = sharedRead(() => this.read());
 
   /**
-   * The store already folds a person's two addressings onto one card, but it
+   * The store already folds a person's two addresses onto one card, but it
    * folds on the phone number a row carries, so a row that has not learned its
    * number yet stays separate. Re-keying on the canonical id here collapses
    * those too — one `Account` per account, whatever the mirror's row shape (I1).

--- a/packages/core/src/channels/whatsapp-messages.test.ts
+++ b/packages/core/src/channels/whatsapp-messages.test.ts
@@ -32,7 +32,7 @@ interface Seed {
 const seeds: Seed[] = [
   { id: "a", chat: PHONE, at: 100, text: "first" },
   { id: "c", chat: PHONE, at: 300, fromMe: true, text: "answered" },
-  // The same second as `c`, on the account's other addressing: the direction
+  // The same second as `c`, on the account's other address: the direction
   // settles the tie, and both have to survive a page boundary.
   { id: "d", chat: LID, at: 300, text: "and on the lid" },
   { id: "e", chat: PHONE, at: 500, text: "latest" },
@@ -76,7 +76,7 @@ describe("whatsAppMessages", () => {
 
   const refs = (entries: { ref: string }[]) => entries.map((entry) => entry.ref);
 
-  it("merges both addressings of the account, newest first", async () => {
+  it("merges both addresses of the account, newest first", async () => {
     const messages = whatsAppMessages(testDb.db);
     const page = await messages.read({ accounts, limit: WHOLE_HISTORY });
     expect(refs(page)).toEqual([`${PHONE}:e`, `${PHONE}:c`, `${LID}:d`, `${PHONE}:a`]);
@@ -118,21 +118,21 @@ describe("whatsAppMessages", () => {
     expect(await messages.read({ accounts: [], limit: WHOLE_HISTORY })).toEqual([]);
   });
 
-  // The scope is the account's addressing set, and the three verbs answer one
+  // The scope is the account's address set, and the three verbs answer one
   // history over it: `count` is the length of the full read and `latest` its
   // first entry. Per scope rather than once, because a store that scoped `read`
   // one way and `count` another would still agree on the widest scope there is.
   it.each([
     {
       scope: accounts,
-      of: "both addressings of the account",
+      of: "both addresses of the account",
       refs: [`${PHONE}:e`, `${PHONE}:c`, `${LID}:d`, `${PHONE}:a`],
     },
-    // `d` arrived on the `@lid` addressing, so a scope naming only the phone
-    // leaves it out — the addressing set is the scope, not the account.
+    // `d` arrived on the `@lid` address, so a scope naming only the phone
+    // leaves it out — the address set is the scope, not the account.
     {
       scope: [{ channel: "whatsapp", addresses: [PHONE] }],
-      of: "one addressing",
+      of: "one address",
       refs: [`${PHONE}:e`, `${PHONE}:c`, `${PHONE}:a`],
     },
     { scope: silent, of: "a contact the mirror holds nothing for", refs: [] },

--- a/packages/core/src/channels/whatsapp-messages.ts
+++ b/packages/core/src/channels/whatsapp-messages.ts
@@ -21,7 +21,7 @@ import { addressesIn, inList, sqlMessages } from "./messages-sql.js";
  *   anyone on it, so no address of an account names one — the `NOT LIKE` is
  *   belt and braces against a group JID arriving as an address.
  * - Reactions. A reaction answers a line rather than being one, and the
- *   account plane's own activity already leaves it out of what an account last
+ *   address book's own activity already leaves it out of what an account last
  *   did. Carrying it here would let a directory row preview a thumbs-up and
  *   open on the message it was aimed at.
  */

--- a/packages/core/src/channels/whatsapp.test.ts
+++ b/packages/core/src/channels/whatsapp.test.ts
@@ -788,7 +788,7 @@ describe("WhatsAppAdapter", () => {
   });
 
   describe("JID canonicalization", () => {
-    // Self has a device-suffixed phone id and a separate LID identity — the two
+    // Self has a device-suffixed phone id and a separate LID address — the two
     // unrelated user numbers WhatsApp uses for "me".
     const SELF_PHONE = "15550101000";
     const SELF_PN = `${SELF_PHONE}@s.whatsapp.net`;

--- a/packages/core/src/channels/whatsapp.ts
+++ b/packages/core/src/channels/whatsapp.ts
@@ -176,7 +176,7 @@ export class WhatsAppAdapter implements ProviderAdapter {
 
         this.seedSelfContact();
 
-        // Hand the guardian auto-mapper our *canonical* self identity, not the raw
+        // Hand the guardian auto-mapper our *canonical* self address, not the raw
         // socket id. `user.id` carries a `:device` suffix (`<pn>:8@s.whatsapp.net`)
         // that never matches the device-stripped JIDs we persist contacts under, so
         // mapping the guardian onto it leaves the self contact unlinked in the People
@@ -426,13 +426,13 @@ export class WhatsAppAdapter implements ProviderAdapter {
     };
   }
 
-  /** Our own phone-number identity (`<pn>@s.whatsapp.net`), device stripped. */
+  /** Our own phone-number address (`<pn>@s.whatsapp.net`), device stripped. */
   private selfPnJid(): string | null {
     const id = this.sock?.user?.id;
     return id ? jidNormalizedUser(id) : null;
   }
 
-  /** Our own LID identity (`<lid>@lid`), device stripped, when WhatsApp reports one. */
+  /** Our own LID address (`<lid>@lid`), device stripped, when WhatsApp reports one. */
   private selfLidJid(): string | null {
     const lid = this.sock?.user?.lid;
     return lid ? jidNormalizedUser(lid) : null;

--- a/packages/core/src/connections/integrations/linkedin.test.ts
+++ b/packages/core/src/connections/integrations/linkedin.test.ts
@@ -58,9 +58,9 @@ async function readHistory(rows: LinkedInHistoryMessage[]): Promise<InboundMessa
 /**
  * The promotion bridge: a mirrored participant that a guardian turned into a
  * person is recognised on their next message with nothing else wired up. That
- * only holds if both sides name the identity the same way — the bare member id.
+ * only holds if both sides name the account the same way — the bare member id.
  */
-describe("LinkedIn message identity", () => {
+describe("LinkedIn message addressing", () => {
   let testDb: TestDb;
   let people: PersonMappingRepository;
 

--- a/packages/core/src/connections/integrations/linkedin.ts
+++ b/packages/core/src/connections/integrations/linkedin.ts
@@ -33,7 +33,7 @@ import {
   openLinkedInBrowserTab,
   parseWhoami,
   runOpencli,
-  type LinkedInIdentity,
+  type LinkedInWhoami,
   type RunOpencli,
 } from "../../channels/linkedin-cli.js";
 import { LinkedInInboxPoller } from "../../channels/linkedin.js";
@@ -77,7 +77,7 @@ const linkedinGrantProfileSchema = z
 export type LinkedInGrantProfile = z.infer<typeof linkedinGrantProfileSchema>;
 
 export function linkedinProfileFromIdentity(
-  identity: LinkedInIdentity,
+  identity: LinkedInWhoami,
   connectedAt: Date,
 ): LinkedInGrantProfile | null {
   const raw: LinkedInGrantProfile = {
@@ -166,7 +166,7 @@ export function makeLinkedInSetup(deps: {
   run: RunOpencli;
   openLoginTab: (url: string) => Promise<boolean>;
 }): SetupFn {
-  const probe = async (signal: AbortSignal): Promise<LinkedInIdentity | null> => {
+  const probe = async (signal: AbortSignal): Promise<LinkedInWhoami | null> => {
     try {
       return parseWhoami(
         await deps.run(["linkedin", "whoami"], { timeoutMs: WHOAMI_TIMEOUT_MS, signal }),
@@ -208,7 +208,7 @@ export function makeLinkedInSetup(deps: {
         const deadline = Date.now() + LOGIN_WAIT_TIMEOUT_MS;
         for (;;) {
           if (signal.aborted) throw new Error("setup cancelled");
-          let found: LinkedInIdentity | null = null;
+          let found: LinkedInWhoami | null = null;
           try {
             found = await probe(signal);
           } catch {

--- a/packages/core/src/connections/integrations/linkedin.ts
+++ b/packages/core/src/connections/integrations/linkedin.ts
@@ -264,7 +264,7 @@ interface LinkedInTalker extends Talker {
 /**
  * The `channel_mappings.channel_user_id` a LinkedIn message resolves through.
  *
- * The bare member id is the identity the mirror keys on — `linkedin_participants`
+ * The bare member id is the address the mirror keys on — `linkedin_participants`
  * is primary-keyed by it and promotion writes it into the mapping — so a promoted
  * participant is recognised on their next message with nothing else wired up.
  *

--- a/packages/core/src/connections/integrations/whatsapp.test.ts
+++ b/packages/core/src/connections/integrations/whatsapp.test.ts
@@ -298,7 +298,7 @@ describe("whatsapp descriptor over a real registry", () => {
 
     expect(conn.status().talk).toEqual({ state: "unlocked" });
     // WhatsAppAdapter.sendMessage addresses by threadId (the chat JID);
-    // channelUserId is the sender identity round-tripped from the inbound message.
+    // channelUserId is the sender's address round-tripped from the inbound message.
     await conn.talk!.send("120@g.us" as ConversationId, { text: "hi" });
     expect(fake.sent).toEqual([
       { channelUserId: "120@g.us", threadId: "120@g.us", msg: { text: "hi" } },

--- a/packages/core/src/db/channel-identity-dedup-migration.test.ts
+++ b/packages/core/src/db/channel-identity-dedup-migration.test.ts
@@ -66,9 +66,9 @@ function databaseWithDuplicates(): Database.Database {
   // Two dismissals of one sender.
   mapping.run("m5", STRANGER_PERSON_ID, "telegram", "tg-dismissed");
   mapping.run("m6", STRANGER_PERSON_ID, "telegram", "tg-dismissed");
-  // The same identifier on another channel is a different identity.
+  // The same identifier on another channel is a different account.
   mapping.run("m7", "alice", "email", "tg-contested");
-  // An identity nobody contests.
+  // An account nobody contests.
   mapping.run("m8", "bob", "telegram", "tg-sole");
 
   return sqlite;
@@ -81,8 +81,8 @@ function survivors(sqlite: Database.Database): string[] {
     .map((row) => (row as { id: string }).id);
 }
 
-describe("channel identity dedup migration", () => {
-  it("keeps one row per identity, preferring a placement over a dismissal", () => {
+describe("channel mapping dedup migration", () => {
+  it("keeps one row per account, preferring a placement over a dismissal", () => {
     const sqlite = databaseWithDuplicates();
     try {
       applyMigration(sqlite, identityIndexMigration());

--- a/packages/core/src/db/repositories/linkedin-store.test.ts
+++ b/packages/core/src/db/repositories/linkedin-store.test.ts
@@ -256,7 +256,7 @@ describe("LinkedInStoreRepository", () => {
         ada.participantId,
         self.participantId,
       ]);
-      // Membership went away; the person identity is kept for other threads.
+      // Membership went away; the person's account is kept for other threads.
       const personRows = testDb.db.all(sql`
         SELECT COUNT(*) AS c FROM linkedin_participants WHERE participant_id = ${grace.participantId}
       `) as Array<{ c: number }>;
@@ -335,10 +335,10 @@ describe("LinkedInStoreRepository", () => {
       expect((await repo.getThreadParticipants("t1")).map((p) => p.participantId)).toEqual([
         grace.participantId,
       ]);
-      const identities = testDb.db.all(sql`
+      const accounts = testDb.db.all(sql`
         SELECT COUNT(*) AS c FROM linkedin_participants
       `) as Array<{ c: number }>;
-      expect(Number(identities[0].c)).toBe(1);
+      expect(Number(accounts[0].c)).toBe(1);
     });
 
     it("is_self survives a re-snapshot and follows the viewer's answer", async () => {
@@ -449,7 +449,7 @@ describe("LinkedInStoreRepository", () => {
 
     // A mirrored participant becomes a Rome person through the existing person
     // create/link flow — there is no second write path here. The bare member id
-    // is the channel identity on both sides, so promotion needs no translation
+    // is the account's address on both sides, so promotion needs no translation
     // step and nothing in this repository ever writes `persons`.
     describe("promotion to a person", () => {
       let people: PersonMappingRepository;
@@ -465,7 +465,7 @@ describe("LinkedInStoreRepository", () => {
         await repo.upsertThreadParticipants("t1", [ada, self]);
       });
 
-      it("lists a mirrored identity as unpromoted until a person claims it", async () => {
+      it("lists a mirrored account as unpromoted until a person claims it", async () => {
         const rows = await repo.listParticipants();
 
         expect(rows.map((r) => r.participantId)).toEqual([ada.participantId, self.participantId]);
@@ -507,7 +507,7 @@ describe("LinkedInStoreRepository", () => {
         // The headline stays on the mirror row: `channel_mappings` has nowhere
         // to put it, and it belongs in the person's memory profile.
         expect(promoted?.headline).toBe("Engineer");
-        // Promoting one identity says nothing about the rest of the inbox.
+        // Promoting one account says nothing about the rest of the inbox.
         expect(rows.find((r) => r.participantId === self.participantId)?.linkedPersonId).toBeNull();
       });
 
@@ -520,7 +520,7 @@ describe("LinkedInStoreRepository", () => {
         });
 
         // The second promotion slugs to a free id (`ada-lovelace-2`), so the
-        // refusal is the held identity's rather than a colliding person id's.
+        // refusal is the held account's rather than a colliding person id's.
         await expect(
           people.create({
             displayName: "Ada Lovelace",
@@ -636,7 +636,7 @@ describe("LinkedInStoreRepository", () => {
         ]);
       });
 
-      it("is idempotent and never duplicates an identity across threads", async () => {
+      it("is idempotent and never duplicates an account across threads", async () => {
         await repo.upsertThreads([
           thread("t1", new Date("2026-08-19T20:00:00Z")),
           thread("t2", new Date("2026-08-18T20:00:00Z")),
@@ -646,10 +646,10 @@ describe("LinkedInStoreRepository", () => {
         await repo.backfillParticipantsFromMessages();
         await repo.backfillParticipantsFromMessages();
 
-        const identities = testDb.db.all(
+        const accounts = testDb.db.all(
           sql`SELECT participant_id FROM linkedin_participants`,
         ) as Array<{ participant_id: string }>;
-        expect(identities.map((r) => r.participant_id)).toEqual(["ACoAAAda0001"]);
+        expect(accounts.map((r) => r.participant_id)).toEqual(["ACoAAAda0001"]);
         expect(await repo.getParticipantThreadIds("ACoAAAda0001")).toEqual(["t1", "t2"]);
       });
 
@@ -688,7 +688,7 @@ describe("LinkedInStoreRepository", () => {
     });
   });
 
-  // The identity union reads a participant as a person-shaped row: who they
+  // The People surface reads a participant as a person-shaped row: who they
   // are, what was last said, and how much of it there is. "What was said" is
   // the direct threads only — a timeline entry names no sender, so a group
   // thread's messages cannot be attributed to one of its members.

--- a/packages/core/src/db/repositories/linkedin-store.test.ts
+++ b/packages/core/src/db/repositories/linkedin-store.test.ts
@@ -476,7 +476,7 @@ describe("LinkedInStoreRepository", () => {
       it("bounds the participant read by default and reads it whole on limit: null", async () => {
         expect(await repo.listParticipants({ limit: 1 })).toHaveLength(1);
         expect(await repo.listParticipants({ limit: null })).toHaveLength(2);
-        // The no-argument call is the one the account plane's fold makes.
+        // The no-argument call is the one the address book's fold makes.
         expect(await repo.listParticipants()).toHaveLength(2);
       });
 

--- a/packages/core/src/db/repositories/linkedin-store.ts
+++ b/packages/core/src/db/repositories/linkedin-store.ts
@@ -18,7 +18,7 @@ import type {
 } from "../../channels/linkedin-sync.js";
 
 // The member-id form lives with the poller/store contract, not here: it is the
-// identity both sides of the mirror agree on. Re-exported so callers reading
+// address both sides of the mirror agree on. Re-exported so callers reading
 // participant rows reach it from the same module those rows come from.
 export { linkedInMemberIdFromProfileUrl };
 
@@ -27,9 +27,9 @@ const HISTORY_READ_LIMIT = 1000;
 const PARTICIPANTS_READ_LIMIT = 10000;
 
 /**
- * One mirrored LinkedIn identity, annotated with whether it has been promoted
+ * One mirrored LinkedIn account, annotated with whether it has been promoted
  * to a curated `persons` entry. `isSelf` rides along rather than being filtered
- * out here: which identities a caller offers for promotion is its own policy,
+ * out here: which accounts a caller offers for promotion is its own policy,
  * and the guardian's own row is still a real member of the threads it appears
  * in.
  */
@@ -40,19 +40,19 @@ export interface LinkedInParticipantContactRow {
   headline: string | null;
   type: string | null;
   isSelf: boolean;
-  /** How many mirrored threads this identity belongs to. */
+  /** How many mirrored threads this account belongs to. */
   threadCount: number;
-  /** The person this identity was promoted into, or null when unpromoted. */
+  /** The person this account was promoted into, or null when unpromoted. */
   linkedPersonId: string | null;
   linkedPersonName: string | null;
   /**
-   * Unix seconds of the newest message on this identity's direct threads, or
+   * Unix seconds of the newest message on this account's direct threads, or
    * null when the mirror holds none. See {@link DIRECT_THREADS} for why a group
    * thread contributes nothing.
    */
   lastMessageAt: number | null;
   lastMessagePreview: string | null;
-  /** Mirrored messages on this identity's direct threads, both directions. */
+  /** Mirrored messages on this account's direct threads, both directions. */
   messageCount: number;
 }
 
@@ -67,7 +67,7 @@ export interface LinkedInThreadParticipantSet {
 export interface LinkedInParticipantBackfillResult {
   /** Threads seeded — threads already read authoritatively are skipped. */
   threads: number;
-  /** Distinct identities the seed proved. */
+  /** Distinct accounts the seed proved. */
   participants: number;
 }
 
@@ -79,7 +79,7 @@ export interface LinkedInParticipantBackfillResult {
  * unambiguously *this* person's history: a timeline entry names no sender, so
  * folding a ten-person thread into one member's dossier would put nine other
  * people's words in their mouth. The People page already holds group chats out
- * of the identity union for the same reason — a group cannot hold a bond.
+ * of the People surface for the same reason — a group cannot hold a bond.
  *
  * Membership decides it, not LinkedIn's `is_group` flag alone: that flag is
  * null until a thread snapshot reports one, and a thread seeded from stored
@@ -119,11 +119,11 @@ function chunked<T>(items: T[], size: number): T[][] {
  * Durable store for the LinkedIn inbox mirror (threads + recent message
  * history). Writes are fed by the inbox poller as a {@link LinkedInSyncSink};
  * reads serve the poller's watermarks, the address book's fold over mirrored
- * identities, and the history talk feature.
+ * accounts, and the history talk feature.
  *
  * Nothing here hands a thread or its messages to a reader as a thread. The
  * dashboard reads LinkedIn through the person contract like every other
- * channel, so every read out of this mirror is addressed by identity —
+ * channel, so every read out of this mirror is addressed by account —
  * {@link LinkedInStoreRepository.listParticipants}, scoped by
  * {@link DIRECT_THREADS}. A thread-shaped read here would have no caller but a
  * thread-shaped surface, and there is none.
@@ -176,7 +176,7 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
     for (const chunk of chunked(messages, UPSERT_CHUNK)) {
       // Unlike WhatsApp's immutable frames, LinkedIn messages can be edited
       // and reactions accrue after delivery, so a re-snapshot refreshes the
-      // mutable fields in place. Identity fields keep their first-seen value.
+      // mutable fields in place. The naming fields keep their first-seen value.
       await this.db
         .insert(linkedinMessages)
         .values(
@@ -250,7 +250,7 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
   }
 
   /**
-   * Replace a thread's participant set with exactly `participants`: identities
+   * Replace a thread's participant set with exactly `participants`: accounts
    * are upserted into `linkedin_participants`, membership rows are added for
    * everyone in the set, and members no longer in it are dropped. An empty
    * array therefore empties the thread — callers must not pass one for a
@@ -260,7 +260,7 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
    * failure part-way through would otherwise leave the thread over-inclusive:
    * the new members added, the departed ones never deleted.
    *
-   * Identity rows outlive membership: a person dropped from one thread keeps
+   * Account rows outlive membership: a person dropped from one thread keeps
    * their row for the other threads they are in.
    *
    * The same transaction stamps the thread's `participants_last_read_at`. Every
@@ -395,13 +395,13 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
       ORDER BY coalesce(m.sent_at, m.created_at) ASC, m.rowid ASC
     `)) as Array<Record<string, unknown>>;
 
-    const identities = new Map<string, LinkedInParticipantInput>();
+    const accounts = new Map<string, LinkedInParticipantInput>();
     const memberships = new Map<string, { threadId: string; participantId: string }>();
     for (const row of rows) {
       const participantId = linkedInMemberIdFromProfileUrl(row.senderProfileUrl as string | null);
       if (!participantId) continue;
       const threadId = String(row.threadId);
-      identities.set(participantId, {
+      accounts.set(participantId, {
         participantId,
         name: (row.senderName as string | null) ?? null,
         headline: (row.senderHeadline as string | null) ?? null,
@@ -413,7 +413,7 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
     if (memberships.size === 0) return { threads: 0, participants: 0 };
 
     await this.db.transaction((tx) => {
-      for (const chunk of chunked([...identities.values()], UPSERT_CHUNK)) {
+      for (const chunk of chunked([...accounts.values()], UPSERT_CHUNK)) {
         tx.insert(linkedinParticipants)
           .values(
             chunk.map((p) => ({
@@ -443,19 +443,19 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
 
     return {
       threads: new Set([...memberships.values()].map((m) => m.threadId)).size,
-      participants: identities.size,
+      participants: accounts.size,
     };
   }
 
   /**
-   * Every stored LinkedIn identity, each row saying whether it has already been
+   * Every stored LinkedIn account, each row saying whether it has already been
    * promoted to a person and what its direct threads last carried. The join is
    * on the member id itself — no translation step — because
    * `linkedin_participants.participant_id` and a `linkedin`
    * `channel_mappings.channel_user_id` are the same identifier by construction.
    *
    * Promotion is a guardian action against these rows, not something this
-   * repository performs: a LinkedIn inbox holds many identities that should
+   * repository performs: a LinkedIn inbox holds many accounts that should
    * never enter the curated person graph, so nothing here writes `persons`.
    *
    * `limit` defaults to a generous cap that suits a single-payload endpoint.

--- a/packages/core/src/db/repositories/linkedin-store.ts
+++ b/packages/core/src/db/repositories/linkedin-store.ts
@@ -118,7 +118,7 @@ function chunked<T>(items: T[], size: number): T[][] {
 /**
  * Durable store for the LinkedIn inbox mirror (threads + recent message
  * history). Writes are fed by the inbox poller as a {@link LinkedInSyncSink};
- * reads serve the poller's watermarks, the account plane's fold over mirrored
+ * reads serve the poller's watermarks, the address book's fold over mirrored
  * identities, and the history talk feature.
  *
  * Nothing here hands a thread or its messages to a reader as a thread. The

--- a/packages/core/src/db/repositories/person-mapping.test.ts
+++ b/packages/core/src/db/repositories/person-mapping.test.ts
@@ -18,7 +18,7 @@ describe("PersonMappingRepository", () => {
     testDb.close();
   });
 
-  /** What marking a sender as a stranger does: file the identity under the
+  /** What marking a sender as a stranger does: file the account under the
    *  sentinel rather than deleting it. */
   async function dismiss(channel: string, channelUserId: string, displayName?: string) {
     if (!(await repo.findById(STRANGER_PERSON_ID))) {
@@ -30,9 +30,9 @@ describe("PersonMappingRepository", () => {
     await repo.addChannelMapping(STRANGER_PERSON_ID, channel, channelUserId, displayName);
   }
 
-  it("findAllWithMappings() reads every person and their identities at once", async () => {
-    // One statement, so an identity moving between two people mid-read cannot
-    // land under both of them — which is the identity union's whole premise.
+  it("findAllWithMappings() reads every person and their accounts at once", async () => {
+    // One statement, so an account moving between two people mid-read cannot
+    // land under both of them — which is what one account, one person means.
     const alice = await repo.create({
       displayName: "Alice",
       bondLevel: "inner-circle",
@@ -53,7 +53,7 @@ describe("PersonMappingRepository", () => {
         .channelMappings.map((m) => `${m.channel}:${m.channelUserId}`)
         .sort(),
     ).toEqual(["telegram:tg-alice", "whatsapp:wa-alice"]);
-    // A person holding no identity is still a person, and the left join has to
+    // A person holding no account is still a person, and the left join has to
     // answer them with an empty list rather than dropping them.
     expect(byId.get(bob)!.channelMappings).toEqual([]);
   });
@@ -107,7 +107,7 @@ describe("PersonMappingRepository", () => {
     const boom = new Error("mapping write failed");
     // The seam the person insert must be enlisted with: forcing the mapping
     // write to throw is the only way to observe the rollback, since the claim
-    // check refuses a held identity before the transaction opens.
+    // check refuses a held account before the transaction opens.
     (repo as unknown as { writeClaim: () => never }).writeClaim = () => {
       throw boom;
     };
@@ -233,7 +233,7 @@ describe("PersonMappingRepository", () => {
     expect(channels).toEqual(["slack", "telegram"]);
   });
 
-  it("updateChannelUserId() re-points one identity and leaves the person's others", async () => {
+  it("updateChannelUserId() re-points one account and leaves the person's others", async () => {
     const personId = await repo.create({
       displayName: "Erin",
       bondLevel: "inner-circle",
@@ -258,7 +258,7 @@ describe("PersonMappingRepository", () => {
     ]);
   });
 
-  it("updateChannelUserId() keeps both when the person already holds the incoming identity", async () => {
+  it("updateChannelUserId() keeps both when the person already holds the incoming account", async () => {
     const personId = await repo.create({
       displayName: "Erin",
       bondLevel: "inner-circle",
@@ -284,7 +284,7 @@ describe("PersonMappingRepository", () => {
     ]);
   });
 
-  it("updateChannelUserId() takes the incoming identity from a rival holder", async () => {
+  it("updateChannelUserId() takes the incoming account from a rival holder", async () => {
     const erin = await repo.create({
       displayName: "Erin",
       bondLevel: "inner-circle",
@@ -303,7 +303,7 @@ describe("PersonMappingRepository", () => {
     expect((await repo.findById(rival))!.channelMappings).toEqual([]);
   });
 
-  it("updateChannelUserId() leaves a rival holder alone when the person's identity is gone", async () => {
+  it("updateChannelUserId() leaves a rival holder alone when the person's account is gone", async () => {
     const erin = await repo.create({ displayName: "Erin", bondLevel: "inner-circle" });
     const rival = await repo.create({
       displayName: "Rival",
@@ -317,7 +317,7 @@ describe("PersonMappingRepository", () => {
     expect((await repo.findByChannelUser("telegram", "tg-erin-new"))!.id).toBe(rival);
   });
 
-  it("updateChannelUserId() reports an identity the person does not hold", async () => {
+  it("updateChannelUserId() reports an account the person does not hold", async () => {
     const personId = await repo.create({
       displayName: "Frank",
       bondLevel: "inner-circle",
@@ -374,8 +374,8 @@ describe("PersonMappingRepository", () => {
     expect(levels).toEqual(["acquaintance", "inner-circle"]);
   });
 
-  describe("channel identity ownership", () => {
-    it("re-points a mapped identity onto its new person rather than adding a second", async () => {
+  describe("account ownership", () => {
+    it("re-points a mapped account onto its new person rather than adding a second", async () => {
       const first = await repo.create({
         displayName: "First",
         bondLevel: "other",
@@ -585,8 +585,8 @@ describe("PersonMappingRepository", () => {
     });
   });
 
-  describe("create() claiming channel identities", () => {
-    it("reclaims an identity that was only dismissed onto the stranger sentinel", async () => {
+  describe("create() claiming accounts", () => {
+    it("reclaims an account that was only dismissed onto the stranger sentinel", async () => {
       await dismiss("whatsapp", "+15551234", "Bob");
 
       const bob = await repo.create({
@@ -600,7 +600,7 @@ describe("PersonMappingRepository", () => {
       expect(stranger!.channelMappings).toHaveLength(0);
     });
 
-    it("carries the dismissed row's channel-side name onto the reclaimed identity", async () => {
+    it("carries the dismissed row's channel-side name onto the reclaimed account", async () => {
       await dismiss("whatsapp", "+15559999", "Bob from work");
 
       const bob = await repo.create({
@@ -616,7 +616,7 @@ describe("PersonMappingRepository", () => {
       expect(rows[0].displayName).toBe("Bob from work");
     });
 
-    it("refuses an identity a real person holds instead of stealing it", async () => {
+    it("refuses an account a real person holds instead of stealing it", async () => {
       const alice = await repo.create({
         displayName: "Alice",
         bondLevel: "inner-circle",
@@ -634,7 +634,7 @@ describe("PersonMappingRepository", () => {
       expect((await repo.findByChannelUser("whatsapp", "+15551234"))?.id).toBe(alice);
     });
 
-    it("names the person holding the identity it refused", async () => {
+    it("names the person holding the account it refused", async () => {
       const alice = await repo.create({
         displayName: "Alice Marsh",
         bondLevel: "inner-circle",
@@ -662,7 +662,7 @@ describe("PersonMappingRepository", () => {
         personId: alice,
         personName: "Alice Marsh",
       });
-      // The unheld identity in the same request is still unheld.
+      // The unheld account in the same request is still unheld.
       expect(await repo.findByChannelUser("telegram", "tg-bob")).toBeNull();
     });
 
@@ -692,7 +692,7 @@ describe("PersonMappingRepository", () => {
       expect((await repo.findById(retried))!.displayName).toBe("Bob");
     });
 
-    it("refuses a held identity from the dashboard path too, leaving no person", async () => {
+    it("refuses a held account from the dashboard path too, leaving no person", async () => {
       const alice = await repo.create({
         displayName: "Alice",
         bondLevel: "inner-circle",
@@ -713,7 +713,7 @@ describe("PersonMappingRepository", () => {
       expect(await repo.findById("bob")).toBeNull();
     });
 
-    it("reclaims a dismissed identity from the dashboard path", async () => {
+    it("reclaims a dismissed account from the dashboard path", async () => {
       await dismiss("whatsapp", "+15558888", "Carol");
 
       await repo.create({

--- a/packages/core/src/db/repositories/person-mapping.ts
+++ b/packages/core/src/db/repositories/person-mapping.ts
@@ -14,7 +14,7 @@ import {
 // predict the ids this repository mints.
 export { generatePersonSlug };
 
-/** An identity cleared for a person to take, with the channel-side name that
+/** An account cleared for a person to take, with the channel-side name that
  *  travels with it. */
 interface ChannelClaim {
   channel: string;
@@ -44,7 +44,7 @@ export interface AccountHolder {
 export class AccountHeldError extends Error {
   constructor(readonly holder: AccountHolder) {
     super(
-      `Channel identity ${holder.channel}:${holder.channelUserId} already belongs to person "${holder.personId}"`,
+      `Account ${holder.channel}:${holder.channelUserId} already belongs to person "${holder.personId}"`,
     );
     this.name = "AccountHeldError";
   }
@@ -85,6 +85,16 @@ export interface NewPersonData {
   approved?: boolean;
 }
 
+/**
+ * The people the guardian knows and which accounts belong to each of them.
+ *
+ * The repository and its verbs keep the `channel_mappings` name: a channel
+ * mapping is a [link](docs/concepts/people.md#link), and `channelUserId` is the
+ * account's own [address](docs/concepts/people.md#address), but the table, the
+ * columns, and the `PersonMappingRepository` interface `@rome-os/app-runtime`
+ * publishes all carry the older names, so renaming here would leave two names
+ * for one thing rather than one.
+ */
 export class PersonMappingRepository {
   constructor(private db: DrizzleDb) {}
 
@@ -228,7 +238,7 @@ export class PersonMappingRepository {
    * One statement rather than one per person, and not only to save the reads:
    * a mapping moving between two people mid-read would otherwise land under
    * both of them (or neither), because each person's mappings would arrive in
-   * their own autocommit query. Every reader of this table assumes an identity
+   * their own autocommit query. Every reader of this table assumes an account
    * has one owner.
    */
   async findAllWithMappings() {
@@ -260,18 +270,18 @@ export class PersonMappingRepository {
   }
 
   /**
-   * Create a person and claim their channel identities, both or neither.
+   * Create a person and claim their accounts, both or neither.
    *
-   * An identity filed under the stranger sentinel is a dismissal rather than a
-   * placement, so naming its sender releases it. An identity a real person
+   * An account filed under the stranger sentinel is a dismissal rather than a
+   * placement, so naming its sender releases it. An account a real person
    * holds stays held: this throws {@link AccountHeldError} instead of stealing
    * it, because creating a person is not a re-point. The refusal is a
-   * rollback, not a partial write — a person committed without their identity
+   * rollback, not a partial write — a person committed without their account
    * would be unreachable and permanent, since {@link findByName} would then
    * reject every retry as a duplicate of the wreckage.
    *
-   * Whatever the caller names, all of it or none of it: the identities are
-   * settled together before the transaction opens, so one held identity in a
+   * Whatever the caller names, all of it or none of it: the accounts are
+   * settled together before the transaction opens, so one held account in a
    * list of five leaves the other four where they were.
    */
   async create(data: {
@@ -294,8 +304,8 @@ export class PersonMappingRepository {
   }
 
   /**
-   * Settle who may take each identity, before any transaction opens, so a
-   * refusal can name the holder. An identity filed under the stranger sentinel
+   * Settle who may take each account, before any transaction opens, so a
+   * refusal can name the holder. An account filed under the stranger sentinel
    * is a dismissal rather than a placement, so it is released to whoever names
    * its sender; one a real person holds is refused. The unique index still
    * backstops a rival claim landing between this read and the write.
@@ -325,7 +335,7 @@ export class PersonMappingRepository {
     return claims;
   }
 
-  /** Take an identity {@link resolveClaims} cleared for this person. */
+  /** Take an account {@link resolveClaims} cleared for this person. */
   private writeClaim(exec: SqliteExec, personId: string, claim: ChannelClaim): void {
     this.writeReleaseStrangerClaim(exec, claim.channel, claim.channelUserId);
     exec
@@ -334,7 +344,7 @@ export class PersonMappingRepository {
       .run();
   }
 
-  /** The row holding a channel identity and the name of the person holding it,
+  /** The row holding an account and the name of the person holding it,
    *  or null when nobody holds it. The join loses nothing — every mapping
    *  references a person row. */
   private async findChannelMapping(channel: string, channelUserId: string) {
@@ -393,7 +403,7 @@ export class PersonMappingRepository {
     channelUserId: string,
     displayName?: string,
   ): string {
-    // Claiming an identity is one statement, not a read followed by a write:
+    // Claiming an account is one statement, not a read followed by a write:
     // `(channel, channel_user_id)` is unique, so a second writer re-points the
     // mapping instead of adding a rival one, whatever order the two arrive in.
     const row = exec
@@ -416,9 +426,9 @@ export class PersonMappingRepository {
     return row.id;
   }
 
-  /** Release a channel identity that was only dismissed onto the stranger
+  /** Release an account that was only dismissed onto the stranger
    *  sentinel, so a caller naming its sender can claim it. Scoped to the
-   *  sentinel deliberately: an identity a real person holds is a placement, and
+   *  sentinel deliberately: an account a real person holds is a placement, and
    *  leaving it in place lets the unique index turn an attempt to take it into
    *  a rollback rather than a silent theft. */
   writeReleaseStrangerClaim(exec: SqliteExec, channel: string, channelUserId: string): void {
@@ -426,13 +436,13 @@ export class PersonMappingRepository {
   }
 
   /**
-   * {@link writeReleaseStrangerClaim} over every addressing of one account, as
+   * {@link writeReleaseStrangerClaim} over every address of one account, as
    * a single statement.
    *
    * One statement rather than one per address because they are one decision: a
    * channel can reach an account several ways, a dismissal is stored against
    * whichever one the guardian dismissed it by, and an undo that committed
-   * some of them would leave the account still dismissed by the addressing it
+   * some of them would leave the account still dismissed by the address it
    * missed.
    */
   writeReleaseStrangerClaims(
@@ -469,7 +479,7 @@ export class PersonMappingRepository {
   }
 
   /** Write helper for {@link updateChannelUserId}, taking an executor (see
-   *  {@link writeChannelMapping}). Returns whether the identity moved, so a
+   *  {@link writeChannelMapping}). Returns whether the account moved, so a
    *  caller that decided on `from` earlier can tell that it is gone. */
   writeChannelUserId(
     exec: SqliteExec,
@@ -493,15 +503,15 @@ export class PersonMappingRepository {
       );
 
     // A rival holding `to` yields it, which is where {@link writeChannelMapping}'s
-    // upsert lands a claim on the same identity. Re-pointing onto a held
-    // identifier would otherwise collide on the identity index and abort the
+    // upsert lands a claim on the same account. Re-pointing onto a held
+    // identifier would otherwise collide on the unique index and abort the
     // caller's transaction — the one outcome a claim on this path must not have,
     // since that transaction also carries the credential.
     //
     // Only a rival's. This person holding `to` themselves is a second account of
     // theirs, not a claim to settle, and deleting it here would merge two of
-    // their identities into one. Conditioned, too, on the re-pointed row still
-    // being there: a `from` that went away leaves the rival holding an identity
+    // their accounts into one. Conditioned, too, on the re-pointed row still
+    // being there: a `from` that went away leaves the rival holding an account
     // nothing is about to take.
     exec
       .delete(channelMappings)
@@ -522,9 +532,9 @@ export class PersonMappingRepository {
       .from(channelMappings)
       .where(and(eq(channelMappings.channel, channel), eq(channelMappings.channelUserId, to)));
 
-    // Scoped to the one identity being re-pointed, not to every identity the
+    // Scoped to the one account being re-pointed, not to every account the
     // person holds on the channel: a person may hold several there, and moving
-    // them all onto `to` would collide on the identity index too.
+    // them all onto `to` would collide on the unique index too.
     const result = exec
       .update(channelMappings)
       .set({ channelUserId: to })
@@ -541,8 +551,8 @@ export class PersonMappingRepository {
   }
 
   /**
-   * Repoint one of a person's channel identities onto a new identifier, leaving
-   * their other identities on that channel alone. Used to heal a stale guardian
+   * Repoint one of a person's accounts onto a new identifier, leaving
+   * their other accounts on that channel alone. Used to heal a stale guardian
    * self JID (e.g. a device-suffixed WhatsApp id captured before
    * canonicalization) onto its canonical form on reconnect.
    *
@@ -564,7 +574,7 @@ export class PersonMappingRepository {
   }
 
   /**
-   * Remove only guardian identities for a channel after its Talk grant is
+   * Remove only guardian accounts for a channel after its Talk grant is
    * explicitly disconnected. Other people mappings remain curated data, and
    * transient transport faults never call this path.
    */
@@ -674,7 +684,7 @@ export class PersonMappingRepository {
    *
    * The links move rather than being rewritten, so each carries its
    * channel-side name across the way a transfer does. Nothing can collide on
-   * the identity index: an account carries at most one link, so no account is
+   * the unique index: an account carries at most one link, so no account is
    * held by both people to begin with.
    *
    * Both rows are read inside the transaction and the refusals are decided

--- a/packages/core/src/db/repositories/whatsapp-store.test.ts
+++ b/packages/core/src/db/repositories/whatsapp-store.test.ts
@@ -45,7 +45,7 @@ describe("WhatsAppStoreRepository", () => {
     expect(await repo.listContacts()).toHaveLength(3);
   });
 
-  it("hides nameless LID-only contacts but keeps LIDs with a phone identity", async () => {
+  it("hides nameless LID-only contacts but keeps LIDs with a phone number", async () => {
     await repo.upsertContacts([
       { jid: "raw-lid@lid" },
       { jid: "phone-backed@lid", phoneNumber: "15551234567" },
@@ -89,7 +89,7 @@ describe("WhatsAppStoreRepository", () => {
     expect(may[0].messageCount).toBe(1);
   });
 
-  it("carries a person link across the merged identity", async () => {
+  it("carries a person link across the merged account", async () => {
     const persons = new PersonMappingRepository(db);
     await persons.create({
       displayName: "May",

--- a/packages/core/src/db/repositories/whatsapp-store.ts
+++ b/packages/core/src/db/repositories/whatsapp-store.ts
@@ -25,7 +25,7 @@ function chunked<T>(items: T[], size: number): T[][] {
 /**
  * Group key folding a single person's two WhatsApp addresses — their
  * phone-number JID (`<pn>@s.whatsapp.net`) and their privacy LID (`<lid>@lid`) —
- * onto one identity. WhatsApp delivers a contact's conversation under the LID
+ * onto one account. WhatsApp delivers a contact's conversation under the LID
  * (which Baileys annotates with the resolved phone number) while the address-book
  * name lives on the `@s.whatsapp.net` row, so one person otherwise shows up as
  * two cards: a named-but-silent one and a talking-but-nameless one. Both rows
@@ -33,7 +33,7 @@ function chunked<T>(items: T[], size: number): T[][] {
  * (`@g.us`) never share a phone number and key on their own JID, so they never
  * merge.
  */
-function identityKey(r: WhatsAppContactAliasRow): string {
+function accountKey(r: WhatsAppContactAliasRow): string {
   if (!r.isGroup && r.phoneNumber) {
     const digits = r.phoneNumber.replace(/\D/g, "");
     if (digits) return `pn:${digits}`;
@@ -57,16 +57,16 @@ function coalesceField<K extends keyof WhatsAppContactAliasRow>(
  * Collapse the LID and phone-number threads of one person into a single card.
  * `rows` arrives in display order (conversations first, then alphabetical), so
  * each group's first row is its best representative — we keep its JID as the
- * card's identity (the conversation-bearing one when a chat exists, so opening
+ * card's own address (the conversation-bearing one when a chat exists, so opening
  * the chat still resolves its messages) and fold the missing pieces in from its
  * siblings: the address-book name, a person link, and the richer message history.
  * Every JID that went into the group is kept in `aliases`, sorted, so a caller
  * that needs the whole address set does not have to re-derive the grouping.
  */
-function consolidateByIdentity(rows: WhatsAppContactAliasRow[]): WhatsAppContactRow[] {
+function consolidateByAccount(rows: WhatsAppContactAliasRow[]): WhatsAppContactRow[] {
   const groups = new Map<string, WhatsAppContactAliasRow[]>();
   for (const r of rows) {
-    const k = identityKey(r);
+    const k = accountKey(r);
     const g = groups.get(k);
     if (g) g.push(r);
     else groups.set(k, [r]);
@@ -332,7 +332,7 @@ export class WhatsAppStoreRepository implements WhatsAppSyncSink {
       messageCount: Number(r.messageCount ?? 0),
     }));
 
-    return consolidateByIdentity(mapped);
+    return consolidateByAccount(mapped);
   }
 
   /** Recent messages for one chat, oldest→newest (newest at the bottom). */

--- a/packages/core/src/db/repositories/whatsapp-store.ts
+++ b/packages/core/src/db/repositories/whatsapp-store.ts
@@ -23,7 +23,7 @@ function chunked<T>(items: T[], size: number): T[][] {
 }
 
 /**
- * Group key folding a single person's two WhatsApp addressings — their
+ * Group key folding a single person's two WhatsApp addresses — their
  * phone-number JID (`<pn>@s.whatsapp.net`) and their privacy LID (`<lid>@lid`) —
  * onto one identity. WhatsApp delivers a contact's conversation under the LID
  * (which Baileys annotates with the resolved phone number) while the address-book
@@ -61,7 +61,7 @@ function coalesceField<K extends keyof WhatsAppContactAliasRow>(
  * the chat still resolves its messages) and fold the missing pieces in from its
  * siblings: the address-book name, a person link, and the richer message history.
  * Every JID that went into the group is kept in `aliases`, sorted, so a caller
- * that needs the whole addressing set does not have to re-derive the grouping.
+ * that needs the whole address set does not have to re-derive the grouping.
  */
 function consolidateByIdentity(rows: WhatsAppContactAliasRow[]): WhatsAppContactRow[] {
   const groups = new Map<string, WhatsAppContactAliasRow[]>();
@@ -82,7 +82,7 @@ function consolidateByIdentity(rows: WhatsAppContactAliasRow[]): WhatsAppContact
     const primary = group[0];
     const linked = group.find((r) => r.linkedPersonId != null);
     // The whole conversation usually lives on one JID, but take the latest row
-    // defensively in case history is split across both addressings.
+    // defensively in case history is split across both addresses.
     const latest = group.reduce(
       (best, r) => ((r.lastMessageAt ?? -1) > (best.lastMessageAt ?? -1) ? r : best),
       primary,

--- a/packages/core/src/db/schema/system.ts
+++ b/packages/core/src/db/schema/system.ts
@@ -76,6 +76,8 @@ export const sessionTurnCheckpoints = sqliteTable(
   (table) => [primaryKey({ columns: [table.sessionId, table.turnId] })],
 );
 
+/** The people the guardian knows (docs/concepts/people.md#person). Table name
+ *  kept: renaming it needs a migration, and every reader already holds it. */
 export const persons = sqliteTable("persons", {
   id: text("id").primaryKey(),
   displayName: text("display_name").notNull(),
@@ -87,6 +89,15 @@ export const persons = sqliteTable("persons", {
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
 });
 
+/**
+ * Which person each account belongs to — a channel mapping is a
+ * [link](docs/concepts/people.md#link), and `channel_user_id` is the account's
+ * own [address](docs/concepts/people.md#address).
+ *
+ * The table, its columns, and its index keep the older names: renaming any of
+ * them needs a migration, and `channelMappings` is also the wire field
+ * `@rome-os/app-runtime` publishes on `PersonRecord`.
+ */
 export const channelMappings = sqliteTable(
   "channel_mappings",
   {
@@ -99,10 +110,10 @@ export const channelMappings = sqliteTable(
     displayName: text("display_name"),
   },
   (table) => [
-    // One channel identity belongs to exactly one person. Held in the database
-    // rather than checked before each write: two concurrent placements of the
-    // same waiting sender both read "unmapped" and both insert, and the People
-    // page would then show that identity under two people at once.
+    // One account belongs to exactly one person. Held in the database rather
+    // than checked before each write: two concurrent placements of the same
+    // waiting sender both read "unlinked" and both insert, and the People page
+    // would then show that account under two people at once.
     uniqueIndex("idx_channel_mappings_identity").on(table.channel, table.channelUserId),
   ],
 );

--- a/packages/core/src/db/schema/system.ts
+++ b/packages/core/src/db/schema/system.ts
@@ -249,7 +249,7 @@ export const linkedinMessages = sqliteTable(
   ],
 );
 
-// One row per LinkedIn identity seen in a thread's participant list. Person-level
+// One row per LinkedIn account seen in a thread's participant list. Person-level
 // facts live here rather than on the membership row so a name or headline is
 // stored once, not once per thread the person appears in.
 export const linkedinParticipants = sqliteTable("linkedin_participants", {
@@ -268,7 +268,7 @@ export const linkedinParticipants = sqliteTable("linkedin_participants", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });
 
-// Thread membership: which identities belong to which thread. Rows carry no
+// Thread membership: which accounts belong to which thread. Rows carry no
 // person-level facts — those live once on `linkedin_participants`.
 export const linkedinThreadParticipants = sqliteTable(
   "linkedin_thread_participants",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -951,7 +951,7 @@ async function main() {
       maxIntervalMs: config.linkedinPollMaxMinutes * 60_000,
     },
     listAgents: () => Array.from(agentLoader.getAll().keys()),
-    // Auto-map the guardian onto their own WhatsApp identity on connect.
+    // Auto-map the guardian onto their own WhatsApp account on connect.
     onWhatsAppGuardianConnected: (selfJid) => {
       mapGuardianToChannel(personMappingRepo, "whatsapp", selfJid).catch((err) => {
         log.error("failed to auto-map guardian on WhatsApp connect", {

--- a/packages/core/src/people/account-decisions.ts
+++ b/packages/core/src/people/account-decisions.ts
@@ -10,7 +10,7 @@
 // real person holds: linking and unlinking are that account's verbs, and a
 // dismissal that quietly displaced a placement would lose the guardian's work.
 //
-// The account, not the addressing. A channel that reaches one account several
+// The account, not the address. A channel that reaches one account several
 // ways is folded by `readAccountDirectory`, so a caller holding any address of
 // an account decides the account — otherwise a dismissal by the address the
 // guardian happened to see would leave the account undismissed by every other
@@ -67,7 +67,7 @@ export async function dismissAccount(
   if (account == null) return { unknown: true };
 
   // What the guardian was looking at. It refuses the account they can see is
-  // placed — including one placed on an addressing other than the one they
+  // placed — including one placed on an address other than the one they
   // named, which only the fold knows is the same account.
   const holder = heldBy(account);
   if (holder) return { conflict: linkConflict(account, holder) };
@@ -158,7 +158,7 @@ function heldBy(account: DirectoryAccount): { id: string; displayName: string } 
  * directory is what decided the account's state, which addresses are one
  * account, and which person holds it, and a write that answered those questions
  * a second way could refuse what the guardian is looking at, or dismiss an
- * addressing of an account it is not allowed to touch.
+ * address of an account it is not allowed to touch.
  */
 async function locate(
   deps: AccountDecisionDeps,

--- a/packages/core/src/people/account-directory.ts
+++ b/packages/core/src/people/account-directory.ts
@@ -3,14 +3,14 @@
 // links the guardian has made, the sentinel log's senders, and the address
 // books Rome mirrors.
 //
-// An account is one person on one channel, whatever addressings that channel
+// An account is one person on one channel, whatever addresses that channel
 // reaches them at. Which of them fold together is the channel's own answer,
 // read once through `AccountFold` (../channels/account-fold.ts), so nothing
 // here is channel-specific and adding a mirror changes nothing in this file.
 //
 // Two reads, because the two surfaces ask two questions — "who does Rome know"
 // and "who has something new". They fold the same address books to decide which
-// addressings are one account, and only the stream goes on to read a history.
+// addresses are one account, and only the stream goes on to read a history.
 
 import {
   accountPresentation,
@@ -22,7 +22,7 @@ import {
 } from "@rome/api-types/people";
 import { STRANGER_PERSON_ID } from "../constants.js";
 import type { AccountNames } from "../channels/account-names.js";
-import { foldAccounts, mirrorRegistry } from "../channels/account-fold.js";
+import { foldAccounts, addressBookRegistry } from "../channels/account-fold.js";
 import type { Accounts } from "../channels/accounts.js";
 import type { DrizzleDb } from "../db/index.js";
 import type { PersonMappingRepository } from "../db/repositories/person-mapping.js";
@@ -52,7 +52,7 @@ interface AccountLink {
  * Every account there is, unordered and unfiltered — the whole directory a page
  * is cut out of (`sliceAccountDirectory`).
  *
- * Whole rather than paged: the fold that decides which addressings are one
+ * Whole rather than paged: the fold that decides which addresses are one
  * account needs every address book entire, and an account past a channel's own
  * cutoff is one the guardian cannot find and no count includes. The cost is one
  * read of each address book for the fold and one more to name what it found.
@@ -173,7 +173,7 @@ async function observeAccounts(deps: AccountDirectoryDeps): Promise<DirectoryAcc
   const mappings = persons.flatMap((person) =>
     person.channelMappings.map((mapping) => ({ ...mapping, person })),
   );
-  const fold = await foldAccounts(mirrorRegistry(deps), { stored: [...senders, ...mappings] });
+  const fold = await foldAccounts(addressBookRegistry(deps), { stored: [...senders, ...mappings] });
 
   /** Who holds each account, decided once before any row is built. */
   const linkOf = new Map<string, AccountLink>();
@@ -191,7 +191,7 @@ async function observeAccounts(deps: AccountDirectoryDeps): Promise<DirectoryAcc
         channel,
         channelUserId: own,
         // A channel with no address book can say nothing about which
-        // addressings are the same account, so an address it named is an
+        // addresses are the same account, so an address it named is an
         // account of its own.
         addresses: [...(addresses ?? [own])].sort(compareCodePoints),
       });
@@ -227,9 +227,9 @@ async function observeAccounts(deps: AccountDirectoryDeps): Promise<DirectoryAcc
  * Whether a claim on an account beats the one already held.
  *
  * A real person outranks the stranger sentinel. The unique index already holds
- * one mapping per identifier, but two mappings can name two addressings of one
+ * one mapping per identifier, but two mappings can name two addresses of one
  * account, and that account is one row: a placement the guardian made is what
- * it should say, and reading the dismissal of a second addressing instead would
+ * it should say, and reading the dismissal of a second address instead would
  * hide someone they already placed. Among real people the lowest id wins, so
  * the answer does not depend on read order.
  */

--- a/packages/core/src/people/activity.ts
+++ b/packages/core/src/people/activity.ts
@@ -43,7 +43,7 @@ export async function readPeopleActivity(
   // One summary per person per store, over every account of theirs that store
   // owns — not one per account. A store reads a set of accounts as a single
   // history, so this is the same read the page makes, and a message that two
-  // addressings of a person both name is one message in both.
+  // addresses of a person both name is one message in both.
   const summaries = accountsByPerson.flatMap((accounts, person) => {
     const byStore = new Map<Messages, MessageAccount[]>();
     for (const account of accounts) {

--- a/packages/core/src/people/resource.ts
+++ b/packages/core/src/people/resource.ts
@@ -65,7 +65,7 @@ async function serialize(
   // One mapping is one account on the wire, so a client can address the link
   // it sees. The activity fold is the one place two mappings of a single
   // account collapse — reporting one person's history twice would be a wrong
-  // number, whereas showing both addressings is only what the guardian stored.
+  // number, whereas showing both addresses is only what the guardian stored.
   const refs = persons.flatMap((person) => person.channelMappings);
 
   // Independent of each other, and both reach the same channel mirrors: read

--- a/packages/core/src/people/timeline-sources.test.ts
+++ b/packages/core/src/people/timeline-sources.test.ts
@@ -31,7 +31,7 @@ const adaLid = "77770001@lid";
 const grace = "12025550111@s.whatsapp.net";
 
 describe("timelineAccounts", () => {
-  it("collapses two addressings of one account onto one account", async () => {
+  it("collapses two addresses of one account onto one account", async () => {
     const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid])]);
 
     const [accounts] = await timelineAccounts({ whatsAppAccounts }, [
@@ -79,7 +79,7 @@ describe("timelineAccounts", () => {
     expect(accounts).toEqual([{ channel: "whatsapp", addresses: ["12025550999@s.whatsapp.net"] }]);
   });
 
-  it("gives a channel with no account plane the mapping's own address", async () => {
+  it("gives a channel with no address book the link's own address", async () => {
     const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid])]);
 
     const [accounts] = await timelineAccounts({ whatsAppAccounts }, [

--- a/packages/core/src/people/timeline-sources.ts
+++ b/packages/core/src/people/timeline-sources.ts
@@ -2,9 +2,11 @@
 // account in. The stores themselves are the channels' — one `Messages` adapter
 // each, in channels/ — and the merge over them is timeline.ts's.
 //
-// Also the fold from a person's channel mappings to the accounts those stores
-// are read for, since the two are the same question asked of one channel: which
+// Also the fold from a person's links to the accounts those stores are read
+// for, since the two are the same question asked of one channel: which
 // addresses are one account, and what was said at them.
+//
+// Vocabulary: docs/concepts/people.md.
 //
 // Direct threads only. Each store scopes itself by the account's own addresses,
 // so a group conversation — addressed by the group rather than by the person —
@@ -46,15 +48,15 @@ export function personMessageStores(deps: { db: DrizzleDb }): Messages[] {
 }
 
 /**
- * Every account each group of mappings is reachable at, with every address the
- * channel folds onto it — one result per group, in the order given.
+ * Every account each group of linked addresses is reachable at, with every
+ * address the channel folds onto it — one result per group, in the order given.
  *
- * Two mappings that name two addressings of one account collapse to one
- * account, so a person mapped under both a WhatsApp phone JID and its `@lid`
- * form reads one timeline rather than two halves of one.
+ * Two links that name two addresses of one account collapse to one account, so
+ * a person linked under both a WhatsApp phone JID and its `@lid` form reads one
+ * timeline rather than two halves of one.
  *
- * A channel with no account plane contributes the mapping's own address and
- * nothing else, which is all the channel can say about who it can reach.
+ * A channel with no address book contributes the link's own address and nothing
+ * else, which is all the channel can say about who it can reach.
  *
  * Positional and over every group at once, like `AccountNames.displayNames`
  * next door: each channel's address book costs a full read, so one caller
@@ -62,14 +64,16 @@ export function personMessageStores(deps: { db: DrizzleDb }): Messages[] {
  */
 export async function timelineAccounts(
   deps: { whatsAppAccounts: AddressBook },
-  groups: readonly (readonly ChannelMapping[])[],
+  groups: readonly (readonly LinkedAddress[])[],
 ): Promise<TimelineAccount[][]> {
-  const channels = new Set(groups.flatMap((group) => group.map((mapping) => mapping.channel)));
+  const channels = new Set(groups.flatMap((group) => group.map((link) => link.channel)));
   const books = await readAddressBooks(deps, channels);
   return groups.map((group) => foldAccounts(books, group));
 }
 
-interface ChannelMapping {
+/** One address a link names. `channelUserId` is the account's own address —
+ *  the wire field's name, kept because the column and the contract carry it. */
+interface LinkedAddress {
   channel: string;
   channelUserId: string;
 }
@@ -82,22 +86,22 @@ type AddressBook = Accounts;
 /** Each channel's accounts, indexed the two ways the fold reads them: which
  *  account an address belongs to, and every address of that account.
  *
- *  Read only for the channels the mappings name, since a plane costs a full
- *  address-book read. LinkedIn has a plane too but is deliberately absent: it
- *  stores a member under its member id and nothing else, so folding it would
- *  buy a whole mirror read and change no answer. It joins here when it starts
- *  storing a second addressing. */
+ *  Read only for the channels the links name, since an address book costs a
+ *  full read. LinkedIn has one too but is deliberately absent: it stores a
+ *  member under its member id and nothing else, so folding it would buy a whole
+ *  read and change no answer. It joins here when it starts storing a second
+ *  address. */
 async function readAddressBooks(
   deps: { whatsAppAccounts: AddressBook },
   channels: ReadonlySet<string>,
 ): Promise<Map<string, FoldedBook>> {
-  const planes = new Map<string, AddressBook>([["whatsapp", deps.whatsAppAccounts]]);
+  const known = new Map<string, AddressBook>([["whatsapp", deps.whatsAppAccounts]]);
   const books = new Map<string, FoldedBook>();
-  for (const [channel, accounts] of planes) {
+  for (const [channel, accounts] of known) {
     if (!channels.has(channel)) continue;
     // One page big enough to hold the listing: its order is stable but the
-    // listing under it is not, so walking cursors across a live mirror would
-    // skip or repeat an account as an inbound message reordered it.
+    // listing under it is not, so walking cursors across a live address book
+    // would skip or repeat an account as an inbound message reordered it.
     const { accounts: listing } = await accounts.listAccounts({ limit: WHOLE_LISTING });
     const of = new Map<string, string>();
     const folded = new Map<string, string[]>();
@@ -123,17 +127,17 @@ interface FoldedBook {
 
 function foldAccounts(
   books: Map<string, FoldedBook>,
-  mappings: readonly ChannelMapping[],
+  links: readonly LinkedAddress[],
 ): TimelineAccount[] {
   const byAccount = new Map<string, TimelineAccount>();
-  for (const mapping of mappings) {
-    const book = books.get(mapping.channel);
-    const accountId = book?.of.get(mapping.channelUserId) ?? mapping.channelUserId;
-    const key = `${mapping.channel}\n${accountId}`;
+  for (const link of links) {
+    const book = books.get(link.channel);
+    const accountId = book?.of.get(link.channelUserId) ?? link.channelUserId;
+    const key = `${link.channel}\n${accountId}`;
     if (byAccount.has(key)) continue;
     byAccount.set(key, {
-      channel: mapping.channel,
-      addresses: [...new Set([mapping.channelUserId, ...(book?.folded.get(accountId) ?? [])])],
+      channel: link.channel,
+      addresses: [...new Set([link.channelUserId, ...(book?.folded.get(accountId) ?? [])])],
     });
   }
   return [...byAccount.values()];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -78,6 +78,14 @@ export interface AgentSession {
   status: "active" | "completed" | "error";
 }
 
+/**
+ * A person and the accounts linked to them.
+ *
+ * `channelMappings` keeps the table's and the wire's name — a channel mapping is
+ * a [link](docs/concepts/people.md#link), and `channelUserId` is the account's
+ * own [address](docs/concepts/people.md#address) — because
+ * `@rome-os/app-runtime` publishes the field to apps.
+ */
 export interface PersonMapping {
   id: string;
   displayName: string;

--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -47,7 +47,7 @@ import {
  * The /people contract — Person, Account, Link — over the fixture store in
  * ./people.ts, so a link made here is visible to the channel thread the mirror
  * endpoints open. Wire types and route map: `@rome/api-types/people`;
- * vocabulary: docs/concepts/identity.md.
+ * vocabulary: docs/concepts/people.md.
  *
  * Mock mode's implementation of the same surface core serves
  * (`packages/core/src/api/routes/people.ts` and `.../accounts.ts`), typed

--- a/packages/web/mock/handlers/people.ts
+++ b/packages/web/mock/handlers/people.ts
@@ -145,8 +145,8 @@ interface PersonFixture {
 /**
  * What a contact row actually stores: address-book facts, and nothing derived.
  *
- * The five omitted fields are all projections on the real API — the identity
- * pair is a join onto `channel_mappings`, and the summary trio is a subquery
+ * The five omitted fields are all projections on the real API — the pair
+ * naming the account is a join onto `channel_mappings`, and the summary trio is a subquery
  * over `wa_messages`. Storing any of them here would let a link or a send leave
  * the card disagreeing with the thread behind it, which is the one thing these
  * fixtures exist to keep honest.
@@ -252,9 +252,9 @@ type SentinelRow = {
   lastMessageAt: number | null;
   reply?: string;
   /** This log row's own id. A timeline `ref` has to be unique across
-   *  everything one source contributes to a person, and one channel
-   *  identity can hold several log rows, so the refs key on this rather
-   *  than on the channel identity those rows share. */
+   *  everything one source contributes to a person, and one account can hold
+   *  several log rows, so the refs key on this rather than on the account those
+   *  rows share. */
   logId: string;
 };
 
@@ -331,9 +331,9 @@ export const sentinelSenders: SentinelRow[] = (
     },
     {
       // A second log row for 林晓, newer than the one above. The log keys on the
-      // exchange rather than the sender, so one identity can hold several — and
+      // exchange rather than the sender, so one account can hold several — and
       // a reader that takes the first would preview an older line than the one
-      // sitting at the top of this identity's own timeline.
+      // sitting at the top of this account's own timeline.
       channel: "feishu",
       channelUserId: "ou_9f21c04ab7",
       displayName: "林晓",
@@ -613,7 +613,7 @@ export function summarize(
   };
 }
 
-/** The person a channel identity currently maps to, or `undefined` while it is
+/** The person an account currently maps to, or `undefined` while it is
  *  still unmapped. The `channel_mappings` lookup both the unknown-sender query
  *  and the contacts join run. */
 export function ownerOf(channel: string, channelUserId: string): PersonFixture | undefined {
@@ -691,7 +691,7 @@ function timelineForChannels(channels: AccountRef[]): TimelineEntry[] {
       const mirrored = threads[jid] ?? [];
       // The sentinel recorded the same arrival the mirror holds, so the two are
       // alternatives rather than additions. With no mirrored thread the
-      // sentinel is all there is, and skipping it leaves an identity that has
+      // sentinel is all there is, and skipping it leaves an account that has
       // plainly messaged with an empty timeline, a null `latest`, and no place
       // in the Unknown count.
       if (mirrored.length === 0) {
@@ -700,7 +700,7 @@ function timelineForChannels(channels: AccountRef[]): TimelineEntry[] {
       }
       for (const message of mirrored) {
         // A reaction is not its own dynamic — `summarize` skips them when it
-        // picks `latest`, so carrying them here would let one identity report
+        // picks `latest`, so carrying them here would let one account report
         // two different newest things. Whether the page renders them against
         // the line they answer is the page rebuild's call.
         if (message.type === "reaction") continue;
@@ -710,7 +710,7 @@ function timelineForChannels(channels: AccountRef[]): TimelineEntry[] {
           body: message.text,
           direction: message.fromMe ? "outbound" : "inbound",
           // A WhatsApp message id is unique within its chat, and a person can
-          // hold several WhatsApp identities, so the chat qualifies it into
+          // hold several WhatsApp accounts, so the chat qualifies it into
           // the source-global ref the contract asks for.
           ref: `${jid}:${message.id}`,
         });
@@ -722,7 +722,7 @@ function timelineForChannels(channels: AccountRef[]): TimelineEntry[] {
   return entries.sort(compareTimelineEntries);
 }
 
-/** Every sentinel log row for one channel identity, as timeline entries. */
+/** Every sentinel log row for one account, as timeline entries. */
 function sentinelEntriesFor(mapping: AccountRef): TimelineEntry[] {
   const entries: TimelineEntry[] = [];
   for (const sender of sentinelSenders) {

--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -116,7 +116,6 @@
     "back": "People",
     "bond": "Bond",
     "linkAccount": "Link account…",
-    "linkNeedsPerson": "Place this identity on the bond ladder first, then link accounts to it",
     "timeline": "Timeline",
     "timelineEmpty": "Nothing has happened on any channel yet.",
     "loadOlder": "Load older",
@@ -126,7 +125,7 @@
     "composerLabel": "Message text",
     "composerPlaceholder": "Message {{name}}…",
     "missingTitle": "That person is not here",
-    "missingBody": "The identity may have been merged into someone else. Head back to People to find them.",
+    "missingBody": "This person may have been merged into someone else. Head back to People to find them.",
     "linkDescription": "The account you pick starts resolving to this person, and its history joins this timeline.",
     "noAccounts": "No accounts yet"
   },

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -116,7 +116,6 @@
     "back": "人物",
     "bond": "亲密度",
     "linkAccount": "关联账号…",
-    "linkNeedsPerson": "请先把这个身份安置到亲密度阶梯上，然后再为它关联账号",
     "timeline": "时间线",
     "timelineEmpty": "各个渠道都还没有任何往来。",
     "loadOlder": "加载更早",
@@ -126,7 +125,7 @@
     "composerLabel": "消息内容",
     "composerPlaceholder": "给 {{name}} 发消息…",
     "missingTitle": "找不到这个人",
-    "missingBody": "该身份可能已被合并到其他人名下。返回人物页面即可找到他们。",
+    "missingBody": "该人物可能已被合并到其他人名下。返回人物页面即可找到他们。",
     "linkDescription": "你选择的账号将归属到此人名下，其历史记录也会并入这条时间线。",
     "noAccounts": "暂无账号"
   },

--- a/packages/web/src/pages/PeoplePage.test.tsx
+++ b/packages/web/src/pages/PeoplePage.test.tsx
@@ -164,7 +164,7 @@ const LINKED_ACCOUNT: WorldAccount = {
 
 /** A LinkedIn sender nobody has placed. LinkedIn had a section of its own on
  *  this page while its threads reached no account read; it has an accounts
- *  plane now, so it arrives here as a sender like any other and is placed by
+ *  address book now, so it arrives here as a sender like any other and is placed by
  *  the same gesture. */
 const LINKEDIN_SENDER: WorldAccount = {
   channel: "linkedin",

--- a/packages/web/src/pages/PeoplePage.test.tsx
+++ b/packages/web/src/pages/PeoplePage.test.tsx
@@ -771,7 +771,7 @@ describe("PeoplePage placement", () => {
     await waitFor(() => expect(screen.queryByText("Rachel Lim")).toBeNull());
     expect(within(chip(/^Unknown/)).queryByText(/^\d+$/)).toBeNull();
     const dismiss = calls.find((c) => c.url.includes("/dismiss"))!;
-    // Named by the pair the contract says is the account's identity, so every
+    // Named by the pair the contract names the account with, so every
     // address it answers to travels with it.
     expect(dismiss.url).toBe("/api/accounts/whatsapp/6591234472%40s.whatsapp.net/dismiss");
   });

--- a/packages/web/src/pages/PeoplePage.tsx
+++ b/packages/web/src/pages/PeoplePage.tsx
@@ -26,7 +26,7 @@ import { usePeopleRoster } from "./people/use-roster";
 /**
  * The People page: an activity stream and a roster, over two reads.
  *
- * Latest answers "who has something new" — one row per identity with a
+ * Latest answers "who has something new" — one row per account with a
  * dynamic, newest first, carrying only what routing needs. Directory answers
  * "who does Rome know" — a contacts list, everyone Rome holds, by name, with no
  * preview and no count anywhere in it. Unknown and Stranger are positions on

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -15,7 +15,7 @@ import {
 import i18n from "@/i18n";
 import PersonDetailPage from "./PersonDetailPage";
 
-// The person page: identity on top, the merged timeline below. What is under
+// The person page: who they are on top, the merged timeline below. What is under
 // test is that the page reads the two routes that own it — `GET /api/people/:id`
 // and `GET /api/people/:id/messages` — and that the timeline it renders is
 // channel-blind: a Telegram entry renders the way a WhatsApp one does, grouped
@@ -474,7 +474,7 @@ describe("PersonDetailPage management", () => {
     });
     expect(link.method).toBe("POST");
     // One call, and it names the account by the pair the contract says is its
-    // identity — every address it answers to travels with it.
+    // account — every address it answers to travels with it.
     expect(link.body).toEqual({
       channel: "whatsapp",
       channelUserId: "6591234472@s.whatsapp.net",

--- a/packages/web/src/pages/PersonDetailPage.tsx
+++ b/packages/web/src/pages/PersonDetailPage.tsx
@@ -15,7 +15,7 @@ import { usePerson, usePersonTimeline } from "./people/use-roster";
 /**
  * One person's page: the dossier.
  *
- * Identity on top — name, bond, the accounts that resolve to this person — then
+ * Who they are on top — name, bond, the accounts that resolve to this person — then
  * the merged timeline of everything said on any of them, grouped by day.
  * Timeline entries are generic, so a channel Rome learns about later shows up
  * here without a change to this page.

--- a/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
+++ b/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
@@ -193,7 +193,7 @@ const STREAM: PeopleRow[] = [
   }),
 ];
 
-/** One row per identity, newest first, carrying only what routing needs. */
+/** One row per account, newest first, carrying only what routing needs. */
 export function StreamDemo() {
   return (
     <Frame label="Latest">
@@ -393,7 +393,7 @@ export function ViewSwitcherDemo() {
 
 /* ------------------------------------------------------------ person page */
 
-/** The dossier: identity card with bond select and linked-account pills, the
+/** The dossier: the person card with bond select and linked-account pills, the
  *  merged timeline grouped by day, a sticky composer. */
 export function PersonPageDemo() {
   const { t } = useTranslation("people");

--- a/packages/web/src/pages/dev/mdx/docs/people-page.mdx
+++ b/packages/web/src/pages/dev/mdx/docs/people-page.mdx
@@ -68,7 +68,7 @@ when senders are waiting.
 
 ## Latest — the stream
 
-One row per identity, newest first, carrying only what routing needs: neutral avatar,
+One row per account, newest first, carrying only what routing needs: neutral avatar,
 name, monochrome source glyph, one line of preview, relative time.
 
 <Specimen title="Stream rows">
@@ -130,7 +130,7 @@ here that it carries on the stream, at the end of its row.
 
 ## The person page
 
-`/people/:personId` is the dossier: identity card with bond select, linked accounts
+`/people/:personId` is the dossier: the person card with bond select, linked accounts
 as neutral glyph + id pills, `Link account…` and `Merge into…`. The merged timeline
 grouped by day sits below it, and a sticky composer sits at the bottom.
 

--- a/packages/web/src/pages/people/people-api.test.ts
+++ b/packages/web/src/pages/people/people-api.test.ts
@@ -109,7 +109,7 @@ test("proposed /people contract walkthrough", async () => {
     { channel: "whatsapp", channelUserId: DEV_JID, displayName: expect.any(String) },
   ]);
 
-  // Link a second account — an unseen LinkedIn identity; linking does not
+  // Link a second account — an unseen LinkedIn account; linking does not
   // require the account to have been observed first. Re-link is idempotent.
   r = await call("POST", `/api/people/${devikaId}/accounts`, {
     channel: "linkedin",

--- a/packages/web/src/pages/people/people-contract.test.ts
+++ b/packages/web/src/pages/people/people-contract.test.ts
@@ -30,10 +30,6 @@ import { protectedPersonReason, STRANGER_PERSON_ID } from "@rome/api-types/perso
 // that does not escape its parts, a search that does not normalize: none of
 // those show up as a failure in the surface that calls them, only as a wrong
 // answer.
-//
-// Previously `identity-contract.test.ts`, against the identity union. The union
-// is retired; these are the rules that outlived it, repointed at the module
-// they live in now.
 
 const entry = (over: Partial<TimelineEntry> = {}): TimelineEntry => ({
   source: "whatsapp",

--- a/packages/web/src/pages/people/people-model.test.ts
+++ b/packages/web/src/pages/people/people-model.test.ts
@@ -87,7 +87,7 @@ describe("peopleRows", () => {
 
   it("leaves a linked account to the person it resolves to", () => {
     // The account and the person are the same human seen from two sides. Two
-    // rows is the duplication the one-row-per-identity rule exists to remove —
+    // rows is the duplication the one-row-per-account rule exists to remove —
     // and the person is the row that can carry a bond.
     const rows = peopleRows(
       [person()],
@@ -105,9 +105,9 @@ describe("peopleRows", () => {
     expect(rows[0].kind).toBe("person");
   });
 
-  it("carries every addressing the server folded onto one account", () => {
+  it("carries every address the server folded onto one account", () => {
     // The `@lid` consolidation is the contract's `addresses`: the server decides
-    // which addressings are one account, and the client renders what it decided.
+    // which addresses are one account, and the client renders what it decided.
     const rows = peopleRows(
       [],
       [

--- a/packages/web/src/pages/people/people-model.ts
+++ b/packages/web/src/pages/people/people-model.ts
@@ -23,7 +23,7 @@ import {
 // The contract is two nouns — a person (`GET /api/people`) and an account
 // somebody is reachable at (`GET /api/accounts`) — and this page is one ladder
 // over both. `PeopleRow` is that join: the shape a row renders from, whichever
-// noun it came from. Everything channel-shaped about it — which addressings are
+// noun it came from. Everything channel-shaped about it — which addresses are
 // one account, what the channel calls it, how much is on record — is the
 // server's answer carried through, not a rule restated here.
 
@@ -228,7 +228,7 @@ export function rowMatchesFilter(row: PeopleRow, filter: PeopleFilter): boolean 
 }
 
 /**
- * The stream: one row per identity that has a dynamic, newest first, over both
+ * The stream: one row per account that has a dynamic, newest first, over both
  * nouns at once.
  *
  * The reader is asking who has something new, and whether Rome has placed the

--- a/packages/web/src/pages/people/rows.tsx
+++ b/packages/web/src/pages/people/rows.tsx
@@ -121,7 +121,7 @@ export function UnknownRow({ row, actions }: { row: PeopleRow; actions?: React.R
 }
 
 /**
- * A directory row is identity only: avatar, name, and the identifier the person
+ * A directory row says who only: avatar, name, and the identifier the person
  * is recognized by. Nothing about what anyone said — the directory read carries
  * none of it, which is what makes this a contacts list rather than a second
  * stream. Clicking a person opens their dossier; an account has none to open
@@ -152,7 +152,7 @@ export function DirectoryRow({
   const fixed = isRowFixed(row);
   const handle = rowHandle(row);
 
-  const identity = (
+  const who = (
     <>
       <span className="block truncate text-ui text-foreground">{row.displayName}</span>
       <span className="block truncate text-aux text-muted-foreground">
@@ -192,10 +192,10 @@ export function DirectoryRow({
       )}
       {onOpen && !fixed ? (
         <button type="button" onClick={onOpen} className="min-w-0 text-left">
-          {identity}
+          {who}
         </button>
       ) : (
-        <span className="min-w-0">{identity}</span>
+        <span className="min-w-0">{who}</span>
       )}
       <span className="flex items-center justify-end gap-2">{actions}</span>
     </div>

--- a/packages/web/src/pages/people/triage.tsx
+++ b/packages/web/src/pages/people/triage.tsx
@@ -36,7 +36,7 @@ import type { PeopleRow, PeopleView } from "./people-model";
 // there is no target list to enumerate and nothing here has to know which moves
 // a row admits.
 //
-// A gesture names the account by the pair the contract says is its identity,
+// A gesture names the account by the pair the contract names it with,
 // never by one of the addresses it answers to: the server folds a WhatsApp
 // contact's phone jid and `@lid` jid into one account, so one call already
 // covers every address the row stands for.

--- a/packages/web/src/pages/people/writes.ts
+++ b/packages/web/src/pages/people/writes.ts
@@ -14,7 +14,7 @@ import type {
 // only names the route and reduces the answer to something a click handler can
 // render.
 //
-// An account is named by the pair the contract says is its identity, never by
+// An account is named by the pair the contract names it with, never by
 // one of the addresses it answers to. The server folds a WhatsApp contact's
 // phone jid and `@lid` jid into one account and reports both in `addresses`, so
 // a gesture on a row already covers every address it stands for — the reason


### PR DESCRIPTION
Closes #70.

## What this PR does

The People migration settled on six nouns — person, account, address, link, message, channel — but the names lagged the model. `docs/concepts/identity.md` still grouped the person, account and link entries under the union noun the two-noun contract replaced. `account-fold.ts` still spoke of mirrors and planes. "Addressing" ran alongside "address" as a second word for one thing, and a handful of identifiers named an account "identity" and an address "identity" in the same file.

One sweep over `packages/*/src` and `docs/`, with every hit either renamed or exempted in place with the mapping stated.

### The grep list

Retired nouns of the migration, run over identifiers, file names, and prose. Every hit is renamed below, exempted below, or another sense of the same word:

| Pattern | Disposition |
|---|---|
| `IdentityCursor\|IdentityDynamic\|identityCursorOf` | Already gone (#89) — the sweep confirms it |
| `MirrorPlane\|TalkAccount\|TimelineSource\|listActivity\|foldAccountRecords\|AccountRecord\|listAddresses` | Already gone (#100) |
| `Mirror(Account\|Planes)\|mirrorRegistry\|mirrorFor\|readPlane` | Renamed |
| `account plane\|message plane\|planes` | Renamed |
| `identit` in the people domain | Renamed |
| `addressing` | Renamed |
| `mapping` (the deprecated alias of *link*) | Exempted, mapping stated |

`identity` names five other concepts — instance identity, caller identity, dashboard identity, an agent's identity, a build's identity — each with its own entry or its own domain. The sweep is defined by sense, not by path: a file qualifies when it carries both `identit` and a people-domain marker (`channelUserId`, `channel_mappings`, `personId`, `bondLevel`, `DirectoryAccount`, `linkedin_participants`, …). Scoping it by path instead is what let the first pass miss the LinkedIn participant store, the WhatsApp contact fold, and several tests; the second commit closes that.

### Docs

`concepts/identity.md` becomes `concepts/people.md`, and every link and anchor across `docs/`, core, and the dashboard mock follows. `Persons` becomes `Person`, matching its singular neighbours. **Address** enters as an entry: the Account entry stated its own contract in the retired "platform user ID" terms, and the exempt wire field needs a definition to point at. Deprecated aliases are recorded in their entries — *platform identity* on Account, *channel mapping* on Link, *channel user id* on Address.

### Code

`MirrorAccount` → `FoldedAccount`, `MirrorPlanes` → `AddressBooks`, `mirrorRegistry` → `addressBookRegistry`, `AccountFold.mirrorFor` → `accountFor`, `readPlane(s)` → `readAddressBook(s)`. `staleIdentity` → `staleAddress`, which is what it returns. `identityKey` → `accountKey` and `consolidateByIdentity` → `consolidateByAccount` in the WhatsApp store, where the fold keys one account's two addresses. `LinkedInIdentity` → `LinkedInWhoami`. "Addressing" becomes "address" across the people and channel surfaces.

### File names

Audited with the same list. Five people-domain names stay, each because it is named for a contract rather than for a retired noun:

| File | Named for |
|---|---|
| `db/repositories/person-mapping.ts` | the `channel_mappings` table |
| `channels/guardian-mapping.ts` | the same |
| `db/ensure-sentinel-persons.ts` | the `persons` table |
| `db/channel-identity-dedup-migration.test.ts` | `idx_channel_mappings_identity`, the index it pins |
| `rome_apps/system/…/add-person-mapping/` | the `add_person_mapping` action id agents call |

`packages/api-types/src/persons.ts` is a finding this PR does **not** act on — see *Not in this PR*.

## Design & Invariants

**The rename stops where the contract starts.** Exemptions carry the mapping in the doc comment beside them rather than a rename: the `channel_mappings` table with its columns and index, `PersonRecord.channelMappings`, the `PersonMappingRepository` and `ChannelMappingRecord` interfaces `@rome-os/app-runtime` publishes, the `person_mapping` approval type, the `persons` table, and `channelUserId` on the wire and in the path.

`PersonMappingRepository` is the load-bearing one, and it is exempted rather than renamed. It is named for the table it wraps, and the SDK publishes an interface of the same name that it must structurally satisfy. Renaming core's class alone would leave two names for one thing — the outcome the sweep exists to remove — and renaming both is a breaking release for a noun the concepts entry already records as a deprecated alias.

Nothing here changes behavior. `@rome-os/app-runtime` gains doc comments only, so the type stays `refactor:` and the package does not bump.

## Trim pass

- **Concepts entries.** Guardian, Visitor, Person, Account, Link, Bond levels each re-checked against the [admission bar](docs/authoring/concepts.md#admission). All still hold: each is used on code, docs and UI copy, and each carries a contract a diff could break silently. Nothing qualifies for eviction. Address is the one addition.
- **Entry candidates.** The list was read through. No candidate is a people noun, none has become an entry, and none has stopped being confusing enough to list. Address was not on it — the sweep surfaced it.
- **Copy.** `detail.linkNeedsPerson` is referenced nowhere and is deleted from both locales rather than swept.

## Test plan

- [x] `pnpm typecheck` — passes across the workspace.
- [x] `pnpm test:unit` — 6086 tests pass, none changed in substance.
- [x] The grep list rerun over `packages/*/src`, `docs/`, and `git ls-files` — every remaining hit is another sense of the word or a recorded exemption.
- [x] Concept anchors verified: every `people.md#…` reference resolves to a heading in the renamed file.
- [x] `biome check` — clean over the touched packages.
- [ ] `pnpm dev:all` — not run. No wiring and no runtime path changes; the diff is names and prose.

## Not in this PR

- **`packages/api-types/src/persons.ts` sitting beside `people.ts`.** Not a retired noun — "persons" is the settled noun's plural and the table's name — but two modules in one directory whose names do not distinguish them, which is the same miss one layer up. It holds the person-id derivation and the protected-row rules, so a name saying that would beat either. Deferred because it is a different finding from the one #70 states, and it moves a package subpath export plus seven importers.
- The channel-interface concepts doc (#101) — Accounts, Messages, and the law binding `read`/`count`/`latest` have no entry. The sweep points `accounts.ts` and `account-fold.ts` at `people.md` for vocabulary in the meantime.
- Renaming the `channel_mappings` table and the SDK's mapping interfaces, which needs a migration and a breaking release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)