### PR TITLE
refactor(core): read a person's timeline accounts as MessageAccount

### DIFF
--- a/packages/core/src/channels/messages.ts
+++ b/packages/core/src/channels/messages.ts
@@ -15,9 +15,14 @@ import type { TimelineEntry } from "@rome/api-types/people";
  * `Account.addresses` on the channel's own address book.
  *
  * The addresses rather than the id, because a store keys its rows by whichever
- * address a message arrived on. A read that named only the address a person
- * mapping happens to carry would answer an empty history for a conversation
- * that plainly exists.
+ * address a message arrived on: a WhatsApp contact is reachable under both a
+ * phone JID and a `@lid` JID, and history hangs off either. A read that named
+ * only the address a person mapping happens to carry would answer an empty
+ * history for a conversation that plainly exists.
+ *
+ * What `timelineAccounts` (../people/timeline-sources.ts) folds a person's
+ * links into, and what every store a person's history is read from is then
+ * scoped by.
  */
 export interface MessageAccount {
   channel: string;

--- a/packages/core/src/people/timeline-sources.test.ts
+++ b/packages/core/src/people/timeline-sources.test.ts
@@ -15,7 +15,12 @@ const account = (id: string, addresses: string[] = [id]): Account => ({
 class FakeAccounts {
   listings = 0;
 
-  constructor(private readonly accounts: readonly Account[]) {}
+  constructor(
+    private readonly accounts: readonly Account[],
+    /** Addresses the listing does not spell out but the channel still answers
+     *  for, as a real address book does: a bare phone number, a profile URL. */
+    private readonly alsoResolves: Readonly<Record<string, string>> = {},
+  ) {}
 
   async listAccounts(_input: { query?: string; cursor?: string; limit: number }) {
     this.listings++;
@@ -23,7 +28,8 @@ class FakeAccounts {
   }
 
   async resolve(address: string): Promise<Account | null> {
-    return this.accounts.find((candidate) => candidate.addresses.includes(address)) ?? null;
+    const named = this.alsoResolves[address] ?? address;
+    return this.accounts.find((candidate) => candidate.addresses.includes(named)) ?? null;
   }
 }
 
@@ -73,6 +79,24 @@ describe("timelineAccounts", () => {
     ]);
     expect(whatsapp.listings).toBe(1);
     expect(telegram.listings).toBe(1);
+  });
+
+  it("folds an address only the channel can resolve onto its account", async () => {
+    // The link names a bare phone number. The listing spells out no such
+    // address, and only the channel knows it reaches Ada — which is why the
+    // fold asks the channel rather than matching the listing itself.
+    const whatsapp = new FakeAccounts([account(ada, [ada, adaLid])], {
+      "+1 202 555 0100": ada,
+    });
+
+    const [accounts] = await timelineAccounts({ channels: channelList({ whatsapp }) }, [
+      [{ channel: "whatsapp", channelUserId: "+1 202 555 0100" }],
+    ]);
+
+    expect(accounts).toHaveLength(1);
+    expect([...(accounts[0]?.addresses ?? [])].sort()).toEqual(
+      ["+1 202 555 0100", ada, adaLid].sort(),
+    );
   });
 
   it("carries every address of an account a mapping names under one of them", async () => {

--- a/packages/core/src/people/timeline-sources.ts
+++ b/packages/core/src/people/timeline-sources.ts
@@ -19,11 +19,10 @@ import {
   type StoredAddress,
 } from "../channels/account-fold.js";
 import { addressBooks, messageStores, type Channels } from "../channels/channel.js";
-import type { Messages } from "../channels/messages.js";
+import type { MessageAccount, Messages } from "../channels/messages.js";
 import { agentMessages } from "../channels/messages-agent.js";
 import { sentinelLogMessages } from "../channels/messages-sentinel.js";
 import type { DrizzleDb } from "../db/index.js";
-import type { TimelineAccount } from "./timeline.js";
 
 /**
  * The stores a person's history is read from, in the order they claim an
@@ -66,7 +65,7 @@ export function personMessageStores(deps: { db: DrizzleDb; channels: Channels })
 export async function timelineAccounts(
   deps: { channels: Channels },
   groups: readonly (readonly StoredAddress[])[],
-): Promise<TimelineAccount[][]> {
+): Promise<MessageAccount[][]> {
   const links = groups.flat();
   const fold = await foldAccounts(booksNamed(deps.channels, links), { stored: links });
   return groups.map((group) => accountsOf(fold, group));
@@ -85,8 +84,8 @@ function booksNamed(channels: Channels, links: readonly StoredAddress[]): Addres
 /** One group's links as the accounts they reach, keyed by the account rather
  *  than by the address a link happened to name, so two links onto one account
  *  are one entry. */
-function accountsOf(fold: AccountFold, links: readonly StoredAddress[]): TimelineAccount[] {
-  const byAccount = new Map<string, TimelineAccount>();
+function accountsOf(fold: AccountFold, links: readonly StoredAddress[]): MessageAccount[] {
+  const byAccount = new Map<string, MessageAccount>();
   for (const link of links) {
     const key = fold.key(link.channel, link.channelUserId);
     if (byAccount.has(key)) continue;

--- a/packages/core/src/people/timeline.ts
+++ b/packages/core/src/people/timeline.ts
@@ -13,25 +13,6 @@ import {
 import type { MessageAccount, Messages } from "../channels/messages.js";
 
 /**
- * One account a person is reachable at, as a timeline read addresses it.
- *
- * `addresses` is every identifier the channel folds onto that account — a
- * WhatsApp contact is reachable under both a phone JID and a `@lid` JID, and
- * history hangs off either. A store that reads only the identifier the person
- * mapping happens to name would answer an empty timeline for a conversation
- * that plainly exists.
- *
- * A {@link MessageAccount} by shape, and read as one: this is what
- * `timelineAccounts` folds a person's mappings into, and what the stores below
- * are then scoped by.
- */
-export interface TimelineAccount {
-  channel: string;
-  /** Non-empty. Order carries no meaning. */
-  addresses: string[];
-}
-
-/**
  * One page of `accounts`' merged history, newest first, resuming after
  * `cursor`.
  *


### PR DESCRIPTION
## What this PR does

`packages/core/src/people/timeline.ts` declared `TimelineAccount`, and `packages/core/src/channels/messages.ts` declares `MessageAccount`. The two carry the same two fields and name the same thing: one account a person is reachable at, named by every address the channel folds onto it. `timelineAccounts` answered with the first, and every consumer — `readPersonTimeline`, `readPeopleActivity`, `assignAccountHeads` — takes the second. The call sites type-checked because the shapes happened to match, so "one name per thing" held by structure rather than by declaration. `TimelineAccount`'s own docblock said as much: "A `MessageAccount` by shape, and read as one."

`MessageAccount` survives, because the port that reads one declares it (`Messages.read`, `count` and `latest` all take it). `timelineAccounts` and `accountsOf` answer with it, and `timeline.ts` declares no account type — it imports the one it already imported for `readPersonTimeline`. That also drops a `people/` to `people/` import that existed only to borrow a type.

The prose the deleted docblock carried moves onto `MessageAccount`, which was making the same argument — read by address rather than by id, or a real conversation answers empty — without the concrete WhatsApp phone-JID and `@lid` case.

## Design & Invariants

No behavior changes. The fold, the read order, the address sets and the page shape are what #156 left them.

`MessageAccount` is the one name for the noun, and its home is the port that consumes it. A caller that folds a person's links into accounts hands the stores what the stores declare they take, rather than a parallel type that has to keep agreeing with it. `addresses` becomes `readonly string[]` at this seam, which is what `Messages` already required of every store.

Vocabulary lives in [`docs/concepts/people.md`](docs/concepts/people.md), which names Person, Account, Address and Link. Neither type was in it; this leaves one type to name if a future PR adds the entry.

## Test plan

- [x] `pnpm typecheck` — 26 workspaces, all pass.
- [x] `pnpm test:unit` — 4222 core tests, 1309 web, 528 ui, plus the smaller packages. All pass.
- [x] `packages/core/src/people/timeline-sources.test.ts` — added a case for a link written as a bare phone number: an address the listing does not spell out and only `Accounts.resolve` matches. It folds onto the account with every address the book holds. The behavior arrived with #156; nothing pinned it.
- [ ] `pnpm dev:all` — not run. The Docker daemon is unreachable from this machine. No config, wiring or runtime path changes here, and `pnpm typecheck` covers the seam.

## Not in this PR

- `TimelineEntry` keeps its name. It reads like a second name for Message, but the agent store answers with rows whose role is `notification` (`channels/messages-agent.ts`), and [`docs/concepts/messaging.md`](docs/concepts/messaging.md) says a notification is not a message. The type is deliberately wider than the noun.
- No `Timeline` entry in `docs/concepts/people.md`. A person's merged history has no name in the concept docs, and naming it has to explain that breadth rather than restate Message.
