### PR TITLE
docs(readme): add composition example and firm up maintenance claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ durable asset](VISION.md)). Building blocks compose: a capability built for
 one task becomes a part in a more ambitious one, so each request can ask for
 more than the last. An inventory-aging action and a customer-churn skill,
 built for separate tasks, later combine to clear seasonal inventory without a
-broad markdown, the arc VISION.md walks in full.
+broad markdown.
 
 Proven actions close the cost and reliability gap, purpose-built apps close
 the interface gap, and maintenance keeps the environment coherent as it

--- a/README.md
+++ b/README.md
@@ -272,12 +272,14 @@ files, and Wabi compounds a network of shareable apps. Rome compounds the
 environment: executable, composable capability owned by you ([why that is the
 durable asset](VISION.md)). Building blocks compose: a capability built for
 one task becomes a part in a more ambitious one, so each request can ask for
-more than the last. Proven actions close the cost and reliability
-gap, purpose-built apps close the interface gap, and the direction is
-maintenance that keeps the environment coherent as it grows. Because the
-environment is open,
-git-tracked, and exportable, it survives a model swap. Users stay for the
-compounding, not the lock-in.
+more than the last. An inventory-aging action and a customer-churn skill,
+built for separate tasks, later combine to clear seasonal inventory without a
+broad markdown, the arc VISION.md walks in full.
+
+Proven actions close the cost and reliability gap, purpose-built apps close
+the interface gap, and maintenance keeps the environment coherent as it
+grows. Because the environment is open, git-tracked, and exportable, it
+survives a model swap. Users stay for the compounding, not the lock-in.
 
 ## Repository map
 


### PR DESCRIPTION
## What this PR does

The comparison section's closing asserts that building blocks compose but never shows it, and its maintenance claim was hedged to "the direction is maintenance" during review of #147, which reads as murky.

This PR makes two changes to the closing of "How Rome compares":

1. A worked composition example after the compounding claim: an inventory-aging action and a customer-churn skill, built for separate tasks, later combine to clear seasonal inventory without a broad markdown. This is the fashion-company arc from [`VISION.md`](VISION.md), compressed to one sentence.
2. The maintenance sentence returns to present tense: "maintenance keeps the environment coherent as it grows." The closing also splits into two paragraphs, one per topic: the unit of compounding, then the gaps that close.

## Design & Invariants

The present-tense maintenance claim is grounded in shipped behavior. The [`dream` app](rome_apps/dream/) runs a periodic self-review agent whose rules require routing updates into existing memory sections and forbid duplicating what is already present, and its `skill-review` agent updates an existing skill in place before creating a new one. The stronger loop (consolidating, refactoring, and retiring capabilities) remains phrased as agenda in the Hermes paragraph, where those specific verbs appear with a [`VISION.md`](VISION.md) link.

The example names only capabilities the vision document itself names, so the README does not invent a scenario the canonical doc cannot back.

## Test plan

- [x] `scripts/check-pr-title.sh` accepts the title.
- [x] Example checked against the fashion-company arc in `VISION.md`.
- [x] Maintenance grounding checked against `rome_apps/dream/src/agents/dream.yaml` and `skill-review.yaml`.
- [x] Prose checked against [`docs/authoring/WRITING.md`](docs/authoring/WRITING.md): no semicolons, no contractions, no em-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)