### PR TITLE
chore: add the respond-to-review skill

### DIFF
--- a/.claude/skills/respond-to-review/SKILL.md
+++ b/.claude/skills/respond-to-review/SKILL.md
@@ -74,17 +74,4 @@ Declining:
 
 Routing: link the follow-up issue in the reply, with one line on why it is separate work.
 
-## Signals
-
-| Signal in the finding | Verdict |
-|---|---|
-| Contradicts a claim the PR description makes | Real — run Test 5 |
-| Names an existing consumer of changed code (shared component, pooled worker) | Real — fix |
-| Comes with a concrete failure sequence you can script | Real — fix |
-| Presented by the bot as optional or non-blocking | Decline |
-| Restates a "Not in this PR" item or documented tradeoff | Decline |
-| Needs a caller, input, or implementation that does not exist | Decline |
-| Defect also present on `main` without this diff | Follow-up issue |
-| "Also fix these other places" | Follow-up issue |
-
 A "Not in this PR" line or a stated tradeoff in the PR description turns a finding into a one-sentence decline. Write those sections before requesting review.

--- a/.claude/skills/respond-to-review/SKILL.md
+++ b/.claude/skills/respond-to-review/SKILL.md
@@ -11,15 +11,7 @@ Classification precedes code. Never start implementing a finding before classify
 
 ## Phase 1 — Gather and dedupe
 
-Pull every review body and inline comment on the PR:
-
-```bash
-REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-gh pr view <PR> -R "$REPO" --json reviews --jq '.reviews[] | "[\(.author.login) / \(.state)]\n\(.body)"'
-gh api "repos/$REPO/pulls/<PR>/comments" --paginate --jq '.[] | "[\(.user.login) on \(.path):\(.line // .original_line)]\n\(.body)"'
-```
-
-1. Drop reviews marked "This review has been superseded."
+1. Pull every review body and inline comment on the PR. Drop reviews marked "This review has been superseded."
 2. Merge duplicate findings — same file, same defect — into one item. Post the answer once and cross-link it from the other thread.
 3. Discard the bots' severity labels and verdicts. Phase 2 re-derives priority.
 

--- a/.claude/skills/respond-to-review/SKILL.md
+++ b/.claude/skills/respond-to-review/SKILL.md
@@ -7,7 +7,7 @@ description: Triage and answer automated code-review findings on a PR without gr
 
 Goal end-state: every finding on the PR has exactly one of four answers — a minimal fix with a test, a corrected claim in the PR description, a follow-up issue, or a written decline. The PR's diff grows as little as possible.
 
-The bots present real defects and noise in the same authoritative voice. The default response to a finding is to add code — for an input nothing produces, a caller that does not exist, or a scope the PR excluded on purpose. So classification precedes code. Never start implementing a finding before classifying it.
+The bots present real defects and noise in the same authoritative voice. Classification precedes code. Never start implementing a finding before classifying it.
 
 ## Phase 1 — Gather and dedupe
 

--- a/.claude/skills/respond-to-review/SKILL.md
+++ b/.claude/skills/respond-to-review/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: respond-to-review
+description: Triage and answer automated code-review findings on a PR without growing its scope. Use when the user asks to "handle / address / respond to review feedback", "go through the bot comments", or after the RomeOS review bots (zoolsher, Jessie-QingYu) post findings on a PR. The core discipline — classify every finding BEFORE writing any code; most findings deserve a reply, not a diff. NOT for requesting a review (that is /code-review) and NOT for reviewing someone else's PR.
+---
+
+# Respond to review feedback
+
+Goal end-state: every review finding on the PR has exactly one of four answers — a minimal fix with a test, a corrected claim in the PR description, a follow-up issue, or a written decline — and the PR's diff grew as little as possible.
+
+The review bots are worth reading and dangerous to obey. Measured over 18 recent PRs (#84–#115): ~43 findings, of which 8–10 were real and worth code. Every P3 was safe to decline. The bots present the noise in the same authoritative voice as the signal, and an agent's default response to any finding is to add code — for a rare input, a caller that does not exist, or a scope the PR deliberately excluded. This skill exists to replace that default with judgment.
+
+**The prime rule: classification precedes code. Never start implementing a finding you have not classified.**
+
+## Phase 1 — Gather and dedupe
+
+Pull every review body and inline comment on the PR:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+gh pr view <PR> -R "$REPO" --json reviews --jq '.reviews[] | "[\(.author.login) / \(.state)]\n\(.body)"'
+gh api "repos/$REPO/pulls/<PR>/comments" --paginate --jq '.[] | "[\(.user.login) on \(.path):\(.line // .original_line)]\n\(.body)"'
+```
+
+- Drop reviews marked "This review has been superseded."
+- The two bots overlap. Merge duplicate findings (same file, same defect) into one item; the answer will be posted once and cross-linked from the other thread.
+- **Discard the bot's severity labels and verdicts.** A P1 REQUEST_CHANGES has been scope expansion; a P2 has been the realest bug in the batch (#86, #91). Severity is re-derived in Phase 2, from evidence.
+
+## Phase 2 — Classify every finding
+
+Run each finding through these tests, in order. The first test that matches decides the bucket.
+
+### Test 1 — the bot already declined it for you
+
+If the finding contains its own hedge — "no action required", "flagging for the record", "consider", "worth noting", "latent today", "optional", "acceptable", "retained deliberately" — the bot is saying it found nothing actionable. Bucket: **decline** (a one-line acknowledgment).
+
+### Test 2 — the PR already declined it
+
+If the finding restates something the PR description discloses — a "Not in this PR" item, a stated tradeoff, a documented transitional state — the decision was already made in the open. Bucket: **decline**, pointing at the section that covers it. (#108's finding was titled "retained deliberately"; #90's finding re-raised a duplication the PR body spent a paragraph justifying.)
+
+### Test 3 — can it happen?
+
+A real finding names a defect reachable **today**: on `main` plus this diff, with the callers and inputs that exist. Ask: what concrete caller, with what concrete input, hits this? If the answer requires a future adapter, a third-party implementation, an input no caller produces (`limit: 0`, astral-plane Unicode in a ref), or a scale nothing is wired to reach — the defect cannot happen. Bucket: **decline**, stating what would have to exist first. If the concern is real-but-future, one sentence in the interface contract or a follow-up issue covers it; code does not.
+
+### Test 4 — did this PR introduce it?
+
+If the defect is real but exists on `main` without this diff — "other entrypoints have the same problem" (#93), "the release process must also move" (#102) — it is adjacent work, not review response. Bucket: **follow-up issue**, linked from the reply.
+
+One exception, from #107: fix a pre-existing bug in this PR only when the PR's own contract makes it load-bearing — for example, the PR claims parity with the old code, so the old bug becomes a new liability on both sides of the migration.
+
+### Test 5 — code or claim?
+
+The finding is real, reachable, and introduced here. The bots are genuinely good at auditing the PR description's own claims ("on every save, workers read them" vs. forked env snapshots, #91; "no message-store read" vs. a leftover sentinel scan, #114). When a finding attacks a claim, there are two candidate fixes — change the code to honor the claim, or shrink the claim — and the choice is not free:
+
+**Trace the claim to the issue the PR closes.**
+
+- **The issue demands the claim** (it is in the acceptance criteria, or it is the reason the issue exists): the claim is a requirement. **Fix the code.** Shrinking the claim would mean the PR no longer closes the issue. (#114: "the directory reads no message store" was the point of #113 — the only valid answer to the leftover read was code.)
+- **The claim is author-added** — a promise on top of what the issue asked for: fix or shrink, **whichever leaves the smaller diff**. Shrinking means editing the PR description honestly and saying so in the reply, never quietly. (#91: instant key propagation to warm workers was a self-imposed promise; shrinking it to "on next worker recycle" was a legitimate option that would have avoided a module-loader mechanism several times the size of the feature.)
+- **No linked issue** (cleanup, self-initiated fix): every claim is author-owned and may be shrunk — but only to be honest, never to dodge. If the shrunken claim makes the PR pointless, the finding is real and demands code.
+- **The claim is in the issue, but the issue is yours and the requirement was arbitrary**: change the issue first, in the open, then shrink.
+
+## Phase 3 — Fix what earned a fix
+
+For each finding in the **fix** bucket:
+
+1. **Reproduce it as a failing test first.** This is the house style (#86, #107) and it is also the last filter: a finding that cannot be turned into a failing test against real callers goes back to Phase 2 as a decline. The test must bite — reverting the fix must fail exactly that test.
+2. **Make the smallest change that passes.** Prefer deleting or narrowing over adding. A defensive branch requires both a test that fails without it and a caller that can reach it.
+3. **Hold a diff budget.** If the accumulated response diff approaches a third of the original PR's diff, stop. The response is no longer review response; it is scope growth, and every added line is new surface for the next review round to find P1s in (#91 grew through four rounds this way). Re-scope: shrink a claim, or move work to a follow-up issue.
+
+## Phase 4 — Answer every thread
+
+No finding is skipped silently. The written record of why a finding was declined is what stops it recurring on the next PR.
+
+**Accepting** (match the tone of the replies on #86 and #107):
+- Confirm it plainly: "Confirmed and fixed in `<commit>` — this was real."
+- State the reproduction: what the failing test asserts and how it failed before the fix.
+- Add what the bot's analysis missed, if anything — a worse failure mode, a second call site given the same guard.
+
+**Declining:**
+- Disclosed tradeoff: one sentence pointing at the PR section that covers it.
+- Unreachable scenario: name the caller or input that would have to exist first, and where the concern is recorded (contract comment, follow-up issue) if it is worth recording.
+- Intended behavior: "This is intended" plus the reason is a complete reply.
+
+**Routing:** link the follow-up issue in the reply, with one line on why it is separate work.
+
+## Calibration table
+
+| Signal in the finding | Likely verdict |
+|---|---|
+| Contradicts a claim the PR description makes | Real — run Test 5 |
+| Names an existing consumer of changed code (shared component, pooled worker) | Real — fix |
+| Comes with a concrete failure sequence you can script | Real — fix |
+| "No action required" / "for the record" / "consider" / "latent" | Decline |
+| Restates a "Not in this PR" or documented tradeoff | Decline |
+| Requires a caller, input, or implementation that does not exist | Decline |
+| Defect also present on `main` without this diff | Follow-up issue |
+| "Also fix these other places" | Follow-up issue |
+
+A thorough PR description is what makes this skill cheap to run: every "Not in this PR" line and stated tradeoff turns a potential debate into a one-sentence decline. Write those sections first; they are the cheapest review response there is.

--- a/.claude/skills/respond-to-review/SKILL.md
+++ b/.claude/skills/respond-to-review/SKILL.md
@@ -7,7 +7,7 @@ description: Triage and answer automated code-review findings on a PR without gr
 
 Goal end-state: every finding on the PR has exactly one of four answers — a minimal fix with a test, a corrected claim in the PR description, a follow-up issue, or a written decline. The PR's diff grows as little as possible.
 
-The bots present real defects and noise in the same authoritative voice. Classification precedes code. Never start implementing a finding before classifying it.
+Classification precedes code. Never start implementing a finding before classifying it.
 
 ## Phase 1 — Gather and dedupe
 
@@ -21,7 +21,7 @@ gh api "repos/$REPO/pulls/<PR>/comments" --paginate --jq '.[] | "[\(.user.login)
 
 1. Drop reviews marked "This review has been superseded."
 2. Merge duplicate findings — same file, same defect — into one item. Post the answer once and cross-link it from the other thread.
-3. Discard the bots' severity labels and verdicts. Severity does not predict which findings are real. Phase 2 re-derives it from evidence.
+3. Discard the bots' severity labels and verdicts. Phase 2 re-derives priority.
 
 ## Phase 2 — Classify every finding
 
@@ -29,21 +29,21 @@ Run each finding through these tests in order. The first test that matches decid
 
 ### Test 1 — the bot hedged
 
-If the finding contains "no action required", "flagging for the record", "consider", "worth noting", "latent today", "optional", "acceptable", or "retained deliberately", the bot found nothing actionable. Bucket: **decline**, with a one-line acknowledgment.
+If the finding contains "no action required", "flagging for the record", "consider", "worth noting", "latent today", "optional", "acceptable", or "retained deliberately": **decline**, with a one-line acknowledgment.
 
 ### Test 2 — the PR already disclosed it
 
-If the finding restates a "Not in this PR" item, a stated tradeoff, or a documented transitional state, the decision is already made in the open. Bucket: **decline**, pointing at the section that covers it.
+If the finding restates a "Not in this PR" item, a stated tradeoff, or a documented transitional state: **decline**, pointing at the section that covers it.
 
 ### Test 3 — no caller can reach it
 
-A real finding names a defect reachable today: on `main` plus this diff, with the callers and inputs that exist. Ask what concrete caller, with what concrete input, hits the defect. If the answer needs a future adapter, a third-party implementation, an input no caller produces, or a scale nothing is wired to reach, the defect cannot happen. Bucket: **decline**, stating what would have to exist first. If the concern matters later, one sentence in the interface contract or a follow-up issue records it. Code does not.
+Ask what concrete caller, with what concrete input, hits the defect on `main` plus this diff. If the answer needs a future adapter, a third-party implementation, an input no caller produces, or a scale nothing is wired to reach: **decline**, stating what would have to exist first. If the concern matters later, record it as one sentence in the interface contract or as a follow-up issue.
 
 ### Test 4 — the defect predates the diff
 
-If the defect exists on `main` without this diff — "other entrypoints have the same problem", "the release process must also move" — it is adjacent work, not review response. Bucket: **follow-up issue**, linked from the reply.
+If the defect exists on `main` without this diff: **follow-up issue**, linked from the reply.
 
-One exception: if the PR's own contract makes the old defect load-bearing — for example, the PR claims parity with the code that carries it — fix it in this PR.
+Exception: if the PR's own claims depend on the old code being correct — for example, a claim of parity with it — fix the defect in this PR.
 
 ### Test 5 — code or claim
 
@@ -62,23 +62,23 @@ For each finding in the **fix** bucket:
 1. Reproduce the finding as a failing test against real callers. If no such test can be written, return the finding to Phase 2 as a decline.
 2. Make the smallest change that passes. Prefer deleting or narrowing over adding. A defensive branch requires both a test that fails without it and a caller that can reach it.
 3. Check that reverting the fix fails exactly the new test.
-4. Watch the accumulated response diff. When it nears a third of the PR's own diff, stop — the work is scope growth, and every added line is new surface for the next review round. Shrink a claim or move the rest to a follow-up issue.
+4. When the accumulated response diff nears a third of the PR's own diff, stop. Shrink a claim or move the rest to a follow-up issue.
 
 ## Phase 4 — Answer every thread
 
-No finding is skipped silently. The written decline is what stops the same finding from recurring on the next PR.
+No finding is skipped silently.
 
 Accepting:
 
 - Confirm it plainly: "Confirmed and fixed in `<commit>` — this was real."
 - State the reproduction: what the failing test asserts and how it failed before the fix.
-- Add what the bot's analysis missed, if anything — a worse failure mode, a second call site given the same guard.
+- Add what the bot's analysis missed, if anything.
 
 Declining:
 
 - Disclosed tradeoff: one sentence pointing at the PR section that covers it.
-- Unreachable scenario: name the caller or input that would have to exist first, and where the concern is recorded if it is worth recording.
-- Intended behavior: "This is intended" plus the reason is a complete reply.
+- Unreachable scenario: name the caller or input that would have to exist first.
+- Intended behavior: "This is intended" plus the reason.
 
 Routing: link the follow-up issue in the reply, with one line on why it is separate work.
 
@@ -95,4 +95,4 @@ Routing: link the follow-up issue in the reply, with one line on why it is separ
 | Defect also present on `main` without this diff | Follow-up issue |
 | "Also fix these other places" | Follow-up issue |
 
-A thorough PR description makes this skill cheap to run. Every "Not in this PR" line and stated tradeoff turns a potential debate into a one-sentence decline. Write those sections before requesting review.
+A "Not in this PR" line or a stated tradeoff in the PR description turns a finding into a one-sentence decline. Write those sections before requesting review.

--- a/.claude/skills/respond-to-review/SKILL.md
+++ b/.claude/skills/respond-to-review/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: respond-to-review
-description: Triage and answer automated code-review findings on a PR without growing its scope. Use when the user asks to "handle / address / respond to review feedback", "go through the bot comments", or after the RomeOS review bots (zoolsher, Jessie-QingYu) post findings on a PR. The core discipline — classify every finding BEFORE writing any code; most findings deserve a reply, not a diff. NOT for requesting a review (that is /code-review) and NOT for reviewing someone else's PR.
+description: Triage and answer automated code-review findings on a PR without growing its scope. Use when the user asks to "handle / address / respond to review feedback", "go through the bot comments", or after the RomeOS review bots (zoolsher, Jessie-QingYu) post findings on a PR. Classify every finding before writing any code — most findings deserve a reply, not a diff. NOT for requesting a review (that is /code-review) and NOT for reviewing someone else's PR.
 ---
 
 # Respond to review feedback
 
-Goal end-state: every review finding on the PR has exactly one of four answers — a minimal fix with a test, a corrected claim in the PR description, a follow-up issue, or a written decline — and the PR's diff grew as little as possible.
+Goal end-state: every finding on the PR has exactly one of four answers — a minimal fix with a test, a corrected claim in the PR description, a follow-up issue, or a written decline. The PR's diff grows as little as possible.
 
-The review bots are worth reading and dangerous to obey. Measured over 18 recent PRs (#84–#115): ~43 findings, of which 8–10 were real and worth code. Every P3 was safe to decline. The bots present the noise in the same authoritative voice as the signal, and an agent's default response to any finding is to add code — for a rare input, a caller that does not exist, or a scope the PR deliberately excluded. This skill exists to replace that default with judgment.
-
-**The prime rule: classification precedes code. Never start implementing a finding you have not classified.**
+The bots present real defects and noise in the same authoritative voice. The default response to a finding is to add code — for an input nothing produces, a caller that does not exist, or a scope the PR excluded on purpose. So classification precedes code. Never start implementing a finding before classifying it.
 
 ## Phase 1 — Gather and dedupe
 
@@ -21,78 +19,81 @@ gh pr view <PR> -R "$REPO" --json reviews --jq '.reviews[] | "[\(.author.login) 
 gh api "repos/$REPO/pulls/<PR>/comments" --paginate --jq '.[] | "[\(.user.login) on \(.path):\(.line // .original_line)]\n\(.body)"'
 ```
 
-- Drop reviews marked "This review has been superseded."
-- The two bots overlap. Merge duplicate findings (same file, same defect) into one item; the answer will be posted once and cross-linked from the other thread.
-- **Discard the bot's severity labels and verdicts.** A P1 REQUEST_CHANGES has been scope expansion; a P2 has been the realest bug in the batch (#86, #91). Severity is re-derived in Phase 2, from evidence.
+1. Drop reviews marked "This review has been superseded."
+2. Merge duplicate findings — same file, same defect — into one item. Post the answer once and cross-link it from the other thread.
+3. Discard the bots' severity labels and verdicts. Severity does not predict which findings are real. Phase 2 re-derives it from evidence.
 
 ## Phase 2 — Classify every finding
 
-Run each finding through these tests, in order. The first test that matches decides the bucket.
+Run each finding through these tests in order. The first test that matches decides the bucket.
 
-### Test 1 — the bot already declined it for you
+### Test 1 — the bot hedged
 
-If the finding contains its own hedge — "no action required", "flagging for the record", "consider", "worth noting", "latent today", "optional", "acceptable", "retained deliberately" — the bot is saying it found nothing actionable. Bucket: **decline** (a one-line acknowledgment).
+If the finding contains "no action required", "flagging for the record", "consider", "worth noting", "latent today", "optional", "acceptable", or "retained deliberately", the bot found nothing actionable. Bucket: **decline**, with a one-line acknowledgment.
 
-### Test 2 — the PR already declined it
+### Test 2 — the PR already disclosed it
 
-If the finding restates something the PR description discloses — a "Not in this PR" item, a stated tradeoff, a documented transitional state — the decision was already made in the open. Bucket: **decline**, pointing at the section that covers it. (#108's finding was titled "retained deliberately"; #90's finding re-raised a duplication the PR body spent a paragraph justifying.)
+If the finding restates a "Not in this PR" item, a stated tradeoff, or a documented transitional state, the decision is already made in the open. Bucket: **decline**, pointing at the section that covers it.
 
-### Test 3 — can it happen?
+### Test 3 — no caller can reach it
 
-A real finding names a defect reachable **today**: on `main` plus this diff, with the callers and inputs that exist. Ask: what concrete caller, with what concrete input, hits this? If the answer requires a future adapter, a third-party implementation, an input no caller produces (`limit: 0`, astral-plane Unicode in a ref), or a scale nothing is wired to reach — the defect cannot happen. Bucket: **decline**, stating what would have to exist first. If the concern is real-but-future, one sentence in the interface contract or a follow-up issue covers it; code does not.
+A real finding names a defect reachable today: on `main` plus this diff, with the callers and inputs that exist. Ask what concrete caller, with what concrete input, hits the defect. If the answer needs a future adapter, a third-party implementation, an input no caller produces, or a scale nothing is wired to reach, the defect cannot happen. Bucket: **decline**, stating what would have to exist first. If the concern matters later, one sentence in the interface contract or a follow-up issue records it. Code does not.
 
-### Test 4 — did this PR introduce it?
+### Test 4 — the defect predates the diff
 
-If the defect is real but exists on `main` without this diff — "other entrypoints have the same problem" (#93), "the release process must also move" (#102) — it is adjacent work, not review response. Bucket: **follow-up issue**, linked from the reply.
+If the defect exists on `main` without this diff — "other entrypoints have the same problem", "the release process must also move" — it is adjacent work, not review response. Bucket: **follow-up issue**, linked from the reply.
 
-One exception, from #107: fix a pre-existing bug in this PR only when the PR's own contract makes it load-bearing — for example, the PR claims parity with the old code, so the old bug becomes a new liability on both sides of the migration.
+One exception: if the PR's own contract makes the old defect load-bearing, fix it in this PR. In #107, the PR claimed parity with old code, so an old bug became a liability on both sides of the migration.
 
-### Test 5 — code or claim?
+### Test 5 — code or claim
 
-The finding is real, reachable, and introduced here. The bots are genuinely good at auditing the PR description's own claims ("on every save, workers read them" vs. forked env snapshots, #91; "no message-store read" vs. a leftover sentinel scan, #114). When a finding attacks a claim, there are two candidate fixes — change the code to honor the claim, or shrink the claim — and the choice is not free:
+The finding is real, reachable, and introduced here. The bots audit the PR description's own claims well. When a finding attacks a claim, two fixes exist — change the code to honor the claim, or shrink the claim — and the choice is not free.
 
 **Trace the claim to the issue the PR closes.**
 
-- **The issue demands the claim** (it is in the acceptance criteria, or it is the reason the issue exists): the claim is a requirement. **Fix the code.** Shrinking the claim would mean the PR no longer closes the issue. (#114: "the directory reads no message store" was the point of #113 — the only valid answer to the leftover read was code.)
-- **The claim is author-added** — a promise on top of what the issue asked for: fix or shrink, **whichever leaves the smaller diff**. Shrinking means editing the PR description honestly and saying so in the reply, never quietly. (#91: instant key propagation to warm workers was a self-imposed promise; shrinking it to "on next worker recycle" was a legitimate option that would have avoided a module-loader mechanism several times the size of the feature.)
-- **No linked issue** (cleanup, self-initiated fix): every claim is author-owned and may be shrunk — but only to be honest, never to dodge. If the shrunken claim makes the PR pointless, the finding is real and demands code.
-- **The claim is in the issue, but the issue is yours and the requirement was arbitrary**: change the issue first, in the open, then shrink.
+- The issue demands the claim, in its acceptance criteria or as its reason to exist: the claim is a requirement. **Fix the code.** A shrunken claim means the PR no longer closes the issue. In #114, "the directory reads no message store" was the point of issue #113, so the only valid answer to a leftover read was code.
+- The claim is author-added, a promise on top of what the issue asked for: fix or shrink, **whichever leaves the smaller diff**. Shrinking means editing the PR description and saying so in the reply, never quietly. In #91, instant key propagation to warm workers was a self-imposed promise. Shrinking it to "on next worker recycle" was a legitimate option.
+- No linked issue: every claim is author-owned and may shrink, but only to be honest, never to dodge. If the shrunken claim makes the PR pointless, the finding is real and demands code.
+- The claim is in the issue, but the issue is yours and the requirement was arbitrary: change the issue first, in the open, then shrink.
 
 ## Phase 3 — Fix what earned a fix
 
 For each finding in the **fix** bucket:
 
-1. **Reproduce it as a failing test first.** This is the house style (#86, #107) and it is also the last filter: a finding that cannot be turned into a failing test against real callers goes back to Phase 2 as a decline. The test must bite — reverting the fix must fail exactly that test.
-2. **Make the smallest change that passes.** Prefer deleting or narrowing over adding. A defensive branch requires both a test that fails without it and a caller that can reach it.
-3. **Hold a diff budget.** If the accumulated response diff approaches a third of the original PR's diff, stop. The response is no longer review response; it is scope growth, and every added line is new surface for the next review round to find P1s in (#91 grew through four rounds this way). Re-scope: shrink a claim, or move work to a follow-up issue.
+1. Reproduce the finding as a failing test against real callers. If no such test can be written, return the finding to Phase 2 as a decline.
+2. Make the smallest change that passes. Prefer deleting or narrowing over adding. A defensive branch requires both a test that fails without it and a caller that can reach it.
+3. Check that reverting the fix fails exactly the new test.
+4. Watch the accumulated response diff. When it nears a third of the PR's own diff, stop — the work is scope growth, and every added line is new surface for the next review round. Shrink a claim or move the rest to a follow-up issue.
 
 ## Phase 4 — Answer every thread
 
-No finding is skipped silently. The written record of why a finding was declined is what stops it recurring on the next PR.
+No finding is skipped silently. The written decline is what stops the same finding from recurring on the next PR.
 
-**Accepting** (match the tone of the replies on #86 and #107):
+Accepting — match the tone of the replies on #86 and #107:
+
 - Confirm it plainly: "Confirmed and fixed in `<commit>` — this was real."
 - State the reproduction: what the failing test asserts and how it failed before the fix.
 - Add what the bot's analysis missed, if anything — a worse failure mode, a second call site given the same guard.
 
-**Declining:**
+Declining:
+
 - Disclosed tradeoff: one sentence pointing at the PR section that covers it.
-- Unreachable scenario: name the caller or input that would have to exist first, and where the concern is recorded (contract comment, follow-up issue) if it is worth recording.
+- Unreachable scenario: name the caller or input that would have to exist first, and where the concern is recorded if it is worth recording.
 - Intended behavior: "This is intended" plus the reason is a complete reply.
 
-**Routing:** link the follow-up issue in the reply, with one line on why it is separate work.
+Routing: link the follow-up issue in the reply, with one line on why it is separate work.
 
-## Calibration table
+## Signals
 
-| Signal in the finding | Likely verdict |
+| Signal in the finding | Verdict |
 |---|---|
 | Contradicts a claim the PR description makes | Real — run Test 5 |
 | Names an existing consumer of changed code (shared component, pooled worker) | Real — fix |
 | Comes with a concrete failure sequence you can script | Real — fix |
 | "No action required" / "for the record" / "consider" / "latent" | Decline |
-| Restates a "Not in this PR" or documented tradeoff | Decline |
-| Requires a caller, input, or implementation that does not exist | Decline |
+| Restates a "Not in this PR" item or documented tradeoff | Decline |
+| Needs a caller, input, or implementation that does not exist | Decline |
 | Defect also present on `main` without this diff | Follow-up issue |
 | "Also fix these other places" | Follow-up issue |
 
-A thorough PR description is what makes this skill cheap to run: every "Not in this PR" line and stated tradeoff turns a potential debate into a one-sentence decline. Write those sections first; they are the cheapest review response there is.
+A thorough PR description makes this skill cheap to run. Every "Not in this PR" line and stated tradeoff turns a potential debate into a one-sentence decline. Write those sections before requesting review.

--- a/.claude/skills/respond-to-review/SKILL.md
+++ b/.claude/skills/respond-to-review/SKILL.md
@@ -81,7 +81,7 @@ Routing: link the follow-up issue in the reply, with one line on why it is separ
 | Contradicts a claim the PR description makes | Real — run Test 5 |
 | Names an existing consumer of changed code (shared component, pooled worker) | Real — fix |
 | Comes with a concrete failure sequence you can script | Real — fix |
-| "No action required" / "for the record" / "consider" / "latent" | Decline |
+| Presented by the bot as optional or non-blocking | Decline |
 | Restates a "Not in this PR" item or documented tradeoff | Decline |
 | Needs a caller, input, or implementation that does not exist | Decline |
 | Defect also present on `main` without this diff | Follow-up issue |

--- a/.claude/skills/respond-to-review/SKILL.md
+++ b/.claude/skills/respond-to-review/SKILL.md
@@ -21,7 +21,7 @@ Run each finding through these tests in order. The first test that matches decid
 
 ### Test 1 — the bot hedged
 
-If the finding contains "no action required", "flagging for the record", "consider", "worth noting", "latent today", "optional", "acceptable", or "retained deliberately": **decline**, with a one-line acknowledgment.
+If the bot itself presents the finding as optional or non-blocking — "no action required", "consider", "worth noting": **decline**, with a one-line acknowledgment.
 
 ### Test 2 — the PR already disclosed it
 

--- a/.claude/skills/respond-to-review/SKILL.md
+++ b/.claude/skills/respond-to-review/SKILL.md
@@ -43,18 +43,17 @@ A real finding names a defect reachable today: on `main` plus this diff, with th
 
 If the defect exists on `main` without this diff — "other entrypoints have the same problem", "the release process must also move" — it is adjacent work, not review response. Bucket: **follow-up issue**, linked from the reply.
 
-One exception: if the PR's own contract makes the old defect load-bearing, fix it in this PR. In #107, the PR claimed parity with old code, so an old bug became a liability on both sides of the migration.
+One exception: if the PR's own contract makes the old defect load-bearing — for example, the PR claims parity with the code that carries it — fix it in this PR.
 
 ### Test 5 — code or claim
 
-The finding is real, reachable, and introduced here. The bots audit the PR description's own claims well. When a finding attacks a claim, two fixes exist — change the code to honor the claim, or shrink the claim — and the choice is not free.
+The finding is real, reachable, and introduced here. If it does not contradict a claim in the PR description, **fix the code**. If it does, trace the claim to the issue the PR closes:
 
-**Trace the claim to the issue the PR closes.**
+- The issue demands the claim: **fix the code**.
+- The claim is author-added, or there is no linked issue: fix the code or shrink the claim, whichever leaves the smaller diff.
+- The issue demands the claim and the requirement is wrong: change the issue first, then shrink the claim.
 
-- The issue demands the claim, in its acceptance criteria or as its reason to exist: the claim is a requirement. **Fix the code.** A shrunken claim means the PR no longer closes the issue. In #114, "the directory reads no message store" was the point of issue #113, so the only valid answer to a leftover read was code.
-- The claim is author-added, a promise on top of what the issue asked for: fix or shrink, **whichever leaves the smaller diff**. Shrinking means editing the PR description and saying so in the reply, never quietly. In #91, instant key propagation to warm workers was a self-imposed promise. Shrinking it to "on next worker recycle" was a legitimate option.
-- No linked issue: every claim is author-owned and may shrink, but only to be honest, never to dodge. If the shrunken claim makes the PR pointless, the finding is real and demands code.
-- The claim is in the issue, but the issue is yours and the requirement was arbitrary: change the issue first, in the open, then shrink.
+Shrinking a claim means editing the PR description and stating the change in the reply.
 
 ## Phase 3 — Fix what earned a fix
 
@@ -69,7 +68,7 @@ For each finding in the **fix** bucket:
 
 No finding is skipped silently. The written decline is what stops the same finding from recurring on the next PR.
 
-Accepting — match the tone of the replies on #86 and #107:
+Accepting:
 
 - Confirm it plainly: "Confirmed and fixed in `<commit>` — this was real."
 - State the reproduction: what the failing test asserts and how it failed before the fix.

--- a/.claude/skills/respond-to-review/SKILL.md
+++ b/.claude/skills/respond-to-review/SKILL.md
@@ -51,7 +51,7 @@ The finding is real, reachable, and introduced here. If it does not contradict a
 
 - The issue demands the claim: **fix the code**.
 - The claim is author-added, or there is no linked issue: fix the code or shrink the claim, whichever leaves the smaller diff.
-- The issue demands the claim and the requirement is wrong: change the issue first, then shrink the claim.
+- The issue demands the claim and the requirement looks wrong: stop and ask the user. Never edit the issue.
 
 Shrinking a claim means editing the PR description and stating the change in the reply.
 


### PR DESCRIPTION
## What this PR does

The review bots surface real defects and noise in the same authoritative voice, and an agent's default response to any finding is to add code — for an input nothing produces, a caller that does not exist, or a scope the PR deliberately excluded. Measured over the findings on #84–#115, roughly a quarter were worth code, and no P3 was. Following the feedback literally grew PRs with specialized branches and scope creep, and each added line became new review surface for the next round.

This PR adds a `respond-to-review` skill that replaces that default with a triage loop: classification precedes code, and every finding gets exactly one of four answers — a minimal fix with a biting test, a corrected claim in the PR description, a follow-up issue, or a written decline.

## Design & Invariants

- **Classification precedes code.** Five ordered tests decide the bucket before any implementation: the bot hedged it; the PR already disclosed it; no caller can reach it today; it predates the diff; else it is real.
- **A claim under attack is traced to the issue the PR closes.** A claim the issue demands is a requirement — the code moves, never the claim. An author-added claim may be shrunk instead, openly, when that leaves the smaller diff.
- **A fix starts as a failing test against real callers.** A finding that cannot be reproduced that way returns to triage as a decline. A defensive branch requires both a test that fails without it and a caller that can reach it.
- **The response diff is budgeted.** Nearing a third of the PR's own diff means the work is scope growth, and it moves to a follow-up issue or a shrunk claim.
- **No thread is skipped silently.** The written decline is what stops the same finding recurring on the next PR.

The bot severity labels are discarded and re-derived: across the sampled PRs a P1 was sometimes scope expansion and a P2 sometimes the realest bug in the batch.

## Test plan

- [x] Skill loads and is listed by the harness under its `respond-to-review` name with the intended triggers.

- [ ] A live run on the next bot-reviewed PR — the first real invocation is the acceptance test.

## Not in this PR

- Automation that invokes the skill when a bot review lands — a hook decision, separate from the runbook.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

