### PR TITLE
docs: make acceptance items name what proves them

### DIFF
--- a/docs/authoring/github-issues.md
+++ b/docs/authoring/github-issues.md
@@ -50,12 +50,21 @@ Suspected root cause states its confidence. A guess labeled as confirmed poisons
 Required sections: Scope, Acceptance. When the task depends on other issues, a **Blocked by** line names them by number.
 
 - **Scope** — the change, and what stays out.
-- **Acceptance** — a checklist of observable outcomes.
+- **Acceptance** — a checklist of observable outcomes, each naming what proves it: a committed test, or a run against the finished branch.
 
 Acceptance items are observable from outside the implementation.
 
 > Prefer: "- [ ] the test fails when an ad-hoc size enters a migrated file".
 > Over: "- [ ] typography is cleaned up".
+
+Every item names what proves it. A committed test lands in the tree and runs in CI on every later change. A check runs once against the finished branch, and the PR test plan carries its evidence. An implementer builds an item that names neither as a committed test.
+
+An item earns a committed test when what it names can break later and nothing else catches the break. An item runs once against the finished branch when the type checker, a deleted route, or an existing test already decides it.
+
+> Prefer: "- [ ] run once: a grep for `/api/persons` returns nothing outside git history."
+> Over: "- [ ] committed test: the source contains no reference to `/api/persons`."
+
+Unless the item states how the deleted thing comes back silently, an absence item runs once. A re-imported export fails the type check and a re-registered route fails the route test, so neither earns a committed test of its own.
 
 Scope names what stays out. A task without a boundary grows during implementation.
 


### PR DESCRIPTION
## What this PR does

Two deletion tasks landed a test that scans the source and asserts the deleted names are absent: `retired-identity-surface.test.ts` in #89 and `retired-interfaces.test.ts` in #118. A follow-up commit in #89 removed the first, and the argument for removing it stayed in that commit message, so #118 rebuilt the same file.

Three things point an implementer there. The Acceptance section of [`github-issues.md`](docs/authoring/github-issues.md) gave one example of a well-formed item, and that example is a lint test failing on a violation. An item such as "a grep for the deleted endpoints returns nothing outside git history" reads against it as a request for a committed test. And 33 source-scanning tests under `packages/` supply the pattern to copy.

Acceptance items now name what proves them. A committed test lands in the tree and runs in CI on every later change. A check runs once against the finished branch, and the PR test plan carries its evidence.

## Design & Invariants

An acceptance item states an outcome. It does not state what proves the outcome, so the same sentence can mean "commit a test" or "look once". Naming the proof closes that gap where the criteria get written, not where an agent guesses.

The rule sorts items rather than ruling tests out. The ad-hoc-size example stays as the model for a committed test, and the grep example joins it as the model for a run against the finished branch. A rule phrased as "an acceptance item is checked, not committed" loses, because it tilts against every committed test, including the ones the repo wants.

An absence item runs once. A re-imported export fails the type check and a re-registered route fails the route test, so a committed absence test adds a second failure for a break the tree already catches. An absence item earns a committed test only when it states how the deleted thing comes back silently.

An item that names neither proof builds as a committed test. That default is deliberate: an author who omits the proof more likely meant a test than a glance.

The two kinds carry no coined names. "A committed test" and "a check that runs once" are plain descriptions, so neither needs the one-line separation from an industry near-miss that [WRITING.md](docs/authoring/WRITING.md) demands of a project term.

## Test plan

- [x] Run once: `scripts/check-pr-title.sh "docs: make acceptance items name what proves them"` passes.
- [x] Run once: the added prose clears [WRITING.md](docs/authoring/WRITING.md) — no semicolons, no contractions, no history words, active voice, one name per thing, sentences under 25 words, paragraphs under six sentences.
- [ ] Not run: `pnpm typecheck` and `pnpm test:unit`. The diff is one Markdown file with no code or link changes.

## Not in this PR

- Marking the items on open issues. #123 holds `ready-for-agent` now and carries "a grep for the deleted endpoints returns nothing outside git history" with no proof named, and #70 carries "running it over `packages/*/src` identifiers and `docs/` returns nothing". Both build as committed tests under the new default.
- Bringing `github-issues.md` up to [`authoring.md`](docs/authoring/authoring.md). The file carries Format only, with no Admission, Eviction, or Intake section, and none of its rules carry a `[mech]`/`[llm]`/`[human]` tag. The new rule matches the file's untagged style rather than tagging one rule alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)