### PR TITLE
docs(readme): add competitor comparison section

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,12 @@ comparison is who and what stands behind the app.
 | --- | --- | --- | --- | --- |
 | **Rome** | Actions, skills, and apps as git-tracked code, plus memory and app-private data | A saved action, without re-running the agent | A purpose-built app, plus chat channels (Telegram, Discord, WhatsApp) | Self-hosted or Rome Cloud |
 | **Grok Bot** (xAI) | Per-bot memory, files, and preferences, plus a shared cloud computer, in xAI's cloud | The model, every time | A chat thread | Hosted only |
-| **Hermes Agent** (Nous Research) | Bounded memory notes and skill documents, as text | The model, every time | A chat thread (chat clients, desktop app, or CLI) | Self-hosted |
-| **Manus** | Files, tools, and databases on a persistent cloud computer, plus knowledge and playbooks | The model, every time | A chat session, plus standalone web apps it builds | Hosted, with app-code export |
+| **Hermes Agent** (Nous Research) | Bounded memory notes and skill documents, as text | The model, or a script-only cron job\* | A chat thread (chat clients, desktop app, or CLI) | Self-hosted |
+| **Manus** | Files, tools, and databases on a persistent cloud computer, plus knowledge and playbooks | The model, or scripts left on its machine\* | A chat session, plus standalone web apps it builds | Hosted, with app-code export |
+
+\* Hermes and Manus can schedule plain scripts that skip the model. A script
+answers only to its timer. A Rome action is a building block: agents, apps,
+and interfaces all call it, and it can pause for approval.
 
 **Grok Bot** gives your named agents an always-on cloud computer, tool
 connections, scheduling, and agent-to-agent delegation. Each bot keeps its own
@@ -226,12 +230,13 @@ ask, and every check runs the agent again. Rome gives repeated work an app, in
 an environment that is open, exportable, and model-agnostic.
 
 **Hermes Agent** is the closest in spirit: MIT-licensed, self-hostable, with
-curated memory, self-written skill documents, and a skill marketplace. The
-difference is what persists: Hermes persists text that informs the next
-reasoning run, so every run still pays the model's full cost and variance.
-Rome persists software: executable actions, app-private databases, and
-purpose-built interfaces. A proven action runs the same way every time without
-the agent, so cost and reliability decouple from the model. Rome already
+curated memory, self-written skill documents, and a skill marketplace. What
+persists is text that informs the next reasoning run, plus script-only cron
+jobs that skip the model but answer only to their timer. Rome persists
+software: executable actions, app-private databases, and purpose-built
+interfaces. An action is a building block rather than a loose script: agents,
+routines, and app interfaces all call the same one, it can pause for
+approval, and every run is recorded. Rome already
 discovers and composes capabilities from earlier work, and its agenda extends
 to consolidating, refactoring, and retiring what goes stale
 ([VISION.md](VISION.md)). And Hermes offers one general interface to the agent
@@ -242,10 +247,11 @@ app for each repeated workload.
 stay, installed tools stay, and scheduled jobs, long-running bots, and
 databases can live on the machine. It also builds full-stack web apps whose
 code you can export and host anywhere. The difference is what that persistence
-is made of. A scheduled Manus job re-runs the agent at metered cost, while a
-saved Rome action runs without the agent. A Manus app is a deliverable that
-stands apart from the agent, while a Rome app is also a capability the agent
-discovers and reuses in later work. And the Manus agent itself, with its knowledge,
+is made of. A Manus schedule re-runs the agent at metered cost or fires a
+script parked on the machine, reusable only by finding the file again, while
+a Rome action is a named operation that every surface can call. A Manus app
+is a deliverable that stands apart from the agent, while a Rome app is also a
+capability the agent discovers and reuses in later work. And the Manus agent itself, with its knowledge,
 playbooks, and machine, runs only in its cloud, while Rome self-hosts.
 
 **Wabi** approaches from the personal software side: a social platform where

--- a/README.md
+++ b/README.md
@@ -270,7 +270,9 @@ The difference is the unit of compounding. Grok Bot compounds hosted bot
 state, Hermes compounds the agent's notes, Manus compounds a machine and its
 files, and Wabi compounds a network of shareable apps. Rome compounds the
 environment: executable, composable capability owned by you ([why that is the
-durable asset](VISION.md)). Proven actions close the cost and reliability
+durable asset](VISION.md)). Building blocks compose: a capability built for
+one task becomes a part in a more ambitious one, so each request can ask for
+more than the last. Proven actions close the cost and reliability
 gap, purpose-built apps close the interface gap, and the direction is
 maintenance that keeps the environment coherent as it grows. Because the
 environment is open,

--- a/README.md
+++ b/README.md
@@ -209,15 +209,16 @@ comparison is who and what stands behind the app.
 | | What accumulates | What runs repeated work | Where you operate it | Hosting |
 | --- | --- | --- | --- | --- |
 | **Rome** | Actions, skills, and apps as git-tracked code, plus memory and app-private data | A saved action, without re-running the agent | A purpose-built app, plus chat channels (Telegram, Discord, WhatsApp) | Self-hosted or Rome Cloud |
-| **Grok Bot** (xAI) | Per-bot chat history and taught skills, in xAI's cloud | The model, every time | A chat thread | Hosted only |
-| **Hermes Agent** (Nous Research) | Memories and skill documents, as text | The model, every time | A chat thread | Self-hosted |
-| **Manus** | Files, knowledge notes, and playbooks, in a hosted sandbox | The model, every time | A per-task chat thread | Hosted only |
+| **Grok Bot** (xAI) | Per-bot memory, files, and preferences, plus a shared cloud computer, in xAI's cloud | The model, every time | A chat thread | Hosted only |
+| **Hermes Agent** (Nous Research) | Bounded memory notes and skill documents, as text | The model, every time | A chat thread (chat clients, desktop app, or CLI) | Self-hosted |
+| **Manus** | Files, tools, and databases on a persistent cloud computer, plus knowledge and playbooks | The model, every time | A chat session, plus standalone web apps it builds | Hosted, with app-code export |
 
-**Grok Bot** gives each named agent an always-on cloud computer, tool
-connections, scheduling, and agent-to-agent delegation. It is closed, hosted,
-and bound to one vendor's models, so what an agent learns lives in xAI's cloud
-and does not leave with you. Its unit of persistence is the bot, and its
-interface is a messenger thread. A thread is a good place to ask for something
+**Grok Bot** gives your named agents an always-on cloud computer, tool
+connections, scheduling, and agent-to-agent delegation. Each bot keeps its own
+memory, files, and preferences, while all of an account's bots share one cloud
+computer. Everything lives in xAI's hosted stack, bound to one vendor's
+models, so leaving means losing what accumulated. The interface is a messenger
+thread: a good place to ask for something
 once and a poor place to operate: inbox triage needs a queue with statuses, a
 price tracker needs a table with history and thresholds, and approvals need a
 review queue that shows what will change. In chat, state is invisible until you
@@ -225,26 +226,27 @@ ask, and every check runs the agent again. Rome gives repeated work an app, in
 an environment that is open, exportable, and model-agnostic.
 
 **Hermes Agent** is the closest in spirit: MIT-licensed, self-hostable, with
-persistent memory, self-written skill documents, and a skill marketplace. The
+curated memory, self-written skill documents, and a skill marketplace. The
 difference is what persists: Hermes persists text that informs the next
 reasoning run, so every run still pays the model's full cost and variance.
 Rome persists software: executable actions, app-private databases, and
 purpose-built interfaces. A proven action runs the same way every time without
-the agent, so cost and reliability decouple from the model. Rome also
-maintains what accumulates: it composes capabilities from earlier work and
-consolidates, refactors, and retires what goes stale, where Hermes grows its
-memory monotonically. And Hermes stops at the chat thread, a place to talk to
-an agent rather than a place to run a product.
+the agent, so cost and reliability decouple from the model. Rome already
+discovers and composes capabilities from earlier work, and its agenda extends
+to consolidating, refactoring, and retiring what goes stale
+([VISION.md](VISION.md)). And Hermes offers one general interface to the agent
+(chat clients, a desktop app, the terminal), while Rome grows a purpose-built
+app for each repeated workload.
 
-**Manus** is built for one-shot delegation. Describe a goal, and it plans,
-works in a hosted sandbox, and returns a finished artifact such as a report, a
-deck, or a website. It persists files, knowledge notes, and playbooks, but a
-playbook improves the next prompt rather than becoming executable, so every
-task runs the agent again at metered cost. Its output is the artifact. The
-same request in Rome also leaves behind the capability that produced it: an
-action to run again, or an app when the work needs a home. And because Manus
-is closed and hosted, the sandbox and everything accumulated in it stay in its
-cloud.
+**Manus** delegates a goal to an agent on a persistent cloud computer: files
+stay, installed tools stay, and scheduled jobs, long-running bots, and
+databases can live on the machine. It also builds full-stack web apps whose
+code you can export and host anywhere. The difference is what that persistence
+is made of. A scheduled Manus job re-runs the agent at metered cost, while a
+saved Rome action runs without the agent. A Manus app is a deliverable that
+stands apart from the agent, while a Rome app is also a capability the agent
+discovers and reuses in later work. And the Manus agent itself, with its knowledge,
+playbooks, and machine, runs only in its cloud, while Rome self-hosts.
 
 **Wabi** approaches from the personal software side: a social platform where
 anyone prompts a mini app into existence, then shares and remixes it, with
@@ -258,13 +260,14 @@ capability also extends what the agent can do next. Wabi asks you to describe
 an app, while Rome asks you to describe an outcome and leaves an app behind
 when the work deserves one.
 
-The difference is the unit of compounding. Grok Bot compounds the bot, Hermes
-compounds the agent's notes, Manus compounds task artifacts, and Wabi
-compounds a network of shareable apps. Rome compounds the environment:
-executable, composable capability owned by you ([why that is the durable
-asset](VISION.md)). Proven actions close the cost and reliability gap,
-purpose-built apps close the interface gap, and maintenance keeps the
-environment coherent as it grows. Because the environment is open,
+The difference is the unit of compounding. Grok Bot compounds hosted bot
+state, Hermes compounds the agent's notes, Manus compounds a machine and its
+files, and Wabi compounds a network of shareable apps. Rome compounds the
+environment: executable, composable capability owned by you ([why that is the
+durable asset](VISION.md)). Proven actions close the cost and reliability
+gap, purpose-built apps close the interface gap, and the direction is
+maintenance that keeps the environment coherent as it grows. Because the
+environment is open,
 git-tracked, and exportable, it survives a model swap. Users stay for the
 compounding, not the lock-in.
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ cd rome
 ./scripts/quickstart-docker.sh
 ```
 
-The dashboard comes up at `http://localhost:7663`, bound to loopback only —
-first-run onboarding is open to whoever reaches it first, so exposing it
+The dashboard comes up at `http://localhost:7663`, bound to loopback only.
+First-run onboarding is open to whoever reaches it first, so exposing it
 beyond the machine takes an explicit `--bind`. State lives in named Docker
 volumes, so re-running the script upgrades the container without losing data.
 Telemetry export stays off unless you set `OTEL_EXPORTER_OTLP_ENDPOINT`. Run
@@ -133,7 +133,7 @@ after the browser closes, and when the user comes back tomorrow.
 
 A useful rule of thumb: **a workflow is a verb; an app is a noun**. Use a
 workflow to perform a task and return a result. Build an app when the work needs
-a home of its own—with user-editable data, multiple actions, or a persistent
+a home of its own, with user-editable data, multiple actions, or a persistent
 agent.
 
 ### Rome can build the missing app
@@ -196,6 +196,77 @@ These are the kinds of requests Rome is designed to follow through on:
 
 Rome can handle one-off tasks, scheduled work, long-running follow-through, and
 purpose-built app experiences without forcing everything into one chat window.
+
+## How Rome compares
+
+Rome sits where two product waves meet: persistent agents and personal
+software. The agent products share Rome's thesis that agents should persist
+and improve. There the comparison is what accumulates, what runs when work
+repeats, and where you operate the result. The personal software platforms
+share Rome's thesis that software should be built per person. There the
+comparison is who and what stands behind the app.
+
+| | What accumulates | What runs repeated work | Where you operate it | Hosting |
+| --- | --- | --- | --- | --- |
+| **Rome** | Actions, skills, and apps as git-tracked code, plus memory and app-private data | A saved action, without re-running the agent | A purpose-built app, plus chat channels (Telegram, Discord, WhatsApp) | Self-hosted or Rome Cloud |
+| **Grok Bot** (xAI) | Per-bot chat history and taught skills, in xAI's cloud | The model, every time | A chat thread | Hosted only |
+| **Hermes Agent** (Nous Research) | Memories and skill documents, as text | The model, every time | A chat thread | Self-hosted |
+| **Manus** | Files, knowledge notes, and playbooks, in a hosted sandbox | The model, every time | A per-task chat thread | Hosted only |
+
+**Grok Bot** gives each named agent an always-on cloud computer, tool
+connections, scheduling, and agent-to-agent delegation. It is closed, hosted,
+and bound to one vendor's models, so what an agent learns lives in xAI's cloud
+and does not leave with you. Its unit of persistence is the bot, and its
+interface is a messenger thread. A thread is a good place to ask for something
+once and a poor place to operate: inbox triage needs a queue with statuses, a
+price tracker needs a table with history and thresholds, and approvals need a
+review queue that shows what will change. In chat, state is invisible until you
+ask, and every check runs the agent again. Rome gives repeated work an app, in
+an environment that is open, exportable, and model-agnostic.
+
+**Hermes Agent** is the closest in spirit: MIT-licensed, self-hostable, with
+persistent memory, self-written skill documents, and a skill marketplace. The
+difference is what persists: Hermes persists text that informs the next
+reasoning run, so every run still pays the model's full cost and variance.
+Rome persists software: executable actions, app-private databases, and
+purpose-built interfaces. A proven action runs the same way every time without
+the agent, so cost and reliability decouple from the model. Rome also
+maintains what accumulates: it composes capabilities from earlier work and
+consolidates, refactors, and retires what goes stale, where Hermes grows its
+memory monotonically. And Hermes stops at the chat thread, a place to talk to
+an agent rather than a place to run a product.
+
+**Manus** is built for one-shot delegation. Describe a goal, and it plans,
+works in a hosted sandbox, and returns a finished artifact such as a report, a
+deck, or a website. It persists files, knowledge notes, and playbooks, but a
+playbook improves the next prompt rather than becoming executable, so every
+task runs the agent again at metered cost. Its output is the artifact. The
+same request in Rome also leaves behind the capability that produced it: an
+action to run again, or an app when the work needs a home. And because Manus
+is closed and hosted, the sandbox and everything accumulated in it stay in its
+cloud.
+
+**Wabi** approaches from the personal software side: a social platform where
+anyone prompts a mini app into existence, then shares and remixes it, with
+Wabi hosting everything. It validates half of Rome's bet, software built per
+person rather than for the average user. But there is no worker behind the
+app: a Wabi app is the end product, and you still operate it yourself. A Rome
+app is the interface to a capability, and the capability faces both ways: you
+work through its views, and agents work through its actions, skills, and data
+in later tasks. Every new Wabi app grows your library, and every new Rome
+capability also extends what the agent can do next. Wabi asks you to describe
+an app, while Rome asks you to describe an outcome and leaves an app behind
+when the work deserves one.
+
+The difference is the unit of compounding. Grok Bot compounds the bot, Hermes
+compounds the agent's notes, Manus compounds task artifacts, and Wabi
+compounds a network of shareable apps. Rome compounds the environment:
+executable, composable capability owned by you ([why that is the durable
+asset](VISION.md)). Proven actions close the cost and reliability gap,
+purpose-built apps close the interface gap, and maintenance keeps the
+environment coherent as it grows. Because the environment is open,
+git-tracked, and exportable, it survives a model swap. Users stay for the
+compounding, not the lock-in.
 
 ## Repository map
 


### PR DESCRIPTION
## What this PR does

The README explains what Rome is but never places it against the products a reader already knows. Anyone arriving from Grok Bot, Hermes Agent, Manus, or Wabi has to derive the difference from [`VISION.md`](VISION.md) on their own.

This PR adds a "How Rome compares" section after "What people do with Rome". It frames Rome as the meeting point of two product waves. The persistent agent products (Grok Bot, Hermes Agent, Manus) get a table comparing what accumulates, what runs repeated work, where you operate it, and hosting, followed by one paragraph each. Wabi gets a prose comparison on a different axis, who and what stands behind the app, because the table's columns assume an agent runs the work. A closing paragraph states the unit of compounding for each product.

The PR also rewrites the README's two prose em-dashes outside the new section, so the file carries one punctuation style. The link-list separators in Documentation keep their em-dashes, matching the docs index convention.

## Design & Invariants

Every claim about Rome names shipped behavior. The chat channels in the table (Telegram, Discord, WhatsApp) match the adapters in `packages/core/src/channels/`, and Slack is absent on purpose because it exists only as an OAuth connection provider. "A saved action, without re-running the agent" restates the routine-to-action contract in [`docs/concepts/data.md`](docs/concepts/data.md).

Competitor claims stay structural (what persists, what runs when work repeats, where you operate the result) rather than quality judgements, so the section does not rot with each competitor release. The section uses the repo's canonical vocabulary: action, skill, app, capability, as defined in [`docs/concepts/`](docs/concepts/index.md).

## Test plan

- [x] `scripts/check-pr-title.sh` accepts the title.
- [x] Channel list verified against `packages/core/src/channels/`.
- [x] Prose checked against [`docs/authoring/WRITING.md`](docs/authoring/WRITING.md): no semicolons, no contractions, active voice.
- [ ] Preview the rendered table on the PR's Files changed tab.

## Not in this PR

- A Wabi row in the comparison table. Its honest cell for "what runs repeated work" is "you do", which reads as a strawman, so Wabi stays in prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)