### PR TITLE
feat(web): give the session details pane and turn-trace drawer URLs

### DIFF
--- a/packages/web/src/components/agent-trace/TraceDrawer.test.tsx
+++ b/packages/web/src/components/agent-trace/TraceDrawer.test.tsx
@@ -106,6 +106,44 @@ describe("traceDrawerOpenPlacementClass", () => {
   });
 });
 
+describe("TraceDrawer stored load", () => {
+  it("still shows a trace whose load outlived a dependency change", async () => {
+    let resolveTrace: (snapshot: TraceSnapshot) => void = () => {};
+    const pending = new Promise<TraceSnapshot>((resolve) => {
+      resolveTrace = resolve;
+    });
+    const target = {
+      kind: "stored" as const,
+      messageId: "parent-trace",
+      sessionId: "parent-session",
+      turnId: "parent-turn",
+      summary: targetSummary,
+    };
+    const drawer = (loadStoredTrace: () => Promise<TraceSnapshot>) => (
+      <TraceDrawer
+        target={target}
+        onClose={() => {}}
+        loadStoredTrace={loadStoredTrace}
+        renderInlineBlock={(block) =>
+          block.type === "result" && block.accounting ? (
+            <UsageSummaryBlock accounting={block.accounting} />
+          ) : null
+        }
+        renderRunBlocks={() => null}
+      />
+    );
+
+    const { rerender } = render(drawer(() => pending));
+    // A re-render that changes a loader dependency — the page's translations
+    // landing, say — must not strand the fetch already in flight for this trace.
+    rerender(drawer(() => pending));
+    resolveTrace(usageSnapshot(true));
+
+    expect(await screen.findByText("13")).toBeTruthy();
+    expect(screen.queryByText("trace.loading")).toBeNull();
+  });
+});
+
 describe("TraceDrawer subagent usage", () => {
   it("loads included usage by default and refetches when the switch is disabled", async () => {
     const loadStoredTrace = vi.fn(async (_messageId: string, include: boolean) =>

--- a/packages/web/src/components/agent-trace/TraceDrawer.tsx
+++ b/packages/web/src/components/agent-trace/TraceDrawer.tsx
@@ -163,11 +163,16 @@ export function TraceDrawer({
     }
     const key = `${remoteTargetKey}:${includeSubagentUsage}:${retryNonce}`;
     if (loadedKeyRef.current === key) return;
-    let cancelled = false;
     loadedKeyRef.current = key;
     if (loadedTargetKeyRef.current !== remoteTargetKey) setRemoteTrace(null);
     setError(null);
     setLoading(true);
+    // The key in the ref, not the effect run, decides whose result counts. An
+    // effect that re-runs for the same key returns above and leaves this load
+    // to finish; anything else has already claimed the ref, so this load lands
+    // nowhere. Tying it to the effect run instead would strand `loading` on
+    // every re-render that happened mid-fetch.
+    const superseded = () => loadedKeyRef.current !== key;
     (async () => {
       try {
         const trace = storedId
@@ -175,7 +180,7 @@ export function TraceDrawer({
           : turnTarget
             ? await loadTurnTrace(turnTarget.sessionId, turnTarget.turnId, includeSubagentUsage)
             : null;
-        if (cancelled) return;
+        if (superseded()) return;
         if (!trace) {
           setError(t("trace.drawer.notAvailable"));
           return;
@@ -183,19 +188,16 @@ export function TraceDrawer({
         loadedTargetKeyRef.current = remoteTargetKey;
         setRemoteTrace(trace);
       } catch (err) {
-        if (cancelled) return;
+        if (superseded()) return;
         setError(
           err instanceof Error
             ? t("trace.drawer.loadFailedReason", { reason: err.message })
             : t("trace.drawer.loadFailed"),
         );
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!superseded()) setLoading(false);
       }
     })();
-    return () => {
-      cancelled = true;
-    };
   }, [
     remoteTargetKey,
     storedId,

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -11,7 +11,15 @@ import {
   SquareActivity,
   X,
 } from "lucide-react";
-import { Link, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
+import {
+  Link,
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -56,7 +64,7 @@ import type {
   RomeSessionsPageResult,
   StreamBlock,
 } from "@/lib/chat-types";
-import type { TraceSegment, TraceSnapshot } from "@rome/api-types/trace-segments";
+import type { TraceSegment, TraceSnapshot, TraceSummary } from "@rome/api-types/trace-segments";
 import type {
   RomeSessionDetail,
   RomeSessionType,
@@ -71,6 +79,14 @@ import type {
 } from "@rome/api-types/sessions";
 import { SessionsOverview, type SessionOverviewGroupDimension } from "./SessionsOverview";
 import {
+  parseSessionSurface,
+  sessionPath,
+  sessionsBasePath,
+  sessionSurfacePath,
+  SESSIONS_FULL_ROUTE_BASE,
+  type SessionSurface,
+} from "./session-surface";
+import {
   costCoverage,
   formatCompactNumber,
   formatCost,
@@ -82,6 +98,13 @@ import {
 } from "./sessions-format";
 
 const PAGE_SIZE = 50;
+// Stand-in header for a trace opened straight from its URL, before the loaded
+// snapshot supplies the real summary.
+const EMPTY_TRACE_SUMMARY: TraceSummary = {
+  distinctApps: [],
+  totalSteps: 0,
+  invocationCounts: {},
+};
 const ALL = "__all__";
 const INTERNAL_SOURCE = "__internal__";
 const NO_OP = () => {};
@@ -835,12 +858,20 @@ function ReadOnlySessionChat({
   session,
   messages,
   liveTurn,
+  surface,
+  onOpenSurface,
+  onCloseSurface,
 }: {
   session: RomeSessionRecord;
   messages: ChatMessage[];
   liveTurn: { turnId: string; snapshot: TraceSnapshot; text: string } | null;
+  surface: SessionSurface;
+  onOpenSurface: (surface: SessionSurface) => void;
+  onCloseSurface: () => void;
 }) {
-  const [traceDrawerTarget, setTraceDrawerTarget] = useState<TraceDrawerTarget | null>(null);
+  // A live trace streams a turn that only exists in this page, so it stays in
+  // state. Stored and turn traces name persisted rows, so the URL holds them.
+  const [liveTraceTarget, setLiveTraceTarget] = useState<TraceDrawerTarget | null>(null);
   const messagesBySession = useMemo(() => {
     const map = new Map<string, ChatMessage[]>();
     for (const message of messages) {
@@ -896,8 +927,33 @@ function ReadOnlySessionChat({
     [],
   );
 
-  const drawerTarget =
-    traceDrawerTarget?.kind === "live" && liveTurn
+  // The drawer's own URL is the source of truth: a stored or turn trace opens
+  // from the address alone, and the loaded messages only enrich its header.
+  const urlTraceTarget = useMemo<TraceDrawerTarget | null>(() => {
+    if (surface.kind === "messageTrace") {
+      const message = messages.find((entry) => entry.id === surface.messageId);
+      return {
+        kind: "stored",
+        messageId: surface.messageId,
+        sessionId: message?.sessionId ?? session.id,
+        turnId: message?.turnId ?? null,
+        summary: message?.traceSummary ?? EMPTY_TRACE_SUMMARY,
+      };
+    }
+    if (surface.kind === "turnTrace") {
+      const message = messages.find((entry) => entry.turnId === surface.turnId);
+      return {
+        kind: "turn",
+        sessionId: session.id,
+        turnId: surface.turnId,
+        summary: message?.traceSummary ?? EMPTY_TRACE_SUMMARY,
+      };
+    }
+    return null;
+  }, [messages, session.id, surface]);
+
+  const liveDrawerTarget =
+    liveTraceTarget?.kind === "live" && liveTurn
       ? {
           kind: "live" as const,
           sessionId: session.id,
@@ -906,14 +962,15 @@ function ReadOnlySessionChat({
           segments: liveTurn.snapshot.segments,
           streaming: true,
         }
-      : traceDrawerTarget;
+      : liveTraceTarget;
+  const drawerTarget = urlTraceTarget ?? liveDrawerTarget;
 
   return (
     <TooltipProvider delayDuration={150}>
       <div className="@container/chat relative flex min-h-0 flex-1 overflow-hidden">
         <div
           className={`relative flex min-h-0 min-w-0 flex-1 flex-col @5xl/chat:transition-[width] @5xl/chat:duration-200 @5xl/chat:ease-out ${traceDrawerContentInsetClass(
-            traceDrawerTarget !== null,
+            drawerTarget !== null,
             false,
           )}`}
         >
@@ -930,7 +987,7 @@ function ReadOnlySessionChat({
               contentRef={NO_OP}
               onOpenLiveTrace={() => {
                 if (!liveTurn) return;
-                setTraceDrawerTarget({
+                setLiveTraceTarget({
                   kind: "live",
                   sessionId: session.id,
                   turnId: liveTurn.turnId,
@@ -938,15 +995,24 @@ function ReadOnlySessionChat({
                   segments: liveTurn.snapshot.segments,
                   streaming: true,
                 });
+                // One drawer at a time: leave the URL surface, which outranks
+                // the live target, or the click would show nothing.
+                if (urlTraceTarget) onCloseSurface();
               }}
-              onOpenStoredTrace={setTraceDrawerTarget}
+              onOpenStoredTrace={(target) => {
+                setLiveTraceTarget(null);
+                if (target.kind === "stored")
+                  onOpenSurface({ kind: "messageTrace", messageId: target.messageId });
+                else if (target.kind === "turn")
+                  onOpenSurface({ kind: "turnTrace", turnId: target.turnId });
+              }}
               actions={actions}
             />
           </div>
         </div>
         <TraceDrawer
           target={drawerTarget}
-          onClose={() => setTraceDrawerTarget(null)}
+          onClose={() => (urlTraceTarget ? onCloseSurface() : setLiveTraceTarget(null))}
           loadStoredTrace={loadStoredTrace}
           allowSubagentUsage
           readOnly
@@ -971,10 +1037,12 @@ function ReadOnlySessionChat({
 
 function SessionDetailsSheet({
   session,
+  basePath,
   open,
   onClose,
 }: {
   session: RomeSessionDetail;
+  basePath: string;
   open: boolean;
   onClose: () => void;
 }) {
@@ -1062,8 +1130,7 @@ function SessionDetailsSheet({
               {session.lineage.parent ? (
                 <Button asChild variant="outline" className="w-full justify-start">
                   <Link
-                    to={`../${encodeURIComponent(session.lineage.parent.id)}`}
-                    relative="path"
+                    to={sessionPath(basePath, session.lineage.parent.id)}
                     state={location.state}
                   >
                     <GitFork />
@@ -1073,11 +1140,7 @@ function SessionDetailsSheet({
               ) : null}
               {session.lineage.children.map((child) => (
                 <Button key={child.id} asChild variant="outline" className="w-full justify-start">
-                  <Link
-                    to={`../${encodeURIComponent(child.id)}`}
-                    relative="path"
-                    state={location.state}
-                  >
+                  <Link to={sessionPath(basePath, child.id)} state={location.state}>
                     <GitFork />
                     Child · {child.displayTitle}
                   </Link>
@@ -1116,12 +1179,12 @@ function SessionDetailsSheet({
   );
 }
 
-function SessionDetailPage({ sessionId }: { sessionId: string }) {
+function SessionDetailPage({ sessionId, surface }: { sessionId: string; surface: SessionSurface }) {
   const location = useLocation();
   const navigate = useNavigate();
-  const fullMode = location.pathname.startsWith("/full/apps/sessions");
+  const basePath = sessionsBasePath(location.pathname);
+  const fullMode = basePath === SESSIONS_FULL_ROUTE_BASE;
   const [session, setSession] = useState<RomeSessionDetail | null>(null);
-  const [detailsOpen, setDetailsOpen] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -1131,6 +1194,18 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
     text: string;
   } | null>(null);
 
+  const openSurface = useCallback(
+    (next: SessionSurface) => navigate(sessionSurfacePath(basePath, sessionId, next)),
+    [basePath, navigate, sessionId],
+  );
+  // Opening a surface pushed an entry, so the back button closes it. Closing
+  // pushes the session URL rather than replacing it, so the surface the user
+  // just left stays reachable through back.
+  const closeSurface = useCallback(
+    () => navigate(sessionPath(basePath, sessionId)),
+    [basePath, navigate, sessionId],
+  );
+
   const handleBack = useCallback(() => {
     // BrowserRouter starts its own history index at zero, so an index above
     // zero means there is an in-app entry we can safely return to.
@@ -1139,8 +1214,8 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
       navigate(-1);
       return;
     }
-    navigate("/sessions");
-  }, [navigate]);
+    navigate(basePath);
+  }, [basePath, navigate]);
 
   const reloadMessages = useCallback(async () => {
     const result = await listRomeSessionMessages(sessionId);
@@ -1310,11 +1385,7 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
         ) : null}
         {session?.parentSessionId ? (
           <Button asChild variant="outline">
-            <Link
-              to={`../${encodeURIComponent(session.parentSessionId)}`}
-              relative="path"
-              state={location.state}
-            >
+            <Link to={sessionPath(basePath, session.parentSessionId)} state={location.state}>
               <GitFork />
               {session.type === "subagent" ? "Parent" : "Forked from"}
             </Link>
@@ -1329,7 +1400,7 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
           </Button>
         ) : null}
         {session ? (
-          <Button variant="outline" onClick={() => setDetailsOpen(true)}>
+          <Button variant="outline" onClick={() => openSurface({ kind: "details" })}>
             Details
           </Button>
         ) : null}
@@ -1343,13 +1414,21 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
           {error ?? "Session not found"}
         </div>
       ) : (
-        <ReadOnlySessionChat session={session} messages={messages} liveTurn={liveTurn} />
+        <ReadOnlySessionChat
+          session={session}
+          messages={messages}
+          liveTurn={liveTurn}
+          surface={surface}
+          onOpenSurface={openSurface}
+          onCloseSurface={closeSurface}
+        />
       )}
       {session ? (
         <SessionDetailsSheet
           session={session}
-          open={detailsOpen}
-          onClose={() => setDetailsOpen(false)}
+          basePath={basePath}
+          open={surface.kind === "details"}
+          onClose={closeSurface}
         />
       ) : null}
     </main>
@@ -1362,13 +1441,24 @@ export default function SessionsPage() {
     <Routes>
       <Route index element={<SessionsIndexPage state={state} view="overview" />} />
       <Route path="all" element={<SessionsIndexPage state={state} view="sessions" />} />
-      <Route path=":sessionId" element={<SessionDetailRoute />} />
+      {/* The splat carries the open surface — details or a trace drawer — so
+          each one has a URL under the session it opens over. */}
+      <Route path=":sessionId/*" element={<SessionDetailRoute />} />
     </Routes>
   );
 }
 
 function SessionDetailRoute() {
-  const { sessionId } = useParams<{ sessionId: string }>();
+  const location = useLocation();
+  const params = useParams<{ sessionId: string; "*": string }>();
+  const sessionId = params.sessionId;
+  const splat = params["*"] ?? "";
+  const surface = parseSessionSurface(splat);
   if (!sessionId) return null;
-  return <SessionDetailPage sessionId={sessionId} />;
+  // A path under the session that names no surface still shows the session, but
+  // from the session's own URL — the chat surface keeps one canonical address.
+  if (surface.kind === "chat" && splat.split("/").filter(Boolean).length > 0) {
+    return <Navigate to={sessionPath(sessionsBasePath(location.pathname), sessionId)} replace />;
+  }
+  return <SessionDetailPage sessionId={sessionId} surface={surface} />;
 }

--- a/packages/web/src/pages/SessionsPage.view-urls.test.tsx
+++ b/packages/web/src/pages/SessionsPage.view-urls.test.tsx
@@ -1,0 +1,324 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TraceSnapshot } from "@rome/api-types/trace-segments";
+import type { TraceDrawerTarget } from "@/components/agent-trace/TraceDrawer";
+import {
+  getRomeSession,
+  listRomeSessionMessages,
+  listRomeSessions,
+  listSessionTurns,
+  openTurnStream,
+} from "@/lib/chat-api";
+import SessionsPage from "./SessionsPage";
+
+// A stable `t` matters: TraceDrawer's loader effect depends on it, so a fresh
+// function per render would spin that effect forever.
+const translate = (key: string) => key;
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: translate }),
+}));
+
+// Stands in for the transcript's own trace triggers: one live, one stored.
+vi.mock("@/components/chat/MessageList", () => ({
+  MessageList: ({
+    onOpenLiveTrace,
+    onOpenStoredTrace,
+  }: {
+    onOpenLiveTrace: () => void;
+    onOpenStoredTrace: (target: TraceDrawerTarget) => void;
+  }) => (
+    <div data-testid="session-messages">
+      <button type="button" onClick={onOpenLiveTrace}>
+        open live trace
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onOpenStoredTrace({
+            kind: "stored",
+            messageId: "trace-message",
+            sessionId: "fork-session",
+            turnId: "fork-turn",
+            summary: TRACE_SUMMARY,
+          })
+        }
+      >
+        open stored trace
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/chat/blocks", () => ({
+  renderFlatBlocks: () => null,
+  renderSingleBlock: (block: { type: string; content?: string }, key: string) => (
+    <span key={key}>{block.content}</span>
+  ),
+}));
+
+vi.mock("@/lib/chat-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/chat-api")>();
+  return {
+    ...actual,
+    getRomeSession: vi.fn(),
+    listRomeSessionMessages: vi.fn(),
+    listRomeSessions: vi.fn(),
+    listSessionTurns: vi.fn(),
+    openTurnStream: vi.fn(),
+  };
+});
+
+const SESSION = {
+  id: "fork-session",
+  name: "feedback: original chat",
+  displayTitle: "Feedback",
+  personaId: null,
+  largeModelSelection: null,
+  projectName: "default",
+  projectPath: "default",
+  agentName: null,
+  type: "fork",
+  sourceChannel: "webchat",
+  sourceThreadId: "original-chat",
+  sourceThreadName: "Original chat",
+  sourceThreadType: "private",
+  triggerKind: "fork",
+  triggerName: "feedback",
+  triggerActionName: null,
+  triggerExecutionId: null,
+  rootActionExecutionId: null,
+  parentActionExecutionId: null,
+  parentSessionId: "original-chat",
+  parentTurnId: "rated-turn",
+  createdAt: "2026-07-12T00:00:00.000Z",
+  activityAt: "2026-07-12T00:00:00.000Z",
+  messageCount: 1,
+  owner: { type: "core", id: "core", label: "Rome", iconUrl: null },
+  stats: {
+    runCount: 1,
+    usage: {
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      totalTokens: 15,
+      costUsd: 0.01,
+      costedRunCount: 1,
+    },
+    outcomes: { completed: 1, interrupted: 0, error: 0, unknown: 0 },
+  },
+  lineage: {
+    parent: {
+      id: "original-chat",
+      displayTitle: "Original chat",
+      type: "webchat",
+      agentName: null,
+      parentTurnId: null,
+      activityAt: "2026-07-12T00:00:00.000Z",
+    },
+    children: [],
+  },
+} as const;
+
+const TRACE_SUMMARY = { distinctApps: [], totalSteps: 2, invocationCounts: {} };
+
+const COLON_MESSAGE_ID = "action:execution-1:reviewer";
+
+const MESSAGES = [
+  {
+    id: COLON_MESSAGE_ID,
+    sessionId: "fork-session",
+    turnId: "fork-turn",
+    role: "assistant" as const,
+    content: "[]",
+    createdAt: "2026-07-12T00:00:00.000Z",
+    traceSummary: TRACE_SUMMARY,
+  },
+  {
+    id: "trace-message",
+    sessionId: "fork-session",
+    turnId: "fork-turn",
+    role: "assistant" as const,
+    content: "[]",
+    createdAt: "2026-07-12T00:00:00.000Z",
+    traceSummary: TRACE_SUMMARY,
+  },
+];
+
+function snapshot(text: string): TraceSnapshot {
+  return {
+    summary: TRACE_SUMMARY,
+    segments: [{ kind: "block", id: "seg-1", ordinal: 0, block: { type: "text", content: text } }],
+  } as TraceSnapshot;
+}
+
+function CurrentPath() {
+  return <div data-testid="path">{useLocation().pathname}</div>;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <CurrentPath />
+      <Routes>
+        <Route path="/sessions/*" element={<SessionsPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const path = () => screen.getByTestId("path").textContent;
+
+beforeEach(() => {
+  vi.mocked(getRomeSession).mockResolvedValue(SESSION);
+  vi.mocked(listRomeSessionMessages).mockResolvedValue(MESSAGES);
+  vi.mocked(listSessionTurns).mockResolvedValue([]);
+  vi.mocked(listRomeSessions).mockResolvedValue({
+    sessions: [],
+    total: 0,
+    offset: 0,
+    limit: 5,
+    nextOffset: null,
+    facets: { types: [], sourceChannels: [] },
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string) => {
+      const url = String(input);
+      if (url.includes("/api/sessions/messages/")) {
+        const messageId = decodeURIComponent(url.split("/messages/")[1].split("/")[0]);
+        return new Response(JSON.stringify({ trace: snapshot(`stored trace body: ${messageId}`) }));
+      }
+      if (url.includes("/trace?")) {
+        return new Response(JSON.stringify({ trace: snapshot("turn trace body") }));
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("session detail surfaces render from their URL", () => {
+  it("opens the details sheet on the details URL", async () => {
+    renderAt("/sessions/fork-session/details");
+
+    const sheet = await screen.findByRole("dialog", { name: "Session details" });
+    expect(sheet.textContent).toContain("Feedback");
+    expect(sheet.textContent).toContain("fork-session");
+  });
+
+  it("opens the trace drawer for the message a stored-trace URL names", async () => {
+    renderAt("/sessions/fork-session/messages/trace-message/trace");
+
+    const drawer = await screen.findByRole("dialog", { name: "trace.drawer.ariaLabel" });
+    expect(await screen.findByText("stored trace body: trace-message")).toBeTruthy();
+    expect(drawer.getAttribute("aria-hidden")).toBe("false");
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toContain(
+      "/api/sessions/messages/trace-message/content",
+    );
+  });
+
+  it("opens the trace drawer for the turn a turn-trace URL names", async () => {
+    renderAt("/sessions/fork-session/turns/fork-turn/trace");
+
+    await screen.findByRole("dialog", { name: "trace.drawer.ariaLabel" });
+    expect(await screen.findByText("turn trace body")).toBeTruthy();
+    expect(vi.mocked(fetch).mock.calls[0]?.[0]).toContain(
+      "/api/sessions/fork-session/turns/fork-turn/trace",
+    );
+  });
+
+  it("sends a path that names no surface back to the session URL", async () => {
+    renderAt("/sessions/fork-session/nonsense");
+
+    await screen.findByTestId("session-messages");
+    expect(path()).toBe("/sessions/fork-session");
+  });
+
+  it("names a message whose id needs escaping", async () => {
+    renderAt(`/sessions/fork-session/messages/${encodeURIComponent(COLON_MESSAGE_ID)}/trace`);
+
+    expect(await screen.findByText(`stored trace body: ${COLON_MESSAGE_ID}`)).toBeTruthy();
+  });
+
+  it("keeps the session URL when no surface is open", async () => {
+    renderAt("/sessions/fork-session");
+
+    await screen.findByTestId("session-messages");
+    expect(screen.queryByRole("dialog", { name: "Session details" })).toBeNull();
+    expect(path()).toBe("/sessions/fork-session");
+  });
+});
+
+describe("only one trace drawer is open at a time", () => {
+  function attachToLiveTurn() {
+    vi.mocked(listSessionTurns).mockResolvedValue([
+      {
+        turnId: "live-turn",
+        streamId: "live-turn",
+        startedAt: "2026-07-12T00:00:00.000Z",
+        status: "running",
+      },
+    ]);
+    vi.mocked(openTurnStream).mockImplementation(
+      async () => new Response(new ReadableStream<Uint8Array>({ start() {} })),
+    );
+  }
+
+  it("closes a stored trace opened over a live one back to the session", async () => {
+    attachToLiveTurn();
+    renderAt("/sessions/fork-session");
+
+    fireEvent.click(await screen.findByRole("button", { name: "open live trace" }));
+    await screen.findByRole("dialog", { name: "trace.drawer.ariaLabel" });
+
+    fireEvent.click(screen.getByRole("button", { name: "open stored trace" }));
+    await waitFor(() => expect(path()).toBe("/sessions/fork-session/messages/trace-message/trace"));
+
+    fireEvent.click(screen.getByRole("button", { name: "trace.drawer.closeAriaLabel" }));
+    await waitFor(() => expect(path()).toBe("/sessions/fork-session"));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "trace.drawer.ariaLabel" })).toBeNull(),
+    );
+  });
+
+  it("leaves the trace URL when the live trace opens over it", async () => {
+    attachToLiveTurn();
+    renderAt("/sessions/fork-session/messages/trace-message/trace");
+
+    await screen.findByText("stored trace body: trace-message");
+    fireEvent.click(screen.getByRole("button", { name: "open live trace" }));
+
+    await waitFor(() => expect(path()).toBe("/sessions/fork-session"));
+    expect(screen.getByRole("dialog", { name: "trace.drawer.ariaLabel" })).toBeTruthy();
+  });
+});
+
+describe("session detail surfaces move the address bar", () => {
+  it("pushes the details URL on open and returns to the session URL on close", async () => {
+    renderAt("/sessions/fork-session");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Details" }));
+    await waitFor(() => expect(path()).toBe("/sessions/fork-session/details"));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Close details" }));
+    await waitFor(() => expect(path()).toBe("/sessions/fork-session"));
+  });
+
+  it("closes the trace drawer back to the session URL", async () => {
+    renderAt("/sessions/fork-session/messages/trace-message/trace");
+
+    fireEvent.click(await screen.findByRole("button", { name: "trace.drawer.closeAriaLabel" }));
+    await waitFor(() => expect(path()).toBe("/sessions/fork-session"));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "trace.drawer.ariaLabel" })).toBeNull(),
+    );
+  });
+});

--- a/packages/web/src/pages/session-surface.test.ts
+++ b/packages/web/src/pages/session-surface.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseSessionSurface,
+  sessionPath,
+  sessionsBasePath,
+  sessionSurfacePath,
+  SESSIONS_FULL_ROUTE_BASE,
+  SESSIONS_ROUTE_BASE,
+} from "./session-surface";
+
+describe("parseSessionSurface", () => {
+  it("reads the bare session route as the chat surface", () => {
+    expect(parseSessionSurface(undefined)).toEqual({ kind: "chat" });
+    expect(parseSessionSurface("")).toEqual({ kind: "chat" });
+    expect(parseSessionSurface("/")).toEqual({ kind: "chat" });
+  });
+
+  it("reads the details, message-trace and turn-trace routes", () => {
+    expect(parseSessionSurface("details")).toEqual({ kind: "details" });
+    expect(parseSessionSurface("messages/msg-1/trace")).toEqual({
+      kind: "messageTrace",
+      messageId: "msg-1",
+    });
+    expect(parseSessionSurface("turns/turn-1/trace")).toEqual({
+      kind: "turnTrace",
+      turnId: "turn-1",
+    });
+  });
+
+  it("falls back to the chat surface for a route it does not name", () => {
+    expect(parseSessionSurface("nonsense")).toEqual({ kind: "chat" });
+    expect(parseSessionSurface("messages/msg-1")).toEqual({ kind: "chat" });
+    expect(parseSessionSurface("turns/turn-1/segments")).toEqual({ kind: "chat" });
+  });
+});
+
+describe("sessionSurfacePath", () => {
+  it("round-trips every surface through its path", () => {
+    const surfaces = [
+      { kind: "chat" } as const,
+      { kind: "details" } as const,
+      { kind: "messageTrace", messageId: "msg-1" } as const,
+      { kind: "turnTrace", turnId: "turn-1" } as const,
+    ];
+    for (const surface of surfaces) {
+      const path = sessionSurfacePath(SESSIONS_ROUTE_BASE, "session-1", surface);
+      expect(parseSessionSurface(path.slice(`${SESSIONS_ROUTE_BASE}/session-1/`.length))).toEqual(
+        surface,
+      );
+    }
+  });
+
+  it("escapes the identifiers it puts in a path", () => {
+    expect(sessionSurfacePath(SESSIONS_ROUTE_BASE, "s/1", { kind: "details" })).toBe(
+      "/sessions/s%2F1/details",
+    );
+    expect(
+      sessionSurfacePath(SESSIONS_ROUTE_BASE, "s1", { kind: "messageTrace", messageId: "m/1" }),
+    ).toBe("/sessions/s1/messages/m%2F1/trace");
+  });
+
+  it("builds under whichever base the page is mounted on", () => {
+    expect(sessionPath(SESSIONS_FULL_ROUTE_BASE, "s1")).toBe("/full/apps/sessions/s1");
+    expect(
+      sessionSurfacePath(SESSIONS_FULL_ROUTE_BASE, "s1", { kind: "turnTrace", turnId: "t1" }),
+    ).toBe("/full/apps/sessions/s1/turns/t1/trace");
+  });
+});
+
+describe("sessionsBasePath", () => {
+  it("picks the mount the current location sits under", () => {
+    expect(sessionsBasePath("/sessions/s1/details")).toBe(SESSIONS_ROUTE_BASE);
+    expect(sessionsBasePath("/full/apps/sessions/s1/details")).toBe(SESSIONS_FULL_ROUTE_BASE);
+  });
+});

--- a/packages/web/src/pages/session-surface.ts
+++ b/packages/web/src/pages/session-surface.ts
@@ -1,0 +1,60 @@
+// Surfaces that open over a session's detail view. Each is a view in its own
+// right — the details sheet and the trace drawer both carry content a user can
+// return to or share — so each gets a URL under the session's own path and
+// renders from that URL alone (docs/northstars/view-urls.md).
+export type SessionSurface =
+  | { kind: "chat" }
+  | { kind: "details" }
+  | { kind: "messageTrace"; messageId: string }
+  | { kind: "turnTrace"; turnId: string };
+
+export const SESSIONS_ROUTE_BASE = "/sessions";
+// show_app addresses the sessions app through /full/apps/sessions, so the same
+// session surface has one path under each mount.
+export const SESSIONS_FULL_ROUTE_BASE = "/full/apps/sessions";
+
+// Answers which of the two mounts a location sits under, and defaults to
+// /sessions for anything else, so a caller can build a path without knowing
+// which one rendered it.
+export function sessionsBasePath(pathname: string): string {
+  return pathname.startsWith(SESSIONS_FULL_ROUTE_BASE)
+    ? SESSIONS_FULL_ROUTE_BASE
+    : SESSIONS_ROUTE_BASE;
+}
+
+// `splat` is the `*` param of the `:sessionId/*` route, which React Router
+// hands back decoded — including an escaped slash, so an identifier carrying
+// one splits into extra segments and claims no surface. A path no surface
+// claims reads as the chat surface, so an old or mistyped URL still renders
+// the session.
+export function parseSessionSurface(splat: string | undefined): SessionSurface {
+  const segments = (splat ?? "").split("/").filter(Boolean);
+  if (segments.length === 1 && segments[0] === "details") return { kind: "details" };
+  if (segments.length === 3 && segments[2] === "trace") {
+    if (segments[0] === "messages") return { kind: "messageTrace", messageId: segments[1] };
+    if (segments[0] === "turns") return { kind: "turnTrace", turnId: segments[1] };
+  }
+  return { kind: "chat" };
+}
+
+export function sessionPath(basePath: string, sessionId: string): string {
+  return `${basePath}/${encodeURIComponent(sessionId)}`;
+}
+
+export function sessionSurfacePath(
+  basePath: string,
+  sessionId: string,
+  surface: SessionSurface,
+): string {
+  const session = sessionPath(basePath, sessionId);
+  switch (surface.kind) {
+    case "details":
+      return `${session}/details`;
+    case "messageTrace":
+      return `${session}/messages/${encodeURIComponent(surface.messageId)}/trace`;
+    case "turnTrace":
+      return `${session}/turns/${encodeURIComponent(surface.turnId)}/trace`;
+    case "chat":
+      return session;
+  }
+}


### PR DESCRIPTION
## What this PR does

On `/sessions/:sessionId`, the details sheet and the turn-trace drawer both carry content a user would want to send someone — context, usage, lineage; a turn's whole segment tree — and neither had an address. They opened from component state, so a reader could not share what they were looking at, reopen it in a fresh session, or close it with the back button.

Each surface now has a URL under the session it opens over:

| Surface | URL |
|---|---|
| Session details sheet | `/sessions/:sessionId/details` |
| Stored trace drawer | `/sessions/:sessionId/messages/:messageId/trace` |
| Turn trace drawer | `/sessions/:sessionId/turns/:turnId/trace` |

The same three exist under the app mount, `/full/apps/sessions/:sessionId/…`.

## Design & Invariants

`packages/web/src/pages/session-surface.ts` holds one route table, read in both directions: `parseSessionSurface` turns the route's splat into a `SessionSurface`, `sessionSurfacePath` turns a surface back into a path. A round-trip test keeps the two honest.

The invariants this PR is asking to keep true, from [docs/northstars/view-urls.md](docs/northstars/view-urls.md):

- The surface renders from the URL and persisted data alone. Loaded messages enrich a trace drawer's header; they never gate whether it opens.
- Closing returns to the session URL, so the back button closes a surface too.
- The chat surface keeps one address: a path under a session that names no surface redirects to the session's own URL.
- One drawer at a time. A URL trace outranks the live one, so opening either closes the other; otherwise closing a stored trace would reveal a live drawer the URL says nothing about.

A `kind: "live"` target still opens from state. It streams a turn that exists only in the running page, so there is nothing persisted for a URL to name — the issue allows this.

Two changes ride along because the feature needs them:

- `TraceDrawer`'s loader now lets the key in its ref, not the effect run, decide whose result counts. A URL-opened target re-renders while its fetch is in flight (messages land, translations land), which re-ran the effect, hit the `loadedKeyRef` early return, and left the drawer stuck on "Loading trace" because the old cleanup had already cancelled the only load in flight. The regression test fails without the fix.
- Lineage and parent links moved from `../<id>` with `relative="path"` to absolute paths. Path-relative resolution broke once a surface segment sat under the session.

## Test plan

- [x] `pnpm --filter rome-web test` — 158 files, 1242 tests. New: 10 in `SessionsPage.view-urls.test.tsx` (both committed acceptance items, plus the drawer interplay and an id needing escaping), 7 in `session-surface.test.ts`, 1 in `TraceDrawer.test.tsx`.
- [x] `pnpm typecheck` and `pnpm test:unit` at the repo root.
- [x] Third acceptance item, in a real Chromium against the SPA: opening and closing the sheet and the drawer move the address bar, the back button restores the prior surface, and fresh loads of `/details` and `/messages/:id/trace` render their surface over the session. Driven against `dev:mock` with the three `/api/sessions` endpoints fulfilled from the browser side, since this machine has no docker socket for `pnpm dev:all`.

## Not in this PR

- The explorer's filter and facet state (`range`, `sort`, `owner`, `model`, the drilled `/sessions/all` facets) — collection state, milestone 2.
- The trace drawer's subagent-usage toggle, which still lives in page state, so one trace URL can render two contents. Not named by #138 and not reachable from the sessions view's own triggers.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)