### PR TITLE
feat(core): let a channel answer for what a conversation holds

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -9,7 +9,7 @@ Browse by domain:
 - [`rome-cloud.md`](rome-cloud.md) — Rome Cloud, Instance sign-in, OAuth handoff. *The operator-run service in front of all instances.*
 - [`agents.md`](agents.md) — Agents (incl. the agent hierarchy). *The LLM-backed runtime entities.*
 - [`sessions.md`](sessions.md) — Sessions, Model pin, Agent runs, Owning app, Forked turns. *The durable boundary around agent work.*
-- [`messaging.md`](messaging.md) — Messages, Channels, Policies, Sentinel, Approvals. *How messages flow in and how the system decides what to do with them.*
+- [`messaging.md`](messaging.md) — Messages, Conversations, Channels, Policies, Sentinel, Approvals. *How messages flow in and how the system decides what to do with them.*
 - [`apps.md`](apps.md) — Rome Apps (incl. ids, SDKs, caller identity, lockfile, install sources, app store, handles, app data, hooks). *The extensibility surface.*
 - [`actions.md`](actions.md) — Actions, Action results, Suspensions, Actor. *The primary unit of executable behavior, its result envelope, and the session identity accountable for it.*
 - [`skills.md`](skills.md) — Skills. *Instructional documents that teach agents how to perform tasks.*

--- a/docs/concepts/messaging.md
+++ b/docs/concepts/messaging.md
@@ -1,4 +1,4 @@
-# Messaging: Messages, Channels, Policies, Sentinel, Approvals
+# Messaging: Messages, Conversations, Channels, Policies, Sentinel, Approvals
 
 ## Message
 
@@ -13,8 +13,24 @@ A message is one thing somebody said — a line a person sent to Rome, or one Ro
 **Not to be confused with:**
 
 - **[Channel](#channels)** — the channel is what carried a message. The message is what was said on it.
+- **[Conversation](#conversation)** — the conversation is the thread a message was said in. The message is the one line.
 - **[Account](people.md#account)** — the account is who said it. The message is what they said.
 - **Notification** — a notification is an out-of-band delivery to the guardian. It lands in the same transcript, but nobody sent it on a channel.
+
+## Conversation
+
+A conversation is the thread a [message](#message) was said in, named by the platform's own id for it. Every message belongs to exactly one.
+
+**Contracts:**
+
+- A direct conversation is addressed by the person on it. A group conversation is addressed by the group and by nobody on it, so no account names one and no read scoped by an account reaches one.
+- A conversation belongs to the [channel](#channels) that holds it. Two channels are free to spell an id the same way and mean two different threads.
+- What a conversation holds and what passed between Rome and a person are two questions to one store, not two histories: a channel answers both from the record it already keeps.
+
+**Not to be confused with:**
+
+- **[Account](people.md#account)** — the account is who Rome is talking to. The conversation is where they said it. On a direct thread the two are named by one string; on a group they are not.
+- **Session** — a session is Rome's own working context for a thread. The conversation is the thread itself, which exists whether or not Rome ever opened a session on it.
 
 ## Channels
 

--- a/packages/core/src/channels/linkedin-messages.test.ts
+++ b/packages/core/src/channels/linkedin-messages.test.ts
@@ -3,7 +3,7 @@ import { countingDb, createTestDb, type TestDb } from "../test/helpers.js";
 import { linkedinMessages, linkedinThreadParticipants, linkedinThreads } from "../db/schema.js";
 import { testMessagesContract, WHOLE_HISTORY } from "./messages-contract.js";
 import { linkedInMessages } from "./linkedin-messages.js";
-import type { MessageAccount } from "./messages.js";
+import type { MessageAccount, MessageConversation } from "./messages.js";
 
 // `linkedin_messages` as a `Messages` store. The mirror holds group threads
 // and rooms the guardian is one of many in; a person's history is the threads
@@ -21,6 +21,8 @@ const TWIN_B = "ACoAATWINB";
 const account = { channel: "linkedin", addresses: [MEMBER] };
 const accounts = [account];
 const silent = [{ channel: "linkedin", addresses: ["ACoAASILENT"] }];
+const room: MessageConversation = { channel: "linkedin", id: "t-room" };
+const emptyThread: MessageConversation = { channel: "linkedin", id: "t-nothing" };
 
 interface ThreadSeed {
   thread: string;
@@ -44,11 +46,17 @@ const threads: ThreadSeed[] = [
     ],
   },
   // Three on the thread: nobody's direct history, whatever LinkedIn's own flag
-  // says about it.
+  // says about it — and so the thread only a conversation read reaches. Enough
+  // of it to page, and a second in it said twice so the ordering has a tie.
   {
     thread: "t-room",
     participants: [SELF, MEMBER, OTHER],
-    messages: [{ id: "f", at: 700, text: "in the room" }],
+    messages: [
+      { id: "f", at: 700, text: "in the room" },
+      { id: "f2", at: 700, self: true, text: "answered the room" },
+      { id: "f3", at: 750, text: "and again" },
+      { id: "f4", at: 800, text: "latest in the room" },
+    ],
   },
   // Two on the thread, but LinkedIn calls it a group.
   {
@@ -172,6 +180,66 @@ describe("linkedInMessages", () => {
     expect(await messages.count(twins)).toBe(1);
   });
 
+  // A thread is the conversation, named by LinkedIn's own id: what the account
+  // scope reaches through membership, a conversation read names outright.
+  it("answers a group thread asked for as a conversation", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const page = await messages.readConversation({ conversation: room, limit: WHOLE_HISTORY });
+    expect(refs(page)).toEqual(["t-room:f4", "t-room:f3", "t-room:f2", "t-room:f"]);
+  });
+
+  it("answers a group thread's messages to no account read", async () => {
+    const messages = linkedInMessages(testDb.db);
+    // Every member of the room, read as the accounts they are: the thread is
+    // three-handed, so it is nobody's direct history.
+    const members: MessageAccount[] = [SELF, MEMBER, OTHER].map((address) => ({
+      channel: "linkedin",
+      addresses: [address],
+    }));
+    const held = await messages.read({ accounts: members, limit: WHOLE_HISTORY });
+    expect(refs(held).some((ref) => ref.startsWith("t-room:"))).toBe(false);
+    // And the thread id is no member id, so naming it as an address answers
+    // nothing at all.
+    const asAccount: MessageAccount[] = [{ channel: "linkedin", addresses: ["t-room"] }];
+    expect(await messages.read({ accounts: asAccount, limit: WHOLE_HISTORY })).toEqual([]);
+    expect(await messages.count(asAccount)).toBe(0);
+    expect(await messages.latest(asAccount)).toBeNull();
+  });
+
+  it("answers a thread LinkedIn calls a group asked for as a conversation", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const page = await messages.readConversation({
+      conversation: { channel: "linkedin", id: "t-flagged" },
+      limit: WHOLE_HISTORY,
+    });
+    expect(refs(page)).toEqual(["t-flagged:g"]);
+  });
+
+  it("answers a direct thread asked for as a conversation", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const page = await messages.readConversation({
+      conversation: { channel: "linkedin", id: "t-direct" },
+      limit: WHOLE_HISTORY,
+    });
+    expect(refs(page)).toEqual([
+      "t-direct:e",
+      "t-direct:c",
+      "t-direct:d",
+      "t-direct:b",
+      "t-direct:a",
+    ]);
+  });
+
+  it("holds nothing for a conversation on another channel", async () => {
+    const messages = linkedInMessages(testDb.db);
+    expect(
+      await messages.readConversation({
+        conversation: { channel: "whatsapp", id: "t-room" },
+        limit: WHOLE_HISTORY,
+      }),
+    ).toEqual([]);
+  });
+
   it("holds nothing for an account on another channel", async () => {
     const messages = linkedInMessages(testDb.db);
     const elsewhere: MessageAccount[] = [{ channel: "whatsapp", addresses: [MEMBER] }];
@@ -265,5 +333,11 @@ describe("linkedInMessages", () => {
 testMessagesContract("linkedInMessages", () => {
   const testDb = createTestDb();
   seedMirror(testDb);
-  return { messages: linkedInMessages(testDb.db), accounts, silent };
+  return {
+    messages: linkedInMessages(testDb.db),
+    accounts,
+    silent,
+    conversation: room,
+    silentConversation: emptyThread,
+  };
 });

--- a/packages/core/src/channels/linkedin-messages.ts
+++ b/packages/core/src/channels/linkedin-messages.ts
@@ -1,38 +1,57 @@
 import { sql } from "drizzle-orm";
 import type { DrizzleDb } from "../db/index.js";
 import type { Messages } from "./messages.js";
-import { addressesIn, inList, sqlMessages } from "./messages-sql.js";
+import { inList, keysIn, sqlMessages } from "./messages-sql.js";
 
 /**
- * `Messages` over the LinkedIn inbox mirror (`linkedin_messages`), restricted
- * to threads that are a conversation between two people.
+ * `Messages` over the LinkedIn inbox mirror (`linkedin_messages`).
  *
- * A LinkedIn message hangs off a thread rather than off a member, so the scope
- * is reached through the thread's membership: a member's history is the
- * messages of the threads they are on. Two conditions keep that to a direct
- * conversation, and both are needed — LinkedIn's own group flag is null until
- * a thread has been snapshotted, so the membership decides the threads it has
- * not answered for yet.
+ * A LinkedIn message hangs off a thread rather than off a member, which is what
+ * makes the two scopes different queries rather than one query with a filter. A
+ * conversation is the thread, named by LinkedIn's own id for it, so it is read
+ * off the messages directly. A member's history is reached through the thread's
+ * membership instead: it is the messages of the threads they are on, restricted
+ * to the threads that are a conversation between two people. Both conditions
+ * are needed for that — LinkedIn's own group flag is null until a thread has
+ * been snapshotted, so the membership decides the threads it has not answered
+ * for yet.
  *
- * A message is answered once for each scoped member of its thread, and the
- * read above folds those together. That is what makes a person holding two
- * member ids on one thread read one history rather than the same messages
- * twice — and, unlike picking a single member per thread, it holds however
- * many members of however many people the scope names at once, which a read
- * grouping a whole directory into one pass depends on.
+ * Under the account scope a message is answered once for each scoped member of
+ * its thread, and the read above folds those together. That is what makes a
+ * person holding two member ids on one thread read one history rather than the
+ * same messages twice — and, unlike picking a single member per thread, it
+ * holds however many members of however many people the scope names at once,
+ * which a read grouping a whole directory into one pass depends on.
  */
 export function linkedInMessages(db: DrizzleDb): Messages {
   return sqlMessages({
     channel: "linkedin",
     db,
     view(scope) {
-      const addresses = addressesIn(scope);
-      const members = inList(sql`tp.participant_id`, addresses);
+      const keys = keysIn(scope.keys);
+      if (scope.by === "conversation") {
+        const threads = inList(sql`m.thread_id`, keys);
+        if (threads === null) return null;
+        // The thread as LinkedIn holds it, group or not and however many are on
+        // it: what the account scope subtracts is exactly what only a
+        // conversation can name.
+        return sql`
+          SELECT
+            'linkedin' AS source,
+            m.thread_id AS key,
+            coalesce(m.sent_at, m.created_at) AS at,
+            CASE WHEN m.sender_is_self THEN 1 ELSE 0 END AS outbound,
+            m.thread_id || ':' || m.message_id AS ref,
+            m.text AS body
+          FROM linkedin_messages m
+          WHERE ${threads}`;
+      }
+      const members = inList(sql`tp.participant_id`, keys);
       if (members === null) return null;
       return sql`
         SELECT
           'linkedin' AS source,
-          tp.participant_id AS address,
+          tp.participant_id AS key,
           coalesce(m.sent_at, m.created_at) AS at,
           CASE WHEN m.sender_is_self THEN 1 ELSE 0 END AS outbound,
           m.thread_id || ':' || m.message_id AS ref,

--- a/packages/core/src/channels/messages-agent.test.ts
+++ b/packages/core/src/channels/messages-agent.test.ts
@@ -9,6 +9,7 @@ import {
   type MessagesContractSubject,
 } from "./messages-contract.js";
 import { agentMessages } from "./messages-agent.js";
+import type { MessageConversation } from "./messages.js";
 
 // `rome_agent_messages` read as a `Messages` store, holding exactly what
 // `agentMessagesSource` holds today: the roles that carry conversation, on
@@ -23,6 +24,8 @@ const OTHER_CHANNEL = "discord";
 
 const account = { channel: CHANNEL, addresses: [DIRECT, DIRECT_ALT] };
 const silent = [{ channel: CHANNEL, addresses: ["tg-nobody"] }];
+const groupThread: MessageConversation = { channel: CHANNEL, id: GROUP };
+const emptyThread: MessageConversation = { channel: CHANNEL, id: "tg-no-session" };
 
 const text = (line: string) => JSON.stringify([{ type: "text", content: line }]);
 
@@ -83,15 +86,22 @@ async function seed(db: DrizzleDb) {
   // The account's other address: one history, not two halves of one.
   await message(db, "m-alt", { sessionId: "s-direct-alt", role: "user", at: 250 });
 
-  // Out of scope, each for its own reason.
+  // Out of every account's scope, each for its own reason.
   await message(db, "m-trace", { sessionId: "s-direct", role: "trace", at: 400 });
-  // Sent by the account, but into a thread the group addresses.
+  // The group's own session, which only a conversation read reaches. Enough of
+  // it to page, and a second in it said twice so the ordering has a tie.
+  //
+  // The first was sent by the account, and is still the group's: a line the
+  // account wrote into a group belongs to the group's thread.
   await message(db, "m-group", {
     sessionId: "s-group",
     role: "user",
     at: 500,
     senderId: DIRECT,
   });
+  await message(db, "m-group-reply", { sessionId: "s-group", role: "assistant", at: 500 });
+  await message(db, "m-group-note", { sessionId: "s-group", role: "notification", at: 520 });
+  await message(db, "m-group-later", { sessionId: "s-group", role: "user", at: 540 });
   await message(db, "m-webchat", { sessionId: "s-webchat", role: "user", at: 600 });
   await message(db, "m-elsewhere", { sessionId: "s-elsewhere", role: "user", at: 550 });
 }
@@ -136,6 +146,44 @@ describe("agentMessages", () => {
       limit: WHOLE_HISTORY,
     });
     expect(asGroup).toEqual([]);
+  });
+
+  // The session's thread is the conversation, and a group's session is the one
+  // no account addresses.
+  it("answers a group's session asked for as a conversation", async () => {
+    const page = await agentMessages(db).readConversation({
+      conversation: groupThread,
+      limit: WHOLE_HISTORY,
+    });
+    expect(page.map((entry) => entry.ref)).toEqual([
+      "agent:m-group-later",
+      "agent:m-group-note",
+      "agent:m-group-reply",
+      "agent:m-group",
+    ]);
+  });
+
+  it("keeps a conversation on its own channel", async () => {
+    // `s-elsewhere` spells this account's thread id on another channel, so the
+    // pair is all that keeps the two conversations apart.
+    const here = await agentMessages(db).readConversation({
+      conversation: { channel: CHANNEL, id: DIRECT },
+      limit: WHOLE_HISTORY,
+    });
+    expect(here.map((entry) => entry.ref)).not.toContain("agent:m-elsewhere");
+    const there = await agentMessages(db).readConversation({
+      conversation: { channel: OTHER_CHANNEL, id: DIRECT },
+      limit: WHOLE_HISTORY,
+    });
+    expect(there.map((entry) => entry.ref)).toEqual(["agent:m-elsewhere"]);
+  });
+
+  it("leaves a trace row out of a conversation too", async () => {
+    const page = await agentMessages(db).readConversation({
+      conversation: { channel: CHANNEL, id: DIRECT },
+      limit: WHOLE_HISTORY,
+    });
+    expect(page.map((entry) => entry.ref)).not.toContain("agent:m-trace");
   });
 
   it("leaves out a session that is not a channel's", async () => {
@@ -300,7 +348,13 @@ testMessagesContract("agentMessages", () => {
   enrolled ??= (async () => {
     const { db } = createTestDb();
     await seed(db);
-    return { messages: agentMessages(db), accounts: [account], silent };
+    return {
+      messages: agentMessages(db),
+      accounts: [account],
+      silent,
+      conversation: groupThread,
+      silentConversation: emptyThread,
+    };
   })();
   return enrolled;
 });

--- a/packages/core/src/channels/messages-agent.ts
+++ b/packages/core/src/channels/messages-agent.ts
@@ -48,12 +48,14 @@ export function agentMessageOutbound(role: SQL, senderId: SQL): SQL {
 /**
  * Rome's own transcript of a channel conversation.
  *
- * Reached through the session's channel address: a channel session is keyed by
- * the thread it belongs to, so a session addressed by the account is that
- * account's direct conversation, and a group's session — addressed by the
- * group rather than by anyone on it — is named by no account and never
- * matches. Which sender a message carries makes no difference: a line the
- * account wrote into a group belongs to the group's thread.
+ * Reached through the session's thread either way it is asked. A channel
+ * session is keyed by the thread it belongs to, so a session addressed by the
+ * account is that account's direct conversation, and a conversation names the
+ * same column by its own id — the two scopes select the same way and differ
+ * only in what they subtract. A group's session is addressed by the group
+ * rather than by anyone on it, so it is named by no account and reached only by
+ * naming the group. Which sender a message carries makes no difference: a line
+ * the account wrote into a group belongs to the group's thread.
  */
 export function agentMessages(db: DrizzleDb): Messages {
   // No `channel`: the transcript holds every channel that has no mirror of its
@@ -61,12 +63,20 @@ export function agentMessages(db: DrizzleDb): Messages {
   return sqlMessages({
     db,
     view(scope) {
-      const addressed = scopePairs(scope, sql`s.source_channel`, sql`s.source_thread_id`);
+      const addressed = scopePairs(scope.keys, sql`s.source_channel`, sql`s.source_thread_id`);
       if (addressed === null) return null;
+      const held =
+        scope.by === "account"
+          ? // Addressing already leaves a group out, since a group's session is
+            // keyed by the group and no account answers to that. Said again on
+            // the store's own terms so the guarantee survives a caller that
+            // hands over a group id as if it were an account's address.
+            sql`${addressed} AND coalesce(s.source_thread_type, '') <> 'group'`
+          : addressed;
       return sql`
         SELECT
           s.source_channel AS source,
-          s.source_thread_id AS address,
+          s.source_thread_id AS key,
           m.created_at AS at,
           ${agentMessageOutbound(sql`m.role`, sql`m.sender_id`)} AS outbound,
           'agent:' || m.id AS ref,
@@ -74,12 +84,7 @@ export function agentMessages(db: DrizzleDb): Messages {
         FROM rome_agent_messages m
         JOIN rome_sessions s ON s.id = m.session_id
         WHERE s.type = 'channel'
-          AND ${addressed}
-          -- Addressing already leaves a group out, since a group's session is
-          -- keyed by the group and no account answers to that. Said again on
-          -- the store's own terms so the guarantee survives a caller that
-          -- hands over a group id as if it were an account's address.
-          AND coalesce(s.source_thread_type, '') <> 'group'
+          AND ${held}
           -- 'notification' is a line that passed outside a turn — something
           -- the person said without waking the agent, or something Rome sent
           -- untied to one. Either way it is conversation, and the direction

--- a/packages/core/src/channels/messages-contract.ts
+++ b/packages/core/src/channels/messages-contract.ts
@@ -10,7 +10,7 @@ import {
   timelineCursor,
   type TimelineEntry,
 } from "@rome/api-types/people";
-import type { MessageAccount, Messages } from "./messages.js";
+import type { MessageAccount, MessageConversation, Messages } from "./messages.js";
 
 /** A limit large enough to hold any history a store can answer — what
  *  messages.ts calls the full read. */
@@ -29,6 +29,17 @@ export interface MessagesContractSubject {
   accounts: MessageAccount[];
   /** Accounts on the store's own channels that it holds nothing for. */
   silent: MessageAccount[];
+  /**
+   * A conversation the store holds, enrolled on the same terms as `accounts`:
+   * at least four messages, two of them in the same second.
+   *
+   * A group wherever the store can hold one. A group is the conversation no
+   * account read reaches, so enrolling one is what proves the verb answers
+   * more than the account reads already did.
+   */
+  conversation: MessageConversation;
+  /** A conversation on one of the store's channels that it holds nothing of. */
+  silentConversation: MessageConversation;
 }
 
 /** Page size the paging assertions walk with. Smaller than the history the
@@ -139,6 +150,87 @@ export function testMessagesContract(
       expect(await store.messages.read({ accounts: store.silent, limit: WHOLE_HISTORY })).toEqual(
         [],
       );
+    });
+
+    // The conversation read pages the same store the account reads page, so it
+    // owes the same page: the order, the cursor and the exhaustion are asserted
+    // over again rather than assumed to carry across. A store is free to answer
+    // the two from two queries — four of the five do — and the query that only
+    // the conversation read reaches is the one nothing else here covers.
+    const fullConversation = async ({ messages, conversation }: MessagesContractSubject) =>
+      messages.readConversation({ conversation, limit: WHOLE_HISTORY });
+
+    it("holds enough of a conversation to prove the law", async () => {
+      const store = await subject();
+      const full = await fullConversation(store);
+      expect(full.length).toBeGreaterThanOrEqual(4);
+      expect(new Set(full.map((entry) => entry.timestamp)).size).toBeLessThan(full.length);
+    });
+
+    it("answers a conversation page newest first, no longer than its limit", async () => {
+      const store = await subject();
+      const page = await store.messages.readConversation({
+        conversation: store.conversation,
+        limit: PAGE,
+      });
+      expect(page.length).toBeLessThanOrEqual(PAGE);
+      expect(page).toEqual([...page].sort(compareTimelineEntries));
+    });
+
+    it("answers only messages of a conversation strictly after the cursor", async () => {
+      const store = await subject();
+      const first = await store.messages.readConversation({
+        conversation: store.conversation,
+        limit: PAGE,
+      });
+      const cursor = first.at(-1);
+      if (!cursor) throw new Error("the store answered no first page to resume from");
+      const next = await store.messages.readConversation({
+        conversation: store.conversation,
+        after: cursor,
+        limit: WHOLE_HISTORY,
+      });
+      expect(next.every((entry) => isAfterTimelineCursor(entry, cursor))).toBe(true);
+    });
+
+    it("pages a conversation to exhaustion over exactly its full read", async () => {
+      const store = await subject();
+      const full = await fullConversation(store);
+
+      const walked: TimelineEntry[] = [];
+      let after: TimelineEntry | null = null;
+      for (let page = 0; page <= Math.ceil(full.length / PAGE); page++) {
+        const entries: TimelineEntry[] = await store.messages.readConversation({
+          conversation: store.conversation,
+          after,
+          limit: PAGE,
+        });
+        if (entries.length === 0) break;
+        walked.push(...entries);
+        after = entries[entries.length - 1] ?? null;
+      }
+
+      expect(walked).toEqual(full);
+    });
+
+    it("gives every message of a conversation its own cursor position", async () => {
+      const store = await subject();
+      const full = await fullConversation(store);
+      expect(new Set(full.map(timelineCursor)).size).toBe(full.length);
+    });
+
+    // An empty page rather than a failure or a null: a conversation the store
+    // has never heard of and one it holds empty are one answer, so a caller
+    // asking about a thread the mirror has not caught up with reads it as a
+    // history with nothing in it yet.
+    it("holds nothing for a silent conversation", async () => {
+      const store = await subject();
+      expect(
+        await store.messages.readConversation({
+          conversation: store.silentConversation,
+          limit: WHOLE_HISTORY,
+        }),
+      ).toEqual([]);
     });
   });
 }

--- a/packages/core/src/channels/messages-memory.test.ts
+++ b/packages/core/src/channels/messages-memory.test.ts
@@ -9,11 +9,19 @@ import { testMessagesContract, WHOLE_HISTORY } from "./messages-contract.js";
 const PHONE = "1555@s.whatsapp.net";
 const LID = "77@lid";
 const MEMBER = "ACoAA1";
-// A group: addressed by neither of the two who speak in it, so its messages
-// name the conversation themselves.
+// A group: addressed by the group and by nobody on it, so its messages are
+// held at the group rather than at whoever spoke — which is how a mirror keys
+// one, a WhatsApp group message hanging off the group's chat.
 const GROUP = "wa-group";
+// Two people on that group. No message of it names either, which is what makes
+// a group unreachable from an account read rather than merely filtered out of
+// one.
 const IN_GROUP_ONE = "9998@s.whatsapp.net";
 const IN_GROUP_TWO = "9997@s.whatsapp.net";
+// The thread the LinkedIn messages below were said in: a conversation named by
+// something other than the address they arrived at, the way a LinkedIn message
+// hangs off a thread rather than off a member.
+const LI_THREAD = "li-thread-1";
 
 const entry = (
   source: string,
@@ -29,28 +37,27 @@ const held: HeldMessage[] = [
   // settles the tie, and both have to survive a page boundary.
   { channel: "whatsapp", address: LID, entry: entry("whatsapp", 300, "wa:d") },
   { channel: "whatsapp", address: PHONE, entry: entry("whatsapp", 500, "wa:e") },
-  { channel: "linkedin", address: MEMBER, entry: entry("linkedin", 200, "li:b") },
-  { channel: "linkedin", address: MEMBER, entry: entry("linkedin", 400, "li:f", "outbound") },
+  {
+    channel: "linkedin",
+    address: MEMBER,
+    conversation: LI_THREAD,
+    entry: entry("linkedin", 200, "li:b"),
+  },
+  {
+    channel: "linkedin",
+    address: MEMBER,
+    conversation: LI_THREAD,
+    entry: entry("linkedin", 400, "li:f", "outbound"),
+  },
   // Out of every scope below: another account on the same channel, and the
   // same string as a WhatsApp address on a channel that is not WhatsApp.
   { channel: "whatsapp", address: "9999@s.whatsapp.net", entry: entry("whatsapp", 600, "wa:x") },
   { channel: "linkedin", address: PHONE, entry: entry("linkedin", 700, "li:x") },
-  // The group, reachable only by naming it. Two of its lines arrived at the
-  // address that said them and name the conversation, and two name it by
-  // arriving at the group itself — which is what a message with no conversation
-  // of its own says.
-  {
-    channel: "whatsapp",
-    address: IN_GROUP_ONE,
-    conversation: GROUP,
-    entry: entry("whatsapp", 800, "wa:g1"),
-  },
-  {
-    channel: "whatsapp",
-    address: IN_GROUP_TWO,
-    conversation: GROUP,
-    entry: entry("whatsapp", 900, "wa:g2"),
-  },
+  // The group, reachable only by naming it. Every line of it is held at the
+  // group, so it names the conversation by arriving there — which is what a
+  // message with no conversation of its own says.
+  { channel: "whatsapp", address: GROUP, entry: entry("whatsapp", 800, "wa:g1") },
+  { channel: "whatsapp", address: GROUP, entry: entry("whatsapp", 900, "wa:g2") },
   // The same second as wa:g2; the direction settles the tie.
   { channel: "whatsapp", address: GROUP, entry: entry("whatsapp", 900, "wa:g3", "outbound") },
   { channel: "whatsapp", address: GROUP, entry: entry("whatsapp", 1000, "wa:g4") },
@@ -101,17 +108,31 @@ describe("memoryMessages", () => {
     expect(page.map((e) => e.ref)).toEqual(["wa:g4", "wa:g3", "wa:g2", "wa:g1"]);
   });
 
-  it("answers a conversation to no account that names one of its speakers", async () => {
-    const speakers = [
-      { channel: "whatsapp", addresses: [IN_GROUP_ONE, IN_GROUP_TWO] },
+  it("answers a group's messages to no account read", async () => {
+    // Every account the fixture holds one for, and two people on the group
+    // besides. A group message is held at the group, so no address names one —
+    // which is the reason the account reads answer direct threads only.
+    const everyone = [
       ...accounts,
+      { channel: "whatsapp", addresses: [IN_GROUP_ONE, IN_GROUP_TWO] },
     ];
-    const page = await messages.read({ accounts: speakers, limit: WHOLE_HISTORY });
-    // Each speaker's own line reaches the address it arrived at — a memory
-    // store subtracts nothing — and the two the group itself holds reach
-    // nobody, which is what an address that names no account means.
-    expect(page.map((e) => e.ref)).not.toContain("wa:g3");
-    expect(page.map((e) => e.ref)).not.toContain("wa:g4");
+    const held = (await messages.read({ accounts: everyone, limit: WHOLE_HISTORY })).map(
+      (e) => e.ref,
+    );
+    for (const ref of ["wa:g1", "wa:g2", "wa:g3", "wa:g4"]) expect(held).not.toContain(ref);
+  });
+
+  it("reads a conversation named by something other than the address", async () => {
+    const page = await messages.readConversation({
+      conversation: { channel: "linkedin", id: LI_THREAD },
+      limit: WHOLE_HISTORY,
+    });
+    expect(page.map((e) => e.ref)).toEqual(["li:f", "li:b"]);
+    // And the same messages still reach the member's own account read: a
+    // direct thread is one history named two ways, not two histories.
+    const member = [{ channel: "linkedin", addresses: [MEMBER] }];
+    expect((await messages.read({ accounts: member, limit: WHOLE_HISTORY })).map((e) => e.ref)) //
+      .toEqual(["li:f", "li:b"]);
   });
 
   it("reads a direct conversation under the address that names it", async () => {

--- a/packages/core/src/channels/messages-memory.test.ts
+++ b/packages/core/src/channels/messages-memory.test.ts
@@ -9,6 +9,11 @@ import { testMessagesContract, WHOLE_HISTORY } from "./messages-contract.js";
 const PHONE = "1555@s.whatsapp.net";
 const LID = "77@lid";
 const MEMBER = "ACoAA1";
+// A group: addressed by neither of the two who speak in it, so its messages
+// name the conversation themselves.
+const GROUP = "wa-group";
+const IN_GROUP_ONE = "9998@s.whatsapp.net";
+const IN_GROUP_TWO = "9997@s.whatsapp.net";
 
 const entry = (
   source: string,
@@ -30,6 +35,25 @@ const held: HeldMessage[] = [
   // same string as a WhatsApp address on a channel that is not WhatsApp.
   { channel: "whatsapp", address: "9999@s.whatsapp.net", entry: entry("whatsapp", 600, "wa:x") },
   { channel: "linkedin", address: PHONE, entry: entry("linkedin", 700, "li:x") },
+  // The group, reachable only by naming it. Two of its lines arrived at the
+  // address that said them and name the conversation, and two name it by
+  // arriving at the group itself — which is what a message with no conversation
+  // of its own says.
+  {
+    channel: "whatsapp",
+    address: IN_GROUP_ONE,
+    conversation: GROUP,
+    entry: entry("whatsapp", 800, "wa:g1"),
+  },
+  {
+    channel: "whatsapp",
+    address: IN_GROUP_TWO,
+    conversation: GROUP,
+    entry: entry("whatsapp", 900, "wa:g2"),
+  },
+  // The same second as wa:g2; the direction settles the tie.
+  { channel: "whatsapp", address: GROUP, entry: entry("whatsapp", 900, "wa:g3", "outbound") },
+  { channel: "whatsapp", address: GROUP, entry: entry("whatsapp", 1000, "wa:g4") },
 ];
 
 const accounts = [
@@ -41,6 +65,8 @@ testMessagesContract("memoryMessages", () => ({
   messages: memoryMessages(held),
   accounts,
   silent: [{ channel: "whatsapp", addresses: ["4444@s.whatsapp.net"] }],
+  conversation: { channel: "whatsapp", id: GROUP },
+  silentConversation: { channel: "whatsapp", id: "wa-quiet-group" },
 }));
 
 describe("memoryMessages", () => {
@@ -65,6 +91,44 @@ describe("memoryMessages", () => {
       { channel: "whatsapp", addresses: [PHONE, LID] },
     ];
     expect(await messages.count(shared)).toBe(4);
+  });
+
+  it("answers a conversation nothing in it is addressed by", async () => {
+    const page = await messages.readConversation({
+      conversation: { channel: "whatsapp", id: GROUP },
+      limit: WHOLE_HISTORY,
+    });
+    expect(page.map((e) => e.ref)).toEqual(["wa:g4", "wa:g3", "wa:g2", "wa:g1"]);
+  });
+
+  it("answers a conversation to no account that names one of its speakers", async () => {
+    const speakers = [
+      { channel: "whatsapp", addresses: [IN_GROUP_ONE, IN_GROUP_TWO] },
+      ...accounts,
+    ];
+    const page = await messages.read({ accounts: speakers, limit: WHOLE_HISTORY });
+    // Each speaker's own line reaches the address it arrived at — a memory
+    // store subtracts nothing — and the two the group itself holds reach
+    // nobody, which is what an address that names no account means.
+    expect(page.map((e) => e.ref)).not.toContain("wa:g3");
+    expect(page.map((e) => e.ref)).not.toContain("wa:g4");
+  });
+
+  it("reads a direct conversation under the address that names it", async () => {
+    const page = await messages.readConversation({
+      conversation: { channel: "whatsapp", id: PHONE },
+      limit: WHOLE_HISTORY,
+    });
+    expect(page.map((e) => e.ref)).toEqual(["wa:e", "wa:c", "wa:a"]);
+  });
+
+  it("scopes a conversation by the channel and the id together", async () => {
+    expect(
+      await messages.readConversation({
+        conversation: { channel: "linkedin", id: GROUP },
+        limit: WHOLE_HISTORY,
+      }),
+    ).toEqual([]);
   });
 
   it("holds nothing for an empty scope", async () => {

--- a/packages/core/src/channels/messages-memory.ts
+++ b/packages/core/src/channels/messages-memory.ts
@@ -18,9 +18,14 @@ export interface HeldMessage {
    * The conversation, when it is not the address.
    *
    * A direct conversation is addressed by the person on it, so a store that
-   * keys a thread by who is on it names both with one string — which is what a
-   * message with no conversation of its own says. A group is addressed by
-   * neither, so its messages name it here.
+   * keys a message by who it passed between names both with one string — which
+   * is what a message with no conversation of its own says. A store that keys a
+   * message by its thread instead names the thread here, the way a LinkedIn
+   * message hangs off a thread rather than off a member.
+   *
+   * A group's messages are held at the group, since that is what addresses one.
+   * So no account names them, and the account reads answer none of them without
+   * subtracting anything — which is the guarantee messages.ts states.
    */
   conversation?: string;
   entry: TimelineEntry;

--- a/packages/core/src/channels/messages-memory.ts
+++ b/packages/core/src/channels/messages-memory.ts
@@ -7,44 +7,65 @@ import {
   isAfterTimelineCursor,
   type TimelineEntry,
 } from "@rome/api-types/people";
-import type { MessageAccount, MessageRead, Messages } from "./messages.js";
+import type { ConversationRead, MessageAccount, MessageRead, Messages } from "./messages.js";
 
-/** One message the store holds, at the address it arrived on. */
+/** One message the store holds, at the address it arrived on and in the
+ *  conversation it was said in. */
 export interface HeldMessage {
   channel: string;
   address: string;
+  /**
+   * The conversation, when it is not the address.
+   *
+   * A direct conversation is addressed by the person on it, so a store that
+   * keys a thread by who is on it names both with one string — which is what a
+   * message with no conversation of its own says. A group is addressed by
+   * neither, so its messages name it here.
+   */
+  conversation?: string;
   entry: TimelineEntry;
 }
 
 /**
- * `Messages` over `held`, scoped by the `(channel, address)` pair — an address
- * on one channel never selects a message another channel stores under the same
- * string.
+ * `Messages` over `held`, scoped by the `(channel, address)` pair or by the
+ * `(channel, conversation)` one — a string on one channel never selects a
+ * message another channel stores under the same string, whichever of the two a
+ * read names.
  *
  * A message is answered once however many of the given accounts name its
  * address, because a read filters the list rather than making a pass per
  * address.
  */
 export function memoryMessages(held: readonly HeldMessage[]): Messages {
+  const ranked = (holds: (message: HeldMessage) => boolean): TimelineEntry[] =>
+    held
+      .filter(holds)
+      .map((message) => message.entry)
+      .sort(compareTimelineEntries);
+
   const full = (accounts: readonly MessageAccount[]): TimelineEntry[] => {
     const scope = new Set(
       accounts.flatMap((account) =>
-        account.addresses.map((address) => addressKey(account.channel, address)),
+        account.addresses.map((address) => pair(account.channel, address)),
       ),
     );
-    return held
-      .filter((message) => scope.has(addressKey(message.channel, message.address)))
-      .map((message) => message.entry)
-      .sort(compareTimelineEntries);
+    return ranked((message) => scope.has(pair(message.channel, message.address)));
   };
+
+  /** One page off a ranking: what every read here answers, and the only place
+   *  the cursor and the limit are applied. */
+  const page = (
+    entries: TimelineEntry[],
+    after: TimelineEntry | null,
+    limit: number,
+  ): TimelineEntry[] =>
+    entries
+      .filter((entry) => after === null || isAfterTimelineCursor(entry, after))
+      .slice(0, Math.max(1, Math.floor(limit)));
 
   return {
     async read(request: MessageRead) {
-      const after = request.after ?? null;
-      const limit = Math.max(1, Math.floor(request.limit));
-      return full(request.accounts)
-        .filter((entry) => after === null || isAfterTimelineCursor(entry, after))
-        .slice(0, limit);
+      return page(full(request.accounts), request.after ?? null, request.limit);
     },
 
     async count(accounts) {
@@ -54,7 +75,19 @@ export function memoryMessages(held: readonly HeldMessage[]): Messages {
     async latest(accounts) {
       return full(accounts)[0] ?? null;
     },
+
+    async readConversation(request: ConversationRead) {
+      const { channel, id } = request.conversation;
+      const inConversation = ranked(
+        (message) => pair(message.channel, conversationOf(message)) === pair(channel, id),
+      );
+      return page(inConversation, request.after ?? null, request.limit);
+    },
   };
 }
 
-const addressKey = (channel: string, address: string) => `${channel}\n${address}`;
+/** The conversation a held message was said in — the address it arrived at
+ *  unless it names another. */
+const conversationOf = (message: HeldMessage) => message.conversation ?? message.address;
+
+const pair = (channel: string, held: string) => `${channel}\n${held}`;

--- a/packages/core/src/channels/messages-sentinel.test.ts
+++ b/packages/core/src/channels/messages-sentinel.test.ts
@@ -8,6 +8,7 @@ import {
   type MessagesContractSubject,
 } from "./messages-contract.js";
 import { sentinelLogMessages } from "./messages-sentinel.js";
+import type { MessageConversation } from "./messages.js";
 
 // `sentinel_log` read as a `Messages` store, holding exactly what
 // `sentinelLogSource` holds today: one row as the two lines it records, and
@@ -20,6 +21,8 @@ const GROUP = "tg-group-1";
 
 const account = { channel: CHANNEL, addresses: [DIRECT, DIRECT_ALT] };
 const silent = [{ channel: CHANNEL, addresses: ["tg-nobody"] }];
+const groupThread: MessageConversation = { channel: CHANNEL, id: GROUP };
+const emptyThread: MessageConversation = { channel: CHANNEL, id: "tg-nothing-logged" };
 
 function row(
   db: DrizzleDb,
@@ -73,8 +76,11 @@ async function seed(db: DrizzleDb) {
   // An empty reply is no reply.
   await row(db, "quiet", { at: 1200, text: "hm", response: "", threadId: "tg-quiet-thread" });
 
-  // Out of scope: the thread a group session covers, and another sender.
+  // Out of every account's scope: the thread a group session covers, which only
+  // a conversation read reaches, and another sender. Two rows in the group, so
+  // the four lines they record are enough to page.
   await row(db, "in-group", { at: 900, text: "hi all", response: "hello", threadId: GROUP });
+  await row(db, "in-group-2", { at: 950, text: "still here", response: "yep", threadId: GROUP });
   await row(db, "stranger", { at: 1300, text: "who?", channelUserId: "tg-stranger" });
 }
 
@@ -117,6 +123,30 @@ describe("sentinelLogMessages", () => {
   it("subtracts a thread Rome knows to be a group, reply included", async () => {
     expect(await refs()).not.toContain("sentinel:in-group");
     expect(await refs()).not.toContain("sentinel:in-group:reply");
+  });
+
+  // The row names its thread as well as its sender, so a conversation read
+  // keys on the thread — which is the only way to the group the account reads
+  // subtract.
+  it("answers a group thread asked for as a conversation", async () => {
+    const page = await sentinelLogMessages(db).readConversation({
+      conversation: groupThread,
+      limit: WHOLE_HISTORY,
+    });
+    expect(page.map((entry) => entry.ref)).toEqual([
+      "sentinel:in-group-2:reply",
+      "sentinel:in-group-2",
+      "sentinel:in-group:reply",
+      "sentinel:in-group",
+    ]);
+  });
+
+  it("keeps a conversation on its own channel", async () => {
+    const elsewhere = await sentinelLogMessages(db).readConversation({
+      conversation: { channel: "discord", id: GROUP },
+      limit: WHOLE_HISTORY,
+    });
+    expect(elsewhere).toEqual([]);
   });
 
   it("subtracts only a group on the row's own channel", async () => {
@@ -162,7 +192,13 @@ testMessagesContract("sentinelLogMessages", () => {
   enrolled ??= (async () => {
     const { db } = createTestDb();
     await seed(db);
-    return { messages: sentinelLogMessages(db), accounts: [account], silent };
+    return {
+      messages: sentinelLogMessages(db),
+      accounts: [account],
+      silent,
+      conversation: groupThread,
+      silentConversation: emptyThread,
+    };
   })();
   return enrolled;
 });

--- a/packages/core/src/channels/messages-sentinel.ts
+++ b/packages/core/src/channels/messages-sentinel.ts
@@ -13,6 +13,10 @@ import { scopePairs, sqlMessages } from "./messages-sql.js";
  * Both halves share the row's one timestamp, and the ordering puts the reply
  * above the line it answers. Each carries its own `ref`, so the two never
  * collapse to one cursor position.
+ *
+ * A log row names both the sender and the thread, so the two scopes are the
+ * same query over two columns: an account read keys on the sender and a
+ * conversation read on the thread. Only the first has a group to subtract.
  */
 export function sentinelLogMessages(db: DrizzleDb): Messages {
   // No `channel`: the log holds every channel's triage side by side, so it is
@@ -20,13 +24,18 @@ export function sentinelLogMessages(db: DrizzleDb): Messages {
   return sqlMessages({
     db,
     view(scope) {
-      const addressed = scopePairs(scope, sql`l.channel`, sql`l.channel_user_id`);
+      const byThread = scope.by === "conversation";
+      const keyColumn = byThread ? sql`l.thread_id` : sql`l.channel_user_id`;
+      const addressed = scopePairs(scope.keys, sql`l.channel`, keyColumn);
       if (addressed === null) return null;
       // A log row names its sender but not whether they were alone. The
       // session that recorded the same thread does, so a thread Rome knows to
-      // be a group is what the scope subtracts — a row whose thread no session
-      // covers is a direct exchange until something says otherwise.
-      const direct = sql`
+      // be a group is what an account scope subtracts — a row whose thread no
+      // session covers is a direct exchange until something says otherwise. A
+      // conversation scope names the thread itself and subtracts nothing.
+      const direct = byThread
+        ? addressed
+        : sql`
         ${addressed}
         AND NOT EXISTS (
           SELECT 1 FROM rome_sessions s
@@ -38,7 +47,7 @@ export function sentinelLogMessages(db: DrizzleDb): Messages {
       return sql`
         SELECT
           l.channel AS source,
-          l.channel_user_id AS address,
+          ${keyColumn} AS key,
           l.created_at AS at,
           0 AS outbound,
           'sentinel:' || l.id AS ref,
@@ -48,7 +57,7 @@ export function sentinelLogMessages(db: DrizzleDb): Messages {
         UNION ALL
         SELECT
           l.channel,
-          l.channel_user_id,
+          ${keyColumn},
           l.created_at,
           1,
           'sentinel:' || l.id || ':reply',

--- a/packages/core/src/channels/messages-sql.ts
+++ b/packages/core/src/channels/messages-sql.ts
@@ -12,32 +12,56 @@
 import { sql, type SQL } from "drizzle-orm";
 import type { TimelineEntry } from "@rome/api-types/people";
 import type { DrizzleDb } from "../db/index.js";
-import type { MessageAccount, MessageRead, Messages } from "./messages.js";
+import type {
+  ConversationRead,
+  MessageAccount,
+  MessageConversation,
+  MessageRead,
+  Messages,
+} from "./messages.js";
 
 /**
  * A store's rows as timeline entries: a SELECT producing exactly the columns
- * `source`, `address`, `at`, `outbound`, `ref`, `body`.
+ * `source`, `key`, `at`, `outbound`, `ref`, `body`.
  *
- * - `source` is the channel an entry arrived on, and `address` an address of
- *   the account it belongs to — one of the addresses the view was given.
+ * - `source` is the channel an entry arrived on, and `key` the scope entry the
+ *   row answers for — one of the strings the view was handed, which is an
+ *   address of the account a message belongs to when the scope asks by account,
+ *   and the id of the conversation it was said in when it asks by conversation.
  * - `at` is epoch seconds, `outbound` is 1 for something Rome said and 0 for
  *   something it was told, `body` is the line to render or NULL.
  * - `ref` must be unique across everything the store can put on one person's
  *   timeline. Ids unique only within a conversation (a WhatsApp message id, a
  *   LinkedIn message id) are qualified by the conversation.
  *
- * A row may repeat one message under several addresses — a LinkedIn thread
- * carrying two member ids of the same person answers under both. The reads
- * below fold those together, so a view is free to attribute rather than choose.
+ * A row may repeat one message under several keys — a LinkedIn thread carrying
+ * two member ids of the same person answers under both. The reads below fold
+ * those together, so a view is free to attribute rather than choose.
  */
 export type MessageViewSql = SQL;
 
-/** One address, on the channel that holds it. What a store is scoped by, since
- *  the pair is what names a conversation: two channels are free to spell an
- *  address the same way and mean two different people. */
-export interface MessageAddress {
+/** One string a store is scoped by, on the channel that holds it — an address,
+ *  or a conversation id. The pair rather than the string alone, since the pair
+ *  is what names the thing: two channels are free to spell one the same way and
+ *  mean two different people, or two different threads. */
+export interface MessageScopeKey {
   channel: string;
-  address: string;
+  key: string;
+}
+
+/**
+ * What a batch of calls asked a store for.
+ *
+ * `by` is the question, and it is the whole difference between the reads a
+ * store answers: the same rows, scoped by who a message passed between or by
+ * the thread it was said in. A batch asks one question — the queues below are
+ * per question — so a view reads `by` once and scopes its rows to match.
+ */
+export interface MessageScope {
+  by: "account" | "conversation";
+  /** Every key the batch named, each once. Never empty: a request that can hold
+   *  nothing is answered without reaching the view at all. */
+  keys: readonly MessageScopeKey[];
 }
 
 export interface SqlMessagesOptions {
@@ -48,19 +72,18 @@ export interface SqlMessagesOptions {
    *
    * Absent for a store that holds every channel's messages side by side and
    * keys them by the pair: Rome's own transcript, the sentinel's log. Such a
-   * store is scoped by `(channel, address)` throughout, and its view is handed
-   * the pairs rather than bare addresses so it can say the same.
+   * store is scoped by `(channel, key)` throughout, and its view is handed the
+   * pairs rather than bare strings so it can say the same.
    */
   channel?: string;
   db: DrizzleDb;
   /**
-   * The store's rows, scoped to every address of every account a batch of
-   * calls named, deduplicated.
+   * The store's rows, scoped to what a batch of calls named.
    *
    * Null when the request can hold nothing, and the store then answers empty
    * without a query.
    */
-  view(scope: readonly MessageAddress[]): MessageViewSql | null;
+  view(scope: MessageScope): MessageViewSql | null;
   /**
    * The view's `body` column mapped to the line to render, for a store whose
    * text is not stored as text — Rome's transcript keeps a JSON array of
@@ -73,9 +96,9 @@ export interface SqlMessagesOptions {
 /**
  * `Messages` over one SQL view.
  *
- * Every call — `read`, `count`, `latest` — is one job on one queue, and the
- * jobs raised in a tick are answered by a single statement. What differs
- * between them is only the shape of the job:
+ * Every call — `read`, `count`, `latest`, `readConversation` — is one job on a
+ * queue, and the jobs raised in a tick are answered by a single statement. What
+ * differs between them is only the shape of the job:
  *
  * - `read` asks for a page and takes the entries.
  * - `latest` asks for a page of one and takes its head.
@@ -85,12 +108,19 @@ export interface SqlMessagesOptions {
  * So the law messages.ts states holds by construction rather than by three
  * queries agreeing: the count is the length of the history the page walks,
  * because both are read off the same ranking of the same rows.
+ *
+ * A queue per question rather than one for all four, because a batch reaches
+ * the view as a single scope: account jobs and conversation jobs pooled
+ * together would ask one SELECT to answer two questions. The grouping that
+ * matters is untouched — a directory read raises account jobs only, and those
+ * still share one pass.
  */
 export function sqlMessages(options: SqlMessagesOptions): Messages {
-  const submit = batched<Job, JobResult>((jobs) => runBatch(options, jobs));
+  const byAccount = batched<Job, JobResult>((jobs) => runBatch(options, "account", jobs));
+  const byConversation = batched<Job, JobResult>((jobs) => runBatch(options, "conversation", jobs));
 
   const job = (accounts: readonly MessageAccount[], after: TimelineEntry | null, limit: number) =>
-    submit({ scope: scopeOf(accounts, options.channel), after, limit });
+    byAccount({ keys: accountKeys(accounts, options.channel), after, limit });
 
   return {
     async read(request: MessageRead) {
@@ -105,6 +135,16 @@ export function sqlMessages(options: SqlMessagesOptions): Messages {
     async latest(accounts) {
       return (await job(accounts, null, 1)).entries[0] ?? null;
     },
+
+    async readConversation(request: ConversationRead) {
+      const limit = Math.max(1, Math.floor(request.limit));
+      const answered = await byConversation({
+        keys: conversationKeys(request.conversation, options.channel),
+        after: request.after ?? null,
+        limit,
+      });
+      return answered.entries;
+    },
   };
 }
 
@@ -116,30 +156,42 @@ export function sqlMessages(options: SqlMessagesOptions): Messages {
  * one channel drops the accounts on every other here; a store that serves them
  * all keeps the channel beside each address and matches on both.
  */
-function scopeOf(
+function accountKeys(
   accounts: readonly MessageAccount[],
   channel: string | undefined,
-): MessageAddress[] {
-  const scope = new Map<string, MessageAddress>();
+): MessageScopeKey[] {
+  const scope = new Map<string, MessageScopeKey>();
   for (const account of accounts) {
     if (channel !== undefined && account.channel !== channel) continue;
     for (const address of account.addresses) {
-      scope.set(`${account.channel}\n${address}`, { channel: account.channel, address });
+      scope.set(`${account.channel}\n${address}`, { channel: account.channel, key: address });
     }
   }
   return [...scope.values()];
 }
 
-/** Every address in a scope, each once — what a view on a single channel needs,
- *  the channel being its own. */
-export function addressesIn(scope: readonly MessageAddress[]): string[] {
-  return [...new Set(scope.map((entry) => entry.address))];
+/** The conversation as the batch names it, and nothing at all when the store
+ *  serves another channel — the same subtraction {@link accountKeys} makes for
+ *  an account, a conversation id being no more portable across channels than an
+ *  address is. */
+function conversationKeys(
+  conversation: MessageConversation,
+  channel: string | undefined,
+): MessageScopeKey[] {
+  if (channel !== undefined && conversation.channel !== channel) return [];
+  return [{ channel: conversation.channel, key: conversation.id }];
+}
+
+/** Every key in a scope, each once — what a view on a single channel needs, the
+ *  channel being its own. */
+export function keysIn(scope: readonly MessageScopeKey[]): string[] {
+  return [...new Set(scope.map((entry) => entry.key))];
 }
 
 /** One call, as the batch sees it. `limit` of {@link COUNT_ONLY} is a job that
  *  wants the length of a history and none of it. */
 interface Job {
-  scope: readonly MessageAddress[];
+  keys: readonly MessageScopeKey[];
   after: TimelineEntry | null;
   limit: number;
 }
@@ -160,26 +212,28 @@ const nothing = (): JobResult => ({ entries: [], total: 0 });
 /**
  * One statement for a whole batch.
  *
- * The jobs enter the query as two tables of their own — which addresses each
- * asked about, and where each wants to resume and how much of the history it
- * wants — so the rows are scoped, ranked and cut per job inside a single pass
- * rather than once per job.
+ * The jobs enter the query as two tables of their own — which keys each asked
+ * about, and where each wants to resume and how much of the history it wants —
+ * so the rows are scoped, ranked and cut per job inside a single pass rather
+ * than once per job.
  */
-async function runBatch(options: SqlMessagesOptions, jobs: Job[]): Promise<JobResult[]> {
-  const asked = jobs.flatMap((job, index) => job.scope.map((entry) => ({ index, ...entry })));
+async function runBatch(
+  options: SqlMessagesOptions,
+  by: MessageScope["by"],
+  jobs: Job[],
+): Promise<JobResult[]> {
+  const asked = jobs.flatMap((job, index) => job.keys.map((entry) => ({ index, ...entry })));
   if (asked.length === 0) return jobs.map(nothing);
 
-  const wanted = new Map(asked.map((entry) => [`${entry.channel}\n${entry.address}`, entry]));
-  const rows = options.view(
-    [...wanted.values()].map(({ channel, address }) => ({
-      channel,
-      address,
-    })),
-  );
+  const wanted = new Map(asked.map((entry) => [`${entry.channel}\n${entry.key}`, entry]));
+  const rows = options.view({
+    by,
+    keys: [...wanted.values()].map(({ channel, key }) => ({ channel, key })),
+  });
   if (rows === null) return jobs.map(nothing);
 
   const scope = sql.join(
-    asked.map((entry) => sql`(${entry.index}, ${entry.channel}, ${entry.address})`),
+    asked.map((entry) => sql`(${entry.index}, ${entry.channel}, ${entry.key})`),
     sql`, `,
   );
   const ask = sql.join(
@@ -188,10 +242,10 @@ async function runBatch(options: SqlMessagesOptions, jobs: Job[]): Promise<JobRe
   );
 
   const answered = (await options.db.all(sql`
-    WITH scope(rq, source, address) AS (VALUES ${scope}),
+    WITH scope(rq, source, held_key) AS (VALUES ${scope}),
     ask(rq, cap, has_cursor, c_at, c_outbound, c_source, c_ref) AS (VALUES ${ask}),
     -- One row per (job, message). DISTINCT because a view may attribute one
-    -- message to several of a job's addresses — a LinkedIn thread carrying two
+    -- message to several of a job's keys — a LinkedIn thread carrying two
     -- member ids of the same person — and a person's history shows a message
     -- once however many ways they are named on it.
     scoped AS (
@@ -203,10 +257,10 @@ async function runBatch(options: SqlMessagesOptions, jobs: Job[]): Promise<JobRe
         held.ref AS ref,
         held.body AS body
       FROM (${rows}) held
-      -- The pair, never the address alone: a store holding several channels
-      -- side by side would otherwise hand one channel's message to a job that
-      -- asked about the same string on another.
-      JOIN scope ON scope.source = held.source AND scope.address = held.address
+      -- The pair, never the key alone: a store holding several channels side by
+      -- side would otherwise hand one channel's message to a job that asked
+      -- about the same string on another.
+      JOIN scope ON scope.source = held.source AND scope.held_key = held.key
     ),
     -- Each job's own history, ranked and measured in one pass. One named
     -- window rather than two inline ones: SQLite shares a partition pass only
@@ -341,27 +395,27 @@ function batched<J, R>(run: (jobs: J[]) => Promise<R[]>): (job: J) => Promise<R>
 }
 
 /**
- * A whole scope as a WHERE clause: `(channel = … AND address IN (…))` per
- * channel, or'd together, and null when the scope is empty.
+ * A whole scope as a WHERE clause: `(channel = … AND key IN (…))` per channel,
+ * or'd together, and null when the scope is empty.
  *
  * What a store holding several channels side by side scopes itself with. The
- * pair rather than the address alone, for the reason the batch's join gives:
- * two channels may spell an address the same way and mean two people.
+ * pair rather than the key alone, for the reason the batch's join gives: two
+ * channels may spell one the same way and mean two different things.
  */
 export function scopePairs(
-  scope: readonly MessageAddress[],
+  scope: readonly MessageScopeKey[],
   channelColumn: SQL,
-  addressColumn: SQL,
+  keyColumn: SQL,
 ): SQL | null {
   const byChannel = new Map<string, string[]>();
-  for (const { channel, address } of scope) {
-    const addresses = byChannel.get(channel);
-    if (addresses) addresses.push(address);
-    else byChannel.set(channel, [address]);
+  for (const { channel, key } of scope) {
+    const keys = byChannel.get(channel);
+    if (keys) keys.push(key);
+    else byChannel.set(channel, [key]);
   }
   const clauses = [...byChannel]
-    .map(([channel, addresses]) => {
-      const held = inList(addressColumn, addresses);
+    .map(([channel, keys]) => {
+      const held = inList(keyColumn, keys);
       return held === null ? null : sql`(${channelColumn} = ${channel} AND ${held})`;
     })
     .filter((clause): clause is SQL => clause !== null);

--- a/packages/core/src/channels/messages.ts
+++ b/packages/core/src/channels/messages.ts
@@ -2,10 +2,13 @@
  * What was said to a channel's accounts, as one store holds it. `Accounts` (accounts.ts) answers who a channel can reach, and this
  * answers what passed between Rome and them.
  *
- * A message is a {@link TimelineEntry}. The shape, the ordering and the cursor
- * belong to the People contract (`@rome/api-types/people`), because what a
- * store answers here is what a person's timeline pages. A second definition of
- * either is a page boundary the two ends disagree about.
+ * A message is a {@link TimelineEntry}, however the store was asked for it. A
+ * store holds one history and ranks it one way, and every read below cuts that
+ * one ranking. The shape, the ordering and the cursor are written down in the
+ * People contract (`@rome/api-types/people`) because a person's timeline was
+ * the first surface to page them, not because it is the only one: a second
+ * shape here would be a second ranking of the same rows, which is a page
+ * boundary the two ends disagree about.
  */
 
 import type { TimelineEntry } from "@rome/api-types/people";
@@ -30,6 +33,24 @@ export interface MessageAccount {
   addresses: readonly string[];
 }
 
+/**
+ * One conversation a store reads for: the thread a message was said in, named
+ * by the platform's own id for it, on the channel that holds it.
+ *
+ * The pair rather than the id alone, for the reason an account carries its
+ * channel — two channels are free to spell an id the same way and mean two
+ * different threads.
+ *
+ * A direct conversation is addressed by the person on it, so on a channel that
+ * keys a thread by who is on it the id is also an address of their account. A
+ * group conversation is addressed by the group and by nobody on it, so no
+ * account names it and only this names it.
+ */
+export interface MessageConversation {
+  channel: string;
+  id: string;
+}
+
 export interface MessageRead {
   accounts: readonly MessageAccount[];
   /** The entry the previous page ended on. Null or absent for the first page. */
@@ -37,16 +58,23 @@ export interface MessageRead {
   limit: number;
 }
 
+export interface ConversationRead {
+  conversation: MessageConversation;
+  /** The entry the previous page ended on. Null or absent for the first page. */
+  after?: TimelineEntry | null;
+  limit: number;
+}
+
 /**
- * One message store, read for a set of accounts at once.
+ * One message store, asked for a set of accounts or for a conversation.
  *
- * The set is read as one history: a person holds several accounts and an
- * account several addresses, and the caller wants the messages merged, not one
- * sequence per address.
+ * A set of accounts is read as one history: a person holds several accounts and
+ * an account several addresses, and the caller wants the messages merged, not
+ * one sequence per address.
  *
- * One law binds the three verbs. Call the *full read* of a set of accounts the
- * `read` with no cursor and a limit large enough to hold everything the store
- * can answer for them:
+ * One law binds the three account-scoped verbs. Call the *full read* of a set
+ * of accounts the `read` with no cursor and a limit large enough to hold
+ * everything the store can answer for them:
  *
  * - `count` is the length of the full read.
  * - `latest` is its first entry, and null when the full read is empty.
@@ -60,9 +88,10 @@ export interface MessageRead {
  * an account. There is no `holds` verb — a second way to ask the same question
  * is a second answer to disagree with.
  *
- * Direct threads only. A group conversation is addressed by the group rather
- * than by any person on it, so no address of an account names it and none of
- * its messages reaches these reads.
+ * `read`, `count` and `latest` answer direct threads only. A group
+ * conversation is addressed by the group rather than by any person on it, so no
+ * address of an account names it and none of its messages reaches those three.
+ * `readConversation` is what reaches it.
  */
 export interface Messages {
   /**
@@ -89,4 +118,27 @@ export interface Messages {
    * it in one pass over a whole directory rather than one page per row.
    */
   latest(accounts: readonly MessageAccount[]): Promise<TimelineEntry | null>;
+
+  /**
+   * The store's newest messages in `conversation`, on `read`'s terms exactly:
+   * at most `limit`, every one strictly after `after`, newest first and total.
+   *
+   * Every message of the conversation, including the ones the account-scoped
+   * verbs answer none of. A group's messages are the case that makes the verb
+   * worth having, and a direct conversation is answered here too — one store
+   * asked a second way, not a second store.
+   *
+   * Every store owes this verb, and none declines it. A store answering the
+   * account reads holds the rows a conversation read wants — it is the same
+   * history keyed the other way — so there is no way to say "not this one"
+   * here. A store that genuinely could not answer would be a second interface,
+   * and splitting one is a change to make when there is a store to make it for.
+   *
+   * An empty page is the whole answer for a conversation the store holds no
+   * messages of. A conversation the store has never heard of and one it holds
+   * empty are answered the same way: no caller has the question that tells
+   * them apart, and a store that failed the first would refuse a conversation
+   * that exists on the channel and has simply not been mirrored yet.
+   */
+  readConversation(request: ConversationRead): Promise<TimelineEntry[]>;
 }

--- a/packages/core/src/channels/whatsapp-messages.test.ts
+++ b/packages/core/src/channels/whatsapp-messages.test.ts
@@ -3,7 +3,7 @@ import { countingDb, createTestDb, type TestDb } from "../test/helpers.js";
 import { waMessages } from "../db/schema.js";
 import { testMessagesContract, WHOLE_HISTORY } from "./messages-contract.js";
 import { whatsAppMessages } from "./whatsapp-messages.js";
-import type { MessageAccount } from "./messages.js";
+import type { MessageAccount, MessageConversation } from "./messages.js";
 
 // `wa_messages` as a `Messages` store. What it must answer is the contract
 // suite's; what it must leave out is the mirror's own scoping — a group thread,
@@ -19,6 +19,8 @@ const GROUP = "1200000@g.us";
 const account = { channel: "whatsapp", addresses: [PHONE, LID] };
 const accounts = [account];
 const silent = [{ channel: "whatsapp", addresses: ["15554444@s.whatsapp.net"] }];
+const groupChat: MessageConversation = { channel: "whatsapp", id: GROUP };
+const emptyChat: MessageConversation = { channel: "whatsapp", id: "1299999@g.us" };
 
 interface Seed {
   id: string;
@@ -36,10 +38,16 @@ const seeds: Seed[] = [
   // settles the tie, and both have to survive a page boundary.
   { id: "d", chat: LID, at: 300, text: "and on the lid" },
   { id: "e", chat: PHONE, at: 500, text: "latest" },
-  // Out of scope, each for its own reason.
+  // Out of every account's scope, each for its own reason.
   { id: "r", chat: PHONE, at: 600, type: "reaction", text: "👍" },
-  { id: "g", chat: GROUP, at: 700, text: "in the group" },
   { id: "o", chat: OTHER, at: 800, text: "another contact" },
+  // The group, which only a conversation read reaches. Enough of it to page,
+  // and a second in it said twice so the ordering has a tie to settle.
+  { id: "g", chat: GROUP, at: 700, text: "in the group" },
+  { id: "g2", chat: GROUP, at: 700, fromMe: true, text: "answered the group" },
+  { id: "g3", chat: GROUP, at: 750, text: "and again" },
+  { id: "g4", chat: GROUP, at: 760, text: "latest in the group" },
+  { id: "gr", chat: GROUP, at: 770, type: "reaction", text: "👍" },
 ];
 
 function seedMirror(testDb: TestDb): void {
@@ -100,6 +108,48 @@ describe("whatsAppMessages", () => {
     const group: MessageAccount[] = [{ channel: "whatsapp", addresses: [GROUP] }];
     expect(await messages.latest(group)).toBeNull();
     expect(await messages.count(group)).toBe(0);
+  });
+
+  // The chat is the conversation: a WhatsApp message hangs off it, and a group
+  // chat is the one no account can name.
+  it("answers a group chat asked for as a conversation", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    const page = await messages.readConversation({ conversation: groupChat, limit: WHOLE_HISTORY });
+    // Newest first, the tie at 700 settled by direction, and the group's own
+    // reaction left out the way every read leaves one out.
+    expect(refs(page)).toEqual([`${GROUP}:g4`, `${GROUP}:g3`, `${GROUP}:g2`, `${GROUP}:g`]);
+  });
+
+  it("answers a group chat's messages to no account read", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    const held = await messages.read({ accounts, limit: WHOLE_HISTORY });
+    expect(refs(held).some((ref) => ref.startsWith(GROUP))).toBe(false);
+    // Nor to a caller that hands the group's own JID over as an address.
+    const asAccount: MessageAccount[] = [{ channel: "whatsapp", addresses: [GROUP] }];
+    expect(await messages.read({ accounts: asAccount, limit: WHOLE_HISTORY })).toEqual([]);
+    expect(await messages.count(asAccount)).toBe(0);
+    expect(await messages.latest(asAccount)).toBeNull();
+  });
+
+  it("answers a direct chat asked for as a conversation", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    // A direct chat is addressed by the contact, so its id is the address the
+    // account already reads under — one store asked a second way.
+    const page = await messages.readConversation({
+      conversation: { channel: "whatsapp", id: PHONE },
+      limit: WHOLE_HISTORY,
+    });
+    expect(refs(page)).toEqual([`${PHONE}:e`, `${PHONE}:c`, `${PHONE}:a`]);
+  });
+
+  it("holds nothing for a conversation on another channel", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    expect(
+      await messages.readConversation({
+        conversation: { channel: "linkedin", id: GROUP },
+        limit: WHOLE_HISTORY,
+      }),
+    ).toEqual([]);
   });
 
   it("holds nothing for an account on another channel", async () => {
@@ -188,5 +238,11 @@ describe("whatsAppMessages", () => {
 testMessagesContract("whatsAppMessages", () => {
   const testDb = createTestDb();
   seedMirror(testDb);
-  return { messages: whatsAppMessages(testDb.db), accounts, silent };
+  return {
+    messages: whatsAppMessages(testDb.db),
+    accounts,
+    silent,
+    conversation: groupChat,
+    silentConversation: emptyChat,
+  };
 });

--- a/packages/core/src/channels/whatsapp-messages.ts
+++ b/packages/core/src/channels/whatsapp-messages.ts
@@ -1,49 +1,52 @@
 import { sql } from "drizzle-orm";
 import type { DrizzleDb } from "../db/index.js";
 import type { Messages } from "./messages.js";
-import { addressesIn, inList, sqlMessages } from "./messages-sql.js";
+import { inList, keysIn, sqlMessages } from "./messages-sql.js";
 
 /**
  * `Messages` over the WhatsApp message mirror (`wa_messages`) — the thread as
  * the channel has it, which is the fullest record of a WhatsApp conversation
  * Rome holds.
  *
- * Scoped by chat: a WhatsApp message hangs off the chat it was said in, and a
- * direct chat is addressed by the contact, so the account's own addresses are
- * the whole scope. A contact reachable both as a phone JID and as a `@lid` JID
- * has a chat under each, and `WhatsAppAccounts` folds both onto one account —
- * so a caller that passes the account's addresses reads one history rather
+ * Scoped by chat either way it is asked. A WhatsApp message hangs off the chat
+ * it was said in, a direct chat is addressed by the contact, and a chat's JID
+ * is what WhatsApp calls the conversation — so an account's addresses and a
+ * conversation's id select on the same column, and the scopes differ only in
+ * what they subtract. A contact reachable both as a phone JID and as a `@lid`
+ * JID has a chat under each, and `WhatsAppAccounts` folds both onto one account
+ * — so a caller that passes the account's addresses reads one history rather
  * than whichever half its person mapping happened to name.
  *
  * Two things the mirror holds are left out:
  *
- * - Group chats (`@g.us`). A group is addressed by the group rather than by
- *   anyone on it, so no address of an account names one — the `NOT LIKE` is
- *   belt and braces against a group JID arriving as an address.
- * - Reactions. A reaction answers a line rather than being one, and the
- *   address book's own activity already leaves it out of what an account last
- *   did. Carrying it here would let a directory row preview a thumbs-up and
- *   open on the message it was aimed at.
+ * - Group chats (`@g.us`), from the account reads. A group is addressed by the
+ *   group rather than by anyone on it, so no address of an account names one —
+ *   the `NOT LIKE` is belt and braces against a group JID arriving as an
+ *   address. A conversation read names the group itself and answers it.
+ * - Reactions, from every read. A reaction answers a line rather than being
+ *   one, and the address book's own activity already leaves it out of what an
+ *   account last did. Carrying it here would let a directory row preview a
+ *   thumbs-up and open on the message it was aimed at, and would put one in a
+ *   conversation between the lines it was aimed at.
  */
 export function whatsAppMessages(db: DrizzleDb): Messages {
   return sqlMessages({
     channel: "whatsapp",
     db,
     view(scope) {
-      const addresses = addressesIn(scope);
-      const chats = inList(sql`m.chat_jid`, addresses);
+      const chats = inList(sql`m.chat_jid`, keysIn(scope.keys));
       if (chats === null) return null;
+      const held = scope.by === "account" ? sql`${chats} AND m.chat_jid NOT LIKE '%@g.us'` : chats;
       return sql`
         SELECT
           'whatsapp' AS source,
-          m.chat_jid AS address,
+          m.chat_jid AS key,
           m.timestamp AS at,
           CASE WHEN m.from_me THEN 1 ELSE 0 END AS outbound,
           m.chat_jid || ':' || m.id AS ref,
           m.text AS body
         FROM wa_messages m
-        WHERE ${chats}
-          AND m.chat_jid NOT LIKE '%@g.us'
+        WHERE ${held}
           AND coalesce(m.type, '') <> 'reaction'`;
     },
   });


### PR DESCRIPTION
Closes #162.

## What this PR does

Rome asks a [channel](https://github.com/rome-os/rome/blob/main/docs/concepts/messaging.md#channels) two questions about its history. One is what passed between Rome and a person, which is what a person's timeline pages. The other is what a conversation holds, including a group conversation nobody in particular is addressed on.

`Messages` answered only the first. The second went to a live connection instead (`handleTalkHistory` → `talk-features.ts`), so it failed whenever the transport was down, and it was not asked through the one interface every channel is read through.

`Messages` now grows `readConversation` beside `read`, `count` and `latest`, and all five stores answer it. Both mirrors already held the group conversations their account reads throw away — WhatsApp by `chat_jid NOT LIKE '%@g.us'`, LinkedIn by `t.is_group` and a participant count of two. The rows were there and nothing asked for them.

## Design & Invariants

**One store asked two ways, not two histories.** A conversation is named by `(channel, id)` for the reason an account carries its channel: two channels are free to spell an id the same way and mean two different threads. `sqlMessages`'s view is handed a scope that says which question the batch asks, so the four SQL stores answer both from one description of their rows. The join column that was `address` is now `key` — an address under an account scope, a conversation id under a conversation scope.

**Two decisions the issue left to this PR.**

*What the read returns.* `TimelineEntry`, the same as the account reads. A store holds one history and ranks it one way, and both reads cut that one ranking — the SQL half literally answers them off the same window. A twin type with the same five fields would need either a second comparator (two rankings of one store's rows) or a cast, and messages.ts already states its order as `compareTimelineEntries`. So the reason moves rather than the type: the shape, the ordering and the cursor are the store's, written down in the People contract because a person's timeline was the first surface to page them.

*What a store answers when it holds no conversation read.* Every store owes the verb; the interface carves out no way to decline it, because a store answering the account reads already holds the rows a conversation read wants. A store that genuinely could not answer would be a second interface, and splitting one is a change to make when there is a store to make it for.

Separately, a conversation the store holds nothing of is answered with an empty page — a conversation never heard of and one held empty are one answer, since no caller has the question that tells them apart, and failing the first would refuse a thread the mirror has simply not caught up with.

**A queue per question.** `sqlMessages` batches account jobs and conversation jobs on separate microtask queues, because a batch reaches the view as a single scope and pooling the two would ask one SELECT to answer two questions. The grouping that matters is untouched: a directory read raises account jobs only and still costs one pass, which the existing per-store batching tests still assert.

Vocabulary for the new noun lands in [`docs/concepts/messaging.md`](docs/concepts/messaging.md#conversation). The northstar it satisfies is already in [`docs/northstars/channels.md`](docs/northstars/channels.md) — "A channel answers for what was said to a person and for what a conversation holds" (#161).

## Test plan

- [x] `testMessagesContract` states the new verb's obligations — order, cursor, exhaustion, distinct cursor positions, and the empty answer — and all five enrolled stores pass them: `agentMessages`, `sentinelLogMessages`, `linkedInMessages`, `memoryMessages`, `whatsAppMessages`. Each enrolls a group conversation, since a group is the conversation no account read reaches.
- [x] `whatsAppMessages` answers a group chat's four messages when asked for that chat, leaves the group's reaction out, and answers none of them to any account read — including one handing the group's JID over as an address (`src/channels/whatsapp-messages.test.ts`).
- [x] `linkedInMessages` answers a three-handed thread and a thread LinkedIn flags as a group when asked for those threads, and answers neither to the account reads of every member on them (`src/channels/linkedin-messages.test.ts`).
- [x] Both channel stores still take nothing but the database — `whatsAppMessages(db)` and `linkedInMessages(db)` are unchanged, and every test above runs against a bare test database with no connection open.
- [x] `pnpm typecheck`.
- [x] `pnpm test:unit` — 377 files, 4413 tests passing. The diff changes no call site of `read`, `count` or `latest`.

## Not in this PR

- Moving `handleTalkHistory` off the live connection onto this read. That is what the read makes possible, not part of adding it.
- Who said each line of a group. `TimelineEntry` carries a direction, not a sender, and the LinkedIn mirror has no sender member id to carry — a field half the channel stores could only answer null for is worth less than the follow-up that gives them one.
- Discord and email joining `channelList`, and the Telegram personal session, whose history read goes through the transport itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
