### PR TITLE
docs(northstars): let a channel report what it can do

### DIFF
--- a/docs/northstars/channels.md
+++ b/docs/northstars/channels.md
@@ -2,11 +2,13 @@
 
 A [channel](../concepts/messaging.md#channels) is one service's conversation with a person. A service can carry more than a conversation. The same connection that carries messages can also let Rome act on the service. A service Rome only reads records from carries no conversation, and is not a channel however much of its data Rome holds.
 
-Every channel answers the same three things. It carries messages both ways, it says who it can reach, and it says what was said there. What a channel cannot answer is a limit of its platform, never a limit of what has been built.
+Every channel answers the same three things. It carries messages, it says who it can reach, and it says what was said there. How much of each it can do is the channel's own answer, and a caller asks for it. What a channel cannot answer about its directory or its history is a limit of its platform, never a limit of what has been built.
 
 ## Statements
 
-- Every channel carries messages in both directions.
+- Every channel receives messages.
+- A channel sends messages when it reports that it sends.
+- A channel reports what it can do. A caller asks the channel and never infers a capability from the channel's name.
 - A caller reads every channel through one interface and names no channel. Adding a channel changes no code above it.
 - A channel says who it can reach, as far as its platform offers a directory.
 - A channel says what was said on it, as far back as its platform lets Rome read.


### PR DESCRIPTION
## What this PR does

The doc opened with a statement no channel could be measured against honestly. "Every channel carries messages in both directions" reads as a flat requirement, so a channel that receives and does not send is a violation with no way to declare itself. LinkedIn is that channel: it mirrors the inbox and throws on send. The statement gave the reconciliation loop only two exits, build a LinkedIn sender or report the doc broken, and neither is what the area wants.

Channels differ in what they can do, and the doc now says so. One statement splits into three: every channel receives, a channel sends when it reports that it sends, and a channel reports what it can do rather than letting a caller infer from its name. The third is the load-bearing one. It moves the question from "does this channel send" to "does this channel say whether it sends", which is checkable on every channel at once.

## Design & Invariants

Capability is the channel's answer, asked for rather than assumed. This is the shape the read side already has — a `Channel` entry carries a null port where it cannot answer, and a caller reads the null rather than knowing which channels have address books. The new statements extend that shape to sending. Nothing above a channel branches on a channel's name to decide what it can do.

The weakened statement does not excuse LinkedIn as it stands. Throwing at send time is not reporting. A channel that reports sending and then fails still violates the second statement, so the honesty work stays on the board under the "A channel reports what it can do" milestone.

The prose paragraph narrows with the statements. "What a channel cannot answer is a limit of its platform, never a limit of what has been built" now covers the directory and the history alone. Sending is deliberately outside that bar: a channel that could send and does not is compliant as long as it says so. That is a real loosening and it is the point of the change, not a side effect.

Alternatives considered. Building a LinkedIn sender would have kept the statement intact, but it answers one channel rather than the class, and the composer that used to send was removed on purpose. Dropping LinkedIn from the channel list was the other option, and it fails the doc's own definition — LinkedIn carries a conversation, so it is a channel whatever Rome can do with it.

## Test plan

- [x] Read the full Statements list for pairs that cannot both hold. The three capability statements are consistent with statements 5 through 8, which scope their own limits to the platform.
- [x] Checked each new statement against the admission rules: declarative present, checkable by reading code, and satisfied by more than one implementation.
- [x] `scripts/check-pr-title.sh "docs(northstars): let a channel report what it can do"`.

## Not in this PR

- Whether the Telegram bot and the Telegram personal session are one channel or two. They address the same Telegram user ids under two channel names, so one person reads as two accounts with two histories. Statement 8 says "on one channel" and does not forbid it, so the loop reports no failure today. This needs research before a statement can be written, and it gets a session of its own.
- Any code change. The gap this doc measures is tracked in #153, and the milestones created alongside this PR carry the slices.
