### PR TITLE
docs(authoring): document directives, relations, and body-comment exceptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ A pnpm monorepo. All code lives under `packages/*` and `rome_apps/*`. Runtime de
 - Before opening a PR, read [`docs/authoring/prs.md`](docs/authoring/prs.md).
 - Before explaining a concept or asserting how a surface behaves, check [`docs/`](docs/README.md) and link instead of re-deriving.
 - Before building or editing an app, read [`rome_apps/CLAUDE.md`](rome_apps/CLAUDE.md).
-- When writing prose (docs, PR text), follow [`docs/authoring/WRITING.md`](docs/authoring/WRITING.md). When writing comments, follow [`docs/authoring/comments.md`](docs/authoring/comments.md).
+- When writing prose (docs, PR text), follow [`docs/authoring/WRITING.md`](docs/authoring/WRITING.md).
+- When writing or editing code comments, follow [`docs/authoring/comments.md`](docs/authoring/comments.md).
 - When a PR touches `@rome-os/app-runtime`, `@rome-os/app-web-sdk`, or `@rome-os/ui`, choose the Conventional Commit type by consumer impact. Test-only changes use `test:` and do not bump the package; releasable changes use `feat:` / `fix:` / `feat!:` (or `BREAKING CHANGE:` in the body). release-please publishes them to npm from Conventional Commits, with no per-PR changeset file. Full flow in [`docs/releases.md`](docs/releases.md).
 - When running the fullstack local loop, use `pnpm dev:all` — containerized Rome with `tsx --watch`, plus rome-obs, Traefik, and the Rsbuild dev server. `pnpm start` and `pnpm start:web` skip the production-shaped wiring, so reach for them only to debug the host process.
 - When changing a file the container does not watch (`package.json`, container env), run `docker compose restart <service>`.

--- a/docs/authoring/comments.md
+++ b/docs/authoring/comments.md
@@ -1,6 +1,6 @@
 # Code Comments
 
-A **code comment** is prose inside a source file. The code states what happens. A comment carries only what the code cannot state: the contract a caller relies on, the why behind a non-obvious choice, or the design that keeps concurrent code safe. Tier tags and the bar this rulebook clears come from [authoring.md](authoring.md). The prose in this file follows [WRITING.md](WRITING.md).
+A **code comment** is prose inside a source file. The code states what happens. A comment carries only what the code cannot state: the contract a caller relies on, the why behind a non-obvious choice, or the argument that a hard algorithm is correct. Tier tags and the bar this rulebook clears come from [authoring.md](authoring.md). The prose in this file follows [WRITING.md](WRITING.md).
 
 The miss that earned this guideline: agent-written diffs kept arriving with comments that restate the line below them or narrate the change that produced them. Review caught each one by hand because the bar lived nowhere.
 
@@ -27,12 +27,44 @@ When the name and the types carry the full contract, the symbol carries no comme
 > Prefer: `function isExpired(session: Session): boolean` with no comment.
 > Over: `/** Checks whether the session is expired. */` above it.
 
+A **directive** is a condition the caller meets or accounts for to call correctly. State every directive the signature cannot carry, and only those: preconditions and postconditions, thread safety, required call order, idempotency, blocking and cancellation, which failures are retryable, ownership and lifetime of a returned value. A directive that holds by default stays unstated. `[llm]`
+
+> Prefer: `/** Call after connect(). Safe to retry — a duplicate send is dropped by message id. The returned buffer belongs to the pool, so copy it to keep it past the next call. */`
+> Over: the same function with a comment stating only what it returns.
+
+A **relation** between two types is stated once. When a type reifies the relation, that type's boundary comment carries the relation and its invariants. When the relation is inlined as a field on one side, the module comment carries it. `[llm]`
+
+> Prefer: `/** Links one Account to one Workspace. An Account holds at most one Membership per Workspace. */` on the `Membership` type.
+> Over: the same invariant stated on `Account.workspaceIds` and again on `Workspace.accountIds`.
+
+An example enters a boundary comment when a caller would otherwise guess the shape of an argument or a return value. Write it with the contract, before the implementation. No tooling runs it. `[llm]`
+
+> Prefer: `/** Parses a cron expression. parse("0 9 * * 1") returns the Monday 09:00 schedule. */`
+> Over: a prose paragraph describing the accepted field order and wildcard syntax.
+
 ### Body comment
 
-A body comment sits anywhere the other two kinds do not: inside a function, or on a declaration no other module imports. Body comments are exceptions — most code carries none. A body comment states a why the code cannot: the reason for a non-obvious choice, or a deviation from common practice and the reason for it. `[llm]`
+A body comment sits anywhere the other two kinds do not: inside a function, or on a declaration no other module imports. Body comments are exceptions — most code carries none. A body comment states one of three things the code cannot: the why behind a non-obvious choice, the argument that a hard algorithm is correct, or a cost the surrounding lines do not show. `[llm]`
 
 > Prefer: `// Baileys delivers history newest-first, so index 0 is the latest message.`
 > Over: `// iterate over the messages in reverse`.
+
+A **correctness argument** covers code a reader cannot check by reading it — concurrency, numeric work, a hand-rolled data structure. State the algorithm in enough detail that a reader can check the algorithm is sound, then check whether the code still matches it. `[llm]`
+
+> Prefer: `// Head advances only after the slot write commits, so a concurrent reader sees either the old slot or the complete new one, never a torn write.`
+> Over: `// advance head after writing`.
+
+A **cost note** covers a performance property the surrounding lines do not show: complexity that depends on how a caller uses the function, an allocation that matters at scale, an I/O or cache effect. A cost visible in the code beside it stays unstated. `[llm]`
+
+> Prefer: `// The reconciler calls this once per open session, so work added here scales with the session count.`
+> Over: `// this loop is O(n)` above a visible loop over n.
+
+### Vocabulary
+
+A comment names a thing by its identifier in the code. A synonym for a named type, function, or field fails, however well it reads. One term per concept across a module. Word choice follows [WRITING.md](WRITING.md). `[llm]`
+
+> Prefer: `// The sentinel drops the event when no ChannelAdapter claims it.`
+> Over: `// The triage layer drops the event when no connector claims it.`
 
 ## Admission
 


### PR DESCRIPTION
## What this PR does

The comment rulebook stated what a boundary comment carries only in general terms — units, null and error behavior, side effects, ordering, invariants. Everything else a caller needs to call correctly had no name and no rule: required call order, idempotency, which failures are retryable, who owns a returned buffer. Body comments admitted exactly one thing, a *why*, so the argument for why a lock-free ring buffer is correct and a note that a helper runs once per open session both failed admission with nowhere else to go.

Six rules close those gaps, each carrying the tier tag and Prefer/Over pair that [authoring.md](docs/authoring/authoring.md) requires of a judgment rule.

The playbook bullet in `CLAUDE.md` paired comment guidance with prose guidance under a condition opening "When writing prose (docs, PR text)". An agent writing TypeScript rules that bullet out before reaching the comments half. It is now its own bullet, keyed on code work.

## Design & Invariants

The file stays organized by where a comment sits — module, boundary, body. The pasted guidance this draws from organizes by a noun/verb/relation model instead. Adopting that frame would have meant rewriting every existing rule, so "relation" enters as a rule under Boundary comment rather than as a fourth kind.

Silence stays the default. The source guidance requires a doc comment on every exported type and method, which contradicts the existing rule that a symbol whose name and types carry the full contract carries no comment. That rule wins, and the new directive rule is scoped to match it: a directive holding by default stays unstated.

Each new rule is `[llm]`-tier, so the audit pass picks it up with the example pair as its fixture. No rule needed a `[mech]` tag — none is decidable by script.

Not adopted from the source: the agent checklist at its end. The tier tags already are the contract with tooling.

## Test plan

- [x] `scripts/check-pr-title.sh "docs(authoring): document directives, relations, and body-comment exceptions"` passes.
- [x] Every new rule carries a tier tag and, for `[llm]`, one passing and one failing example — 18 tagged rules in the file.
- [x] No semicolons in the file, per WRITING.md.
- [x] Every relative link in `docs/authoring/comments.md` resolves on disk.
- [x] The four sections `authoring.md` requires of a per-type guideline — Format, Admission, Eviction, Intake — are all still present.

## Not in this PR

- No audit pass over existing comments in `packages/` against the new rules. The rulebook lands first, and eviction happens as each file is next touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)