### PR TITLE
docs(northstars): state the view-URL ideal

### DIFF
--- a/docs/northstars/view-urls.md
+++ b/docs/northstars/view-urls.md
@@ -1,0 +1,14 @@
+# View URLs
+
+A **view** is UI whose content a user can return to or share: a page, a tab, a detail pane, a content-bearing panel or sheet, or a collection under a filter, search, or sort. A **control** is UI that composes the next action — a menu, a picker, a confirmation prompt, a transient popover — and is not a view. A step in a flow that cannot render without in-progress input is a control. A setting that changes the arrangement of a view's content without changing the content is a presentation preference, not a distinct view.
+
+## Statements
+
+- Every view has a URL. Opening that URL in a fresh session renders that view.
+- Distinct views have distinct URLs. A view has one canonical URL.
+- A view renders from its URL and persisted data alone. State that exists only in the running page may enrich a view but never gates its content.
+- Navigating between views updates the URL. The browser back button returns to the previous view.
+- The state of a collection view — its filter, search, sort, and position — is part of its URL.
+- Per-user presentation preferences stay out of the URL.
+- A URL that ever named a view keeps rendering that view, directly or by redirect.
+- A view inside an app has its URL within the app's own path namespace, under the same statements.


### PR DESCRIPTION
### What this PR does

No written rule says which UI states in Rome deserve a URL. Views accrete in component state — the sessions explorer drops its filters from the URL, the People and Routines view toggles are unshareable, and the trace drawer cannot be linked. This PR adds the north-star doc for view addressability: every view has a unique URL. The `loop-reconcile` skill computes the gap against its Statements and files the work issues.

Three milestones slice the end state on GitHub: dashboard views are addressable, dashboard collection state rides the URL, and app views are addressable.

### Test plan

- [x] Statements pass the `loop-northstar` admission rules — declarative present, checkable, no file or type named.
- [x] The Statements list contains no two claims that cannot both hold, walked as a set.

### Not in this PR

- Work issues closing the gap — `loop-reconcile` files them from the Statements.
- Rationale for URL-as-source-of-truth — an ADR can carry it if the choice starts constraining diffs.