### PR TITLE
feat(web): add a question timeline to the chat transcript

### DIFF
--- a/packages/web/src/components/chat/Chat.test.tsx
+++ b/packages/web/src/components/chat/Chat.test.tsx
@@ -39,9 +39,13 @@ vi.mock("@/pages/free/use-free-cells", () => ({
 }));
 
 vi.mock("@/hooks/use-stick-to-bottom", () => ({
+  // Callback refs, matching the real hook. Chat composes these with its own
+  // refs and CALLS them, so a ref object here would throw on mount — and a
+  // vi.mock factory is not checked against the module's real shape, so nothing
+  // but a test run would catch it.
   useStickToBottom: () => ({
-    contentRef: { current: null },
-    scrollRef: { current: null },
+    contentRef: vi.fn(),
+    scrollRef: vi.fn(),
     scrollToBottom: vi.fn(),
   }),
 }));

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -82,12 +82,6 @@ import type {
   StreamBlock,
 } from "@/lib/chat-types";
 import { SCROLL_BOTTOM_THRESHOLD_PX } from "@/lib/chat-constants";
-
-// Leave a jumped-to question clear of the top edge — flush against it reads
-// as cut off.
-const TIMELINE_JUMP_OFFSET_PX = 24;
-// How long the landed-on question stays tinted.
-const TIMELINE_LANDING_MS = 900;
 import { buildOptimisticUserText } from "@/lib/chat-helpers";
 import { parseSSEEvents } from "@/lib/chat-sse";
 import {
@@ -113,6 +107,12 @@ import {
   useWorkspaceContextRegistry,
 } from "@/pages/free/workspace-context";
 import { autoPlaceApp } from "@/pages/free/use-free-cells";
+
+// Leave a jumped-to question clear of the top edge — flush against it reads
+// as cut off.
+const TIMELINE_JUMP_OFFSET_PX = 24;
+// How long the landed-on question stays tinted.
+const TIMELINE_LANDING_MS = 900;
 
 // Chat Component
 
@@ -426,13 +426,12 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
     return ids;
   }, [displayMessages, mainSessionId]);
 
-  // The timeline rail's data source — the same main-session filter mainTurnIds
-  // uses. Memoized on displayMessages, which a streaming turn never touches, so
-  // this identity is stable across stream ticks and the rail's effect does not
-  // tear down and re-observe every frame.
+  // The timeline rail's data source. Memoized on displayMessages, which a
+  // streaming turn never touches, so this identity is stable across stream
+  // ticks and the rail's effect does not tear down and re-observe every frame.
   const timelineQuestions = useMemo(
-    () => buildTimelineQuestions(displayMessages, mainSessionId),
-    [displayMessages, mainSessionId],
+    () => buildTimelineQuestions(displayMessages),
+    [displayMessages],
   );
 
   const landingTimerRef = useRef<number | undefined>(undefined);

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -55,6 +55,8 @@ import { useFreeCells, type WidgetType } from "@/pages/free/use-free-cells";
 import type { TraceSegment, TraceSnapshot, TraceSummary } from "@rome/api-types/trace-segments";
 import { useSmoothText } from "@/hooks/use-smooth-text";
 import { useStickToBottom } from "@/hooks/use-stick-to-bottom";
+import { ChatTimelineRail } from "@/components/chat/ChatTimelineRail";
+import { buildTimelineQuestions } from "@/components/chat/chat-timeline";
 import { useStreamingSessions } from "@/hooks/use-streaming-sessions";
 import { useSseEvents } from "@/hooks/use-sse-events";
 import { renderFlatBlocks, renderSingleBlock } from "@/components/chat/blocks";
@@ -80,6 +82,12 @@ import type {
   StreamBlock,
 } from "@/lib/chat-types";
 import { SCROLL_BOTTOM_THRESHOLD_PX } from "@/lib/chat-constants";
+
+// Leave a jumped-to question clear of the top edge — flush against it reads
+// as cut off.
+const TIMELINE_JUMP_OFFSET_PX = 24;
+// How long the landed-on question stays tinted.
+const TIMELINE_LANDING_MS = 900;
 import { buildOptimisticUserText } from "@/lib/chat-helpers";
 import { parseSSEEvents } from "@/lib/chat-sse";
 import {
@@ -354,6 +362,28 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
     thresholdPx: SCROLL_BOTTOM_THRESHOLD_PX,
   });
 
+  // The timeline rail measures against these two nodes, so they are held as
+  // state rather than refs: its effect has to re-run once they mount. Both
+  // callbacks forward to the stick-to-bottom hook, which owns them first. Its
+  // refs are stable (useCallback with no deps), so these are too and React
+  // never re-invokes them; the cost is one extra render on mount.
+  const [scrollerEl, setScrollerEl] = useState<HTMLElement | null>(null);
+  const [contentEl, setContentEl] = useState<HTMLElement | null>(null);
+  const attachScroller = useCallback(
+    (node: HTMLDivElement | null) => {
+      setScrollerEl(node);
+      stickScrollRef(node);
+    },
+    [stickScrollRef],
+  );
+  const attachContent = useCallback(
+    (node: HTMLElement | null) => {
+      setContentEl(node);
+      stickContentRef(node);
+    },
+    [stickContentRef],
+  );
+
   useImperativeHandle(
     ref,
     () => ({
@@ -395,6 +425,53 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
     }
     return ids;
   }, [displayMessages, mainSessionId]);
+
+  // The timeline rail's data source — the same main-session filter mainTurnIds
+  // uses. Memoized on displayMessages, which a streaming turn never touches, so
+  // this identity is stable across stream ticks and the rail's effect does not
+  // tear down and re-observe every frame.
+  const timelineQuestions = useMemo(
+    () => buildTimelineQuestions(displayMessages, mainSessionId),
+    [displayMessages, mainSessionId],
+  );
+
+  const landingTimerRef = useRef<number | undefined>(undefined);
+  useEffect(() => () => window.clearTimeout(landingTimerRef.current), []);
+
+  const jumpToQuestion = useCallback(
+    (messageId: string) => {
+      const scroller = scrollerEl;
+      if (!scroller) return;
+      const anchor = [...scroller.querySelectorAll<HTMLElement>("[data-timeline-anchor]")].find(
+        (el) => el.getAttribute("data-timeline-anchor") === messageId,
+      );
+      if (!anchor) return;
+      const top =
+        anchor.getBoundingClientRect().top -
+        scroller.getBoundingClientRect().top +
+        scroller.scrollTop;
+      // `auto`, not `smooth`, and deliberately so. use-stick-to-bottom treats a
+      // scroll outside its 300ms user-gesture window as accidental drift and
+      // snaps back to the bottom while pinned; an instant scroll emits its one
+      // event on the frame right after this click's pointerdown, safely inside
+      // that window, so the hook releases the pin for us. A smooth scroll's
+      // later frames fall outside it. Instant also reads better here: you land
+      // and start reading rather than watching half a second of blur.
+      scroller.scrollTo({ top: Math.max(top - TIMELINE_JUMP_OFFSET_PX, 0), behavior: "auto" });
+
+      // Every user bubble is the same tint, so without this you cannot tell
+      // whether the jump landed on the question you picked.
+      window.clearTimeout(landingTimerRef.current);
+      for (const el of scroller.querySelectorAll("[data-timeline-landed]")) {
+        el.removeAttribute("data-timeline-landed");
+      }
+      anchor.setAttribute("data-timeline-landed", "");
+      landingTimerRef.current = window.setTimeout(() => {
+        anchor.removeAttribute("data-timeline-landed");
+      }, TIMELINE_LANDING_MS);
+    },
+    [scrollerEl],
+  );
 
   const enterShareMode = useCallback(() => {
     setSelectedShareTurns(new Set(mainTurnIds));
@@ -1607,106 +1684,119 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
               moves the sidebar/composer. `overscroll-contain` kills page-level
               rubber-banding/scroll-chaining; momentum scrolling keeps the iPad
               touch feel. */}
-          <div
-            ref={stickScrollRef}
-            className="relative flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain"
-          >
-            <MessageList
-              rows={rows}
-              live={{
-                isStreaming: displayedStreaming,
-                runningTurnId,
-                snapshot: currentSnapshot,
-                text: liveAssistantText,
-                blockIx: floorSessionStream?.assistantBlockIx,
-                sourceText: floorSessionStream?.assistantText,
-                identity: floorIdentity,
-              }}
-              selection={
-                shareMode
-                  ? {
-                      active: true,
-                      selectedTurns: selectedShareTurns,
-                      selectableSessionId: mainSessionId,
-                      onToggleTurn: toggleShareTurn,
-                    }
-                  : undefined
-              }
-              contentRef={stickContentRef}
-              onOpenLiveTrace={openLiveTraceDrawer}
-              onOpenStoredTrace={setTraceDrawerTarget}
-              onOpenSubagentTrace={openSubagentTraceDrawer}
-              activeTraceTarget={traceDrawerTarget}
-              subagentIconByName={subagentIconByName}
-              actions={blockActions}
-              feedback
-            />
+          {/* Positioning + measurement parent for the timeline rail. Its own
+              container name matters: `@container/chat` is declared on the outer
+              element and does NOT narrow when the trace drawer reserves its
+              480px on this column, so a gate keyed to it would show the rail at
+              widths where the transcript has no gutter left. */}
+          <div className="@container/transcript relative flex min-h-0 flex-1 flex-col">
+            <div
+              ref={attachScroller}
+              className="relative flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain"
+            >
+              <MessageList
+                rows={rows}
+                live={{
+                  isStreaming: displayedStreaming,
+                  runningTurnId,
+                  snapshot: currentSnapshot,
+                  text: liveAssistantText,
+                  blockIx: floorSessionStream?.assistantBlockIx,
+                  sourceText: floorSessionStream?.assistantText,
+                  identity: floorIdentity,
+                }}
+                selection={
+                  shareMode
+                    ? {
+                        active: true,
+                        selectedTurns: selectedShareTurns,
+                        selectableSessionId: mainSessionId,
+                        onToggleTurn: toggleShareTurn,
+                      }
+                    : undefined
+                }
+                contentRef={attachContent}
+                onOpenLiveTrace={openLiveTraceDrawer}
+                onOpenStoredTrace={setTraceDrawerTarget}
+                onOpenSubagentTrace={openSubagentTraceDrawer}
+                activeTraceTarget={traceDrawerTarget}
+                subagentIconByName={subagentIconByName}
+                actions={blockActions}
+                feedback
+              />
 
-            {/* The single floating composer — a `sticky bottom-0` floor inside the
+              {/* The single floating composer — a `sticky bottom-0` floor inside the
                 message scroller, so messages scroll behind its translucent blur
                 ("scroll under the composer") instead of stopping at a solid dock.
                 It talks to whoever holds the floor (the open handoff's specialist,
                 or the main agent). In share mode it's swapped for the ShareBar,
                 which configures + mints the link for the turns selected above. */}
-            <div className="pointer-events-none sticky bottom-0 z-10 px-3 pb-[calc(var(--rome-safe-area-bottom)+1rem)] md:px-6 md:pb-[calc(var(--rome-safe-area-bottom)+1.5rem)]">
-              <div className="pointer-events-auto mx-auto max-w-5xl">
-                {shareMode ? (
-                  <ShareBar
-                    sessionId={mainSessionId}
-                    selectedTurnIds={[...selectedShareTurns]}
-                    onExit={exitShareMode}
-                  />
-                ) : isArchived ? (
-                  <div className="flex items-center justify-between gap-3 rounded-16 border border-border bg-surface/95 px-4 py-3 text-ui text-muted-foreground shadow-10 backdrop-blur-md supports-[backdrop-filter]:bg-surface/80">
-                    <span className="min-w-0 flex-1">{t("archived.readOnly")}</span>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={() => void handleUnarchive()}
-                    >
-                      <ArchiveRestore data-icon="inline-start" className="size-3.5" />
-                      {t("archived.unarchive")}
-                    </Button>
-                  </div>
-                ) : (
-                  <ChatComposer
-                    ref={composerRef}
-                    // The box look lives on the composer now so the chip row can sit
-                    // outside it; this mount adds the floating blur/translucency.
-                    boxClassName="rounded-16 border border-border bg-surface/95 p-4 shadow-10 backdrop-blur-md supports-[backdrop-filter]:bg-surface/80"
-                    onSend={handleComposerSend}
-                    isStreaming={displayedStreaming}
-                    onStop={() => void stopMessage()}
-                    streamError={streamError}
-                    // The chip names the floor agent — the specialist during a
-                    // handoff, the main agent otherwise.
-                    pinnedAgentMention={floorAgentMention}
-                    lockAgentMention
-                    designingInteraction={
-                      floorHandoff
-                        ? {
-                            agentLabel: floorHandoff.agentLabel,
-                            // A pending submission turns the banner into an Approve
-                            // that resolves the handoff with that payload.
-                            onApprove: activeSubmission
-                              ? () =>
-                                  void handleResolveHandoff(
-                                    floorHandoff,
-                                    activeSubmission.payload,
-                                    "Approved",
-                                  )
-                              : undefined,
-                            // Cancel lives here now (off the @mention seam): dismiss
-                            // the handoff and hand the floor back to the caller.
-                            onCancel: () => handleCancelHandoff(floorHandoff),
-                          }
-                        : null
-                    }
-                  />
-                )}
+              <div className="pointer-events-none sticky bottom-0 z-10 px-3 pb-[calc(var(--rome-safe-area-bottom)+1rem)] md:px-6 md:pb-[calc(var(--rome-safe-area-bottom)+1.5rem)]">
+                <div className="pointer-events-auto mx-auto max-w-5xl">
+                  {shareMode ? (
+                    <ShareBar
+                      sessionId={mainSessionId}
+                      selectedTurnIds={[...selectedShareTurns]}
+                      onExit={exitShareMode}
+                    />
+                  ) : isArchived ? (
+                    <div className="flex items-center justify-between gap-3 rounded-16 border border-border bg-surface/95 px-4 py-3 text-ui text-muted-foreground shadow-10 backdrop-blur-md supports-[backdrop-filter]:bg-surface/80">
+                      <span className="min-w-0 flex-1">{t("archived.readOnly")}</span>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => void handleUnarchive()}
+                      >
+                        <ArchiveRestore data-icon="inline-start" className="size-3.5" />
+                        {t("archived.unarchive")}
+                      </Button>
+                    </div>
+                  ) : (
+                    <ChatComposer
+                      ref={composerRef}
+                      // The box look lives on the composer now so the chip row can sit
+                      // outside it; this mount adds the floating blur/translucency.
+                      boxClassName="rounded-16 border border-border bg-surface/95 p-4 shadow-10 backdrop-blur-md supports-[backdrop-filter]:bg-surface/80"
+                      onSend={handleComposerSend}
+                      isStreaming={displayedStreaming}
+                      onStop={() => void stopMessage()}
+                      streamError={streamError}
+                      // The chip names the floor agent — the specialist during a
+                      // handoff, the main agent otherwise.
+                      pinnedAgentMention={floorAgentMention}
+                      lockAgentMention
+                      designingInteraction={
+                        floorHandoff
+                          ? {
+                              agentLabel: floorHandoff.agentLabel,
+                              // A pending submission turns the banner into an Approve
+                              // that resolves the handoff with that payload.
+                              onApprove: activeSubmission
+                                ? () =>
+                                    void handleResolveHandoff(
+                                      floorHandoff,
+                                      activeSubmission.payload,
+                                      "Approved",
+                                    )
+                                : undefined,
+                              // Cancel lives here now (off the @mention seam): dismiss
+                              // the handoff and hand the floor back to the caller.
+                              onCancel: () => handleCancelHandoff(floorHandoff),
+                            }
+                          : null
+                      }
+                    />
+                  )}
+                </div>
               </div>
             </div>
+            <ChatTimelineRail
+              scroller={scrollerEl}
+              content={contentEl}
+              questions={timelineQuestions}
+              onJump={jumpToQuestion}
+            />
           </div>
         </div>
         <TraceDrawer

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -1690,9 +1690,15 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
               480px on this column, so a gate keyed to it would show the rail at
               widths where the transcript has no gutter left. */}
           <div className="@container/transcript relative flex min-h-0 flex-1 flex-col">
+            {/* The right inset opens the timeline rail's lane. Without it the
+                transcript's own `max-w-5xl` body reaches the container edge
+                once the container drops under 1024px, and the dots would land
+                on the bubbles. Padding sits inside the scroller's border box,
+                so the scrollbar does not move — only the content shifts. The
+                query MUST match ChatTimelineRail's visibility gate. */}
             <div
               ref={attachScroller}
-              className="relative flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain"
+              className="relative flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain @min-[48rem]/transcript:pr-8"
             >
               <MessageList
                 rows={rows}

--- a/packages/web/src/components/chat/ChatTimelineRail.test.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.test.tsx
@@ -1,11 +1,17 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+// Real bundles, so the hide control's accessible name is the shipped
+// string rather than its key — the same thing a screen reader would read.
+import "@/i18n";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ChatTimelineRail } from "./ChatTimelineRail";
 import type { TimelineQuestion } from "./chat-timeline";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
 
 const QUESTIONS: TimelineQuestion[] = [
   { messageId: "q1", text: "how do I ship this?" },
@@ -13,6 +19,14 @@ const QUESTIONS: TimelineQuestion[] = [
   { messageId: "q3", text: "why is it slow?" },
   { messageId: "q4", text: "can we cache it?" },
 ];
+
+// The dots, excluding the hide control — which is a button too, but is
+// deliberately focusable and is not one of the questions. Hidden dots stay
+// mounted so the retract animates, and leave the a11y tree via aria-hidden —
+// which is exactly what getAllByRole filters on.
+function dots(): HTMLElement[] {
+  return screen.getAllByRole("button").filter((el) => el.getAttribute("aria-expanded") === null);
+}
 
 function rect(top: number, height = 0): DOMRect {
   return {
@@ -99,7 +113,7 @@ function renderRail(
 describe("ChatTimelineRail", () => {
   it("renders one dot per question, labelled with its text", () => {
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    expect(screen.getAllByRole("button")).toHaveLength(4);
+    expect(dots()).toHaveLength(4);
     expect(screen.getByRole("button", { name: "how do I ship this?" })).toBeTruthy();
   });
 
@@ -124,7 +138,7 @@ describe("ChatTimelineRail", () => {
       QUESTIONS,
       onJump,
     );
-    expect(screen.getAllByRole("button")).toHaveLength(4);
+    expect(dots()).toHaveLength(4);
     fireEvent.click(screen.getByRole("button", { name: "can we cache it?" }));
     expect(onJump).toHaveBeenCalledWith("q4");
   });
@@ -133,9 +147,14 @@ describe("ChatTimelineRail", () => {
     // ~40 dots would otherwise add ~40 tab stops to the chat. ⌘K search is the
     // keyboard path to a message.
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    for (const dot of screen.getAllByRole("button")) {
+    for (const dot of dots()) {
       expect(dot.getAttribute("tabindex")).toBe("-1");
     }
+    // The hide control is the exception: one control, so it keeps its tab stop
+    // and its focus ring.
+    expect(
+      screen.getByRole("button", { name: "Hide timeline" }).getAttribute("tabindex"),
+    ).toBeNull();
   });
 
   it("renders no dots below the question floor", () => {
@@ -156,5 +175,31 @@ describe("ChatTimelineRail", () => {
   it("renders no dots without a scroller", () => {
     const { container } = renderRail(null, QUESTIONS);
     expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+
+  it("hides the dots and offers to bring them back", () => {
+    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
+    expect(dots()).toHaveLength(4);
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide timeline" }));
+    expect(dots()).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show timeline" }));
+    expect(dots()).toHaveLength(4);
+  });
+
+  it("remembers a hide across mounts", () => {
+    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
+    fireEvent.click(screen.getByRole("button", { name: "Hide timeline" }));
+    cleanup();
+
+    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
+    expect(dots()).toHaveLength(0);
+    expect(screen.getByRole("button", { name: "Show timeline" })).toBeTruthy();
+  });
+
+  it("offers no control when there is no timeline to hide", () => {
+    renderRail(stubScroller(SPREAD_ANCHORS.slice(0, 2)), QUESTIONS.slice(0, 2));
+    expect(screen.queryByRole("button")).toBeNull();
   });
 });

--- a/packages/web/src/components/chat/ChatTimelineRail.test.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ChatTimelineRail } from "./ChatTimelineRail";
+import type { TimelineQuestion } from "./chat-timeline";
+
+afterEach(() => cleanup());
+
+const QUESTIONS: TimelineQuestion[] = [
+  { messageId: "q1", text: "how do I ship this?" },
+  { messageId: "q2", text: "what broke the build?" },
+  { messageId: "q3", text: "why is it slow?" },
+  { messageId: "q4", text: "can we cache it?" },
+];
+
+function rect(top: number, height = 0): DOMRect {
+  return {
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 0,
+    width: 0,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+// jsdom has no layout: every rect is zero and scrollHeight/clientHeight are 0,
+// which would trip the rail's gates before any of its wiring ran. Stub the
+// metrics so what is under test is the component's own behaviour; the geometry
+// itself is covered with plain numbers in chat-timeline.test.ts.
+function stubScroller(anchors: Array<{ id: string; top: number }>): HTMLElement {
+  const scroller = document.createElement("div");
+  for (const anchor of anchors) {
+    const el = document.createElement("div");
+    el.setAttribute("data-timeline-anchor", anchor.id);
+    el.getBoundingClientRect = () => rect(anchor.top);
+    scroller.appendChild(el);
+  }
+  scroller.getBoundingClientRect = () => rect(0, 600);
+  Object.defineProperty(scroller, "scrollHeight", { value: 3000, configurable: true });
+  Object.defineProperty(scroller, "clientHeight", { value: 600, configurable: true });
+  Object.defineProperty(scroller, "scrollTop", { value: 0, writable: true, configurable: true });
+  document.body.appendChild(scroller);
+  return scroller;
+}
+
+const SPREAD_ANCHORS = [
+  { id: "q1", top: 0 },
+  { id: "q2", top: 600 },
+  { id: "q3", top: 1200 },
+  { id: "q4", top: 1800 },
+];
+
+/**
+ * Render, then give the track a height and re-run the measurement.
+ *
+ * The track's own `clientHeight` drives the layout (that is what keeps the
+ * computed and painted positions in one coordinate space), and jsdom reports 0
+ * for it until it is stubbed — which cannot happen before the first render. The
+ * second pass hands the effect a fresh `questions` identity so it re-measures
+ * against the stubbed height, which is the path that ships.
+ */
+function renderRail(
+  scroller: HTMLElement | null,
+  questions: TimelineQuestion[],
+  onJump: (messageId: string) => void = () => {},
+) {
+  // The rail lives inside Chat's single TooltipProvider (Chat.tsx), which owns
+  // the shared hover delay — it deliberately does not nest one of its own.
+  const view = render(
+    <TooltipProvider>
+      <ChatTimelineRail
+        scroller={scroller}
+        content={scroller}
+        questions={questions}
+        onJump={onJump}
+      />
+    </TooltipProvider>,
+  );
+  const track = view.container.querySelector<HTMLElement>("[data-timeline-track]");
+  if (track) Object.defineProperty(track, "clientHeight", { value: 500, configurable: true });
+  view.rerender(
+    <TooltipProvider>
+      <ChatTimelineRail
+        scroller={scroller}
+        content={scroller}
+        questions={[...questions]}
+        onJump={onJump}
+      />
+    </TooltipProvider>,
+  );
+  return view;
+}
+
+describe("ChatTimelineRail", () => {
+  it("renders one dot per question, labelled with its text", () => {
+    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
+    expect(screen.getAllByRole("button")).toHaveLength(4);
+    expect(screen.getByRole("button", { name: "how do I ship this?" })).toBeTruthy();
+  });
+
+  it("jumps to the question a dot points at", () => {
+    const onJump = vi.fn();
+    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS, onJump);
+    fireEvent.click(screen.getByRole("button", { name: "what broke the build?" }));
+    expect(onJump).toHaveBeenCalledWith("q2");
+  });
+
+  it("keeps every question clickable when they crowd together", () => {
+    // All four within 12px of content. They spread down the track instead of
+    // merging, so none becomes unreachable — the whole point of spreading.
+    const onJump = vi.fn();
+    renderRail(
+      stubScroller([
+        { id: "q1", top: 0 },
+        { id: "q2", top: 4 },
+        { id: "q3", top: 8 },
+        { id: "q4", top: 12 },
+      ]),
+      QUESTIONS,
+      onJump,
+    );
+    expect(screen.getAllByRole("button")).toHaveLength(4);
+    fireEvent.click(screen.getByRole("button", { name: "can we cache it?" }));
+    expect(onJump).toHaveBeenCalledWith("q4");
+  });
+
+  it("stays out of the tab order", () => {
+    // ~40 dots would otherwise add ~40 tab stops to the chat. ⌘K search is the
+    // keyboard path to a message.
+    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
+    for (const dot of screen.getAllByRole("button")) {
+      expect(dot.getAttribute("tabindex")).toBe("-1");
+    }
+  });
+
+  it("renders no dots below the question floor", () => {
+    const { container } = renderRail(
+      stubScroller(SPREAD_ANCHORS.slice(0, 2)),
+      QUESTIONS.slice(0, 2),
+    );
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+
+  it("renders no dots when the transcript fits on one screen", () => {
+    const scroller = stubScroller(SPREAD_ANCHORS);
+    Object.defineProperty(scroller, "scrollHeight", { value: 700, configurable: true });
+    const { container } = renderRail(scroller, QUESTIONS);
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+
+  it("renders no dots without a scroller", () => {
+    const { container } = renderRail(null, QUESTIONS);
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+});

--- a/packages/web/src/components/chat/ChatTimelineRail.test.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.test.tsx
@@ -143,16 +143,46 @@ describe("ChatTimelineRail", () => {
     expect(onJump).toHaveBeenCalledWith("q4");
   });
 
-  it("lets a keyboard reach every question", () => {
-    // Search cannot scroll to a message yet, so the rail is the only way to
-    // reach an earlier question — it cannot be pointer-only.
+  it("takes one tab stop for the whole column", () => {
+    // Search cannot scroll to a message yet, so the rail is the only keyboard
+    // route to an earlier question — but forty questions must not mean forty
+    // tab stops. Exactly one dot is tabbable; arrows reach the rest.
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    for (const dot of dots()) {
-      expect(dot.getAttribute("tabindex")).toBe("0");
-    }
+    expect(dots().map((d) => d.getAttribute("tabindex"))).toEqual(["0", "-1", "-1", "-1"]);
     expect(
       screen.getByRole("button", { name: "Hide timeline" }).getAttribute("tabindex"),
     ).toBeNull();
+  });
+
+  it("moves between questions with the arrow keys", () => {
+    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
+    const all = dots();
+    all[0].focus();
+
+    fireEvent.keyDown(all[0], { key: "ArrowDown" });
+    expect(document.activeElement).toBe(all[1]);
+    expect(dots().map((d) => d.getAttribute("tabindex"))).toEqual(["-1", "0", "-1", "-1"]);
+
+    fireEvent.keyDown(all[1], { key: "ArrowUp" });
+    expect(document.activeElement).toBe(all[0]);
+
+    fireEvent.keyDown(all[0], { key: "End" });
+    expect(document.activeElement).toBe(all[3]);
+
+    fireEvent.keyDown(all[3], { key: "Home" });
+    expect(document.activeElement).toBe(all[0]);
+  });
+
+  it("stops at the ends rather than wrapping", () => {
+    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
+    const all = dots();
+    all[0].focus();
+    fireEvent.keyDown(all[0], { key: "ArrowUp" });
+    expect(document.activeElement).toBe(all[0]);
+
+    all[3].focus();
+    fireEvent.keyDown(all[3], { key: "ArrowDown" });
+    expect(document.activeElement).toBe(all[3]);
   });
 
   it("takes hidden dots out of the tab order", () => {

--- a/packages/web/src/components/chat/ChatTimelineRail.test.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 // Real bundles, so the hide control's accessible name is the shipped
 // string rather than its key — the same thing a screen reader would read.
 import "@/i18n";
@@ -8,7 +8,9 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { ChatTimelineRail } from "./ChatTimelineRail";
 import type { TimelineQuestion } from "./chat-timeline";
 
+beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
 afterEach(() => {
+  vi.useRealTimers();
   cleanup();
   localStorage.clear();
 });
@@ -236,6 +238,45 @@ describe("ChatTimelineRail", () => {
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
     expect(dots()).toHaveLength(0);
     expect(screen.getByRole("button", { name: "Show timeline" })).toBeTruthy();
+  });
+
+  it("keeps watching while hidden with nothing to show", () => {
+    // A hidden rail that measured nothing — too narrow, too short — must stay
+    // subscribed, or becoming eligible later leaves no Show control until the
+    // next message or a reload.
+    const observed: Element[] = [];
+    let fire: (() => void) | null = null;
+    const RealRO = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      constructor(cb: () => void) {
+        fire = cb;
+      }
+      observe(el: Element) {
+        observed.push(el);
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      localStorage.setItem("rome-timeline-hidden", "1");
+      // A transcript under two viewports: ineligible, so nothing is measured.
+      const scroller = stubScroller(SPREAD_ANCHORS);
+      Object.defineProperty(scroller, "scrollHeight", { value: 700, configurable: true });
+      renderRail(scroller, QUESTIONS);
+      expect(screen.queryByRole("button")).toBeNull();
+      expect(observed.length).toBeGreaterThan(0);
+
+      // It grows past the threshold; the observer has to bring the control back.
+      Object.defineProperty(scroller, "scrollHeight", { value: 3000, configurable: true });
+      act(() => {
+        fire?.();
+        vi.advanceTimersByTime(200);
+      });
+      expect(screen.getByRole("button", { name: "Show timeline" })).toBeTruthy();
+    } finally {
+      globalThis.ResizeObserver = RealRO;
+    }
   });
 
   it("offers no control when there is no timeline to hide", () => {

--- a/packages/web/src/components/chat/ChatTimelineRail.test.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.test.tsx
@@ -143,18 +143,28 @@ describe("ChatTimelineRail", () => {
     expect(onJump).toHaveBeenCalledWith("q4");
   });
 
-  it("stays out of the tab order", () => {
-    // ~40 dots would otherwise add ~40 tab stops to the chat. ⌘K search is the
-    // keyboard path to a message.
+  it("lets a keyboard reach every question", () => {
+    // Search cannot scroll to a message yet, so the rail is the only way to
+    // reach an earlier question — it cannot be pointer-only.
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
     for (const dot of dots()) {
-      expect(dot.getAttribute("tabindex")).toBe("-1");
+      expect(dot.getAttribute("tabindex")).toBe("0");
     }
-    // The hide control is the exception: one control, so it keeps its tab stop
-    // and its focus ring.
     expect(
       screen.getByRole("button", { name: "Hide timeline" }).getAttribute("tabindex"),
     ).toBeNull();
+  });
+
+  it("takes hidden dots out of the tab order", () => {
+    // They stay mounted so the retract animates, and carry aria-hidden — which
+    // must never contain something focusable.
+    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
+    fireEvent.click(screen.getByRole("button", { name: "Hide timeline" }));
+    const hiddenDots = [...document.querySelectorAll<HTMLElement>("[data-timeline-track] button")];
+    expect(hiddenDots).toHaveLength(4);
+    for (const dot of hiddenDots) {
+      expect(dot.getAttribute("tabindex")).toBe("-1");
+    }
   });
 
   it("renders no dots below the question floor", () => {

--- a/packages/web/src/components/chat/ChatTimelineRail.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.tsx
@@ -217,14 +217,20 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
                     free-positioned dot fails by construction. The label is the
                     question alone — Radix already wires the tooltip as
                     aria-describedby, so a "jump to" prefix would make a screen
-                    reader announce the question twice. */}
+                    reader announce the question twice.
+
+                    Keyboard-reachable, and focus is styled like hover so the
+                    dot under the caret reads like the one under the cursor.
+                    Hidden dots leave the tab order explicitly rather than
+                    relying on `visibility`, so nothing focusable ever sits
+                    inside `aria-hidden`. */}
                     <button
                       type="button"
-                      tabIndex={-1}
+                      tabIndex={hidden ? -1 : 0}
                       aria-label={label}
                       onClick={() => onJump(node.messageId)}
                       style={{ top: `${node.fraction * 100}%` }}
-                      className="pointer-events-auto absolute right-6 size-3.5 -translate-y-1/2 translate-x-1/2 rounded-full before:absolute before:inset-[5px] before:rounded-full before:scale-100 before:bg-muted-foreground before:opacity-40 before:transition-[opacity,scale] before:duration-200 before:ease-out motion-reduce:before:transition-none group-hover:before:opacity-70 hover:before:scale-150 hover:before:opacity-100"
+                      className="pointer-events-auto absolute right-6 size-3.5 -translate-y-1/2 translate-x-1/2 rounded-full before:absolute before:inset-[5px] before:rounded-full before:scale-100 before:bg-muted-foreground before:opacity-40 before:transition-[opacity,scale] before:duration-200 before:ease-out motion-reduce:before:transition-none group-hover:before:opacity-70 hover:before:scale-150 hover:before:opacity-100 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring focus-visible:before:scale-150 focus-visible:before:opacity-100"
                     />
                   </TooltipTrigger>
                   {/* The offset clears the dot: TooltipContent's arrow is 10px

--- a/packages/web/src/components/chat/ChatTimelineRail.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -18,6 +19,17 @@ const MEASURE_DEBOUNCE_MS = 150;
 
 const EMPTY: TimelineNode[] = [];
 
+// Matches how the sidebar remembers its own collapse (RomeShellLayout).
+const HIDDEN_KEY = "rome-timeline-hidden";
+
+function readHidden(): boolean {
+  try {
+    return localStorage.getItem(HIDDEN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
 export interface ChatTimelineRailProps {
   /** The chat's single scrolling node. */
   scroller: HTMLElement | null;
@@ -36,13 +48,16 @@ export interface ChatTimelineRailProps {
  * A faint column of dots down the right gutter of the transcript — one per past
  * user question. Hovering names the question, clicking jumps to it.
  *
- * Deliberately the quietest thing on screen: 4px dots at 40% opacity, no
- * connecting line, and opacity as the only transition. Nothing here moves or
- * changes size while the user reads.
+ * Deliberately the quietest thing on screen: 4px dots at 40% opacity and no
+ * connecting line. Nothing here moves or resizes on its own — the only motion
+ * is a dot growing under the cursor, which the reader asked for by pointing at
+ * it. That is why there is no scroll-following "current position" dot: motion
+ * nobody invited is what pulls the eye off the text.
  */
 export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatTimelineRailProps) {
   const { t } = useTranslation("chat");
   const [nodes, setNodes] = useState<TimelineNode[]>(EMPTY);
+  const [hidden, setHidden] = useState(readHidden);
   // The dots are positioned as a percentage of THIS element, so the layout math
   // is given this element's height rather than the scroller's. Measuring the
   // track directly is what keeps the computed and painted positions in one
@@ -108,58 +123,119 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
     };
   }, [scroller, content, questions]);
 
+  const toggleHidden = useCallback(() => {
+    setHidden((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(HIDDEN_KEY, next ? "1" : "0");
+      } catch {}
+      return next;
+    });
+  }, []);
+
+  // The track stays mounted even with nothing to show. `measure` reads its
+  // height, so an early return here would leave `trackRef` null, which would
+  // make the measurement bail, which would keep `nodes` empty — the rail would
+  // never appear at all. Only the contents are conditional.
+  const empty = nodes.length === 0;
+
   return (
-    // Hidden below @6xl (1152px): under that the transcript's max-w-5xl body
-    // reaches the container edge and the dots would sit ~8px off the user's own
-    // bubbles. The container is `transcript`, declared on Chat's scroller
-    // wrapper — NOT `chat`, which is declared on an outer element that never
-    // narrows when the trace drawer takes its 480px.
+    // A dot's centre sits 24px in from the container's right edge — far enough
+    // that its 14px hit target clears a 15px classic scrollbar entirely, so the
+    // scrollbar stays grabbable on Windows and Linux where it is a real control.
+    //
+    // The other side used to be the binding constraint: the transcript is
+    // `mx-auto max-w-5xl`, so once the container drops under 1024px the body
+    // fills it and a bubble's edge runs straight into the dots. Chat now gives
+    // the scroller a matching right inset under the SAME query, which opens a
+    // permanent lane for the rail — so this gate is only about whether the
+    // surface is big enough to be worth navigating, not about whether the dots
+    // fit. Keep the two queries in sync: Chat.tsx's `pr-8` is what makes any
+    // width below 1024 safe.
+    //
+    // The container is `transcript`, declared on Chat's scroller wrapper — NOT
+    // `chat`, which is declared on an outer element that never narrows when the
+    // trace drawer takes its 480px.
     //
     // Pointer events stay off the whole strip and are re-enabled only on the
     // dots, so the native scrollbar and the composer's right edge remain
     // grabbable underneath.
     <div
       aria-label={t("timeline.label")}
-      className="pointer-events-none absolute inset-y-0 right-0 z-10 hidden w-8 @6xl/transcript:block"
+      className="group pointer-events-none absolute inset-y-0 right-0 z-10 hidden w-8 @min-[48rem]/transcript:block"
     >
-      {/* Stops well above the sticky composer so no dot ever paints on it. */}
+      {/* One tab stop, unlike the dots — this is a real control, so it takes
+          focus and draws the design system's focus ring. It sits in the band the
+          track leaves free at the top, so it never shares a row with a dot. */}
+      {empty ? null : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={toggleHidden}
+              aria-label={hidden ? t("timeline.show") : t("timeline.hide")}
+              aria-expanded={!hidden}
+              className="pointer-events-auto absolute top-6 right-6 flex size-6 -translate-y-1/2 translate-x-1/2 items-center justify-center rounded-full text-muted-foreground opacity-30 transition-opacity duration-200 ease-out group-hover:opacity-70 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring motion-reduce:transition-none"
+            >
+              {hidden ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left" sideOffset={8}>
+            {hidden ? t("timeline.show") : t("timeline.hide")}
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {/* Starts below the control's band and stops well above the sticky
+          composer, so no dot ever paints on either.
+
+          Hiding slides the column out to the right and fades it, rather than
+          unmounting it, so the effect runs in both directions. `visibility`
+          carries the safety: it flips discretely at the END of the transition,
+          so the dots stay painted while they slide away and stop taking pointer
+          events the instant they are gone. `aria-hidden` takes them out of the
+          accessibility tree at the same time. */}
       <div
         ref={trackRef}
         data-timeline-track
-        className="group absolute right-0 top-8 bottom-32 w-8"
+        aria-hidden={hidden}
+        className={`absolute top-16 right-0 bottom-32 w-8 transition-[opacity,translate,visibility] duration-200 ease-out motion-reduce:transition-none ${
+          hidden ? "invisible translate-x-6 opacity-0" : "visible translate-x-0 opacity-100"
+        }`}
       >
-        {nodes.map((node) => {
-          const question = questions.find((q) => q.messageId === node.messageId);
-          if (!question) return null;
-          const label = summarizeQuestion(question.text);
-          return (
-            <Tooltip key={node.messageId}>
-              <TooltipTrigger asChild>
-                {/* A bare <button>, never the ui-kit Button: the /chat layout
+        {empty
+          ? null
+          : nodes.map((node) => {
+              const question = questions.find((q) => q.messageId === node.messageId);
+              if (!question) return null;
+              const label = summarizeQuestion(question.text);
+              return (
+                <Tooltip key={node.messageId}>
+                  <TooltipTrigger asChild>
+                    {/* A bare <button>, never the ui-kit Button: the /chat layout
                     invariant sweep measures every [data-slot="button"] for
                     vertical centring and sibling-uniform heights, which a
                     free-positioned dot fails by construction. The label is the
                     question alone — Radix already wires the tooltip as
                     aria-describedby, so a "jump to" prefix would make a screen
                     reader announce the question twice. */}
-                <button
-                  type="button"
-                  tabIndex={-1}
-                  aria-label={label}
-                  onClick={() => onJump(node.messageId)}
-                  style={{ top: `${node.fraction * 100}%` }}
-                  className="pointer-events-auto absolute right-4 size-3.5 -translate-y-1/2 translate-x-1/2 rounded-full before:absolute before:inset-[5px] before:rounded-full before:bg-muted-foreground before:opacity-40 before:transition-opacity group-hover:before:opacity-70 hover:before:opacity-100"
-                />
-              </TooltipTrigger>
-              {/* The offset clears the dot: TooltipContent's arrow is 10px
+                    <button
+                      type="button"
+                      tabIndex={-1}
+                      aria-label={label}
+                      onClick={() => onJump(node.messageId)}
+                      style={{ top: `${node.fraction * 100}%` }}
+                      className="pointer-events-auto absolute right-6 size-3.5 -translate-y-1/2 translate-x-1/2 rounded-full before:absolute before:inset-[5px] before:rounded-full before:scale-100 before:bg-muted-foreground before:opacity-40 before:transition-[opacity,scale] before:duration-200 before:ease-out motion-reduce:before:transition-none group-hover:before:opacity-70 hover:before:scale-150 hover:before:opacity-100"
+                    />
+                  </TooltipTrigger>
+                  {/* The offset clears the dot: TooltipContent's arrow is 10px
                   rotated 45°, which at the default offset of 0 would land on
                   top of a 4px dot. */}
-              <TooltipContent side="left" sideOffset={8}>
-                {label}
-              </TooltipContent>
-            </Tooltip>
-          );
-        })}
+                  <TooltipContent side="left" sideOffset={8}>
+                    {label}
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
       </div>
     </div>
   );

--- a/packages/web/src/components/chat/ChatTimelineRail.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.tsx
@@ -78,17 +78,23 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
     }
     let timer = 0;
 
-    const measure = () => {
+    /** Lays the dots out, and reports whether there are any. */
+    const measure = (): boolean => {
       const track = trackRef.current;
+      // A zero-height track means the rail is CSS-hidden below its breakpoint,
+      // where the sweep below can only ever produce nothing. Checking it first
+      // keeps a narrow viewport from paying for a forced layout on every
+      // debounce tick of a streaming reply.
       if (
         !track ||
+        track.clientHeight === 0 ||
         !shouldShowTimeline(questions.length, {
           scrollHeight: scroller.scrollHeight,
           clientHeight: scroller.clientHeight,
         })
       ) {
         setNodes((prev) => (prev.length === 0 ? prev : EMPTY));
-        return;
+        return false;
       }
       // Rects rather than offsetTop: SelectableRow makes rows `relative` in
       // share mode, which would silently re-parent offsetTop onto the row.
@@ -113,6 +119,7 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
         minGapPx: MIN_NODE_GAP_PX,
       });
       setNodes((prev) => (sameNodes(prev, next) ? prev : next));
+      return next.length > 0;
     };
 
     const schedule = () => {
@@ -123,12 +130,17 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
     // Always measure once, even while hidden: the node count is what decides
     // whether the show control renders at all, and skipping this would strand a
     // reader who hid the rail and then reloaded with no way to bring it back.
-    measure();
-    // Beyond that first pass there is nothing to keep in sync while the column
-    // is away, and a streaming reply would otherwise drive a layout flush plus
-    // a re-render every debounce tick for something not on screen. Unhiding
+    const anyDots = measure();
+    // With dots to keep, a hidden column has nothing left to stay in sync with,
+    // and a streaming reply would otherwise drive a layout flush plus a
+    // re-render every debounce tick for something not on screen. Unhiding
     // re-runs this effect, so the dots are measured fresh when they return.
-    if (hidden) return () => window.clearTimeout(timer);
+    //
+    // With NO dots the observer has to stay: the rail may still become eligible
+    // — a wider viewport, a transcript that grows past two screens — and the
+    // show control has to appear when it does rather than waiting for the next
+    // message or a reload.
+    if (hidden && anyDots) return () => window.clearTimeout(timer);
 
     const observer = new ResizeObserver(schedule);
     observer.observe(scroller);
@@ -197,8 +209,11 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
     // dots, so the native scrollbar and the composer's right edge remain
     // grabbable underneath.
     <div
-      role="navigation"
-      aria-label={t("timeline.label")}
+      // No landmark until there is a timeline inside it. Short chats are the
+      // common case, and an empty named region is something a screen-reader
+      // user lands in and finds nothing.
+      role={empty ? undefined : "navigation"}
+      aria-label={empty ? undefined : t("timeline.label")}
       className="group pointer-events-none absolute inset-y-0 right-0 z-10 hidden w-8 @min-[48rem]/transcript:block"
     >
       {/* One tab stop, unlike the dots — this is a real control, so it takes
@@ -254,7 +269,10 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
                     free-positioned dot fails by construction. The label is the
                     question alone — Radix already wires the tooltip as
                     aria-describedby, so a "jump to" prefix would make a screen
-                    reader announce the question twice.
+                    reader add a prefix to a question it announces twice
+                    regardless: Radix wires the tooltip as the description while
+                    this is the name, so both carry the question. Naming the
+                    action instead would not remove the repetition, only pad it.
 
                     Focus is styled like hover, so the dot under the caret
                     reads like the one under the cursor. Only the roving dot is

--- a/packages/web/src/components/chat/ChatTimelineRail.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -63,6 +63,13 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
   // track directly is what keeps the computed and painted positions in one
   // coordinate space.
   const trackRef = useRef<HTMLDivElement | null>(null);
+  // The column is one composite control, not forty. Only the roving dot is in
+  // the tab order; arrows move between dots from there. Tabbing every dot would
+  // bury the rest of the page behind dozens of stops in exactly the long chats
+  // this exists for, and dropping them from the tab order altogether would
+  // leave the transcript with no keyboard route back to an earlier question.
+  const [rovingIndex, setRovingIndex] = useState(0);
+  const dotRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   useEffect(() => {
     if (!scroller) {
@@ -113,7 +120,16 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
       timer = window.setTimeout(measure, MEASURE_DEBOUNCE_MS);
     };
 
+    // Always measure once, even while hidden: the node count is what decides
+    // whether the show control renders at all, and skipping this would strand a
+    // reader who hid the rail and then reloaded with no way to bring it back.
     measure();
+    // Beyond that first pass there is nothing to keep in sync while the column
+    // is away, and a streaming reply would otherwise drive a layout flush plus
+    // a re-render every debounce tick for something not on screen. Unhiding
+    // re-runs this effect, so the dots are measured fresh when they return.
+    if (hidden) return () => window.clearTimeout(timer);
+
     const observer = new ResizeObserver(schedule);
     observer.observe(scroller);
     if (content && content !== scroller) observer.observe(content);
@@ -121,7 +137,27 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
       window.clearTimeout(timer);
       observer.disconnect();
     };
-  }, [scroller, content, questions]);
+  }, [scroller, content, questions, hidden]);
+
+  // Clamped rather than reset: questions arrive while the chat runs, and the
+  // caret should not jump back to the top each time one does.
+  const activeDot = Math.min(rovingIndex, Math.max(nodes.length - 1, 0));
+
+  const onDotKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const last = nodes.length - 1;
+      let next: number;
+      if (event.key === "ArrowDown" || event.key === "ArrowRight") next = Math.min(index + 1, last);
+      else if (event.key === "ArrowUp" || event.key === "ArrowLeft") next = Math.max(index - 1, 0);
+      else if (event.key === "Home") next = 0;
+      else if (event.key === "End") next = last;
+      else return;
+      event.preventDefault();
+      setRovingIndex(next);
+      dotRefs.current[next]?.focus();
+    },
+    [nodes.length],
+  );
 
   const toggleHidden = useCallback(() => {
     setHidden((prev) => {
@@ -161,6 +197,7 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
     // dots, so the native scrollbar and the composer's right edge remain
     // grabbable underneath.
     <div
+      role="navigation"
       aria-label={t("timeline.label")}
       className="group pointer-events-none absolute inset-y-0 right-0 z-10 hidden w-8 @min-[48rem]/transcript:block"
     >
@@ -204,7 +241,7 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
       >
         {empty
           ? null
-          : nodes.map((node) => {
+          : nodes.map((node, index) => {
               const question = questions.find((q) => q.messageId === node.messageId);
               if (!question) return null;
               const label = summarizeQuestion(question.text);
@@ -219,15 +256,19 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
                     aria-describedby, so a "jump to" prefix would make a screen
                     reader announce the question twice.
 
-                    Keyboard-reachable, and focus is styled like hover so the
-                    dot under the caret reads like the one under the cursor.
-                    Hidden dots leave the tab order explicitly rather than
-                    relying on `visibility`, so nothing focusable ever sits
-                    inside `aria-hidden`. */}
+                    Focus is styled like hover, so the dot under the caret
+                    reads like the one under the cursor. Only the roving dot is
+                    tabbable; hidden dots leave the tab order entirely, so
+                    nothing focusable ever sits inside `aria-hidden`. */}
                     <button
                       type="button"
-                      tabIndex={hidden ? -1 : 0}
+                      ref={(el) => {
+                        dotRefs.current[index] = el;
+                      }}
+                      tabIndex={hidden || index !== activeDot ? -1 : 0}
                       aria-label={label}
+                      onKeyDown={(event) => onDotKeyDown(event, index)}
+                      onFocus={() => setRovingIndex(index)}
                       onClick={() => onJump(node.messageId)}
                       style={{ top: `${node.fraction * 100}%` }}
                       className="pointer-events-auto absolute right-6 size-3.5 -translate-y-1/2 translate-x-1/2 rounded-full before:absolute before:inset-[5px] before:rounded-full before:scale-100 before:bg-muted-foreground before:opacity-40 before:transition-[opacity,scale] before:duration-200 before:ease-out motion-reduce:before:transition-none group-hover:before:opacity-70 hover:before:scale-150 hover:before:opacity-100 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring focus-visible:before:scale-150 focus-visible:before:opacity-100"

--- a/packages/web/src/components/chat/ChatTimelineRail.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  layoutTimelineNodes,
+  MIN_NODE_GAP_PX,
+  sameNodes,
+  shouldShowTimeline,
+  summarizeQuestion,
+  type MeasuredAnchor,
+  type TimelineNode,
+  type TimelineQuestion,
+} from "@/components/chat/chat-timeline";
+
+// Re-measuring is trailing-debounced: a streamed reply grows the content on
+// every token, and measuring N anchors forces a layout flush each time.
+const MEASURE_DEBOUNCE_MS = 150;
+
+const EMPTY: TimelineNode[] = [];
+
+export interface ChatTimelineRailProps {
+  /** The chat's single scrolling node. */
+  scroller: HTMLElement | null;
+  /**
+   * The growing content wrapper inside the scroller. Observed separately
+   * because content height changes do not resize the scroller itself, so a
+   * ResizeObserver on the scroller alone would never fire and the dots would go
+   * stale mid-conversation.
+   */
+  content: HTMLElement | null;
+  questions: TimelineQuestion[];
+  onJump: (messageId: string) => void;
+}
+
+/**
+ * A faint column of dots down the right gutter of the transcript — one per past
+ * user question. Hovering names the question, clicking jumps to it.
+ *
+ * Deliberately the quietest thing on screen: 4px dots at 40% opacity, no
+ * connecting line, and opacity as the only transition. Nothing here moves or
+ * changes size while the user reads.
+ */
+export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatTimelineRailProps) {
+  const { t } = useTranslation("chat");
+  const [nodes, setNodes] = useState<TimelineNode[]>(EMPTY);
+  // The dots are positioned as a percentage of THIS element, so the layout math
+  // is given this element's height rather than the scroller's. Measuring the
+  // track directly is what keeps the computed and painted positions in one
+  // coordinate space.
+  const trackRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!scroller) {
+      setNodes((prev) => (prev.length === 0 ? prev : EMPTY));
+      return;
+    }
+    let timer = 0;
+
+    const measure = () => {
+      const track = trackRef.current;
+      if (
+        !track ||
+        !shouldShowTimeline(questions.length, {
+          scrollHeight: scroller.scrollHeight,
+          clientHeight: scroller.clientHeight,
+        })
+      ) {
+        setNodes((prev) => (prev.length === 0 ? prev : EMPTY));
+        return;
+      }
+      // Rects rather than offsetTop: SelectableRow makes rows `relative` in
+      // share mode, which would silently re-parent offsetTop onto the row.
+      const base = scroller.getBoundingClientRect().top - scroller.scrollTop;
+      // One sweep into a map, rather than a selector query per question: it is
+      // a single DOM traversal instead of N, and it keeps message ids out of a
+      // selector string entirely.
+      const elements = new Map<string, HTMLElement>();
+      for (const el of scroller.querySelectorAll<HTMLElement>("[data-timeline-anchor]")) {
+        const id = el.getAttribute("data-timeline-anchor");
+        if (id) elements.set(id, el);
+      }
+      const anchors: MeasuredAnchor[] = [];
+      for (const question of questions) {
+        const el = elements.get(question.messageId);
+        if (!el) continue;
+        anchors.push({ messageId: question.messageId, top: el.getBoundingClientRect().top - base });
+      }
+      const next = layoutTimelineNodes(anchors, {
+        contentHeight: scroller.scrollHeight,
+        trackHeight: track.clientHeight,
+        minGapPx: MIN_NODE_GAP_PX,
+      });
+      setNodes((prev) => (sameNodes(prev, next) ? prev : next));
+    };
+
+    const schedule = () => {
+      window.clearTimeout(timer);
+      timer = window.setTimeout(measure, MEASURE_DEBOUNCE_MS);
+    };
+
+    measure();
+    const observer = new ResizeObserver(schedule);
+    observer.observe(scroller);
+    if (content && content !== scroller) observer.observe(content);
+    return () => {
+      window.clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, [scroller, content, questions]);
+
+  return (
+    // Hidden below @6xl (1152px): under that the transcript's max-w-5xl body
+    // reaches the container edge and the dots would sit ~8px off the user's own
+    // bubbles. The container is `transcript`, declared on Chat's scroller
+    // wrapper — NOT `chat`, which is declared on an outer element that never
+    // narrows when the trace drawer takes its 480px.
+    //
+    // Pointer events stay off the whole strip and are re-enabled only on the
+    // dots, so the native scrollbar and the composer's right edge remain
+    // grabbable underneath.
+    <div
+      aria-label={t("timeline.label")}
+      className="pointer-events-none absolute inset-y-0 right-0 z-10 hidden w-8 @6xl/transcript:block"
+    >
+      {/* Stops well above the sticky composer so no dot ever paints on it. */}
+      <div
+        ref={trackRef}
+        data-timeline-track
+        className="group absolute right-0 top-8 bottom-32 w-8"
+      >
+        {nodes.map((node) => {
+          const question = questions.find((q) => q.messageId === node.messageId);
+          if (!question) return null;
+          const label = summarizeQuestion(question.text);
+          return (
+            <Tooltip key={node.messageId}>
+              <TooltipTrigger asChild>
+                {/* A bare <button>, never the ui-kit Button: the /chat layout
+                    invariant sweep measures every [data-slot="button"] for
+                    vertical centring and sibling-uniform heights, which a
+                    free-positioned dot fails by construction. The label is the
+                    question alone — Radix already wires the tooltip as
+                    aria-describedby, so a "jump to" prefix would make a screen
+                    reader announce the question twice. */}
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  aria-label={label}
+                  onClick={() => onJump(node.messageId)}
+                  style={{ top: `${node.fraction * 100}%` }}
+                  className="pointer-events-auto absolute right-4 size-3.5 -translate-y-1/2 translate-x-1/2 rounded-full before:absolute before:inset-[5px] before:rounded-full before:bg-muted-foreground before:opacity-40 before:transition-opacity group-hover:before:opacity-70 hover:before:opacity-100"
+                />
+              </TooltipTrigger>
+              {/* The offset clears the dot: TooltipContent's arrow is 10px
+                  rotated 45°, which at the default offset of 0 would land on
+                  top of a 4px dot. */}
+              <TooltipContent side="left" sideOffset={8}>
+                {label}
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/chat/MessageList.test.tsx
+++ b/packages/web/src/components/chat/MessageList.test.tsx
@@ -14,6 +14,7 @@ import {
   MessageList,
   type BlockActions,
   type LivePreview,
+  type ShareSelection,
 } from "./MessageList";
 import { buildRows, type AgentIdentity } from "./chat-view";
 import type { ChatMessage } from "@/lib/chat-types";
@@ -486,5 +487,102 @@ describe("MessageList Plan placement", () => {
     expect(recapToggle.getAttribute("aria-expanded")).toBe("true");
     expect(recapContent?.hidden).toBe(false);
     expect(screen.getByText("Concise recap")).toBeTruthy();
+  });
+});
+
+// The timeline rail finds its scroll targets by this attribute, and Chat paints
+// the post-jump landing tint on the same wrapper. Both break silently if a
+// render branch drops it, so each branch is covered.
+function questionTurn(text: string, id: string, turnId?: string): ChatMessage {
+  return {
+    id,
+    sessionId: "s-1",
+    ...(turnId ? { turnId } : {}),
+    role: "user",
+    content: text,
+    createdAt: "2026-06-13T00:00:00.000Z",
+  };
+}
+
+function settledList(messages: ChatMessage[], selection?: ShareSelection) {
+  const actions: BlockActions = {
+    onApprovalResolved: () => {},
+    onSubmitAppComponent: () => {},
+    onDismissAppComponent: () => {},
+    interactionResults: new Map(),
+  };
+  return (
+    <ThemeProvider>
+      <MessageList
+        rows={buildRows(messages, new Map([["s-1", IDENTITY]]), IDENTITY, {
+          runningTurnId: null,
+          isStreaming: false,
+        })}
+        live={{
+          isStreaming: false,
+          runningTurnId: null,
+          snapshot: null,
+          text: "",
+          identity: IDENTITY,
+        }}
+        selection={selection}
+        contentRef={() => {}}
+        onOpenLiveTrace={() => {}}
+        onOpenStoredTrace={() => {}}
+        actions={actions}
+      />
+    </ThemeProvider>
+  );
+}
+
+function anchorIds(container: HTMLElement): (string | null)[] {
+  return [...container.querySelectorAll("[data-timeline-anchor]")].map((el) =>
+    el.getAttribute("data-timeline-anchor"),
+  );
+}
+
+describe("timeline anchors", () => {
+  it("tags every user row with its message id, and nothing else", () => {
+    const first = questionTurn("first question", "u-first");
+    const second = questionTurn("second question", "u-second");
+    const { container } = render(settledList([first, commentary("an answer", "a-answer"), second]));
+
+    expect(anchorIds(container)).toEqual(["u-first", "u-second"]);
+  });
+
+  it("keeps the anchor on a selectable row during share selection", () => {
+    // Share mode wraps the row in SelectableRow with a click overlay. The
+    // anchor has to survive that branch or the rail silently stops working
+    // whenever share mode is on.
+    const question = questionTurn("still addressable", "u-share", "turn-9");
+    const { container } = render(
+      settledList([question], {
+        active: true,
+        selectedTurns: new Set<string>(),
+        selectableSessionId: "s-1",
+        onToggleTurn: () => {},
+      }),
+    );
+
+    expect(anchorIds(container)).toEqual(["u-share"]);
+    // The overlay still works — the anchor wrapper sits inside SelectableRow,
+    // not around it, so it cannot swallow the toggle.
+    expect(screen.getByRole("button", { name: "Select message" })).toBeTruthy();
+  });
+
+  it("keeps the anchor on a row share mode cannot select", () => {
+    // No turnId, so this row is dimmed rather than made selectable — a third
+    // render branch, and it still has to carry the anchor.
+    const question = questionTurn("no turn id", "u-dimmed");
+    const { container } = render(
+      settledList([question], {
+        active: true,
+        selectedTurns: new Set<string>(),
+        selectableSessionId: "s-1",
+        onToggleTurn: () => {},
+      }),
+    );
+
+    expect(anchorIds(container)).toEqual(["u-dimmed"]);
   });
 });

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -554,14 +554,27 @@ export function MessageList({
             />
           );
           const tail = row === anchorRow ? standalone : null;
-          if (!selection?.active) return [view, tail];
+          // The timeline rail locates its scroll targets by this attribute, and
+          // Chat paints the post-jump landing tint on the same wrapper. It goes
+          // around the view inside every branch, so share mode cannot strip it.
+          // A plain div with no classes adds no box: UserMessage's own `mb-4`
+          // still collapses through it, so row rhythm is unchanged.
+          const anchored = (node: ReactNode, key?: string) =>
+            row.kind === "user" ? (
+              <div key={key} data-timeline-anchor={row.message.id}>
+                {node}
+              </div>
+            ) : (
+              node
+            );
+          if (!selection?.active) return [anchored(view, row.key), tail];
           const { turnId, sessionId } = rowTurnRef(row);
           if (!turnId || sessionId !== selection.selectableSessionId) {
             // Not selectable (child-session row, or no turn): still dim it so the
             // selection state reads clearly across the whole transcript.
             return [
               <div key={row.key} className="pl-9 opacity-60">
-                {view}
+                {anchored(view)}
               </div>,
               tail,
             ];
@@ -573,7 +586,7 @@ export function MessageList({
               onToggle={() => selection.onToggleTurn(turnId)}
               label={selection.selectedTurns.has(turnId) ? "Deselect message" : "Select message"}
             >
-              {view}
+              {anchored(view)}
             </SelectableRow>,
             tail,
           ];

--- a/packages/web/src/components/chat/chat-timeline.test.ts
+++ b/packages/web/src/components/chat/chat-timeline.test.ts
@@ -125,13 +125,39 @@ describe("layoutTimelineNodes", () => {
     expect(nodes.map((n) => Math.round(n.fraction * 500))).toEqual([0, 8, 16]);
   });
 
-  it("clamps at the end of the track once saturated", () => {
+  it("ends the last dot at the foot of the track", () => {
     const anchors: MeasuredAnchor[] = [
       { messageId: "a", top: 1000 },
       { messageId: "b", top: 1000 },
     ];
     const nodes = layoutTimelineNodes(anchors, opts);
-    expect(nodes.map((n) => n.fraction)).toEqual([1, 1]);
+    expect(nodes.map((n) => Math.round(n.fraction * 500))).toEqual([492, 500]);
+  });
+
+  it("pulls a dense run at the bottom back up instead of stacking it", () => {
+    // Three questions in the last 1% of the transcript. A forward-only pass
+    // clamps the last two onto the same pixel, so one of them can never be
+    // clicked — while the track still has 484px of unused room above.
+    const anchors: MeasuredAnchor[] = [
+      { messageId: "a", top: 990 },
+      { messageId: "b", top: 995 },
+      { messageId: "c", top: 1000 },
+    ];
+    const nodes = layoutTimelineNodes(anchors, opts);
+    expect(nodes.map((n) => Math.round(n.fraction * 500))).toEqual([484, 492, 500]);
+  });
+
+  it("keeps every dot distinct up to the track's real capacity", () => {
+    // 60 questions all at the very bottom; a 500px track at an 8px gap holds
+    // 63, so none of them may share a position.
+    const anchors: MeasuredAnchor[] = Array.from({ length: 60 }, (_, i) => ({
+      messageId: `q${i}`,
+      top: 1000,
+    }));
+    const ys = layoutTimelineNodes(anchors, opts).map((n) => n.fraction * 500);
+    expect(new Set(ys.map((y) => Math.round(y))).size).toBe(60);
+    expect(Math.min(...ys)).toBeGreaterThanOrEqual(0);
+    expect(Math.max(...ys)).toBeCloseTo(500, 5);
   });
 
   it("returns nothing before layout", () => {

--- a/packages/web/src/components/chat/chat-timeline.test.ts
+++ b/packages/web/src/components/chat/chat-timeline.test.ts
@@ -31,17 +31,21 @@ describe("buildTimelineQuestions", () => {
     const a = msg("user", MAIN, text("first question"));
     const b = msg("assistant", MAIN, text("an answer"));
     const c = msg("user", MAIN, text("second question"));
-    expect(buildTimelineQuestions([a, b, c], MAIN)).toEqual([
+    expect(buildTimelineQuestions([a, b, c])).toEqual([
       { messageId: a.id, text: "first question" },
       { messageId: c.id, text: "second question" },
     ]);
   });
 
-  it("drops handoff child-session questions", () => {
+  it("includes questions asked during a handoff", () => {
+    // While a handoff is open the composer posts to the child session. Dropping
+    // those would leave a whole stretch of the conversation off the rail with
+    // nothing to explain the gap.
     const mine = msg("user", MAIN, text("mine"));
-    const theirs = msg("user", CHILD, text("theirs"));
-    expect(buildTimelineQuestions([mine, theirs], MAIN)).toEqual([
+    const duringHandoff = msg("user", CHILD, text("asked the specialist"));
+    expect(buildTimelineQuestions([mine, duringHandoff])).toEqual([
       { messageId: mine.id, text: "mine" },
+      { messageId: duringHandoff.id, text: "asked the specialist" },
     ]);
   });
 
@@ -53,7 +57,7 @@ describe("buildTimelineQuestions", () => {
       { type: "interaction_result", toolUseId: "t-1", output: { approved: true } },
     ]);
     const blank = msg("user", MAIN, text("   "));
-    expect(buildTimelineQuestions([resolution, blank], MAIN)).toEqual([]);
+    expect(buildTimelineQuestions([resolution, blank])).toEqual([]);
   });
 });
 
@@ -158,6 +162,26 @@ describe("layoutTimelineNodes", () => {
     expect(new Set(ys.map((y) => Math.round(y))).size).toBe(60);
     expect(Math.min(...ys)).toBeGreaterThanOrEqual(0);
     expect(Math.max(...ys)).toBeCloseTo(500, 5);
+  });
+
+  it("tightens the gap rather than stacking once the track overflows", () => {
+    // 60 questions on a 400px track: at an 8px gap only 51 fit, so a fixed gap
+    // would clamp the surplus onto y=0 and make all but one unreachable.
+    const anchors: MeasuredAnchor[] = Array.from({ length: 60 }, (_, i) => ({
+      messageId: `q${i}`,
+      top: 1000,
+    }));
+    const nodes = layoutTimelineNodes(anchors, {
+      contentHeight: 1000,
+      trackHeight: 400,
+      minGapPx: 8,
+    });
+    const ys = nodes.map((n) => n.fraction * 400);
+    expect(new Set(ys).size).toBe(60);
+    expect(ys[0]).toBeCloseTo(0, 5);
+    expect(ys[59]).toBeCloseTo(400, 5);
+    // Evenly spread across the track at the tightened gap.
+    expect(ys[1] - ys[0]).toBeCloseTo(400 / 59, 5);
   });
 
   it("returns nothing before layout", () => {

--- a/packages/web/src/components/chat/chat-timeline.test.ts
+++ b/packages/web/src/components/chat/chat-timeline.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "@/lib/chat-types";
+import {
+  buildTimelineQuestions,
+  layoutTimelineNodes,
+  sameNodes,
+  shouldShowTimeline,
+  summarizeQuestion,
+  type MeasuredAnchor,
+} from "./chat-timeline";
+
+const MAIN = "main";
+const CHILD = "child";
+
+let seq = 0;
+function msg(role: ChatMessage["role"], sessionId: string, blocks: unknown[]): ChatMessage {
+  seq += 1;
+  return {
+    id: `m${seq}`,
+    sessionId,
+    turnId: `t${seq}`,
+    role,
+    content: JSON.stringify(blocks),
+    createdAt: new Date(0).toISOString(),
+  };
+}
+const text = (content: string) => [{ type: "text", content }];
+
+describe("buildTimelineQuestions", () => {
+  it("keeps main-session user messages in transcript order", () => {
+    const a = msg("user", MAIN, text("first question"));
+    const b = msg("assistant", MAIN, text("an answer"));
+    const c = msg("user", MAIN, text("second question"));
+    expect(buildTimelineQuestions([a, b, c], MAIN)).toEqual([
+      { messageId: a.id, text: "first question" },
+      { messageId: c.id, text: "second question" },
+    ]);
+  });
+
+  it("drops handoff child-session questions", () => {
+    const mine = msg("user", MAIN, text("mine"));
+    const theirs = msg("user", CHILD, text("theirs"));
+    expect(buildTimelineQuestions([mine, theirs], MAIN)).toEqual([
+      { messageId: mine.id, text: "mine" },
+    ]);
+  });
+
+  it("drops user turns that render no bubble", () => {
+    // UserMessage returns null for a text-less turn (an interaction_result
+    // resolving an approval card), so a dot pointing at one would scroll
+    // nowhere.
+    const resolution = msg("user", MAIN, [
+      { type: "interaction_result", toolUseId: "t-1", output: { approved: true } },
+    ]);
+    const blank = msg("user", MAIN, text("   "));
+    expect(buildTimelineQuestions([resolution, blank], MAIN)).toEqual([]);
+  });
+});
+
+describe("summarizeQuestion", () => {
+  it("collapses whitespace onto one line", () => {
+    expect(summarizeQuestion("how do\n\n  I   ship this?")).toBe("how do I ship this?");
+  });
+
+  it("truncates past the cap", () => {
+    expect(summarizeQuestion("abcdefghij", 5)).toBe("abcde…");
+  });
+});
+
+describe("shouldShowTimeline", () => {
+  const tall = { scrollHeight: 3000, clientHeight: 700 };
+
+  it("shows for a long chat with enough questions", () => {
+    expect(shouldShowTimeline(6, tall)).toBe(true);
+  });
+
+  it("hides below the question floor", () => {
+    expect(shouldShowTimeline(3, tall)).toBe(false);
+  });
+
+  it("hides when the transcript is under two viewports tall", () => {
+    expect(shouldShowTimeline(6, { scrollHeight: 900, clientHeight: 700 })).toBe(false);
+  });
+
+  it("hides before layout", () => {
+    expect(shouldShowTimeline(6, { scrollHeight: 0, clientHeight: 0 })).toBe(false);
+  });
+});
+
+describe("layoutTimelineNodes", () => {
+  const opts = { contentHeight: 1000, trackHeight: 500, minGapPx: 8 };
+
+  it("places each dot at its share of the content height", () => {
+    const anchors: MeasuredAnchor[] = [
+      { messageId: "a", top: 0 },
+      { messageId: "b", top: 500 },
+    ];
+    expect(layoutTimelineNodes(anchors, opts)).toEqual([
+      { messageId: "a", fraction: 0 },
+      { messageId: "b", fraction: 0.5 },
+    ]);
+  });
+
+  it("pushes a crowded dot down instead of dropping it", () => {
+    // b is 4px below a on a 500px track — under the 8px floor. It moves to 8px
+    // (fraction 0.016) and stays clickable. This is the whole point: merging
+    // would make b unreachable while looking identical to a lossless dot.
+    const anchors: MeasuredAnchor[] = [
+      { messageId: "a", top: 0 },
+      { messageId: "b", top: 8 },
+    ];
+    const nodes = layoutTimelineNodes(anchors, opts);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0].fraction).toBe(0);
+    expect(nodes[1].fraction).toBeCloseTo(0.016, 5);
+  });
+
+  it("keeps pushing across a dense run", () => {
+    const anchors: MeasuredAnchor[] = [
+      { messageId: "a", top: 0 },
+      { messageId: "b", top: 2 },
+      { messageId: "c", top: 4 },
+    ];
+    const nodes = layoutTimelineNodes(anchors, opts);
+    expect(nodes.map((n) => Math.round(n.fraction * 500))).toEqual([0, 8, 16]);
+  });
+
+  it("clamps at the end of the track once saturated", () => {
+    const anchors: MeasuredAnchor[] = [
+      { messageId: "a", top: 1000 },
+      { messageId: "b", top: 1000 },
+    ];
+    const nodes = layoutTimelineNodes(anchors, opts);
+    expect(nodes.map((n) => n.fraction)).toEqual([1, 1]);
+  });
+
+  it("returns nothing before layout", () => {
+    expect(
+      layoutTimelineNodes([{ messageId: "a", top: 0 }], {
+        contentHeight: 0,
+        trackHeight: 500,
+        minGapPx: 8,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("sameNodes", () => {
+  it("ignores sub-pixel drift", () => {
+    expect(
+      sameNodes([{ messageId: "a", fraction: 0.5 }], [{ messageId: "a", fraction: 0.5005 }]),
+    ).toBe(true);
+  });
+
+  it("notices a real move", () => {
+    expect(
+      sameNodes([{ messageId: "a", fraction: 0.5 }], [{ messageId: "a", fraction: 0.6 }]),
+    ).toBe(false);
+  });
+
+  it("notices a new question", () => {
+    expect(
+      sameNodes(
+        [{ messageId: "a", fraction: 0 }],
+        [
+          { messageId: "a", fraction: 0 },
+          { messageId: "b", fraction: 1 },
+        ],
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/web/src/components/chat/chat-timeline.ts
+++ b/packages/web/src/components/chat/chat-timeline.ts
@@ -83,9 +83,16 @@ export function shouldShowTimeline(
  * swallowed questions unreachable by click while looking identical to a
  * lossless dot — the rail would lie, in exactly the long conversations it
  * exists for. Spreading trades local positional fidelity for the guarantee that
- * every question stays individually clickable. Past saturation the dots pile up
- * at the end of the track, which reads as "too many to show" instead of
- * silently dropping them.
+ * every question stays individually clickable.
+ *
+ * Two passes, because one is not enough. The forward pass pushes each crowded
+ * dot below its predecessor. On its own that collapses at the bottom edge: a
+ * run of questions near the end of the transcript is pushed past the track and
+ * clamped, so several dots land on the same pixel and all but one become
+ * unclickable — the exact failure spreading exists to avoid. The backward pass
+ * pulls such a run back up, which the track has room for whenever the dots fit
+ * at all. Only a genuine overflow (more dots than `trackHeight / minGapPx`)
+ * still overlaps, now at the top, where the alternative is dropping questions.
  */
 export function layoutTimelineNodes(
   anchors: MeasuredAnchor[],
@@ -93,15 +100,26 @@ export function layoutTimelineNodes(
 ): TimelineNode[] {
   const { contentHeight, trackHeight, minGapPx } = opts;
   if (contentHeight <= 0 || trackHeight <= 0) return [];
-  const nodes: TimelineNode[] = [];
+
+  const ys: number[] = [];
   let floor = 0;
   for (const anchor of anchors) {
     const natural = Math.min(Math.max(anchor.top / contentHeight, 0), 1) * trackHeight;
-    const y = Math.min(Math.max(natural, floor), trackHeight);
-    nodes.push({ messageId: anchor.messageId, fraction: y / trackHeight });
+    const y = Math.max(natural, floor);
+    ys.push(y);
     floor = y + minGapPx;
   }
-  return nodes;
+
+  let ceiling = trackHeight;
+  for (let i = ys.length - 1; i >= 0; i--) {
+    if (ys[i] > ceiling) ys[i] = ceiling;
+    ceiling = ys[i] - minGapPx;
+  }
+
+  return ys.map((y, i) => ({
+    messageId: anchors[i].messageId,
+    fraction: Math.max(y, 0) / trackHeight,
+  }));
 }
 
 /**

--- a/packages/web/src/components/chat/chat-timeline.ts
+++ b/packages/web/src/components/chat/chat-timeline.ts
@@ -1,0 +1,120 @@
+import { userMessageText } from "@/components/chat/chat-view";
+import type { ChatMessage } from "@/lib/chat-types";
+
+// The pure model behind the question timeline rail. It never touches the DOM:
+// the rail hands it measured pixels and gets back fractions. jsdom reports zero
+// for every rect, so this split is what makes the layout rules testable at all.
+
+/** Below this many questions the rail is not worth its pixels. */
+export const MIN_TIMELINE_QUESTIONS = 4;
+
+/** Minimum on-track distance between two dots, in px. */
+export const MIN_NODE_GAP_PX = 8;
+
+const SUMMARY_MAX_CHARS = 60;
+
+/** Sub-pixel drift that must not trigger a re-render. */
+const FRACTION_EPSILON = 0.002;
+
+export interface TimelineQuestion {
+  messageId: string;
+  /** The question's plain text, exactly as the bubble renders it. */
+  text: string;
+}
+
+/** A question's measured offset from the top of the scrollable content. */
+export interface MeasuredAnchor {
+  messageId: string;
+  top: number;
+}
+
+export interface TimelineNode {
+  messageId: string;
+  /** 0..1 position down the TRACK — used directly as a CSS percentage. */
+  fraction: number;
+}
+
+/**
+ * The questions the rail can point at: main-session user turns that actually
+ * render a bubble. Handoff child turns are excluded for the same reason
+ * `mainTurnIds` in Chat.tsx excludes them — they ride along with their parent
+ * and are not independently addressable. Text-less user turns are excluded
+ * because `UserMessage` returns null for them, so there would be no anchor.
+ */
+export function buildTimelineQuestions(
+  messages: ChatMessage[],
+  mainSessionId: string,
+): TimelineQuestion[] {
+  const questions: TimelineQuestion[] = [];
+  for (const message of messages) {
+    if (message.role !== "user" || message.sessionId !== mainSessionId) continue;
+    const text = userMessageText(message.content).trim();
+    if (!text) continue;
+    questions.push({ messageId: message.id, text });
+  }
+  return questions;
+}
+
+/**
+ * A one-line label. You need enough to recognise a question you wrote, not to
+ * re-read it — 60 chars keeps the tooltip to one line at typical lengths, and
+ * keeps the Chinese build from rendering an essay in a 320px box.
+ */
+export function summarizeQuestion(text: string, maxChars = SUMMARY_MAX_CHARS): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length > maxChars ? `${flat.slice(0, maxChars)}…` : flat;
+}
+
+/** The rail is for chats you cannot scan by scrolling. */
+export function shouldShowTimeline(
+  questionCount: number,
+  metrics: { scrollHeight: number; clientHeight: number },
+): boolean {
+  if (questionCount < MIN_TIMELINE_QUESTIONS) return false;
+  if (metrics.clientHeight <= 0) return false;
+  return metrics.scrollHeight >= metrics.clientHeight * 2;
+}
+
+/**
+ * Project anchors onto the track, pushing any dot that would crowd its
+ * predecessor further down.
+ *
+ * Spreading, not merging. Merging crowded dots into one node makes the
+ * swallowed questions unreachable by click while looking identical to a
+ * lossless dot — the rail would lie, in exactly the long conversations it
+ * exists for. Spreading trades local positional fidelity for the guarantee that
+ * every question stays individually clickable. Past saturation the dots pile up
+ * at the end of the track, which reads as "too many to show" instead of
+ * silently dropping them.
+ */
+export function layoutTimelineNodes(
+  anchors: MeasuredAnchor[],
+  opts: { contentHeight: number; trackHeight: number; minGapPx: number },
+): TimelineNode[] {
+  const { contentHeight, trackHeight, minGapPx } = opts;
+  if (contentHeight <= 0 || trackHeight <= 0) return [];
+  const nodes: TimelineNode[] = [];
+  let floor = 0;
+  for (const anchor of anchors) {
+    const natural = Math.min(Math.max(anchor.top / contentHeight, 0), 1) * trackHeight;
+    const y = Math.min(Math.max(natural, floor), trackHeight);
+    nodes.push({ messageId: anchor.messageId, fraction: y / trackHeight });
+    floor = y + minGapPx;
+  }
+  return nodes;
+}
+
+/**
+ * Whether a fresh measurement is worth committing. The rail re-measures on
+ * every content resize, which during a streamed reply means many times a
+ * second; without this the rail would re-render (and re-render every Radix
+ * tooltip root) on drift too small to see.
+ */
+export function sameNodes(a: TimelineNode[], b: TimelineNode[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every(
+    (node, i) =>
+      node.messageId === b[i].messageId &&
+      Math.abs(node.fraction - b[i].fraction) < FRACTION_EPSILON,
+  );
+}

--- a/packages/web/src/components/chat/chat-timeline.ts
+++ b/packages/web/src/components/chat/chat-timeline.ts
@@ -35,19 +35,25 @@ export interface TimelineNode {
 }
 
 /**
- * The questions the rail can point at: main-session user turns that actually
- * render a bubble. Handoff child turns are excluded for the same reason
- * `mainTurnIds` in Chat.tsx excludes them — they ride along with their parent
- * and are not independently addressable. Text-less user turns are excluded
- * because `UserMessage` returns null for them, so there would be no anchor.
+ * Every question the rail can point at: user turns that actually render a
+ * bubble, in transcript order.
+ *
+ * Deliberately not filtered to the main session. While a handoff is open the
+ * composer posts to the child session, so a filter would drop every question
+ * asked during that handoff — a whole stretch of the conversation missing from
+ * the rail with nothing to explain the gap. Those rows are spliced into
+ * `displayMessages` and carry their own anchors, so they are addressable like
+ * any other. Share selection does filter by session, but that decides which
+ * turns can be frozen into a link, not what can be scrolled to.
+ *
+ * Text-less user turns are excluded because `UserMessage` returns null for
+ * them, so there would be no anchor. The suppressed handoff seed is already
+ * absent from `displayMessages`.
  */
-export function buildTimelineQuestions(
-  messages: ChatMessage[],
-  mainSessionId: string,
-): TimelineQuestion[] {
+export function buildTimelineQuestions(messages: ChatMessage[]): TimelineQuestion[] {
   const questions: TimelineQuestion[] = [];
   for (const message of messages) {
-    if (message.role !== "user" || message.sessionId !== mainSessionId) continue;
+    if (message.role !== "user") continue;
     const text = userMessageText(message.content).trim();
     if (!text) continue;
     questions.push({ messageId: message.id, text });
@@ -91,8 +97,14 @@ export function shouldShowTimeline(
  * clamped, so several dots land on the same pixel and all but one become
  * unclickable — the exact failure spreading exists to avoid. The backward pass
  * pulls such a run back up, which the track has room for whenever the dots fit
- * at all. Only a genuine overflow (more dots than `trackHeight / minGapPx`)
- * still overlaps, now at the top, where the alternative is dropping questions.
+ * at all.
+ *
+ * When they do not fit — more questions than `trackHeight / minGapPx`, which a
+ * long chat in a short window reaches — the gap tightens so the whole set still
+ * spans the track. Every dot keeps a distinct centre and a sliver of itself to
+ * click. Holding the gap fixed instead would push the surplus off the top and
+ * clamp it there, stacking those questions on one pixel and making all but the
+ * last unreachable.
  */
 export function layoutTimelineNodes(
   anchors: MeasuredAnchor[],
@@ -101,19 +113,22 @@ export function layoutTimelineNodes(
   const { contentHeight, trackHeight, minGapPx } = opts;
   if (contentHeight <= 0 || trackHeight <= 0) return [];
 
+  const gap =
+    anchors.length > 1 ? Math.min(minGapPx, trackHeight / (anchors.length - 1)) : minGapPx;
+
   const ys: number[] = [];
   let floor = 0;
   for (const anchor of anchors) {
     const natural = Math.min(Math.max(anchor.top / contentHeight, 0), 1) * trackHeight;
     const y = Math.max(natural, floor);
     ys.push(y);
-    floor = y + minGapPx;
+    floor = y + gap;
   }
 
   let ceiling = trackHeight;
   for (let i = ys.length - 1; i >= 0; i--) {
     if (ys[i] > ceiling) ys[i] = ceiling;
-    ceiling = ys[i] - minGapPx;
+    ceiling = ys[i] - gap;
   }
 
   return ys.map((y, i) => ({

--- a/packages/web/src/components/chat/chat-view.ts
+++ b/packages/web/src/components/chat/chat-view.ts
@@ -47,7 +47,9 @@ export interface ChatView {
   interactionResults: Map<string, Record<string, unknown>>;
 }
 
-function userMessageText(content: string): string {
+// Exported for the timeline rail, which labels its dots with the same plain
+// text the transcript renders in the bubble.
+export function userMessageText(content: string): string {
   try {
     const parsed = JSON.parse(content);
     if (!Array.isArray(parsed)) return content;

--- a/packages/web/src/globals.css
+++ b/packages/web/src/globals.css
@@ -594,3 +594,13 @@ html.is-electron [data-app-titlebar="strip"] {
   height: 2rem;
   z-index: 1;
 }
+
+/* Set for ~900ms on the question a timeline dot jumped to. Every user bubble
+   carries the same tint, so without a confirmation you cannot tell whether the
+   jump landed where you meant. Attribute-scoped, so it can only ever affect a
+   row the rail explicitly marked. */
+[data-timeline-landed] {
+  background: color-mix(in srgb, var(--primary) 6%, transparent);
+  border-radius: 0.75rem;
+  transition: background 300ms ease-out;
+}

--- a/packages/web/src/globals.css
+++ b/packages/web/src/globals.css
@@ -601,6 +601,6 @@ html.is-electron [data-app-titlebar="strip"] {
    row the rail explicitly marked. */
 [data-timeline-landed] {
   background: color-mix(in srgb, var(--primary) 6%, transparent);
-  border-radius: 0.75rem;
+  border-radius: var(--rome-radius-12);
   transition: background 300ms ease-out;
 }

--- a/packages/web/src/globals.css
+++ b/packages/web/src/globals.css
@@ -599,8 +599,10 @@ html.is-electron [data-app-titlebar="strip"] {
    carries the same tint, so without a confirmation you cannot tell whether the
    jump landed where you meant. Attribute-scoped, so it can only ever affect a
    row the rail explicitly marked. */
-[data-timeline-landed] {
-  background: color-mix(in srgb, var(--primary) 6%, transparent);
+[data-timeline-anchor] {
   border-radius: var(--rome-radius-12);
   transition: background 300ms ease-out;
+}
+[data-timeline-landed] {
+  background: color-mix(in srgb, var(--primary) 6%, transparent);
 }

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -53,6 +53,9 @@
     "unavailableTitle": "This shared chat is unavailable",
     "unavailableBody": "The link may have been revoked or is no longer valid."
   },
+  "timeline": {
+    "label": "Question timeline"
+  },
   "roles": {
     "agent": "Assistant"
   },

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -54,7 +54,9 @@
     "unavailableBody": "The link may have been revoked or is no longer valid."
   },
   "timeline": {
-    "label": "Question timeline"
+    "label": "Question timeline",
+    "hide": "Hide timeline",
+    "show": "Show timeline"
   },
   "roles": {
     "agent": "Assistant"

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -54,7 +54,9 @@
     "unavailableBody": "链接可能已被撤销或失效。"
   },
   "timeline": {
-    "label": "提问时间线"
+    "label": "提问时间线",
+    "hide": "隐藏时间线",
+    "show": "显示时间线"
   },
   "roles": {
     "agent": "助手"

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -53,6 +53,9 @@
     "unavailableTitle": "该分享对话不可用",
     "unavailableBody": "链接可能已被撤销或失效。"
   },
+  "timeline": {
+    "label": "提问时间线"
+  },
   "roles": {
     "agent": "助手"
   },


### PR DESCRIPTION
## What this PR does

Returning to an earlier question in a long chat means scrolling back and reading bubbles until one looks right. There is no index of the conversation, and search (⌘K) does not scroll to its match — it drops you at the bottom of the session.

This adds a column of small dots down the right gutter of the transcript, one per past user question. Hovering a dot names the question; clicking scrolls to it and tints the message for a moment so the landing is visible. A control at the top hides the column, and the choice persists.

## Design & Invariants

**Dots spread, they never merge.** Crowded dots are pushed down to keep an 8px minimum gap, and a backward pass pulls a run back up when the forward pass would clamp it at the foot of the track. Past the track's capacity the gap tightens so the whole set still fits with distinct centres, rather than stacking the surplus on one pixel. Merging them would make the swallowed questions unreachable by click while looking identical to a lossless dot, so the rail would misreport exactly the conversations it exists for. Local positional fidelity degrades in dense stretches; every question stays individually clickable. Past saturation the dots pile at the end of the track, which reads as "too many to show" rather than dropping questions silently.

**The rail's visibility gate and the scroller's right inset are one decision.** The transcript is `mx-auto max-w-5xl` with right-aligned bubbles, so below 1024px the body fills its container and a bubble's edge runs into the dots. `Chat.tsx` gives the scroller a matching `pr-8` under the same container query, which opens a permanent lane. Changing one query without the other puts the dots back on the messages. Both sites carry a comment saying so. The inset lives on Chat's scroller rather than on `MessageList`, which `SessionsPage` and `PublicChat` also render.

**The container is `transcript`, not `chat`.** `@container/chat` is declared on an outer element that does not narrow when the trace drawer reserves its 480px, so a gate keyed to it would show the rail at widths where the gutter is already gone. The new positioning wrapper declares its own container.

**Jumping scrolls with `auto`, not `smooth`.** `use-stick-to-bottom` reads a scroll outside its 300ms user-gesture window as accidental drift and snaps back to the bottom while pinned. An instant scroll emits its one event on the frame after the click's `pointerdown`, inside that window, so the hook releases the pin on its own. A smooth scroll's later frames fall outside it.

**Hiding animates because the dots stay mounted.** `visibility` flips discretely at the end of a transition, so the dots stay painted while they slide out and stop taking pointer events the instant they are gone. `aria-hidden` removes them from the accessibility tree at the same moment.

**The column is one keyboard stop, not one per question.** Search cannot scroll to a message, so the rail is the only keyboard route to an earlier question — but forty questions must not mean forty tab stops. A single roving dot holds the tab stop; arrows, `Home`, and `End` move between dots from there, without wrapping. Focus is styled like hover, and hidden dots leave the tab order entirely so nothing focusable sits inside `aria-hidden`.

**Pointer events are enabled on the dots alone**, never on the strip, so the native scrollbar and the composer's right edge stay usable underneath. A dot's centre sits 24px in from the edge, far enough that its hit target clears a 15px classic scrollbar rather than covering part of it — invisible on macOS's overlay scrollbars, a control you cannot grab anywhere else.

**Measurement is debounced and change-gated.** A streamed reply grows the content on every token, and measuring N anchors forces a layout flush. Positions settle 150ms after the last resize, and a measurement that moved nothing does not re-render.

Geometry lives in `chat-timeline.ts`, which never touches the DOM. jsdom reports zero for every rect, so rules coupled to elements could not be covered.

## Test plan

- [x] `pnpm --filter rome-web test` — 159 files, 1300 tests. 33 are new: layout, spreading, gates, and change detection in `chat-timeline.test.ts`; anchors across all three `MessageList` render branches, including share selection; rendering, jumping, hiding, and persistence in `ChatTimelineRail.test.tsx`.
- [x] `pnpm --filter rome-web exec rsbuild build` — the container queries, the retract transition, and the landing tint are arbitrary values that compile to nothing when misspelled, so each was confirmed in the emitted CSS.
- [x] Browser, 43-turn transcript: hover names the question and grows the dot; clicking lands on it with a fading tint; clicking from the bottom of the transcript does not snap back; the scrollbar and the composer stay usable; dense stretches stay individually readable and a pushed-down dot lands where its height implies; hiding retracts the column and survives a reload; the rail appears on a 14-inch laptop and disappears cleanly below 768px.
- [ ] `pnpm --filter rome-web typecheck` — not green locally. `remark-gfm` and `@types/mdx` are declared but absent from this tree, and the three errors sit in `rsbuild.config.ts` and `src/pages/dev/mdx/`. Verified pre-existing on a clean tree, and a run with the missing type library dropped reports no errors in any file this PR touches. Left to CI.

## Not in this PR

- **Touch devices.** The rail hides below 768px. The obstacle is not width but hover: a tap jumps without the preview the feature is built around, and the transcript's 16px padding cannot hold a 44px touch target. Reaching phones means a different form — an entry point opening a list of questions — not a lower breakpoint.
- **Scroll-to-match for search.** `jumpToQuestion` is the first working scroll-to-message primitive here. Wiring ⌘K onto it is a follow-up.
- **A jump-to-latest control.** Clicking a dot mid-stream detaches from the live tail with no way back, but scrolling up by hand does the same today. `isAtBottom` is returned by `use-stick-to-bottom` and unused. Pre-existing gap, unrelated code.
- **Hit targets on a saturated track.** Layout keeps every dot at a distinct position, but each trigger is a fixed 14px box. Once the tightened gap falls under 7px the boxes overlap across a dot's centre, and since later dots paint on top, clicking the dot you see activates the following question. Reaching that needs roughly 95 questions in a maximised window, or 40 in a half-height one. Shrinking the boxes to fit is the obvious patch, but the better answer is to spread the dots under the cursor instead — a magnification falloff that opens up whichever stretch you are pointing at. That is a new interaction model rather than a fix, so it lands with the fix in a follow-up rather than expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


