### PR TITLE
feat(web): give the file-browser history panel a URL

### DIFF
--- a/packages/web/src/components/file-browser/FileView.tsx
+++ b/packages/web/src/components/file-browser/FileView.tsx
@@ -48,6 +48,8 @@ export function FileViewHeader({ onMobileBack }: { onMobileBack: () => void }) {
   const hasUnflushedDiskWrites = selectedFile?.editable ? content !== lastDiskContent : false;
   const hasUnresolvedEdits = hasChanges || hasUnflushedDiskWrites;
 
+  const toggleHistory = () => store.getState().ui.setShowHistory(!showHistory);
+
   const autoSavePolicy = selectedFile?.editable
     ? store.getState().file.resolveAutoSavePolicy(selectedFile)
     : null;
@@ -158,13 +160,7 @@ export function FileViewHeader({ onMobileBack }: { onMobileBack: () => void }) {
         )}
         <button
           type="button"
-          onClick={() => {
-            if (showHistory) {
-              store.getState().ui.setShowHistory(false);
-              return;
-            }
-            void store.getState().ui.loadHistory();
-          }}
+          onClick={toggleHistory}
           className={`hidden rounded-8 px-3 py-1 text-ui @min-[1024px]/fb:inline-flex ${
             showHistory
               ? "bg-info-bg text-info-fg"
@@ -175,13 +171,7 @@ export function FileViewHeader({ onMobileBack }: { onMobileBack: () => void }) {
         </button>
         <button
           type="button"
-          onClick={() => {
-            if (showHistory) {
-              store.getState().ui.setShowHistory(false);
-              return;
-            }
-            void store.getState().ui.loadHistory();
-          }}
+          onClick={toggleHistory}
           className={`rounded-8 p-2 @min-[1024px]/fb:hidden ${
             showHistory
               ? "bg-info-bg text-info-fg"

--- a/packages/web/src/components/file-browser/HistoryPanel.tsx
+++ b/packages/web/src/components/file-browser/HistoryPanel.tsx
@@ -7,7 +7,10 @@ export function HistoryPanel() {
   const loadingHistory = useFileBrowserStore((s) => s.ui.loadingHistory);
 
   return (
-    <div className="hidden w-80 flex-shrink-0 overflow-y-auto border-l border-border bg-surface-muted p-4 @min-[1024px]/fb:block">
+    <section
+      aria-label={t("history.heading")}
+      className="hidden w-80 flex-shrink-0 overflow-y-auto border-l border-border bg-surface-muted p-4 @min-[1024px]/fb:block"
+    >
       <h3 className="mb-3 text-section text-muted-foreground">{t("history.heading")}</h3>
       {loadingHistory ? (
         <p className="text-ui text-subtle-foreground">{t("history.loading")}</p>
@@ -37,7 +40,7 @@ export function HistoryPanel() {
           ))}
         </div>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/packages/web/src/components/file-browser/hooks/useUrlSelectionSync.ts
+++ b/packages/web/src/components/file-browser/hooks/useUrlSelectionSync.ts
@@ -2,8 +2,11 @@ import { useEffect } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { isCancelledError, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { useFileBrowserStoreApi } from "../store/context";
-import { getFileBrowserRouteLogicalPath } from "@/lib/file-browser-routing";
+import { useFileBrowserStore, useFileBrowserStoreApi } from "../store/context";
+import {
+  getFileBrowserRouteLogicalPath,
+  isFileBrowserHistoryUrl,
+} from "@/lib/file-browser-routing";
 
 /**
  * URL-as-SSOT bridge. When the route changes, we resolve the
@@ -17,6 +20,9 @@ export function useUrlSelectionSync(opts: { embedded: boolean }) {
   const params = useParams<{ "*"?: string }>();
   const queryClient = useQueryClient();
   const wildcard = params["*"];
+  const historyInUrl = isFileBrowserHistoryUrl(location.search);
+  const selectedPath = useFileBrowserStore((s) => s.selection.selectedPath);
+  const showHistory = useFileBrowserStore((s) => s.ui.showHistory);
 
   useEffect(() => {
     if (opts.embedded) return;
@@ -110,4 +116,13 @@ export function useUrlSelectionSync(opts: { embedded: boolean }) {
     store,
     wildcard,
   ]);
+
+  // Opening a file clears `showHistory`, so this waits on `selectedPath` and
+  // re-runs once the file the URL names has landed.
+  useEffect(() => {
+    if (opts.embedded) return;
+    if (historyInUrl === showHistory) return;
+    if (historyInUrl && !selectedPath) return;
+    store.getState().ui.setShowHistory(historyInUrl, { syncUrl: false });
+  }, [historyInUrl, opts.embedded, selectedPath, showHistory, store]);
 }

--- a/packages/web/src/components/file-browser/store/create.test.ts
+++ b/packages/web/src/components/file-browser/store/create.test.ts
@@ -1,8 +1,9 @@
 import { QueryClient } from "@tanstack/react-query";
 import type { TFunction } from "i18next";
 import { createFileBrowserStore } from "./create";
+import type { FileBrowserConfig } from "./types";
 
-function createTestStore() {
+function createTestStore(overrides: Partial<FileBrowserConfig> = {}) {
   return createFileBrowserStore({
     apiBasePath: "/api/files",
     logicalRootPath: "/projects",
@@ -13,6 +14,7 @@ function createTestStore() {
     getRouteSnapshot: () => ({ pathname: "/projects/current", search: "", hash: "" }),
     t: ((key: string) => key) as TFunction,
     embedded: false,
+    ...overrides,
   });
 }
 
@@ -70,5 +72,63 @@ describe("file-browser action selection", () => {
     await expect(confirmed).resolves.toBe(true);
     expect(store.getState().ui.discardChangesConfirmOpen).toBe(false);
     expect(store.getState().file.content).toBe("saved");
+  });
+});
+
+describe("file-browser history panel URL", () => {
+  function createHistoryStore(
+    overrides: Partial<FileBrowserConfig> & { navigate: FileBrowserConfig["navigate"] },
+  ) {
+    const store = createTestStore({
+      logicalRootPath: "projects",
+      initialSelectedFolderPath: "projects",
+      getRouteSnapshot: () => ({ pathname: "/projects/notes.txt", search: "", hash: "" }),
+      ...overrides,
+    });
+    store.setState((state) => ({
+      selection: { ...state.selection, selectedPath: "projects/notes.txt" },
+    }));
+    return store;
+  }
+
+  // `route` is reassigned between the two calls the way the router re-binds it
+  // per render: a store reading its first snapshot forever fails the close.
+  it("puts the open panel in the URL and takes it back out on close", () => {
+    const navigate = vi.fn();
+    let route = { pathname: "/projects/notes.txt", search: "", hash: "" };
+    const store = createHistoryStore({ navigate, getRouteSnapshot: () => route });
+
+    store.getState().ui.setShowHistory(true);
+    expect(navigate).toHaveBeenLastCalledWith("/projects/notes.txt?history=1", { replace: false });
+
+    route = { ...route, search: "?history=1" };
+    store.getState().ui.setShowHistory(false);
+    expect(navigate).toHaveBeenLastCalledWith("/projects/notes.txt", { replace: false });
+  });
+
+  it("drops the panel from the URL when the selection moves", () => {
+    const navigate = vi.fn();
+    const store = createHistoryStore({
+      navigate,
+      getRouteSnapshot: () => ({
+        pathname: "/projects/notes.txt",
+        search: "?history=1",
+        hash: "",
+      }),
+    });
+
+    store.getState().selection.navigateToPath("projects/other.txt");
+
+    expect(navigate).toHaveBeenLastCalledWith("/projects/other.txt", { replace: false });
+  });
+
+  it("leaves the URL alone for an embedded mount", () => {
+    const navigate = vi.fn();
+    const store = createHistoryStore({ navigate, embedded: true });
+
+    store.getState().ui.setShowHistory(true);
+
+    expect(store.getState().ui.showHistory).toBe(true);
+    expect(navigate).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/file-browser/store/create.ts
+++ b/packages/web/src/components/file-browser/store/create.ts
@@ -14,7 +14,7 @@ import {
 import { getFileBrowserPathChangeUpdate } from "@/lib/file-browser-path-change";
 import {
   getFileBrowserDirectoryAncestors,
-  getFileBrowserUrlPath,
+  getFileBrowserUrlLocation,
 } from "@/lib/file-browser-routing";
 import {
   getNextBrowserSelection,
@@ -72,8 +72,7 @@ interface CreateResponse {
 export type FileBrowserStoreApi = StoreApi<FileBrowserState>;
 
 export function createFileBrowserStore(config: FileBrowserConfig): FileBrowserStoreApi {
-  const { apiBasePath, logicalRootPath, queryClient, navigate, getRouteSnapshot, embedded } =
-    config;
+  const { apiBasePath, logicalRootPath, queryClient, embedded } = config;
 
   const resolveQueryKey = (path: string) =>
     ["file-browser", logicalRootPath, "resolve", path] as const;
@@ -102,7 +101,7 @@ export function createFileBrowserStore(config: FileBrowserConfig): FileBrowserSt
     return data;
   }
 
-  const initialRouteSnapshot = getRouteSnapshot();
+  const initialRouteSnapshot = config.getRouteSnapshot();
 
   const store = createStore<FileBrowserState>()((set, get) => {
     /**
@@ -303,12 +302,17 @@ export function createFileBrowserStore(config: FileBrowserConfig): FileBrowserSt
 
         navigateToPath(path, opts) {
           if (embedded) return;
+          // Read the router off `config`, not the factory's closure: `navigate`
+          // and the route snapshot are re-bound every render and synced into
+          // state, so the captured pair reports the first render forever.
+          const { navigate, getRouteSnapshot } = get().config;
           const route = getRouteSnapshot();
-          const nextPathname = getFileBrowserUrlPath(logicalRootPath, path);
-          const hideSidebar = new URLSearchParams(route.search).get("hideSidebar");
-          const nextLocation = hideSidebar === "1" ? `${nextPathname}?hideSidebar=1` : nextPathname;
-          get().refs.acceptedBrowserPath = nextPathname;
-          if (route.pathname === nextPathname) return;
+          const nextLocation = getFileBrowserUrlLocation(logicalRootPath, path, {
+            route,
+            showHistory: opts?.showHistory,
+          });
+          get().refs.acceptedBrowserPath = nextLocation;
+          if (`${route.pathname}${route.search}${route.hash}` === nextLocation) return;
           navigate(nextLocation, { replace: opts?.replace ?? false });
         },
 
@@ -745,8 +749,13 @@ export function createFileBrowserStore(config: FileBrowserConfig): FileBrowserSt
         setShowSearch(value) {
           set((s) => ({ ui: { ...s.ui, showSearch: value } }));
         },
-        setShowHistory(value) {
+        setShowHistory(value, opts) {
           set((s) => ({ ui: { ...s.ui, showHistory: value } }));
+          const selectedPath = get().selection.selectedPath;
+          if (opts?.syncUrl !== false && selectedPath) {
+            get().selection.navigateToPath(selectedPath, { showHistory: value });
+          }
+          if (value) void get().ui.loadHistory();
         },
         setNameDialog(value) {
           set((s) => ({ ui: { ...s.ui, nameDialog: value } }));
@@ -779,7 +788,7 @@ export function createFileBrowserStore(config: FileBrowserConfig): FileBrowserSt
         async loadHistory() {
           const selectedPath = get().selection.selectedPath;
           if (!selectedPath) return;
-          set((s) => ({ ui: { ...s.ui, showHistory: true, loadingHistory: true } }));
+          set((s) => ({ ui: { ...s.ui, loadingHistory: true } }));
           try {
             const response = await fetch(
               `${apiBasePath}/history?path=${encodeURIComponent(selectedPath)}`,

--- a/packages/web/src/components/file-browser/store/types.ts
+++ b/packages/web/src/components/file-browser/store/types.ts
@@ -190,7 +190,7 @@ export interface SelectionSlice {
   applyTreeClick(path: string, mods: TreeClickModifiers): string[];
   clearMultiSelect(): void;
   prepareContextMenu(node: Pick<TreeNode, "path" | "type">): string[];
-  navigateToPath(path: string | null, opts?: { replace?: boolean }): void;
+  navigateToPath(path: string | null, opts?: { replace?: boolean; showHistory?: boolean }): void;
 }
 
 export interface FileSlice {
@@ -264,7 +264,10 @@ export interface UiSlice {
   filesPaneDrillPath: string | null;
   setSearchQuery(value: string): void;
   setShowSearch(value: boolean): void;
-  setShowHistory(value: boolean): void;
+  /** Opens or closes the history panel, fetching its entries on open. The panel
+   * is a view (`docs/northstars/view-urls.md`), so this also moves the URL;
+   * `syncUrl: false` is for the sync that reads the URL in the first place. */
+  setShowHistory(value: boolean, opts?: { syncUrl?: boolean }): void;
   setNameDialog(value: NameDialogState | null): void;
   setDeleteConfirm(value: DeleteConfirmState | null): void;
   setMoveDialog(value: MoveDialogState | null): void;

--- a/packages/web/src/lib/file-browser-routing.test.ts
+++ b/packages/web/src/lib/file-browser-routing.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   getFileBrowserDirectoryAncestors,
   getFileBrowserRouteLogicalPath,
+  getFileBrowserUrlLocation,
   getFileBrowserUrlPath,
+  isFileBrowserHistoryUrl,
   shouldSyncRootPanelTriggerUrl,
 } from "./file-browser-routing";
 
@@ -40,6 +42,52 @@ describe("file browser routing", () => {
       "projects/app/src",
     ]);
     expect(getFileBrowserDirectoryAncestors("memory/IDENTITY.md", "memory")).toEqual([]);
+  });
+
+  it("gives the open history panel a URL and drops it when closed", () => {
+    const route = { pathname: "/memory/Research%20Notes.md", search: "", hash: "" };
+    expect(
+      getFileBrowserUrlLocation("memory", "memory/Research Notes.md", {
+        route,
+        showHistory: true,
+      }),
+    ).toBe("/memory/Research%20Notes.md?history=1");
+    expect(
+      getFileBrowserUrlLocation("memory", "memory/Research Notes.md", {
+        route: { ...route, search: "?history=1" },
+      }),
+    ).toBe("/memory/Research%20Notes.md");
+  });
+
+  it("carries hideSidebar across history toggles and drops every other param", () => {
+    expect(
+      getFileBrowserUrlLocation("projects", "projects/app/README.md", {
+        route: { pathname: "/projects/app/README.md", search: "?hideSidebar=1&stale=x", hash: "" },
+        showHistory: true,
+      }),
+    ).toBe("/projects/app/README.md?hideSidebar=1&history=1");
+    expect(
+      getFileBrowserUrlLocation("projects", null, {
+        route: { pathname: "/projects", search: "?hideSidebar=1", hash: "" },
+      }),
+    ).toBe("/projects?hideSidebar=1");
+  });
+
+  it("keeps an anchor within its own document and drops it on the way out", () => {
+    const route = { pathname: "/memory/notes.md", search: "", hash: "#section-2" };
+    expect(
+      getFileBrowserUrlLocation("memory", "memory/notes.md", { route, showHistory: true }),
+    ).toBe("/memory/notes.md?history=1#section-2");
+    expect(getFileBrowserUrlLocation("memory", "memory/other.md", { route })).toBe(
+      "/memory/other.md",
+    );
+  });
+
+  it("reads the history panel out of a route's query", () => {
+    expect(isFileBrowserHistoryUrl("?history=1")).toBe(true);
+    expect(isFileBrowserHistoryUrl("?hideSidebar=1&history=1")).toBe(true);
+    expect(isFileBrowserHistoryUrl("?history=0")).toBe(false);
+    expect(isFileBrowserHistoryUrl("")).toBe(false);
   });
 
   it("syncs the root panel trigger URL only on desktop", () => {

--- a/packages/web/src/lib/file-browser-routing.ts
+++ b/packages/web/src/lib/file-browser-routing.ts
@@ -63,3 +63,33 @@ export function getFileBrowserDirectoryAncestors(path: string, logicalRootPath: 
   }
   return ancestors;
 }
+
+/**
+ * The canonical location for a selection: pathname, then the query the next
+ * view keeps. `hideSidebar` outlives navigation; the open history panel is a
+ * view of its own (`docs/northstars/view-urls.md`) and so rides the URL too.
+ * Every other param is dropped, which is what closes the panel whenever the
+ * selection moves. The hash survives only within one document, since an anchor
+ * means nothing in the next file.
+ */
+export function getFileBrowserUrlLocation(
+  logicalRootPath: string,
+  path: string | null,
+  opts: { route: { pathname: string; search: string; hash: string }; showHistory?: boolean },
+): string {
+  const pathname = getFileBrowserUrlPath(logicalRootPath, path);
+  const next = new URLSearchParams();
+  if (new URLSearchParams(opts.route.search).get("hideSidebar") === "1") {
+    next.set("hideSidebar", "1");
+  }
+  if (opts.showHistory) {
+    next.set("history", "1");
+  }
+  const query = next.toString();
+  const hash = pathname === opts.route.pathname ? opts.route.hash : "";
+  return `${pathname}${query ? `?${query}` : ""}${hash}`;
+}
+
+export function isFileBrowserHistoryUrl(search: string): boolean {
+  return new URLSearchParams(search).get("history") === "1";
+}

--- a/packages/web/src/pages/FileBrowserHistoryUrl.test.tsx
+++ b/packages/web/src/pages/FileBrowserHistoryUrl.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import i18n from "@/i18n";
+import MemoryPage from "./MemoryPage";
+import ProjectsPage from "./ProjectsPage";
+
+// The editor and the watch stream are the only two things a file browser needs
+// that jsdom cannot supply; neither is under test here.
+vi.mock("@/components/monaco-file-editor", () => ({
+  MonacoFileEditor: () => <div data-testid="editor" />,
+}));
+
+class StubEventSource {
+  readonly close = vi.fn();
+  addEventListener() {}
+  removeEventListener() {}
+}
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+  globalThis.EventSource = StubEventSource as unknown as typeof EventSource;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const COMMIT_MESSAGE = "Record the second draft";
+
+/** Serves the probes a file browser fires while opening one file. */
+function mockBackend(apiBasePath: string, filePath: string) {
+  vi.spyOn(globalThis, "fetch").mockImplementation((async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const ok = (json: unknown) => ({ ok: true, status: 200, json: async () => json }) as Response;
+    if (url.startsWith(`${apiBasePath}/history`)) {
+      return ok([{ date: "2026-08-01T00:00:00Z", hash: "abc1234def", message: COMMIT_MESSAGE }]);
+    }
+    if (url.startsWith(`${apiBasePath}/resolve`)) return ok({ path: filePath, type: "file" });
+    if (url.startsWith(`${apiBasePath}/file`)) {
+      return ok({
+        assetUrl: null,
+        content: "second draft",
+        editable: true,
+        kind: "text",
+        mimeType: "text/plain",
+        path: filePath,
+        size: 12,
+      });
+    }
+    return ok([]); // /tree
+  }) as typeof fetch);
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return (
+    <>
+      <output data-testid="location">{`${location.pathname}${location.search}`}</output>
+      <button type="button" onClick={() => navigate(-1)}>
+        Back
+      </button>
+    </>
+  );
+}
+
+function renderHostRoute(route: string, initialUrl: string, page: React.ReactNode) {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <MemoryRouter initialEntries={[initialUrl]}>
+        <LocationProbe />
+        <Routes>
+          <Route path={route} element={page} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function historyRequests(apiBasePath: string): string[] {
+  return vi
+    .mocked(globalThis.fetch)
+    .mock.calls.map(([input]) => String(input))
+    .filter((url) => url.startsWith(`${apiBasePath}/history`));
+}
+
+describe("the file-browser history panel has a URL", () => {
+  it("renders the panel for the URL's file on /memory in a fresh session", async () => {
+    mockBackend("/api/memory", "memory/notes.txt");
+    renderHostRoute("/memory/*", "/memory/notes.txt?history=1", <MemoryPage />);
+
+    const panel = await screen.findByRole("region", { name: "Git History" });
+    expect(panel.textContent).toContain(COMMIT_MESSAGE);
+    await waitFor(() =>
+      expect(historyRequests("/api/memory")).toContain(
+        "/api/memory/history?path=memory%2Fnotes.txt",
+      ),
+    );
+  });
+
+  it("renders the panel for the URL's file on /projects in a fresh session", async () => {
+    mockBackend("/api/projects", "projects/app/README.txt");
+    renderHostRoute("/projects/*", "/projects/app/README.txt?history=1", <ProjectsPage />);
+
+    const panel = await screen.findByRole("region", { name: "Git History" });
+    expect(panel.textContent).toContain(COMMIT_MESSAGE);
+    await waitFor(() =>
+      expect(historyRequests("/api/projects")).toContain(
+        "/api/projects/history?path=projects%2Fapp%2FREADME.txt",
+      ),
+    );
+  });
+
+  it("does not open the panel for a plain file URL", async () => {
+    mockBackend("/api/memory", "memory/notes.txt");
+    renderHostRoute("/memory/*", "/memory/notes.txt", <MemoryPage />);
+
+    await screen.findByTestId("editor");
+    expect(screen.queryByRole("region", { name: "Git History" })).toBeNull();
+    expect(historyRequests("/api/memory")).toEqual([]);
+  });
+
+  it("moves the address bar as the panel toggles, and closes on back", async () => {
+    mockBackend("/api/memory", "memory/notes.txt");
+    renderHostRoute("/memory/*", "/memory/notes.txt", <MemoryPage />);
+    const location = () => screen.getByTestId("location").textContent;
+
+    await screen.findByTestId("editor");
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
+    await screen.findByRole("region", { name: "Git History" });
+    expect(location()).toBe("/memory/notes.txt?history=1");
+
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
+    await waitFor(() => expect(screen.queryByRole("region", { name: "Git History" })).toBeNull());
+    expect(location()).toBe("/memory/notes.txt");
+
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    await screen.findByRole("region", { name: "Git History" });
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+    await waitFor(() => expect(screen.queryByRole("region", { name: "Git History" })).toBeNull());
+    expect(location()).toBe("/memory/notes.txt");
+  });
+});


### PR DESCRIPTION
## What this PR does

The file-browser history panel renders the commit history of the open file — content, not a control — but it opened only through `ui.showHistory`. It had no address: you could not link a colleague to it, a reload lost it, and back did nothing.

`?history=1` on a host file route now names the open panel. Opening that URL in a fresh session renders the panel for the URL's file, and closing returns to the plain file URL, so back closes it too.

| URL | View |
|---|---|
| `/memory/<path>?history=1` | that memory file with its history panel open |
| `/projects/<path>?history=1` | that project file with its history panel open |
| `/memory/<path>?hideSidebar=1&history=1` | the same, inside an embedder that hides the shell chrome |
| `/memory/<path>?history=1#<anchor>` | the same, scrolled to an anchor in that document |

## Design & Invariants

The panel is a view under [`docs/northstars/view-urls.md`](../blob/main/docs/northstars/view-urls.md), so the URL owns whether it is open. `setShowHistory` became the whole toggle — flag, URL, and the fetch — and `useUrlSelectionSync` reads the param back. `loadHistory` went back to being only the fetch.

Invariants:

- One canonical location per selection, built in one place (`getFileBrowserUrlLocation`): pathname, then `hideSidebar` and `history`, then the hash. Every other param is dropped, which is what closes the panel whenever the selection moves.
- A hash survives only within one document. An anchor means nothing in the next file.
- Embedded mounts still short-circuit URL sync. They keep store-only behavior.
- The URL-reading effect waits on `selectedPath`, because opening a file clears `showHistory`. A fresh session lands the file first, then opens the panel.

Opening and closing both push. Open and closed are two distinct views, and the northstar has back return to the previous view — so back after a close re-opens, by design. The alternative, closing with `replace`, leaves a dead entry that back cannot distinguish from the file itself.

Two defects the panel URL forced open, neither optional to reach the behavior:

- `navigateToPath` read `navigate` and `getRouteSnapshot` off the store factory's closure, but `FileBrowserPage` re-binds both every render and syncs them into `config`. The store reported the first render's route forever, so closing the panel produced no navigation at all. It now reads them off live config — which also means `hideSidebar` preservation had been running off a stale snapshot.
- The URL builder dropped the hash while `useUrlSelectionSync` compares against `pathname+search+hash`. Toggling on an anchored URL stripped the anchor.

`HistoryPanel`'s root is now a named `<section>`, giving the panel an accessible name that distinguishes it from the mobile sheet.

## Test plan

- [x] `pnpm typecheck` — clean across the monorepo.
- [x] `pnpm --filter rome-web test` — 157 files, 1235 tests pass.
- [x] Committed: `pages/FileBrowserHistoryUrl.test.tsx` renders the real `MemoryPage` and `ProjectsPage` at a history URL in a fresh session and asserts the panel shows for that file; also covers toggle-and-back and that a plain file URL fires no history request.
- [x] Committed: `lib/file-browser-routing.test.ts` pins the canonical location, `hideSidebar` carry-over, and the anchor rule. `store/create.test.ts` pins the URL round-trip, the drop on selection change, and the embedded no-op.
- [x] Real browser, chromium against `pnpm start:web:mock`, on `/projects`: fresh session at `?history=1` renders the panel; toggling moves the address bar both ways; back closes it; selecting another file drops the param; an anchor survives a toggle.
- [ ] Real browser on `/memory`. Mock mode ships no `/api/memory` handlers and the fullstack loop needs Docker, which was unavailable here. The committed test covers the real `MemoryPage` for both fresh-session render and toggle-and-back.

## Not in this PR

- The search results panel (`ui.showSearch`, `ui.searchQuery`) — its address is inseparable from the query, which is collection state, milestone 2.
- The FilesPane mobile folder drill — a selection navigator, so a control, not a view.
- Normalizing `?history=1` away when the URL names no file. Telling "the file has not loaded yet" from "this URL names no file" needs the `/resolve` result; the next navigation drops the param.

Closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)