### PR TITLE
feat(web): give each People view its own URL

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -19,6 +19,11 @@ const CallbackPage = lazy(() => import("./pages/CallbackPage"));
 const SharePage = lazy(() => import("./pages/share/SharePage"));
 const ActivityPage = lazy(() => import("./pages/ActivityPage"));
 const PeoplePage = lazy(() => import("./pages/PeoplePage"));
+// The /people redirect lives with the views it forwards to, so the paths are
+// written once; it rides their chunk, which is the one about to render anyway.
+const PeopleIndexRedirect = lazy(() =>
+  import("./pages/PeoplePage").then((m) => ({ default: m.PeopleIndexRedirect })),
+);
 const PersonDetailPage = lazy(() => import("./pages/PersonDetailPage"));
 const MemoryPage = lazy(() => import("./pages/MemoryPage"));
 const ProjectsPage = lazy(() => import("./pages/ProjectsPage"));
@@ -132,7 +137,13 @@ export default function App() {
             <Route path="/" element={<Navigate to="/chat" replace />} />
             <Route path="/chat/*" element={<FreePage />} />
             <Route path="/activity" element={<ActivityPage />} />
-            <Route path="/people" element={<PeoplePage />} />
+            {/* The two People views are routes, so each is linkable and back
+                steps between them. Both are static segments and outrank the
+                person route below them, which is what keeps a dossier at the
+                same depth as the views it is opened from. */}
+            <Route path="/people" element={<PeopleIndexRedirect />} />
+            <Route path="/people/latest" element={<PeoplePage view="latest" />} />
+            <Route path="/people/directory" element={<PeoplePage view="directory" />} />
             <Route path="/people/:personId" element={<PersonDetailPage />} />
             <Route path="/memory/*" element={<MemoryPage />} />
             <Route path="/projects/*" element={<ProjectsPage />} />

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -25,6 +25,9 @@ const PeopleIndexRedirect = lazy(() =>
   import("./pages/PeoplePage").then((m) => ({ default: m.PeopleIndexRedirect })),
 );
 const PersonDetailPage = lazy(() => import("./pages/PersonDetailPage"));
+const PersonLegacyRedirect = lazy(() =>
+  import("./pages/PersonDetailPage").then((m) => ({ default: m.PersonLegacyRedirect })),
+);
 const MemoryPage = lazy(() => import("./pages/MemoryPage"));
 const ProjectsPage = lazy(() => import("./pages/ProjectsPage"));
 const RoutinesPage = lazy(() => import("./pages/RoutinesPage"));
@@ -138,13 +141,17 @@ export default function App() {
             <Route path="/chat/*" element={<FreePage />} />
             <Route path="/activity" element={<ActivityPage />} />
             {/* The two People views are routes, so each is linkable and back
-                steps between them. Both are static segments and outrank the
-                person route below them, which is what keeps a dossier at the
-                same depth as the views it is opened from. */}
+                steps between them. The dossier takes its own segment rather
+                than sharing theirs: a person id is a slug of the display name
+                the guardian gave them, so `latest` and `directory` are ids they
+                can mint, and a static view route would leave such a person
+                unreachable. The bare `/people/:personId` forwards, so an
+                address a person was already reached by keeps working. */}
             <Route path="/people" element={<PeopleIndexRedirect />} />
             <Route path="/people/latest" element={<PeoplePage view="latest" />} />
             <Route path="/people/directory" element={<PeoplePage view="directory" />} />
-            <Route path="/people/:personId" element={<PersonDetailPage />} />
+            <Route path="/people/person/:personId" element={<PersonDetailPage />} />
+            <Route path="/people/:personId" element={<PersonLegacyRedirect />} />
             <Route path="/memory/*" element={<MemoryPage />} />
             <Route path="/projects/*" element={<ProjectsPage />} />
             <Route path="/sessions/*" element={<SessionsPage />} />

--- a/packages/web/src/pages/PeoplePage.test.tsx
+++ b/packages/web/src/pages/PeoplePage.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   countPeople,
@@ -21,7 +21,7 @@ import {
   type StreamAccount,
 } from "@rome/api-types/people";
 import i18n from "@/i18n";
-import PeoplePage from "./PeoplePage";
+import PeoplePage, { PeopleIndexRedirect } from "./PeoplePage";
 
 // The People page as the guardian drives it: a stream that routes to whoever
 // has something new, and a directory — a contacts list — that reads the roster.
@@ -422,17 +422,43 @@ function mockApi(
   return { calls, state };
 }
 
-function renderPage() {
+/** The People routes as `App.tsx` declares them, so a test drives the same
+ *  redirect, the same two view paths and the same person route the app does —
+ *  and a control that navigates is exercised end to end rather than against a
+ *  single route that would swallow every address it produced. */
+function renderPage(entry = "/people") {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={["/people"]}>
+      <MemoryRouter initialEntries={[entry]}>
         <Routes>
-          <Route path="/people" element={<PeoplePage />} />
+          <Route path="/people" element={<PeopleIndexRedirect />} />
+          <Route path="/people/latest" element={<PeoplePage view="latest" />} />
+          <Route path="/people/directory" element={<PeoplePage view="directory" />} />
           <Route path="/people/:personId" element={<div>person page</div>} />
         </Routes>
+        <Address />
+        <Back />
       </MemoryRouter>
     </QueryClientProvider>,
+  );
+}
+
+/** Reports the address the page is at, for the assertions about what a control
+ *  put in it. Rendered inside the router so it sees every navigation. */
+function Address() {
+  const location = useLocation();
+  return <div data-testid="address">{`${location.pathname}${location.search}`}</div>;
+}
+
+/** The browser's back button, which `MemoryRouter` has no chrome for. What it
+ *  lands on is the assertion that says which gestures spent a history entry. */
+function Back() {
+  const navigate = useNavigate();
+  return (
+    <button type="button" data-testid="back" onClick={() => navigate(-1)}>
+      back
+    </button>
   );
 }
 
@@ -999,5 +1025,100 @@ describe("PeoplePage load failures", () => {
 
     expect(await screen.findByText("Nothing new yet")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+  });
+});
+
+// Every control on the page is in the address, so each of them is a link to
+// share, a state to reload into, and a step the back button can undo.
+describe("PeoplePage puts its controls in the address", () => {
+  const address = () => screen.getByTestId("address").textContent;
+  const searchBox = () => screen.getByRole("searchbox") as HTMLInputElement;
+  const checked = (name: string) =>
+    screen.getByRole("radio", { name }).getAttribute("aria-checked") === "true";
+
+  it("forwards /people to the stream, keeping the chip and term it arrived with", async () => {
+    mockApi({ people: [GUARDIAN, FRIEND] });
+    renderPage("/people?level=inner-circle&q=wei");
+
+    await waitFor(() => expect(address()).toBe("/people/latest?level=inner-circle&q=wei"));
+  });
+
+  it("opens the view its address names, not the default one", async () => {
+    mockApi({ people: [GUARDIAN, FRIEND, QUIET_PERSON] });
+    renderPage("/people/directory");
+
+    // The quiet person is a directory row and never a stream one, so their
+    // presence is what says which view the address opened.
+    expect(await screen.findByText("Nadia Petrova")).toBeTruthy();
+    expect(checked("Directory")).toBe(true);
+  });
+
+  it("moves the view into the path and the chip into the query", async () => {
+    const user = userEvent.setup();
+    mockApi({ people: [GUARDIAN, FRIEND] });
+    renderPage();
+
+    await screen.findByText("Wei Chen");
+    expect(address()).toBe("/people/latest");
+
+    await showDirectory(user);
+    await waitFor(() => expect(address()).toBe("/people/directory"));
+
+    await user.click(chip(/^Inner circle/));
+    await waitFor(() => expect(address()).toBe("/people/directory?level=inner-circle"));
+  });
+
+  it("carries the chip across a view change, and back undoes one choice", async () => {
+    const user = userEvent.setup();
+    mockApi({ people: [GUARDIAN, FRIEND] });
+    renderPage();
+
+    await screen.findByText("Wei Chen");
+    await user.click(chip(/^Inner circle/));
+    await waitFor(() => expect(address()).toBe("/people/latest?level=inner-circle"));
+
+    await showDirectory(user);
+    await waitFor(() => expect(address()).toBe("/people/directory?level=inner-circle"));
+
+    // One deliberate choice, one history entry: back undoes the view change
+    // and returns to the stream still on the chip picked before it.
+    await user.click(screen.getByTestId("back"));
+    await waitFor(() => expect(address()).toBe("/people/latest?level=inner-circle"));
+  });
+
+  it("puts the typed term in the address without an entry per letter", async () => {
+    const user = userEvent.setup();
+    mockApi({ people: [GUARDIAN, FRIEND] });
+    renderPage();
+
+    await screen.findByText("Wei Chen");
+    await showDirectory(user);
+    await user.type(searchBox(), "wei");
+    await waitFor(() => expect(address()).toBe("/people/directory?q=wei"));
+    expect(searchBox().value).toBe("wei");
+
+    // Three keystrokes replaced the view's entry rather than stacking three on
+    // top of it, so one step back is the way out of the directory — not a walk
+    // through "we" and "w" to get there.
+    await user.click(screen.getByTestId("back"));
+    await waitFor(() => expect(address()).toBe("/people/latest"));
+  });
+
+  it("opens the box on the term its address names, and searches for it", async () => {
+    const { calls } = mockApi({ people: [GUARDIAN, FRIEND, QUIET_PERSON] });
+    renderPage("/people/latest?q=nadia");
+
+    await waitFor(() => expect(searchBox().value).toBe("nadia"));
+    await waitFor(() =>
+      expect(calls.some((call) => call.url.includes("/api/people?q=nadia"))).toBe(true),
+    );
+  });
+
+  it("falls back to every level when the address names one the rail dropped", async () => {
+    mockApi({ people: [GUARDIAN, FRIEND] });
+    renderPage("/people/latest?level=former-colleague");
+
+    expect(await screen.findByText("Wei Chen")).toBeTruthy();
+    expect(checked("All")).toBe(true);
   });
 });

--- a/packages/web/src/pages/PeoplePage.test.tsx
+++ b/packages/web/src/pages/PeoplePage.test.tsx
@@ -435,7 +435,7 @@ function renderPage(entry = "/people") {
           <Route path="/people" element={<PeopleIndexRedirect />} />
           <Route path="/people/latest" element={<PeoplePage view="latest" />} />
           <Route path="/people/directory" element={<PeoplePage view="directory" />} />
-          <Route path="/people/:personId" element={<div>person page</div>} />
+          <Route path="/people/person/:personId" element={<div>person page</div>} />
         </Routes>
         <Address />
         <Back />
@@ -448,7 +448,12 @@ function renderPage(entry = "/people") {
  *  put in it. Rendered inside the router so it sees every navigation. */
 function Address() {
   const location = useLocation();
-  return <div data-testid="address">{`${location.pathname}${location.search}`}</div>;
+  return (
+    <>
+      <div data-testid="address">{`${location.pathname}${location.search}`}</div>
+      <div data-testid="origin">{(location.state as { from?: string } | null)?.from ?? ""}</div>
+    </>
+  );
 }
 
 /** The browser's back button, which `MemoryRouter` has no chrome for. What it
@@ -1120,5 +1125,22 @@ describe("PeoplePage puts its controls in the address", () => {
 
     expect(await screen.findByText("Wei Chen")).toBeTruthy();
     expect(checked("All")).toBe(true);
+  });
+});
+
+// A dossier is opened from a view, and the view it was opened from is what its
+// back link owes the guardian. The address travels with the navigation rather
+// than being inferred from history, which a merge rewrites.
+describe("PeoplePage hands the dossier the view it was opened from", () => {
+  it("names the view, the chip and the term the person was reached from", async () => {
+    const user = userEvent.setup();
+    mockApi({ people: [GUARDIAN, FRIEND, QUIET_PERSON] });
+    renderPage("/people/directory?level=inner-circle");
+
+    await user.click(await screen.findByRole("button", { name: /Wei Chen/ }));
+
+    expect(await screen.findByText("person page")).toBeTruthy();
+    expect(screen.getByTestId("address").textContent).toBe("/people/person/wei-chen");
+    expect(screen.getByTestId("origin").textContent).toBe("/people/directory?level=inner-circle");
   });
 });

--- a/packages/web/src/pages/PeoplePage.tsx
+++ b/packages/web/src/pages/PeoplePage.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useMemo } from "react";
+import { Navigate, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { CircleAlert, RefreshCw } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -13,7 +13,12 @@ import { DismissedEntry, UnknownEntry } from "./people/triage";
 import {
   directoryGroups,
   FILTER_ORDER,
+  FILTER_PARAM,
   levelCounts,
+  parsePeopleFilter,
+  PEOPLE_VIEW_PATH,
+  peoplePath,
+  SEARCH_PARAM,
   streamRows,
   type LevelCounts,
   type PeopleFilter,
@@ -47,6 +52,12 @@ import { usePeopleRoster } from "./people/use-roster";
  * opened by the same gestures. A channel added after this page was written
  * lands here the same way, without a section.
  *
+ * Both views are routes — `/people/latest` and `/people/directory` — and the
+ * chip and the search term ride the query beside them. The page holds no
+ * control state of its own: what is on screen is what the address says, so a
+ * view is linkable, a reload returns to it, and back steps through the choices
+ * that got there.
+ *
  * Every number on screen is the server's. The directory pages, so a count taken
  * over the rows that happened to arrive would report no waiting senders as soon
  * as placed people filled page one — and it is why a write settles by
@@ -67,14 +78,44 @@ const LEVEL_HINT_KEY: Partial<Record<RowLevel, string>> = {
   stranger: "levelHints.stranger",
 };
 
-export default function PeoplePage() {
+/**
+ * `/people` is the root the two views share and renders neither: it forwards to
+ * the stream, carrying whatever chip and term the link arrived with, so an
+ * address written before the views had their own still lands somewhere.
+ */
+export function PeopleIndexRedirect() {
+  const { search } = useLocation();
+  return <Navigate to={{ pathname: PEOPLE_VIEW_PATH.latest, search }} replace />;
+}
+
+export default function PeoplePage({ view }: { view: PeopleView }) {
   const { t } = useTranslation("people");
   const { t: tCommon } = useTranslation("common");
   const navigate = useNavigate();
 
-  const [view, setView] = useState<PeopleView>("latest");
-  const [filter, setFilter] = useState<PeopleFilter>("all");
-  const [search, setSearch] = useState("");
+  // Every control on this page is in the address: the view in the path, the
+  // chip and the term in the query. So each of the three moves by navigating,
+  // and each reads back out of the URL rather than out of a second copy that
+  // could disagree with it.
+  const [params] = useSearchParams();
+  const filter = parsePeopleFilter(params.get(FILTER_PARAM));
+  const search = params.get(SEARCH_PARAM) ?? "";
+
+  // A view or a chip is one deliberate choice and gets a history entry, so back
+  // undoes it. Typing does not: a term reached by keystroke would otherwise
+  // leave one entry per letter between the guardian and the page they came
+  // from.
+  const go = (
+    next: { view?: PeopleView; filter?: PeopleFilter; search?: string },
+    options?: { replace?: boolean },
+  ) =>
+    navigate(
+      peoplePath(next.view ?? view, {
+        filter: next.filter ?? filter,
+        search: next.search ?? search,
+      }),
+      options,
+    );
 
   // The view picks the account read: the contacts list, or the recents surface.
   //
@@ -165,7 +206,7 @@ export default function PeoplePage() {
           <SegmentedControl<PeopleView>
             aria-label={t("views.label")}
             value={view}
-            onValueChange={setView}
+            onValueChange={(next) => go({ view: next })}
             options={[
               { value: "latest", label: t("views.latest") },
               { value: "directory", label: t("views.directory") },
@@ -177,7 +218,7 @@ export default function PeoplePage() {
           <Input
             type="search"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => go({ search: e.target.value }, { replace: true })}
             placeholder={t("search.placeholder")}
             aria-label={t("search.label")}
             className="w-full sm:w-72"
@@ -185,7 +226,7 @@ export default function PeoplePage() {
           <FilterChipGroup<PeopleFilter>
             aria-label={t("filters.groupLabel")}
             value={filter}
-            onValueChange={setFilter}
+            onValueChange={(next) => go({ filter: next })}
             className="flex-1"
             options={FILTER_ORDER.map((option) => ({
               value: option,

--- a/packages/web/src/pages/PeoplePage.tsx
+++ b/packages/web/src/pages/PeoplePage.tsx
@@ -18,6 +18,7 @@ import {
   parsePeopleFilter,
   PEOPLE_VIEW_PATH,
   peoplePath,
+  personPath,
   SEARCH_PARAM,
   streamRows,
   type LevelCounts,
@@ -172,8 +173,15 @@ export default function PeoplePage({ view }: { view: PeopleView }) {
   // Only a person has a dossier: a dossier is a merged history, and a history
   // is what a person has. An account nobody has placed carries its evidence on
   // its own row instead.
+  //
+  // The address being left goes with it, so the dossier's back link returns to
+  // this view on this chip and this term rather than to whichever entry happens
+  // to sit behind it.
   const openRow = (row: PeopleRow) => {
-    if (row.kind === "person") navigate(`/people/${encodeURIComponent(row.id)}`);
+    if (row.kind !== "person") return;
+    navigate(personPath(row.id), {
+      state: { from: peoplePath(view, { filter, search }) },
+    });
   };
 
   const loading = roster.isPending;

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { TimelineEntry } from "@rome/api-types/people";
 import {
@@ -207,19 +207,32 @@ function mockApi(
   return calls;
 }
 
-function renderPage(id = "wei-chen") {
+/** The dossier under the People routes `App.tsx` declares, so where its back
+ *  link lands is decided by the same history the app gives it. `before` is what
+ *  the guardian was looking at when they opened the person — nothing, when the
+ *  dossier is the address they arrived on. */
+function renderPage(id = "wei-chen", before?: string) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const entries = before ? [before, `/people/${id}`] : [`/people/${id}`];
   const view = render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[`/people/${id}`]}>
+      <MemoryRouter initialEntries={entries} initialIndex={entries.length - 1}>
         <Routes>
-          <Route path="/people" element={<div>people page</div>} />
+          <Route path="/people/latest" element={<div>the stream</div>} />
+          <Route path="/people/directory" element={<div>the directory</div>} />
           <Route path="/people/:personId" element={<PersonDetailPage />} />
         </Routes>
+        <Address />
       </MemoryRouter>
     </QueryClientProvider>,
   );
   return { ...view, queryClient };
+}
+
+/** The address the dossier's back link left the guardian on. */
+function Address() {
+  const location = useLocation();
+  return <div data-testid="address">{`${location.pathname}${location.search}`}</div>;
 }
 
 describe("PersonDetailPage", () => {
@@ -422,7 +435,7 @@ describe("PersonDetailPage", () => {
     expect(await screen.findByText("Nothing has happened on any channel yet.")).toBeTruthy();
   });
 
-  it("goes back to the roster", async () => {
+  it("goes back to the stream when the dossier is the address the guardian arrived on", async () => {
     const user = userEvent.setup();
     mockApi();
     renderPage();
@@ -430,7 +443,19 @@ describe("PersonDetailPage", () => {
     await screen.findByRole("heading", { name: "Wei Chen" });
     await user.click(screen.getByRole("button", { name: "People" }));
 
-    expect(await screen.findByText("people page")).toBeTruthy();
+    expect(await screen.findByText("the stream")).toBeTruthy();
+  });
+
+  it("returns to the view the person was opened from, on the chip it was on", async () => {
+    const user = userEvent.setup();
+    mockApi();
+    renderPage("wei-chen", "/people/directory?level=inner-circle");
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("button", { name: "People" }));
+
+    expect(await screen.findByText("the directory")).toBeTruthy();
+    expect(screen.getByTestId("address").textContent).toBe("/people/directory?level=inner-circle");
   });
 });
 

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -13,7 +13,7 @@ import {
   type PersonResource,
 } from "@rome/api-types/people";
 import i18n from "@/i18n";
-import PersonDetailPage from "./PersonDetailPage";
+import PersonDetailPage, { PersonLegacyRedirect } from "./PersonDetailPage";
 
 // The person page: who they are on top, the merged timeline below. What is under
 // test is that the page reads the two routes that own it — `GET /api/people/:id`
@@ -213,14 +213,17 @@ function mockApi(
  *  dossier is the address they arrived on. */
 function renderPage(id = "wei-chen", before?: string) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  const entries = before ? [before, `/people/${id}`] : [`/people/${id}`];
+  const entries = before
+    ? [before, { pathname: `/people/person/${id}`, state: { from: before } }]
+    : [`/people/person/${id}`];
   const view = render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={entries} initialIndex={entries.length - 1}>
         <Routes>
           <Route path="/people/latest" element={<div>the stream</div>} />
           <Route path="/people/directory" element={<div>the directory</div>} />
-          <Route path="/people/:personId" element={<PersonDetailPage />} />
+          <Route path="/people/person/:personId" element={<PersonDetailPage />} />
+          <Route path="/people/:personId" element={<PersonLegacyRedirect />} />
         </Routes>
         <Address />
       </MemoryRouter>
@@ -564,5 +567,58 @@ describe("PersonDetailPage management", () => {
     await user.click(await screen.findByRole("option", { name: "Inner circle" }));
 
     expect(await screen.findByRole("alert")).toBeTruthy();
+  });
+});
+
+// A person id is a slug of the guardian's own display name, so `latest` and
+// `directory` are ids a guardian can mint. The dossier answers under its own
+// segment for that reason, and the address a person was reached by keeps
+// working.
+describe("PersonDetailPage is reachable whatever the guardian named the person", () => {
+  it("opens a person whose id collides with a view name", async () => {
+    mockApi({ person: { ...PERSON, id: "latest", displayName: "Latest" } });
+    renderPage("latest");
+
+    expect(await screen.findByRole("heading", { name: "Latest" })).toBeTruthy();
+  });
+
+  it("forwards the address a person used to be reached by", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockApi();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/people/wei-chen"]}>
+          <Routes>
+            <Route path="/people/latest" element={<div>the stream</div>} />
+            <Route path="/people/person/:personId" element={<PersonDetailPage />} />
+            <Route path="/people/:personId" element={<PersonLegacyRedirect />} />
+          </Routes>
+          <Address />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Wei Chen" })).toBeTruthy();
+    expect(screen.getByTestId("address").textContent).toBe("/people/person/wei-chen");
+  });
+});
+
+describe("PersonDetailPage back link survives a merge", () => {
+  it("returns to the view it was opened from, not to the person the merge deleted", async () => {
+    const user = userEvent.setup();
+    mockApi({ people: [DUPLICATE] });
+    renderPage("wei-chen", "/people/directory?level=inner-circle");
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("button", { name: "Merge into another person…" }));
+    await user.click(await screen.findByRole("button", { name: /W\. Chen/ }));
+    await screen.findByRole("heading", { name: "W. Chen" });
+
+    // The merge deleted Wei Chen, so stepping back through history would land
+    // on a dossier that 404s. The survivor carries the origin instead.
+    await user.click(screen.getByRole("button", { name: "People" }));
+
+    expect(await screen.findByText("the directory")).toBeTruthy();
+    expect(screen.getByTestId("address").textContent).toBe("/people/directory?level=inner-circle");
   });
 });

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { TimelineEntry } from "@rome/api-types/people";
 import {
@@ -226,6 +226,7 @@ function renderPage(id = "wei-chen", before?: string) {
           <Route path="/people/:personId" element={<PersonLegacyRedirect />} />
         </Routes>
         <Address />
+        <BrowserBack />
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -236,6 +237,17 @@ function renderPage(id = "wei-chen", before?: string) {
 function Address() {
   const location = useLocation();
   return <div data-testid="address">{`${location.pathname}${location.search}`}</div>;
+}
+
+/** The browser's Back button. What it reaches after the back link is what says
+ *  whether that link consumed the dossier's history entry or stacked another. */
+function BrowserBack() {
+  const navigate = useNavigate();
+  return (
+    <button type="button" data-testid="browser-back" onClick={() => navigate(-1)}>
+      browser back
+    </button>
+  );
 }
 
 describe("PersonDetailPage", () => {
@@ -620,5 +632,39 @@ describe("PersonDetailPage back link survives a merge", () => {
 
     expect(await screen.findByText("the directory")).toBeTruthy();
     expect(screen.getByTestId("address").textContent).toBe("/people/directory?level=inner-circle");
+  });
+});
+
+// The back link is an arrow, and an arrow that stacks a third entry lets the
+// browser's own Back undo the click that was meant to leave.
+describe("PersonDetailPage back link consumes the dossier's history entry", () => {
+  it("does not leave the dossier reachable by pressing Back after it", async () => {
+    const user = userEvent.setup();
+    mockApi();
+    renderPage("wei-chen", "/people/directory?level=inner-circle");
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("button", { name: "People" }));
+    expect(await screen.findByText("the directory")).toBeTruthy();
+
+    await user.click(screen.getByTestId("browser-back"));
+
+    expect(screen.queryByRole("heading", { name: "Wei Chen" })).toBeNull();
+    expect(screen.getByTestId("address").textContent).toBe("/people/directory?level=inner-circle");
+  });
+
+  it("does not leave a pasted dossier reachable by pressing Back after it", async () => {
+    const user = userEvent.setup();
+    mockApi();
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("button", { name: "People" }));
+    expect(await screen.findByText("the stream")).toBeTruthy();
+
+    await user.click(screen.getByTestId("browser-back"));
+
+    expect(screen.queryByRole("heading", { name: "Wei Chen" })).toBeNull();
+    expect(screen.getByTestId("address").textContent).toBe("/people/latest");
   });
 });

--- a/packages/web/src/pages/PersonDetailPage.tsx
+++ b/packages/web/src/pages/PersonDetailPage.tsx
@@ -61,8 +61,7 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
   // the arrow honest about which view it owes. A dossier reached by pasted link
   // has no view behind it and replaces itself with the one `/people` is.
   const origin = (location.state as { from?: string } | null)?.from;
-  const back = () =>
-    origin ? navigate(-1) : navigate(PEOPLE_VIEW_PATH.latest, { replace: true });
+  const back = () => (origin ? navigate(-1) : navigate(PEOPLE_VIEW_PATH.latest, { replace: true }));
 
   const personQuery = usePerson(personId);
   const timeline = usePersonTimeline(personId);

--- a/packages/web/src/pages/PersonDetailPage.tsx
+++ b/packages/web/src/pages/PersonDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft, CircleAlert } from "lucide-react";
 import { formatWhatsAppPhone, type TimelineEntry } from "@rome/api-types/people";
@@ -10,7 +10,7 @@ import { Avatar } from "./people/avatar";
 import { ChannelPill } from "./people/channel-meta";
 import { clockTime, dayLabel, navigatorLocale, startOfDay } from "./people/format";
 import { PersonManagement } from "./people/manage";
-import { PEOPLE_VIEW_PATH } from "./people/people-model";
+import { PEOPLE_VIEW_PATH, personPath } from "./people/people-model";
 import { usePerson, usePersonTimeline } from "./people/use-roster";
 
 /**
@@ -51,13 +51,13 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
   const navigate = useNavigate();
   const location = useLocation();
 
-  // Back to where the dossier was opened from, which is a real address now that
-  // each People view has one: a guardian who reached this person from the
-  // directory, on a chip, returns to that and not to the default stream. A
-  // dossier opened by pasted link has nothing behind it — react-router marks
-  // that first entry "default" — so it falls back to the view `/people` is.
-  const back = () =>
-    location.key === "default" ? navigate(PEOPLE_VIEW_PATH.latest) : navigate(-1);
+  // Where the dossier was opened from, carried on the navigation that opened
+  // it. An address rather than a step through history: a merge ends with this
+  // person deleted and the survivor's dossier open, so counting entries
+  // backwards walks onto a person who no longer exists. A dossier reached by
+  // pasted link carries no origin and falls back to the view `/people` is.
+  const origin = (location.state as { from?: string } | null)?.from;
+  const back = () => navigate(origin ?? PEOPLE_VIEW_PATH.latest);
 
   const personQuery = usePerson(personId);
   const timeline = usePersonTimeline(personId);
@@ -143,10 +143,14 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
           </div>
           {/* A merge ends with this person gone, so the page that had them open
               follows the account history to the survivor rather than sitting on
-              a route that now 404s. */}
+              a route that now 404s. It replaces rather than pushes, and hands
+              the survivor the same origin: the entry this dossier occupies
+              names a person the merge just deleted. */}
           <PersonManagement
             person={person}
-            onMerged={(survivorId) => navigate(`/people/${encodeURIComponent(survivorId)}`)}
+            onMerged={(survivorId) =>
+              navigate(personPath(survivorId), { replace: true, state: { from: origin } })
+            }
           />
         </div>
 
@@ -228,6 +232,19 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
       </PageBody>
     </PageShell>
   );
+}
+
+/**
+ * The address a person was reached by before the dossier took its own segment.
+ *
+ * A person id never named a view, so forwarding is unambiguous: `/people/wei-chen`
+ * meant that dossier and still reaches it. The two view segments are matched by
+ * their own routes ahead of this one and never arrive here.
+ */
+export function PersonLegacyRedirect() {
+  const params = useParams<{ personId: string }>();
+  const location = useLocation();
+  return <Navigate to={personPath(params.personId ?? "")} state={location.state} replace />;
 }
 
 function BackLink({ onClick }: { onClick: () => void }) {

--- a/packages/web/src/pages/PersonDetailPage.tsx
+++ b/packages/web/src/pages/PersonDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft, CircleAlert } from "lucide-react";
 import { formatWhatsAppPhone, type TimelineEntry } from "@rome/api-types/people";
@@ -10,6 +10,7 @@ import { Avatar } from "./people/avatar";
 import { ChannelPill } from "./people/channel-meta";
 import { clockTime, dayLabel, navigatorLocale, startOfDay } from "./people/format";
 import { PersonManagement } from "./people/manage";
+import { PEOPLE_VIEW_PATH } from "./people/people-model";
 import { usePerson, usePersonTimeline } from "./people/use-roster";
 
 /**
@@ -48,6 +49,15 @@ export default function PersonDetailPageRoute() {
 function PersonDetailPage({ personId }: { personId: string | undefined }) {
   const { t } = useTranslation("people");
   const navigate = useNavigate();
+  const location = useLocation();
+
+  // Back to where the dossier was opened from, which is a real address now that
+  // each People view has one: a guardian who reached this person from the
+  // directory, on a chip, returns to that and not to the default stream. A
+  // dossier opened by pasted link has nothing behind it — react-router marks
+  // that first entry "default" — so it falls back to the view `/people` is.
+  const back = () =>
+    location.key === "default" ? navigate(PEOPLE_VIEW_PATH.latest) : navigate(-1);
 
   const personQuery = usePerson(personId);
   const timeline = usePersonTimeline(personId);
@@ -74,7 +84,7 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
     return (
       <PageShell>
         <PageBody>
-          <BackLink onClick={() => navigate("/people")} />
+          <BackLink onClick={back} />
           <Alert variant="destructive">
             <CircleAlert aria-hidden="true" />
             <AlertTitle>
@@ -103,7 +113,7 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
   return (
     <PageShell>
       <PageBody>
-        <BackLink onClick={() => navigate("/people")} />
+        <BackLink onClick={back} />
 
         <div className="flex flex-wrap items-start gap-4 rounded-14 border border-border bg-surface p-5 shadow-1">
           <Avatar name={person.displayName} tone="bg-surface-muted text-muted-foreground" />

--- a/packages/web/src/pages/PersonDetailPage.tsx
+++ b/packages/web/src/pages/PersonDetailPage.tsx
@@ -52,12 +52,17 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
   const location = useLocation();
 
   // Where the dossier was opened from, carried on the navigation that opened
-  // it. An address rather than a step through history: a merge ends with this
-  // person deleted and the survivor's dossier open, so counting entries
-  // backwards walks onto a person who no longer exists. A dossier reached by
-  // pasted link carries no origin and falls back to the view `/people` is.
+  // it. An origin says a view sits behind this dossier, so the arrow spends the
+  // dossier's own history entry rather than stacking a third — otherwise the
+  // browser's Back undoes the click that was meant to leave.
+  //
+  // A merge is why the origin is carried rather than inferred: it deletes this
+  // person and puts the survivor in their entry, so the address is what keeps
+  // the arrow honest about which view it owes. A dossier reached by pasted link
+  // has no view behind it and replaces itself with the one `/people` is.
   const origin = (location.state as { from?: string } | null)?.from;
-  const back = () => navigate(origin ?? PEOPLE_VIEW_PATH.latest);
+  const back = () =>
+    origin ? navigate(-1) : navigate(PEOPLE_VIEW_PATH.latest, { replace: true });
 
   const personQuery = usePerson(personId);
   const timeline = usePersonTimeline(personId);

--- a/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
+++ b/packages/web/src/pages/dev/mdx/docs/people-demo.tsx
@@ -398,7 +398,7 @@ export function ViewSwitcherDemo() {
 export function PersonPageDemo() {
   const { t } = useTranslation("people");
   return (
-    <Frame label="/people/:personId">
+    <Frame label="/people/person/:personId">
       <div className="flex flex-col gap-4 p-2">
         <div className="flex items-start gap-3">
           <Avatar name="Mira Okafor" size="lg" />

--- a/packages/web/src/pages/people/people-model.test.ts
+++ b/packages/web/src/pages/people/people-model.test.ts
@@ -8,6 +8,8 @@ import type {
 import {
   directoryGroups,
   levelCounts,
+  parsePeopleFilter,
+  peoplePath,
   peopleRows,
   rowHandle,
   streamRows,
@@ -300,5 +302,39 @@ describe("rowHandle", () => {
   it("falls back to the raw identifier on a channel with no phone shape", () => {
     const [row] = peopleRows([], [contact({ channel: "discord", channelUserId: "6128843201" })]);
     expect(rowHandle(row)).toBe("6128843201");
+  });
+});
+
+describe("peoplePath", () => {
+  it("gives each view its own address", () => {
+    expect(peoplePath("latest", { filter: "all", search: "" })).toBe("/people/latest");
+    expect(peoplePath("directory", { filter: "all", search: "" })).toBe("/people/directory");
+  });
+
+  it("carries the chip and the term, and leaves the defaults out", () => {
+    expect(peoplePath("directory", { filter: "unknown", search: "" })).toBe(
+      "/people/directory?level=unknown",
+    );
+    expect(peoplePath("latest", { filter: "all", search: "wei chen" })).toBe(
+      "/people/latest?q=wei+chen",
+    );
+    expect(peoplePath("latest", { filter: "stranger", search: "wei" })).toBe(
+      "/people/latest?level=stranger&q=wei",
+    );
+  });
+});
+
+describe("parsePeopleFilter", () => {
+  it("takes the chips the rail offers", () => {
+    expect(parsePeopleFilter("inner-circle")).toBe("inner-circle");
+    expect(parsePeopleFilter("stranger")).toBe("stranger");
+  });
+
+  it("answers a missing or unoffered level with every level", () => {
+    // Guardian is a ladder position with no chip, so an address naming it is
+    // as unusable as one naming a level that never existed.
+    expect(parsePeopleFilter("guardian")).toBe("all");
+    expect(parsePeopleFilter("former-colleague")).toBe("all");
+    expect(parsePeopleFilter(null)).toBe("all");
   });
 });

--- a/packages/web/src/pages/people/people-model.ts
+++ b/packages/web/src/pages/people/people-model.ts
@@ -55,6 +55,51 @@ export const FILTER_ORDER: PeopleFilter[] = [
   "stranger",
 ];
 
+/**
+ * Where each view answers, and what the controls above it ride in the query.
+ *
+ * The view is the route rather than a piece of component state, so a directory
+ * is something to link to, the back button steps between the two, and a reload
+ * comes back to what was on screen. The chip and the term ride the query under
+ * the names the reads themselves take — `level` and `q` — so a shared address
+ * reads as the request it produces.
+ */
+export const PEOPLE_VIEW_PATH: Record<PeopleView, string> = {
+  latest: "/people/latest",
+  directory: "/people/directory",
+};
+export const FILTER_PARAM = "level";
+export const SEARCH_PARAM = "q";
+
+/**
+ * The chip a URL asks for, or "all" when it names none the rail offers.
+ *
+ * An address is typed, kept and shared, so it will eventually name a level the
+ * rail has stopped offering. Falling back leaves the page on its default view
+ * rather than with a rail where nothing is selected.
+ */
+export function parsePeopleFilter(raw: string | null | undefined): PeopleFilter {
+  return FILTER_ORDER.includes(raw as PeopleFilter) ? (raw as PeopleFilter) : "all";
+}
+
+/**
+ * The address a view, a chip and a term make together — every link this page
+ * builds, from whichever one of the three the guardian just moved.
+ *
+ * Defaults are left out, so the plain `/people/latest` is what the page is
+ * usually at and a query parameter means somebody chose something.
+ */
+export function peoplePath(
+  view: PeopleView,
+  controls: { filter: PeopleFilter; search: string },
+): string {
+  const query = new URLSearchParams();
+  if (controls.filter !== "all") query.set(FILTER_PARAM, controls.filter);
+  if (controls.search) query.set(SEARCH_PARAM, controls.search);
+  const suffix = query.toString();
+  return suffix ? `${PEOPLE_VIEW_PATH[view]}?${suffix}` : PEOPLE_VIEW_PATH[view];
+}
+
 /** Directory groups, in ladder order. */
 export const GROUP_ORDER: RowLevel[] = [...BOND_LADDER];
 

--- a/packages/web/src/pages/people/people-model.ts
+++ b/packages/web/src/pages/people/people-model.ts
@@ -72,6 +72,18 @@ export const FILTER_PARAM = "level";
 export const SEARCH_PARAM = "q";
 
 /**
+ * Where one person's dossier answers.
+ *
+ * Under its own segment, because a person id is a slug of the display name the
+ * guardian gave them: `generatePersonSlug("Latest")` is `latest`. Sharing the
+ * views' segment would leave a person named after one of them with no address
+ * that reaches their dossier.
+ */
+export function personPath(personId: string): string {
+  return `/people/person/${encodeURIComponent(personId)}`;
+}
+
+/**
  * The chip a URL asks for, or "all" when it names none the rail offers.
  *
  * An address is typed, kept and shared, so it will eventually name a level the


### PR DESCRIPTION
## What this PR does

The stream and the directory were one address. `/people` held both, and which one showed was component state, so a guardian could not link to the directory, a reload dropped them back on the stream, and the back button left the page rather than undoing the toggle they had just made. The filter chip and the search term were lost the same way.

Each view is a route now, and the two controls above it ride the query.

```
/people                        → /people/latest, carrying any query it arrived with
/people/latest                 → the stream
/people/directory              → the roster
/people/person/:personId       → the dossier
/people/:personId              → forwards to /people/person/:personId
```

Query: `?level=<chip>` and `?q=<term>`.

## Design & Invariants

The page holds no control state of its own. What is on screen is what the address says, read back through `useSearchParams` and the route's own `view` prop. A second copy of the view or the chip could disagree with the URL, so there is not one.

Defaults stay out of the address. `peoplePath` omits `level` at "all" and `q` when empty, so `/people/latest` is what the page usually sits at and a query parameter means the guardian chose something.

An address is typed, kept and shared, so it will eventually name a level the rail has stopped offering. `parsePeopleFilter` answers an unknown or absent level with "all" rather than leaving the rail with nothing selected.

A view or a chip is one deliberate choice and spends a history entry, so back undoes it. Typing replaces instead, or a term reached by keystroke would leave one entry per letter between the guardian and the page they came from. The debounce before the wire is unchanged and still lives in `use-roster.ts`.

The dossier takes its own segment rather than sharing the views'. A person id is not opaque — `generatePersonSlug` derives it from the display name the guardian gave them, so `generatePersonSlug("Latest")` is `latest`. Static view routes would outrank `/people/:personId` and leave a person named after a view with no address that reached their dossier. The bare `/people/:personId` forwards, so an address a person was already reached by keeps working.

The dossier's back link went to `/people`, which now forwards to the stream and would drop the directory and chip the guardian came from. The view it was opened from travels with the navigation that opened it, on location state.

That origin is what makes the arrow's history discipline safe. It says a view sits behind this dossier, so the arrow spends the dossier's own entry rather than stacking a third — a back link that pushes lets the browser's Back undo the click that was meant to leave. A merge deletes this person and puts the survivor in their entry, which is why the origin is carried rather than inferred, and why the survivor inherits it. A dossier reached by pasted link has no view behind it and replaces itself with the stream.

The alternative was `?view=directory`, matching the `useSearchParams` pattern in `channels-settings-page.tsx` and touching no routes. A path segment reads as a page rather than as a modifier on one, which is what the two views are.

## Test plan

- [x] `pnpm --filter rome-web typecheck` — clean.
- [x] `pnpm --filter rome-web test` — 1236 passed across 156 files.
- [x] `biome check` on the seven touched files — clean.
- [x] 15 new tests: the redirect, a cold load of each view, the toggle and chip writing the address, back undoing a chip but not a keystroke, a reload holding view + chip + term, an unoffered level falling back, the dossier returning to the view it was opened from, a person whose id collides with a view name, the legacy person address forwarding, and the back link after a merge.
- [x] Each fix reverted on its own fails exactly its own tests and nothing else.
- [x] Driven in a browser against `pnpm start:web:mock`: `/people` settles on `/people/latest`; toggle, chip and typing write the address; back undoes the chip rather than the letters; a cold `/people/directory?level=stranger&q=a` opens on exactly that and survives a reload; `?level=nonsense` falls back to All; a directory row opens `/people/person/nadia-petrova`; `/people/nadia-petrova` forwards there; merging from the directory and clicking back returns to `/people/directory?level=inner-circle` rather than to the deleted person; a pasted dossier link lands on `/people/latest`; and after the back arrow in either case, the browser's Back leaves the app rather than reopening the dossier. No console errors.

## Not in this PR

- `e2e/layout-invariants.spec.ts` still sweeps `/people`, which forwards to the stream. The directory is separately addressable now and could join that list, which is coverage the sweep has never had rather than coverage this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

