### PR TITLE
docs(northstars): state the channel ideal

### DIFF
--- a/docs/northstars/channels.md
+++ b/docs/northstars/channels.md
@@ -1,0 +1,14 @@
+# Channels
+
+A [channel](../concepts/messaging.md#channels) is one service's conversation with a person. A service can carry more than a conversation. The same connection that carries messages can also let Rome act on the service. A service Rome only reads records from carries no conversation, and is not a channel however much of its data Rome holds.
+
+Every channel answers the same three things. It carries messages both ways, it says who it can reach, and it says what was said there. What a channel cannot answer is a limit of its platform, never a limit of what has been built.
+
+## Statements
+
+- Every channel carries messages in both directions.
+- A caller reads every channel through one interface and names no channel. Adding a channel changes no code above it.
+- A channel says who it can reach, as far as its platform offers a directory.
+- A channel says what was said on it, as far back as its platform lets Rome read.
+- A channel says who it reaches and what was said on it without its message transport.
+- A person reachable several ways on one channel is one account with one history.


### PR DESCRIPTION
## What this PR does

Nothing states what a channel should be able to do, so each service was built to whatever depth its adapter author reached. Every service sends and receives. Two of nine say who they can reach or what was said there, and the rest do not — which is a fact about what got written, not about the platforms. Two of those gaps are permanent (a bot token cannot enumerate its users) and five are not, and nothing in the code or the docs tells them apart.

Six statements for the end state, in `docs/northstars/channels.md`, so `loop-reconcile` can compute that gap and file the work.

## Design & Invariants

A channel carries messages both ways, says who it can reach, and says what was said there — each as far as its platform allows and no further. What a channel cannot answer is a limit of the platform, never a limit of what has been built.

The first statement draws the line the vocabulary needs: a service Rome only reads records from is not a channel, however much of its data Rome holds. The doc does not name which services fall on which side.

Two things stay out on purpose. Nothing states how a channel represents "cannot answer", which is interface shape rather than an ideal state. Nothing states where a conversation's history lives when its channel can hold none, which is not a channel's business.

The transport statement names the message path rather than liveness. A channel that answers by reading a local copy and one that answers by calling the platform are the same to a caller, so requiring an answer with no live connection at all would make local copies mandatory and put a storage strategy in the north star.

## Test plan

- [x] Statement admission: every statement is declarative present tense, verifiable by reading the code, and satisfiable by more than one implementation. None names a file, function, or type.
- [x] Consistency: walked all six against each other, no pair conflicts.
- [x] Prose rules: no semicolons, no contractions, no history words.

## Not in this PR

- Milestones. The slice — directory before history, since they layer — is a separate decision.
- Any change to code or to `docs/concepts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)