### PR TITLE
refactor(core): read a person's timeline accounts through the channel list

### DIFF
--- a/packages/core/src/api/deps.ts
+++ b/packages/core/src/api/deps.ts
@@ -4,7 +4,6 @@ import type { DrizzleDb } from "../db/index.js";
 import type { PersonMappingRepository } from "../db/repositories/person-mapping.js";
 import type { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
 import type { Channels } from "../channels/channel.js";
-import type { WhatsAppAccounts } from "../channels/whatsapp-accounts.js";
 import type { AccountNames } from "../channels/account-names.js";
 import type { WebChatRepository } from "../db/repositories/webchat.js";
 import type { WebhookInvocationsRepository } from "../db/repositories/webhook-invocations.js";
@@ -75,9 +74,6 @@ export interface ApiDeps {
   personMappingRepo: PersonMappingRepository;
   /** Durable mirror of the WhatsApp address book + message history (People tab). */
   whatsAppStoreRepo: WhatsAppStoreRepository;
-  /** WhatsApp's address book over that mirror — who it can reach, folded onto
-   *  one account per person, and what was last said to each. */
-  whatsAppAccounts: WhatsAppAccounts;
   /** Every channel Rome reads, each carrying its address book and what was said
    *  on it. LinkedIn reaches the API only through here — no route reads its
    *  store directly. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1207,7 +1207,6 @@ async function main() {
       actionLoader,
       personMappingRepo,
       whatsAppStoreRepo,
-      whatsAppAccounts,
       channels,
       accountNames,
       webchatRepo,

--- a/packages/core/src/people/resource.ts
+++ b/packages/core/src/people/resource.ts
@@ -12,7 +12,6 @@
 import type { PersonResource } from "@rome/api-types/people";
 import { STRANGER_PERSON_ID } from "../constants.js";
 import type { AccountNames } from "../channels/account-names.js";
-import type { Accounts } from "../channels/accounts.js";
 import type { Channels } from "../channels/channel.js";
 import type { DrizzleDb } from "../db/index.js";
 import type { PersonMappingRepository } from "../db/repositories/person-mapping.js";
@@ -22,7 +21,6 @@ import { personMessageStores, timelineAccounts } from "./timeline-sources.js";
 export interface PeopleReadDeps {
   db: DrizzleDb;
   personMappingRepo: Pick<PersonMappingRepository, "findAllWithMappings" | "findById">;
-  whatsAppAccounts: Accounts;
   channels: Channels;
   accountNames: Pick<AccountNames, "displayNames">;
 }

--- a/packages/core/src/people/timeline-sources.test.ts
+++ b/packages/core/src/people/timeline-sources.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@rstest/core";
-import type { Account, AccountId } from "../channels/accounts.js";
+import type { Account, AccountId, Accounts } from "../channels/accounts.js";
+import type { Channels } from "../channels/channel.js";
 import { timelineAccounts } from "./timeline-sources.js";
 
 const account = (id: string, addresses: string[] = [id]): Account => ({
@@ -26,15 +27,23 @@ class FakeAccounts {
   }
 }
 
+/** A channel list as this file reads one: names bound to address books, a null
+ *  book for a channel that can say nothing about who it reaches. No message
+ *  store, since nothing under test reads a history. */
+const channelList = (books: Record<string, Accounts | null>): Channels =>
+  Object.entries(books).map(([name, accounts]) => ({ name, accounts, messages: null }));
+
 const ada = "12025550100@s.whatsapp.net";
 const adaLid = "77770001@lid";
 const grace = "12025550111@s.whatsapp.net";
+const adaTelegram = "778001";
+const adaTelegramHandle = "@ada";
 
 describe("timelineAccounts", () => {
   it("collapses two addresses of one account onto one account", async () => {
-    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid])]);
+    const whatsapp = new FakeAccounts([account(ada, [ada, adaLid])]);
 
-    const [accounts] = await timelineAccounts({ whatsAppAccounts }, [
+    const [accounts] = await timelineAccounts({ channels: channelList({ whatsapp }) }, [
       [
         { channel: "whatsapp", channelUserId: ada },
         { channel: "whatsapp", channelUserId: adaLid },
@@ -42,13 +51,34 @@ describe("timelineAccounts", () => {
     ]);
 
     expect(accounts).toEqual([{ channel: "whatsapp", addresses: [ada, adaLid] }]);
-    expect(whatsAppAccounts.listings).toBe(1);
+    expect(whatsapp.listings).toBe(1);
+  });
+
+  it("reads one account per channel, each folded by that channel's own book", async () => {
+    const whatsapp = new FakeAccounts([account(ada, [ada, adaLid])]);
+    const telegram = new FakeAccounts([account(adaTelegram, [adaTelegram, adaTelegramHandle])]);
+
+    const [accounts] = await timelineAccounts({ channels: channelList({ whatsapp, telegram }) }, [
+      [
+        { channel: "whatsapp", channelUserId: adaLid },
+        { channel: "telegram", channelUserId: adaTelegramHandle },
+      ],
+    ]);
+
+    expect(
+      accounts?.map((found) => ({ ...found, addresses: [...found.addresses].sort() })),
+    ).toEqual([
+      { channel: "whatsapp", addresses: [ada, adaLid].sort() },
+      { channel: "telegram", addresses: [adaTelegram, adaTelegramHandle].sort() },
+    ]);
+    expect(whatsapp.listings).toBe(1);
+    expect(telegram.listings).toBe(1);
   });
 
   it("carries every address of an account a mapping names under one of them", async () => {
-    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid])]);
+    const whatsapp = new FakeAccounts([account(ada, [ada, adaLid])]);
 
-    const [accounts] = await timelineAccounts({ whatsAppAccounts }, [
+    const [accounts] = await timelineAccounts({ channels: channelList({ whatsapp }) }, [
       [{ channel: "whatsapp", channelUserId: adaLid }],
     ]);
 
@@ -57,9 +87,9 @@ describe("timelineAccounts", () => {
   });
 
   it("keeps two accounts apart", async () => {
-    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid]), account(grace)]);
+    const whatsapp = new FakeAccounts([account(ada, [ada, adaLid]), account(grace)]);
 
-    const [accounts] = await timelineAccounts({ whatsAppAccounts }, [
+    const [accounts] = await timelineAccounts({ channels: channelList({ whatsapp }) }, [
       [
         { channel: "whatsapp", channelUserId: adaLid },
         { channel: "whatsapp", channelUserId: grace },
@@ -70,9 +100,9 @@ describe("timelineAccounts", () => {
   });
 
   it("gives an address the address book does not hold its own timeline", async () => {
-    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid])]);
+    const whatsapp = new FakeAccounts([account(ada, [ada, adaLid])]);
 
-    const [accounts] = await timelineAccounts({ whatsAppAccounts }, [
+    const [accounts] = await timelineAccounts({ channels: channelList({ whatsapp }) }, [
       [{ channel: "whatsapp", channelUserId: "12025550999@s.whatsapp.net" }],
     ]);
 
@@ -80,21 +110,22 @@ describe("timelineAccounts", () => {
   });
 
   it("gives a channel with no address book the link's own address", async () => {
-    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid])]);
+    const whatsapp = new FakeAccounts([account(ada, [ada, adaLid])]);
 
-    const [accounts] = await timelineAccounts({ whatsAppAccounts }, [
-      [{ channel: "linkedin", channelUserId: "ACoAAAda0001" }],
-    ]);
+    const [accounts] = await timelineAccounts(
+      { channels: channelList({ whatsapp, linkedin: null }) },
+      [[{ channel: "linkedin", channelUserId: "ACoAAAda0001" }]],
+    );
 
     expect(accounts).toEqual([{ channel: "linkedin", addresses: ["ACoAAAda0001"] }]);
     // No mapping named WhatsApp, so its address book is never read.
-    expect(whatsAppAccounts.listings).toBe(0);
+    expect(whatsapp.listings).toBe(0);
   });
 
   it("answers one result per group, in the order given", async () => {
-    const whatsAppAccounts = new FakeAccounts([account(ada, [ada, adaLid]), account(grace)]);
+    const whatsapp = new FakeAccounts([account(ada, [ada, adaLid]), account(grace)]);
 
-    const groups = await timelineAccounts({ whatsAppAccounts }, [
+    const groups = await timelineAccounts({ channels: channelList({ whatsapp }) }, [
       [{ channel: "whatsapp", channelUserId: grace }],
       [],
       [{ channel: "whatsapp", channelUserId: adaLid }],
@@ -105,6 +136,6 @@ describe("timelineAccounts", () => {
     expect(groups[1]).toEqual([]);
     expect(groups[2]?.[0]?.channel).toBe("whatsapp");
     // One read serves every group.
-    expect(whatsAppAccounts.listings).toBe(1);
+    expect(whatsapp.listings).toBe(1);
   });
 });

--- a/packages/core/src/people/timeline-sources.ts
+++ b/packages/core/src/people/timeline-sources.ts
@@ -12,8 +12,13 @@
 // so a group conversation — addressed by the group rather than by the person —
 // never reaches a person's timeline.
 
-import type { Accounts } from "../channels/accounts.js";
-import { messageStores, type Channels } from "../channels/channel.js";
+import {
+  foldAccounts,
+  type AccountFold,
+  type AddressBooks,
+  type StoredAddress,
+} from "../channels/account-fold.js";
+import { addressBooks, messageStores, type Channels } from "../channels/channel.js";
 import type { Messages } from "../channels/messages.js";
 import { agentMessages } from "../channels/messages-agent.js";
 import { sentinelLogMessages } from "../channels/messages-sentinel.js";
@@ -59,86 +64,44 @@ export function personMessageStores(deps: { db: DrizzleDb; channels: Channels })
  * asking about a directory of people must not pay for one read per row.
  */
 export async function timelineAccounts(
-  deps: { whatsAppAccounts: AddressBook },
-  groups: readonly (readonly LinkedAddress[])[],
+  deps: { channels: Channels },
+  groups: readonly (readonly StoredAddress[])[],
 ): Promise<TimelineAccount[][]> {
-  const channels = new Set(groups.flatMap((group) => group.map((link) => link.channel)));
-  const books = await readAddressBooks(deps, channels);
-  return groups.map((group) => foldAccounts(books, group));
+  const links = groups.flat();
+  const fold = await foldAccounts(booksNamed(deps.channels, links), { stored: links });
+  return groups.map((group) => accountsOf(fold, group));
 }
 
-/** One address a link names. `channelUserId` is the account's own address —
- *  the wire field's name, kept because the column and the contract carry it. */
-interface LinkedAddress {
-  channel: string;
-  channelUserId: string;
+/** The address books of the channels the links name, and nothing else. An
+ *  address book costs a full read, and a channel no link names folds nothing,
+ *  so a person on one channel pays for one book rather than for the list. */
+function booksNamed(channels: Channels, links: readonly StoredAddress[]): AddressBooks {
+  const named = new Set(links.map((link) => link.channel));
+  return Object.fromEntries(
+    Object.entries(addressBooks(channels)).filter(([channel]) => named.has(channel)),
+  );
 }
 
-/** The listing half of a channel's address book: the accounts, each carrying
- *  every address it answers to. There is no separate address map to ask for —
- *  the listing already says which addresses are one account. */
-type AddressBook = Accounts;
-
-/** Each channel's accounts, indexed the two ways the fold reads them: which
- *  account an address belongs to, and every address of that account.
- *
- *  Named here rather than read off the channel list, and only for the channels
- *  the links name, since an address book costs a full read. LinkedIn has one
- *  too but is deliberately absent: it stores a member under its member id and
- *  nothing else, so folding it would buy a whole read and change no answer. It
- *  joins here when it starts storing a second address. */
-async function readAddressBooks(
-  deps: { whatsAppAccounts: AddressBook },
-  channels: ReadonlySet<string>,
-): Promise<Map<string, FoldedBook>> {
-  const known = new Map<string, AddressBook>([["whatsapp", deps.whatsAppAccounts]]);
-  const books = new Map<string, FoldedBook>();
-  for (const [channel, accounts] of known) {
-    if (!channels.has(channel)) continue;
-    // One page big enough to hold the listing: its order is stable but the
-    // listing under it is not, so walking cursors across a live address book
-    // would skip or repeat an account as an inbound message reordered it.
-    const { accounts: listing } = await accounts.listAccounts({ limit: WHOLE_LISTING });
-    const of = new Map<string, string>();
-    const folded = new Map<string, string[]>();
-    for (const account of listing) {
-      // The id among them, whether or not the channel spelled it out as an
-      // address: it is a form the account answers to.
-      const addresses = [...new Set([account.id as string, ...account.addresses])];
-      folded.set(account.id, addresses);
-      for (const address of addresses) of.set(address, account.id);
-    }
-    books.set(channel, { of, folded });
-  }
-  return books;
-}
-
-/** One channel's listing, indexed by address and by account. */
-interface FoldedBook {
-  /** Which account each address belongs to. */
-  of: Map<string, string>;
-  /** Every address of each account. */
-  folded: Map<string, string[]>;
-}
-
-function foldAccounts(
-  books: Map<string, FoldedBook>,
-  links: readonly LinkedAddress[],
-): TimelineAccount[] {
+/** One group's links as the accounts they reach, keyed by the account rather
+ *  than by the address a link happened to name, so two links onto one account
+ *  are one entry. */
+function accountsOf(fold: AccountFold, links: readonly StoredAddress[]): TimelineAccount[] {
   const byAccount = new Map<string, TimelineAccount>();
   for (const link of links) {
-    const book = books.get(link.channel);
-    const accountId = book?.of.get(link.channelUserId) ?? link.channelUserId;
-    const key = `${link.channel}\n${accountId}`;
+    const key = fold.key(link.channel, link.channelUserId);
     if (byAccount.has(key)) continue;
     byAccount.set(key, {
       channel: link.channel,
-      addresses: [...new Set([link.channelUserId, ...(book?.folded.get(accountId) ?? [])])],
+      // The link's own address among them, whatever the book says: a channel
+      // that folds nothing onto it is still read at the address the guardian
+      // stored.
+      addresses: [
+        ...new Set([
+          link.channelUserId,
+          ...(fold.accountFor(link.channel, link.channelUserId)?.aliases ?? []),
+        ]),
+      ],
     });
   }
   return [...byAccount.values()];
 }
-
-/** One page big enough to hold any listing — what `Accounts.listAccounts`
- *  says to ask for when a caller needs every account exactly once. */
-const WHOLE_LISTING = Number.MAX_SAFE_INTEGER;


### PR DESCRIPTION
Closes #154.

## What this PR does

`packages/core/src/people/timeline-sources.ts` named one channel. `timelineAccounts` took `deps: { whatsAppAccounts: AddressBook }`, `readAddressBooks` built `new Map([["whatsapp", deps.whatsAppAccounts]])`, and the file carried a private fold of an address book beside the one in `channels/account-fold.ts`. A channel joining the channel list changed no code above that file except this one, where it changed two lines — and the second fold was a second answer to a question `account-fold.ts` already answers.

`timelineAccounts` now takes `{ channels }`, reads the books through `addressBooks(deps.channels)`, and folds them with `foldAccounts`. The file names no channel and holds no fold of its own. That removes the last reader of `whatsAppAccounts`, so the field leaves `PeopleReadDeps`, `ApiDeps` and the `apiDeps` literal in `index.ts`. `channelList` still takes it, which is the one place a channel's address book is named.

## Design & Invariants

The signature shape holds: positional over every group at once, one address-book read per channel, `TimelineAccount[][]` in the order given. Two links onto one account stay one entry, and a channel with no address book still contributes the link's own address and nothing else.

Only the books of the channels the links name are read. An address book costs a full read and a channel no link names folds nothing, so a person on one channel pays for one book rather than for the list. A channel filtered out here is read exactly as a channel with no address book: `AccountFold` answers with the address the caller gave.

LinkedIn's book now joins a read that skipped it. The PR accepts that read rather than special-casing it. Skipping a book that folds nothing needs a channel to declare it in advance, which `Channel` does not carry, and `account-directory.ts` already pays the same read on its own path. LinkedIn stores a member under its member id alone, so the fold changes no answer for a link naming a member id — and it does change one for a link naming a profile URL, which `Accounts.resolve` folds onto the member id instead of leaving as a second account.

Which channels have an address book is `channel-list.ts`'s answer. `Accounts`, `Messages`, `Channel` and `ProviderAdapter` are untouched, and no channel gains a book.

## Test plan

- [x] `pnpm typecheck` — every workspace passes.
- [x] `pnpm test:unit` — 363 core test files, plus web and ui, all pass. `src/api/routes/people.test.ts` covers `GET /people` and `/people/:id/messages` over real WhatsApp and LinkedIn mirrors and is unchanged.
- [x] `packages/core/src/people/timeline-sources.test.ts` — added a case for a person linked on two channels that both hold address books, which reads one folded account per channel with every address each book folds onto it. The test builds the channel list and passes no channel name. The existing cases hold with `{ whatsAppAccounts }` gone, including the one where a channel with no address book contributes only the link's own address and its neighbour's book is never read.
- [x] API parity against `main`: a throwaway harness seeded a WhatsApp account under both a phone JID and a `@lid`, a LinkedIn thread, and a person linked to both, then dumped `GET /api/people`, the person's timeline and `?channel=whatsapp`. The payloads are byte-identical to `main` apart from one baseline seed's `latest.timestamp`, which the sentinel log stamps at insert time. The harness is not committed.
- [x] `grep -rn whatsAppAccounts` — every remaining hit is `channel-list.ts`, `index.ts:235`, `index.ts:239`, or a test building a channel list through `channelList`.
- [ ] `pnpm dev:all` — not run. The Docker daemon is unreachable from this machine. The change adds no config and no wiring beyond the removed dependency, which `pnpm typecheck` covers against the required `ApiDeps` fields.

## Not in this PR

- No channel gains an address book — that is `channel-list.ts`'s answer, not this file's.
- The private `WHOLE_LISTING` in `timeline-sources.ts` goes away with the fold, so `account-fold.ts` owns the one that is left. No other duplicate of it is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)