### PR TITLE
docs(northstars): say a channel answers for a conversation too

### DIFF
--- a/docs/northstars/channels.md
+++ b/docs/northstars/channels.md
@@ -12,5 +12,6 @@ Every channel answers the same three things. It carries messages, it says who it
 - A caller reads every channel through one interface and names no channel. Adding a channel changes no code above it.
 - A channel says who it can reach, as far as its platform offers a directory.
 - A channel says what was said on it, as far back as its platform lets Rome read.
+- A channel answers for what was said to a person and for what a conversation holds.
 - A channel says who it reaches and what was said on it without its message transport.
 - A person reachable several ways on one channel is one account with one history.


### PR DESCRIPTION
## What this PR does

The doc treats "what was said on a channel" as one question. It is two. Rome shows a person their history by asking what passed between Rome and that person, and an agent asks what a conversation holds, including a group conversation no single person is addressed on. The second question has no statement backing it, so the channel read side was built to answer only the first, and the agent's history read goes to a live connection instead.

That gap surfaced while reconciling the history milestone (#158). The milestone asked a channel to answer for its history one way, which read as one duplicate to remove. Tracing the only caller showed two different questions rather than two answers to one.

## Design & Invariants

Both reads answer from one source. For a channel holding a mirror that is the mirror, and for a channel that calls its platform that is the same API. This is one store asked two ways, not two histories, and the new statement says so without naming how a channel exposes either.

The existing statement about answering without the message transport now covers both reads. A conversation read that needs a live connection fails it exactly as an account read would.

No statement forbids the transport-side history path directly, because none is needed. A caller reaching a history through a connection is not reading through the one interface every channel is read through, so the existing statement about that interface already rules it out.

Alternatives considered. Leaving the conversation read outside the channel and on the connection would have kept the doc unchanged. It fails on liveness: a history that needs a connected transport is the case the read and transport split exists to prevent. Putting the conversation read behind its own channel port was the other option, and it was rejected because both reads answer from one source and one store asked two ways is one contract.

## Test plan

- [x] Walked the full Statements list for pairs that cannot both hold. The new statement is consistent with the two around it, which scope their limits to the platform and to the transport.
- [x] Checked the new statement against the admission rules: declarative present, checkable by reading code, and satisfied by more than one implementation.
- [x] `scripts/check-pr-title.sh "docs(northstars): say a channel answers for a conversation too"`.

## Not in this PR

- What a store answers when it holds no conversation read. No channel needs that today, so the statement does not carve out a case that does not exist.
- What shape a conversation read returns. The account reads return a person's timeline entry, and a conversation read is not a person's timeline. This is a contract decision for the PR that adds the read.
