### PR TITLE
feat(web): fold the directory's placement gestures into a row menu

### DIFF
--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -142,6 +142,10 @@
     "label": "Link to existing person",
     "selectPlaceholder": "Select a person…"
   },
+  "placeMenu": {
+    "create": "Create profile…",
+    "link": "Link to person…"
+  },
   "linkPicker": {
     "heldBy": "now {{owner}}'s"
   },

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -142,6 +142,10 @@
     "label": "关联到已有人物",
     "selectPlaceholder": "选择一位人物…"
   },
+  "placeMenu": {
+    "create": "创建资料…",
+    "link": "关联到人物…"
+  },
   "linkPicker": {
     "heldBy": "当前属于 {{owner}}"
   },

--- a/packages/web/src/pages/PeoplePage.test.tsx
+++ b/packages/web/src/pages/PeoplePage.test.tsx
@@ -614,20 +614,33 @@ describe("PeoplePage directory", () => {
     expect(screen.queryByText(/\d+ messages?/)).toBeNull();
   });
 
-  it("still offers the placement gestures on an account nobody has decided about", async () => {
+  it("folds the placement gestures into one row menu on an account nobody has decided about", async () => {
     const user = userEvent.setup();
-    mockApi({ people: [FRIEND], accounts: [UNKNOWN_SENDER] });
+    const { calls } = mockApi({ people: [FRIEND], accounts: [UNKNOWN_SENDER] });
     renderPage();
 
     await screen.findByText("Wei Chen");
     await showDirectory(user);
 
-    // The contacts row carries the same three verbs the stream's dense row does
-    // — the decision is available wherever the account is.
+    // The decision is available wherever the account is, but the roster is for
+    // reading: the row wears one quiet control, and the stream's three verbs
+    // sit behind it.
     await screen.findByText("Rachel Lim");
-    expect(screen.getByRole("button", { name: "Create" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Link" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Treat as stranger" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Create" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Treat as stranger" })).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Actions for Rachel Lim" }));
+    expect(await screen.findByRole("menuitem", { name: "Create profile…" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Link to person…" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Treat as stranger" })).toBeTruthy();
+
+    // The menu reaches the same verb the stream's button does: one request
+    // creating the person with the account already on it.
+    await user.click(screen.getByRole("menuitem", { name: "Create profile…" }));
+    await user.click(await screen.findByRole("button", { name: "Create profile" }));
+    await waitFor(() =>
+      expect(calls.some((c) => c.method === "POST" && c.url === "/api/people")).toBe(true),
+    );
   });
 
   it("pages the directory by name, resuming at the cursor the server named", async () => {

--- a/packages/web/src/pages/PeoplePage.tsx
+++ b/packages/web/src/pages/PeoplePage.tsx
@@ -142,7 +142,8 @@ export default function PeoplePage() {
   // on the row their view has. The stream renders them dense — a placement and
   // a restore both decide on what the sender actually sent, so the evidence is
   // on the row rather than a click away — and the directory renders them as the
-  // contacts line every other row is, with the buttons at the end of it.
+  // contacts line every other row is, with the gestures behind a `⋯` menu at
+  // the end of it.
   const unplaced = (row: PeopleRow, variant: PeopleView) =>
     row.level === "stranger" ? (
       <DismissedEntry key={row.id} row={row} variant={variant} />

--- a/packages/web/src/pages/dev/mdx/docs/people-page.mdx
+++ b/packages/web/src/pages/dev/mdx/docs/people-page.mdx
@@ -123,8 +123,10 @@ it.
 The guardian row is fixed: not moved, not merged, not selected. Nobody else is held
 back — a contact the address book synced and nobody has ever heard from is in the
 Unknown group like any other account, because looking someone up is what this view is
-for. An account nobody has decided about carries the same three placement gestures
-here that it carries on the stream, at the end of its row.
+for. An account nobody has decided about admits the same three placement gestures
+here that it admits on the stream, folded behind a `⋯` menu at the end of its row —
+the Unknown group can hold a whole synced address book, and a row of buttons per
+contact would out-shout the roster the view exists to read.
 
 ---
 

--- a/packages/web/src/pages/people/rows.tsx
+++ b/packages/web/src/pages/people/rows.tsx
@@ -127,9 +127,9 @@ export function UnknownRow({ row, actions }: { row: PeopleRow; actions?: React.R
  * stream. Clicking a person opens their dossier; an account has none to open
  * until it is placed on somebody.
  *
- * `actions` is whatever gesture the row's position admits: placing an account
- * nobody has decided about, or taking a dismissal back. The gestures themselves
- * are `people/triage.tsx`; the row only says where they go.
+ * `actions` is whatever gesture the row's position admits: a `⋯` menu placing
+ * an account nobody has decided about, or taking a dismissal back. The gestures
+ * themselves are `people/triage.tsx`; the row only says where they go.
  */
 export function DirectoryRow({
   row,

--- a/packages/web/src/pages/people/triage.tsx
+++ b/packages/web/src/pages/people/triage.tsx
@@ -1,6 +1,7 @@
 import { useId, useState } from "react";
 import { useForm } from "@tanstack/react-form";
 import { useTranslation } from "react-i18next";
+import { MoreHorizontal } from "lucide-react";
 import {
   ASSIGNABLE_BOND_LEVELS,
   normalizeBondLevel,
@@ -9,6 +10,13 @@ import {
   type PersonResource,
 } from "@rome/api-types/people";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import {
@@ -256,7 +264,7 @@ function LinkForm({
  * The stream's row is dense: a placement decision runs on the evidence — which
  * channel, which number, what they last said — so all of it is on the row. The
  * directory carries none of that, so its row is the contacts line every other
- * row in that view is, and the buttons sit at the end of it.
+ * row in that view is, and the gestures sit behind a `⋯` menu at the end of it.
  */
 function entryRow(variant: PeopleView) {
   return variant === "directory" ? DirectoryRow : UnknownRow;
@@ -363,47 +371,76 @@ export function UnknownEntry({
   }
 
   const Row = entryRow(variant);
+  // The verbs wear the shape their view has room for. The stream is the triage
+  // surface, a handful of senders waiting on a decision, so its dense row
+  // carries the three as buttons. The directory's Unknown group is everyone
+  // Rome has not placed — a synced address book can put hundreds of rows in it
+  // — and three buttons per contact would out-shout the roster the view exists
+  // to read, so there they fold into one quiet row menu.
+  const triageButtons = (
+    <span className="flex items-center gap-1">
+      <Button type="button" size="sm" onClick={() => openAction("create")} disabled={acting}>
+        {t("actions.create")}
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => openAction("link")}
+        disabled={acting}
+      >
+        {t("actions.link")}
+      </Button>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        onClick={() => setConfirmingDismiss(true)}
+        disabled={acting}
+      >
+        <BusyLabel
+          idle={t("actions.markStranger")}
+          busy={t("actions.markingStranger")}
+          isBusy={acting}
+        />
+      </Button>
+    </span>
+  );
+  const rowMenu = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        {/* A `Button` rather than `IconButton` for the `ghost` aria-expanded
+            paint, which marks the row whose menu is open. */}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          disabled={acting}
+          aria-label={t("actions.rowMenu", { name })}
+        >
+          <MoreHorizontal aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={() => openAction("create")}>
+          {t("placeMenu.create")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => openAction("link")}>
+          {t("placeMenu.link")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {/* Deliberately the same words as the confirm dialog's button: the item
+            that opens the confirm and the button that carries it out promise
+            the same thing. */}
+        <DropdownMenuItem variant="destructive" onSelect={() => setConfirmingDismiss(true)}>
+          {t("actions.markStranger")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
   return (
     <div>
-      <Row
-        row={row}
-        actions={
-          !action && (
-            <span className="flex items-center gap-1">
-              <Button
-                type="button"
-                size="sm"
-                onClick={() => openAction("create")}
-                disabled={acting}
-              >
-                {t("actions.create")}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => openAction("link")}
-                disabled={acting}
-              >
-                {t("actions.link")}
-              </Button>
-              <Button
-                type="button"
-                variant="destructive"
-                size="sm"
-                onClick={() => setConfirmingDismiss(true)}
-                disabled={acting}
-              >
-                <BusyLabel
-                  idle={t("actions.markStranger")}
-                  busy={t("actions.markingStranger")}
-                  isBusy={acting}
-                />
-              </Button>
-            </span>
-          )
-        }
-      />
+      <Row row={row} actions={!action && (variant === "directory" ? rowMenu : triageButtons)} />
 
       {/* With no form open the failure belongs to the dismissal, whose button
           sits on the row above. */}


### PR DESCRIPTION
## What this PR does

The directory view's Unknown group holds every account Rome has not placed. A synced address book can fill it with hundreds of contacts, and each row carried three buttons — Create, Link, Treat as stranger. The roster the view exists to read arrived under a wall of controls.

The three gestures now sit behind a `⋯` menu at the end of the directory's row. The stream keeps its buttons.

## Design & Invariants

A view's row carries the gestures in the shape that view has room for. The stream is the triage surface: a handful of senders waiting on a decision, with the evidence already on a dense row, so the three verbs stay as buttons there. The directory is a contacts list read by name, so the same three verbs fold into one control per row.

Which verbs a row admits does not change with the view. Both surfaces call the same handlers, and each gesture stays the verb of the `/people` contract it always was — a create, a link, or a decision about the account. The confirmation before a dismissal and the two-step transfer on a held account are untouched.

The menu is the design the page's own note already carried. [`people-page.mdx`](packages/web/src/pages/dev/mdx/docs/people-page.mdx) sketched a `⋯` row menu in a specimen written in the note rather than imported, on the grounds that the page did not carry one. The directory half of that lands here, and the note now describes what ships.

The trigger is a `Button` with `variant=\"ghost\"` rather than an `IconButton`, for the `aria-expanded` paint that marks which row has a menu open. The dismissal item reuses the confirm dialog's own words, so the item that opens the confirmation and the button that carries it out promise the same thing.

## Test plan

- [x] `pnpm typecheck` — passes.
- [x] `pnpm test:unit` — 528 tests across 36 files pass. The directory test now asserts the buttons are gone, opens the menu, checks all three items, and drives `Create profile…` through to the `POST /api/people` write.
- [x] Exercised in the browser against `pnpm start:web:mock`. The Unknown group renders 11 contacts as two-line rows with one `⋯` each, the menu opens with the three verbs and the dismissal in destructive red, and picking `Create profile…` expands the inline form. No console errors.
- [ ] Not checked on a touch viewport, where the trigger takes the 44px floor from `touch-target`.

## Not in this PR

- The stream's own rows. The note sketches a `⋯` menu there too, and the dense row is the surface where the three verbs earn their width.
- The menu's move-to-level items and the bulk bar, which the note also sketches. A bulk gesture is N writes behind one confirmation, and the contract has no verb that answers what a partial failure leaves behind — tracked in [#67](https://github.com/rome-os/rome/issues/67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)