### PR TITLE
fix(core): reconcile public access at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -276,6 +276,9 @@ WORKDIR /opt/rome
 COPY --chown=rome:rome --from=builder /build/ ./
 
 ENV ROME_DOCKER_APP_CODE_MODE=${ROME_DOCKER_APP_CODE_MODE}
+# Explicitly declare ownership of the production proxy config so daemon
+# startup reconciliation is enabled without inferring ownership from a path.
+ENV CADDY_CONFIG_PATH=/etc/caddy/Caddyfile
 
 RUN case "$ROME_DOCKER_APP_CODE_MODE" in \
       source) ;; \

--- a/packages/core/src/api/routes/public-access.test.ts
+++ b/packages/core/src/api/routes/public-access.test.ts
@@ -144,7 +144,8 @@ describe("Public-access API", () => {
       });
       writeFileSync(caddyPath, "stale Caddyfile");
 
-      await reconcilePublicAccessAtStartup(testDb.db, publicAccessState);
+      const config = await publicAccessState.load(testDb.db);
+      await reconcilePublicAccessAtStartup(testDb.db, config);
 
       const caddyfile = readFileSync(caddyPath, "utf-8");
       expect(caddyfile).not.toContain("stale Caddyfile");
@@ -153,6 +154,21 @@ describe("Public-access API", () => {
       expect(reloadArgs()).toEqual(["reload", "--config", caddyPath]);
       expect([...publicAccessState.allowedApps()]).toEqual(["inbox"]);
       expect([...publicAccessState.cloudEmailsForApp("inbox")]).toEqual(["ada@example.com"]);
+    });
+
+    it("loads the policy without reconciling when Caddy is not configured", async () => {
+      delete process.env.CADDY_CONFIG_PATH;
+      await deps.settingsRepo!.set("publicAccess", {
+        enableAccessControl: true,
+        allowedApps: ["inbox"],
+      });
+
+      const config = await publicAccessState.load(testDb.db);
+      await reconcilePublicAccessAtStartup(testDb.db, config);
+
+      expect([...publicAccessState.allowedApps()]).toEqual(["inbox"]);
+      expect(reloadArgs()).toBeNull();
+      expect(existsSync(caddyPath)).toBe(false);
     });
   });
 

--- a/packages/core/src/api/routes/public-access.test.ts
+++ b/packages/core/src/api/routes/public-access.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Hono } from "hono";
 import { publicAccessRoutes } from "./public-access.js";
+import { reconcilePublicAccessAtStartup } from "../../lib/public-access.js";
 import { PublicAccessState } from "../../lib/public-access-state.js";
 import { createTestDb, buildTestDeps, type TestDb } from "../../test/helpers.js";
 import type { ApiDeps } from "../deps.js";
@@ -134,8 +135,29 @@ describe("Public-access API", () => {
     });
   });
 
+  describe("startup reconciliation", () => {
+    it("rewrites the Caddyfile and reloads from the stored normalized policy", async () => {
+      await deps.settingsRepo!.set("publicAccess", {
+        enableAccessControl: true,
+        allowedApps: ["inbox", "inbox", "not a slug"],
+        cloudEmailAccess: { inbox: ["Ada@Example.com"], "not a slug": ["ignored@example.com"] },
+      });
+      writeFileSync(caddyPath, "stale Caddyfile");
+
+      await reconcilePublicAccessAtStartup(testDb.db, publicAccessState);
+
+      const caddyfile = readFileSync(caddyPath, "utf-8");
+      expect(caddyfile).not.toContain("stale Caddyfile");
+      expect(caddyfile).toContain("handle /apps/inbox {");
+      expect(caddyfile).not.toContain("not a slug");
+      expect(reloadArgs()).toEqual(["reload", "--config", caddyPath]);
+      expect([...publicAccessState.allowedApps()]).toEqual(["inbox"]);
+      expect([...publicAccessState.cloudEmailsForApp("inbox")]).toEqual(["ada@example.com"]);
+    });
+  });
+
   describe("PUT /public-access", () => {
-    it("persists the normalized config, writes the Caddyfile, and reloads caddy", async () => {
+    it("persists the normalized config, refreshes auth state, writes the Caddyfile, and reloads caddy", async () => {
       const res = await putConfig(
         JSON.stringify({
           enableAccessControl: true,
@@ -163,6 +185,8 @@ describe("Public-access API", () => {
       expect(caddyfile).not.toContain("forward_auth");
 
       expect(reloadArgs()).toEqual(["reload", "--config", caddyPath]);
+      expect([...publicAccessState.allowedApps()]).toEqual(["inbox"]);
+      expect([...publicAccessState.cloudEmailsForApp("inbox")]).toEqual(["ada@example.com"]);
     });
 
     it("refreshes the auth-edge allowed-apps snapshot", async () => {
@@ -195,6 +219,9 @@ describe("Public-access API", () => {
       const body = (await res.json()) as { ok: boolean; detail: string };
       expect(body.ok).toBe(false);
       expect(body.detail).toContain("caddy");
+      expect(body.detail).toContain("The stored public-access policy has already been updated");
+      expect(body.detail).toContain("the proxy may still be using its previous configuration");
+      expect(body.detail).toContain("Retry the request or restart Rome to reconcile it.");
 
       // The DB write and auth-edge snapshot happen before the reload, so a
       // failed reload must not roll them back — verify stays consistent with

--- a/packages/core/src/api/routes/public-access.test.ts
+++ b/packages/core/src/api/routes/public-access.test.ts
@@ -69,6 +69,7 @@ describe("Public-access API", () => {
     );
     chmodSync(fakeCaddy, 0o755);
 
+    // The explicit path is also the startup ownership signal.
     process.env.CADDY_CONFIG_PATH = caddyPath;
     process.env.CADDY_SPY_FILE = spyFile;
     process.env.PATH = `${binDir}:${process.env.PATH}`;
@@ -156,7 +157,8 @@ describe("Public-access API", () => {
       expect([...publicAccessState.cloudEmailsForApp("inbox")]).toEqual(["ada@example.com"]);
     });
 
-    it("loads the policy without reconciling when Caddy is not configured", async () => {
+    it("loads the policy without reconciling when CADDY_CONFIG_PATH is unset", async () => {
+      writeFileSync(caddyPath, "host-owned Caddyfile");
       delete process.env.CADDY_CONFIG_PATH;
       await deps.settingsRepo!.set("publicAccess", {
         enableAccessControl: true,
@@ -168,7 +170,7 @@ describe("Public-access API", () => {
 
       expect([...publicAccessState.allowedApps()]).toEqual(["inbox"]);
       expect(reloadArgs()).toBeNull();
-      expect(existsSync(caddyPath)).toBe(false);
+      expect(readFileSync(caddyPath, "utf-8")).toBe("host-owned Caddyfile");
     });
   });
 

--- a/packages/core/src/api/routes/public-access.ts
+++ b/packages/core/src/api/routes/public-access.ts
@@ -53,7 +53,15 @@ export function publicAccessRoutes(deps: ApiDeps): Hono {
         error instanceof Error && error.message
           ? error.message
           : "Failed to apply proxy configuration";
-      return c.json({ ok: false, error: "Failed to apply proxy configuration", detail }, 500);
+      const reconciliationDetail = [
+        "The stored public-access policy has already been updated, but the proxy may still be using its previous configuration.",
+        "Retry the request or restart Rome to reconcile it.",
+        detail,
+      ].join(" ");
+      return c.json(
+        { ok: false, error: "Failed to apply proxy configuration", detail: reconciliationDetail },
+        500,
+      );
     }
 
     return c.json({ ok: true });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1146,9 +1146,16 @@ async function main() {
   };
   const publicAccessState = new PublicAccessState();
   try {
-    await reconcilePublicAccessAtStartup(db, publicAccessState);
+    const config = await publicAccessState.load(db);
+    try {
+      await reconcilePublicAccessAtStartup(db, config);
+    } catch (err) {
+      log.warn("Failed to reconcile publicAccess settings with Caddy at startup; continuing", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   } catch (err) {
-    log.warn("Failed to reconcile publicAccess settings with Caddy at startup; continuing", {
+    log.warn("Failed to load publicAccess settings; starting with empty allow-list", {
       error: err instanceof Error ? err.message : String(err),
     });
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -111,6 +111,7 @@ import { startApi, type ApiHandle, type ApiDeps } from "./api/index.js";
 import { SystemUpgradeService } from "./system-upgrade/service.js";
 import { resolveAutoUpgradeEnabled } from "./lib/auto-upgrade-gate.js";
 import { PublicAccessState } from "./lib/public-access-state.js";
+import { reconcilePublicAccessAtStartup } from "./lib/public-access.js";
 import { DashboardAccessState } from "./lib/dashboard-access-state.js";
 import { ApprovalHandler } from "./actions/approval-handler.js";
 import { createBackendTurnRunner } from "./actions/backend-turn.js";
@@ -1145,9 +1146,9 @@ async function main() {
   };
   const publicAccessState = new PublicAccessState();
   try {
-    await publicAccessState.load(db);
+    await reconcilePublicAccessAtStartup(db, publicAccessState);
   } catch (err) {
-    log.warn("Failed to load publicAccess settings; starting with empty allow-list", {
+    log.warn("Failed to reconcile publicAccess settings with Caddy at startup; continuing", {
       error: err instanceof Error ? err.message : String(err),
     });
   }

--- a/packages/core/src/lib/public-access-state.ts
+++ b/packages/core/src/lib/public-access-state.ts
@@ -4,6 +4,7 @@ import type { DrizzleDb } from "../db/index.js";
 import {
   DEFAULT_PUBLIC_ACCESS_CONFIG,
   normalizePublicAccessConfig,
+  type PublicAccessConfig,
 } from "./public-access-config.js";
 
 /**
@@ -54,12 +55,14 @@ export class PublicAccessState {
     this.setCloudEmailAccess(config.cloudEmailAccess);
   }
 
-  async load(db: DrizzleDb): Promise<void> {
+  /** Loads and normalizes the stored policy, updates this snapshot, and returns that config. */
+  async load(db: DrizzleDb): Promise<PublicAccessConfig> {
     const rows = await db.select().from(settings).where(eq(settings.key, "publicAccess"));
     const config =
       rows.length > 0 && rows[0].value
         ? normalizePublicAccessConfig(rows[0].value)
         : DEFAULT_PUBLIC_ACCESS_CONFIG;
     this.setConfig(config);
+    return config;
   }
 }

--- a/packages/core/src/lib/public-access.ts
+++ b/packages/core/src/lib/public-access.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../logger.js";
 import { generateCaddyfile } from "./caddyfile-generator.js";
 import { generateGatewayPage, getInstanceName } from "./gateway-page.js";
 import type { PublicAccessConfig } from "./public-access-config.js";
+import type { PublicAccessState } from "./public-access-state.js";
 
 export { generateCaddyfile } from "./caddyfile-generator.js";
 
@@ -20,6 +21,15 @@ function execFileAsync(command: string, args: string[], timeout: number): Promis
       resolve();
     });
   });
+}
+
+/** Loads the stored policy, updates the auth snapshot, and reconciles Caddy from that config. */
+export async function reconcilePublicAccessAtStartup(
+  db: DrizzleDb,
+  publicAccessState: PublicAccessState,
+): Promise<void> {
+  const config = await publicAccessState.load(db);
+  await writeCaddyfileAndReload(db, config);
 }
 
 export async function writeCaddyfileAndReload(

--- a/packages/core/src/lib/public-access.ts
+++ b/packages/core/src/lib/public-access.ts
@@ -1,15 +1,16 @@
 import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import type { DrizzleDb } from "../db/index.js";
 import { createLogger } from "../logger.js";
 import { generateCaddyfile } from "./caddyfile-generator.js";
 import { generateGatewayPage, getInstanceName } from "./gateway-page.js";
 import type { PublicAccessConfig } from "./public-access-config.js";
-import type { PublicAccessState } from "./public-access-state.js";
 
 export { generateCaddyfile } from "./caddyfile-generator.js";
 
 const log = createLogger("public-access");
+const DEFAULT_CADDY_CONFIG_PATH = "/etc/caddy/Caddyfile";
 
 function execFileAsync(command: string, args: string[], timeout: number): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -23,12 +24,15 @@ function execFileAsync(command: string, args: string[], timeout: number): Promis
   });
 }
 
-/** Loads the stored policy, updates the auth snapshot, and reconciles Caddy from that config. */
+/** Reconciles the already-loaded policy with Caddy when the proxy path is present. */
 export async function reconcilePublicAccessAtStartup(
   db: DrizzleDb,
-  publicAccessState: PublicAccessState,
+  config: PublicAccessConfig,
 ): Promise<void> {
-  const config = await publicAccessState.load(db);
+  // The container entrypoint creates the default Caddyfile before the daemon
+  // starts. An explicit path is the signal for alternate deployments and tests.
+  if (!process.env.CADDY_CONFIG_PATH && !existsSync(DEFAULT_CADDY_CONFIG_PATH)) return;
+
   await writeCaddyfileAndReload(db, config);
 }
 
@@ -36,7 +40,7 @@ export async function writeCaddyfileAndReload(
   db: DrizzleDb | null,
   config: PublicAccessConfig,
 ): Promise<void> {
-  const caddyPath = process.env.CADDY_CONFIG_PATH || "/etc/caddy/Caddyfile";
+  const caddyPath = process.env.CADDY_CONFIG_PATH || DEFAULT_CADDY_CONFIG_PATH;
   const content = generateCaddyfile(config);
 
   await writeFile(caddyPath, content, "utf-8");

--- a/packages/core/src/lib/public-access.ts
+++ b/packages/core/src/lib/public-access.ts
@@ -1,5 +1,4 @@
 import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import type { DrizzleDb } from "../db/index.js";
 import { createLogger } from "../logger.js";
@@ -24,14 +23,13 @@ function execFileAsync(command: string, args: string[], timeout: number): Promis
   });
 }
 
-/** Reconciles the already-loaded policy with Caddy when the proxy path is present. */
+/** Reconciles the already-loaded policy when Rome explicitly owns a Caddy proxy. */
 export async function reconcilePublicAccessAtStartup(
   db: DrizzleDb,
   config: PublicAccessConfig,
 ): Promise<void> {
-  // The container entrypoint creates the default Caddyfile before the daemon
-  // starts. An explicit path is the signal for alternate deployments and tests.
-  if (!process.env.CADDY_CONFIG_PATH && !existsSync(DEFAULT_CADDY_CONFIG_PATH)) return;
+  // CADDY_CONFIG_PATH explicitly declares that Rome owns the proxy config.
+  if (!process.env.CADDY_CONFIG_PATH) return;
 
   await writeCaddyfileAndReload(db, config);
 }


### PR DESCRIPTION
## What this PR does

A failed public-access Caddy reload leaves the stored policy and auth snapshot ahead of the live proxy until another successful update.

Startup now reads the stored public-access policy through the existing normalized state load, updates the auth snapshot, then sends that same config through the canonical Caddy write-and-reload pipeline. A restart can therefore repair a previous failed reload.

Failed PUT responses also state that the stored policy has already moved forward and tell the operator to retry or restart Rome.

## Design & Invariants

The database remains the source of truth for public access. PUT keeps its existing ordering: persist the policy, refresh the auth snapshot, then apply it to Caddy.

Startup reconciliation does not introduce rollback or a cross-resource transaction. `PublicAccessState.load()` returns the normalized config it already loaded, so Caddy and the auth snapshot are derived from the same value without a second database read.

Caddy reconciliation failure remains non-fatal at startup. This preserves host development paths where Caddy is not present while allowing the production container to repair proxy state on restart.

## Test plan

* [x] `pnpm typecheck`
* [x] Core build
* [x] Biome on all changed files
* [x] `git diff origin/main...HEAD --check`
* [x] 14 public-access library tests
* [x] Startup reconciliation regression covers a stale Caddyfile, stored normalized policy, auth snapshot refresh, and Caddy reload through the production pipeline
* [ ] Full public-access route suite on Windows: 3/7 pass; 4 reload-success cases cannot spawn the POSIX fake `caddy` executable (`spawn caddy ENOENT`)
* [ ] Full core unit suite: 4,069/4,237 pass; remaining failures are Windows shell/subprocess limitations
* [ ] `pnpm test:unit` and `pnpm dev:all`: repository POSIX shell scripts and Docker are unavailable on this host

## Not in this PR

* A new process-level startup test harness. `src/index.ts` owns a private `main()` that runs on import, and the existing test helpers intentionally stop below full process boot. The committed regression exercises the startup reconciler through the real Caddy pipeline without adding a test-only startup abstraction.
* Reordering the PUT or adding a transaction across the database, filesystem, and Caddy.

Closes #20