### PR TITLE
refactor(web): lay the link-account picker out as a table

### DIFF
--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -143,7 +143,12 @@
     "selectPlaceholder": "Select a person…"
   },
   "linkPicker": {
-    "heldBy": "now {{owner}}'s"
+    "columns": {
+      "channel": "Channel",
+      "name": "Name",
+      "handle": "Handle",
+      "heldBy": "Held by"
+    }
   },
   "strangerConfirm": {
     "title": "Treat {{name}} as a stranger?",

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -143,7 +143,12 @@
     "selectPlaceholder": "选择一位人物…"
   },
   "linkPicker": {
-    "heldBy": "当前属于 {{owner}}"
+    "columns": {
+      "channel": "渠道",
+      "name": "名称",
+      "handle": "账号",
+      "heldBy": "当前归属"
+    }
   },
   "strangerConfirm": {
     "title": "将 {{name}} 视为陌生人？",

--- a/packages/web/src/pages/people/manage.tsx
+++ b/packages/web/src/pages/people/manage.tsx
@@ -27,6 +27,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { usePeople } from "@/hooks/use-people";
 import { ChannelPill } from "./channel-meta";
 import { MutationError } from "./triage";
@@ -173,7 +181,9 @@ function LinkAccountPicker({ person, onClose }: { person: PersonResource; onClos
 
   return (
     <>
-      <Dialog open onClose={onClose} size="md" ariaLabel={t("detail.linkAccount")}>
+      {/* Wider than the merge picker: four columns of account identity, and a
+          handle is as long as the channel makes it. */}
+      <Dialog open onClose={onClose} size="lg" ariaLabel={t("detail.linkAccount")}>
         <DialogHeader onClose={onClose} closeLabel={t("actions.close")}>
           <DialogTitle>{t("detail.linkAccount")}</DialogTitle>
           <DialogDescription>{t("detail.linkDescription")}</DialogDescription>
@@ -191,32 +201,55 @@ function LinkAccountPicker({ person, onClose }: { person: PersonResource; onClos
               {directory.isPending ? t("page.loading") : t("page.emptyForSearch")}
             </p>
           ) : (
-            <ul className="max-h-72 overflow-y-auto">
-              {candidates.map((account) => (
-                <li key={accountRef(account)}>
-                  <button
-                    type="button"
-                    disabled={busy}
-                    onClick={() => void link(account)}
-                    className="flex w-full items-center gap-3 border-b border-border-subtle px-2 py-2 text-left last:border-b-0 hover:bg-surface"
-                  >
-                    <ChannelPill channel={account.channel} />
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate text-ui text-foreground">
-                        {account.displayName}
-                      </span>
-                      <span className="block truncate text-aux text-muted-foreground">
-                        <span className="font-mono tabular-nums">{handleOf(account)}</span>
-                        {/* Whose it is right now, so picking one already held is
-                            a decision rather than a surprise. */}
-                        {account.personName &&
-                          ` · ${t("linkPicker.heldBy", { owner: account.personName })}`}
-                      </span>
-                    </span>
-                  </button>
-                </li>
-              ))}
-            </ul>
+            <div className="max-h-72 overflow-y-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead>{t("linkPicker.columns.channel")}</TableHead>
+                    <TableHead>{t("linkPicker.columns.name")}</TableHead>
+                    <TableHead>{t("linkPicker.columns.handle")}</TableHead>
+                    {/* Whose it is right now, so picking one already held is a
+                        decision rather than a surprise. */}
+                    <TableHead>{t("linkPicker.columns.heldBy")}</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {candidates.map((account) => (
+                    <TableRow
+                      key={accountRef(account)}
+                      className="cursor-pointer"
+                      onClick={() => void link(account)}
+                    >
+                      <TableCell>
+                        <ChannelPill channel={account.channel} />
+                      </TableCell>
+                      <TableCell className="w-full max-w-0 text-foreground">
+                        {/* The row is the hit area, and this is the same gesture
+                            for the keyboard — so one press must not arrive as
+                            two writes. */}
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            void link(account);
+                          }}
+                          className="block max-w-full truncate text-left outline-none focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                        >
+                          {account.displayName}
+                        </button>
+                      </TableCell>
+                      <TableCell className="max-w-64 truncate font-mono tabular-nums text-aux text-muted-foreground">
+                        {handleOf(account)}
+                      </TableCell>
+                      <TableCell className="max-w-40 truncate text-aux text-muted-foreground">
+                        {account.personName}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           )}
           <MutationError message={error} />
         </DialogBody>


### PR DESCRIPTION
## What this PR does

The link-account picker stacked each candidate's name over its handle, and appended the current owner to the handle line as prose (`+65 9123 4472 · now Mira Chen's`). Nothing lined up down the list. Reading which channel an account belongs to, or who already holds it, meant reading every row.

The rows are a table now — Channel, Name, Handle, Held by — so each field sits under its own heading, in its own column. The owner moves out of the prose suffix into the Held by column, which retires the `linkPicker.heldBy` string in favour of `linkPicker.columns.*`.

## Design & Invariants

The row stays the hit area, and the name cell holds a button carrying the account's name. That button is the keyboard path to the same gesture, so it stops propagation — one press must reach the contract as one write, because a second link on an account another person holds re-attributes its history again.

The picker keeps offering accounts it cannot silently link. An account another person holds is still a row, and picking it still answers with the conflict that names the holder, which is what makes the transfer confirm an explicit second step rather than a failed write.

The dialog widens from `md` to `lg`. Four columns of account identity do not fit in `max-w-lg` once a channel-native handle (`6591234472@s.whatsapp.net`) claims its column — the Name column collapsed to `Ar…`. Handle and Held by carry width caps and truncate, so Name absorbs whatever they leave.

A sticky header was tried and dropped. `Table` wraps its `<table>` in an `overflow-auto` div, which becomes the sticky containing block and defeats `sticky top-0` in the scroll box outside it. No other `Table` in the repo carries one.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — including `PersonDetailPage.test.tsx`, which drives both picker paths, and the i18n key-parity suite over the new `linkPicker.columns.*` keys in `en` and `zh-CN`
- [x] `biome check` on the changed files
- [x] Exercised in the browser under `pnpm start:web:mock`: clicking the name button and clicking a row cell each issue exactly one `POST /api/people/:id/accounts`; keyboard focus lands on the row name with a visible outline; a row someone else holds still raises the "Move this account?" confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)