### PR TITLE
feat(web): jump back to the live tail from the chat floor

### DIFF
--- a/packages/web/src/components/chat/Chat.test.tsx
+++ b/packages/web/src/components/chat/Chat.test.tsx
@@ -38,6 +38,9 @@ vi.mock("@/pages/free/use-free-cells", () => ({
   useFreeCells: () => ({ addWidget: vi.fn(), placements: [] }),
 }));
 
+// Mutable so a test can put the viewport away from the tail; reset in beforeEach.
+const stickToBottom = vi.hoisted(() => ({ isAtBottom: true, scrollToBottom: vi.fn() }));
+
 vi.mock("@/hooks/use-stick-to-bottom", () => ({
   // Callback refs, matching the real hook. Chat composes these with its own
   // refs and CALLS them, so a ref object here would throw on mount — and a
@@ -46,7 +49,8 @@ vi.mock("@/hooks/use-stick-to-bottom", () => ({
   useStickToBottom: () => ({
     contentRef: vi.fn(),
     scrollRef: vi.fn(),
-    scrollToBottom: vi.fn(),
+    isAtBottom: stickToBottom.isAtBottom,
+    scrollToBottom: stickToBottom.scrollToBottom,
   }),
 }));
 
@@ -170,6 +174,7 @@ class MockEventSource {
 }
 
 beforeEach(() => {
+  stickToBottom.isAtBottom = true;
   mockUseSessionIdentity.mockReturnValue({
     sessionName: null,
     pinnedAgentMention: null,
@@ -412,5 +417,26 @@ describe("Chat turn stream lifecycle", () => {
     });
     expect(replacementSignal?.aborted).toBe(false);
     expect(screen.getByTestId("chat-composer").getAttribute("data-streaming")).toBe("true");
+  });
+});
+
+describe("Chat jump to latest", () => {
+  it("hides the control while the viewport is already at the tail", () => {
+    renderChat(<Chat sessionId="session-1" />);
+    expect(screen.getByLabelText("jumpToLatest").className).toContain("invisible");
+  });
+
+  it("jumps instantly once the viewport has left the tail", async () => {
+    stickToBottom.isAtBottom = false;
+    renderChat(<Chat sessionId="session-1" />);
+
+    const control = screen.getByLabelText("jumpToLatest");
+    expect(control.className).not.toContain("invisible");
+    await userEvent.click(control);
+
+    // "auto", not "smooth": a smooth animation's first scroll event lands inside
+    // the hook's user-gesture window while still short of the bottom, and is read
+    // as the user scrolling away — releasing the pin this click just re-engaged.
+    expect(stickToBottom.scrollToBottom).toHaveBeenCalledWith("auto");
   });
 });

--- a/packages/web/src/components/chat/Chat.test.tsx
+++ b/packages/web/src/components/chat/Chat.test.tsx
@@ -429,6 +429,10 @@ describe("Chat jump to latest", () => {
   it("jumps instantly once the viewport has left the tail", async () => {
     stickToBottom.isAtBottom = false;
     renderChat(<Chat sessionId="session-1" />);
+    // Chat's session-switch effect has already logged its own scrollToBottom
+    // ("auto") by now, which would satisfy the assertion below on its own —
+    // leaving the click free to pass anything. Only the click's call may count.
+    stickToBottom.scrollToBottom.mockClear();
 
     const control = screen.getByLabelText("jumpToLatest");
     expect(control.className).not.toContain("invisible");

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -1754,17 +1754,23 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
                     the END of the transition, so the faded-out button stops taking
                     clicks and leaves the tab order instead of lurking invisibly
                     over the transcript. */}
-                <button
-                  type="button"
+                <IconButton
+                  size="md"
+                  label={t("jumpToLatest")}
+                  icon={<ArrowDown />}
+                  // IconButton mirrors its label into `title`, which the browser
+                  // renders as a native tooltip. The aria-label already names the
+                  // control, and a lone arrow above the composer needs no gloss.
+                  title={undefined}
                   onClick={() => scrollToBottom("auto")}
-                  aria-label={t("jumpToLatest")}
                   className={cn(
-                    "pointer-events-auto absolute bottom-full left-1/2 mb-3 flex size-8 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-surface/95 text-muted-foreground shadow-10 backdrop-blur-md transition-[opacity,visibility] duration-150 ease-out supports-[backdrop-filter]:bg-surface/80 hover:text-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring motion-reduce:transition-none",
+                    // `touch-target` because this control, unlike the timeline
+                    // rail, has no width gate: it is reachable on a phone, where
+                    // the 36px step is under the 44px floor.
+                    "touch-target pointer-events-auto absolute bottom-full left-1/2 mb-3 -translate-x-1/2 rounded-full border border-border bg-surface/95 text-muted-foreground shadow-10 backdrop-blur-md transition-[opacity,visibility] duration-150 ease-out supports-[backdrop-filter]:bg-surface/80 hover:text-foreground motion-reduce:transition-none",
                     isAtBottom ? "invisible opacity-0" : "visible opacity-100",
                   )}
-                >
-                  <ArrowDown className="size-4" />
-                </button>
+                />
                 <div className="pointer-events-auto mx-auto max-w-5xl">
                   {shareMode ? (
                     <ShareBar

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from "react-router-dom";
 import {
   Archive,
   ArchiveRestore,
+  ArrowDown,
   MoreHorizontal,
   Pin,
   PinOff,
@@ -358,6 +359,7 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
   const {
     contentRef: stickContentRef,
     scrollRef: stickScrollRef,
+    isAtBottom,
     scrollToBottom,
   } = useStickToBottom({
     thresholdPx: SCROLL_BOTTOM_THRESHOLD_PX,
@@ -1734,6 +1736,35 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
                 or the main agent). In share mode it's swapped for the ShareBar,
                 which configures + mints the link for the turns selected above. */}
               <div className="pointer-events-none sticky bottom-0 z-10 px-3 pb-[calc(var(--rome-safe-area-bottom)+1rem)] md:px-6 md:pb-[calc(var(--rome-safe-area-bottom)+1.5rem)]">
+                {/* Back to the live tail. It rides the sticky floor rather than the
+                    scroller, so it tracks a composer whose height changes with the
+                    draft, and it sits in every floor state — scrolling has nothing
+                    to do with which one is showing.
+
+                    `auto`, never `smooth`: scrollToBottom re-engages the pin and
+                    then animates, and a smooth animation emits scroll events while
+                    the click is still inside the hook's user-gesture window. The
+                    first one reports "not at the bottom yet" and is read as the
+                    user scrolling away, which releases the pin the call just set —
+                    the view lands at the bottom with following switched off. One
+                    instant jump emits a single event, already at the bottom.
+
+                    Kept mounted and faded rather than unmounted, so the exit
+                    animates too. `visibility` is what makes that safe: it flips at
+                    the END of the transition, so the faded-out button stops taking
+                    clicks and leaves the tab order instead of lurking invisibly
+                    over the transcript. */}
+                <button
+                  type="button"
+                  onClick={() => scrollToBottom("auto")}
+                  aria-label={t("jumpToLatest")}
+                  className={cn(
+                    "pointer-events-auto absolute bottom-full left-1/2 mb-3 flex size-8 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-surface/95 text-muted-foreground shadow-10 backdrop-blur-md transition-[opacity,visibility] duration-150 ease-out supports-[backdrop-filter]:bg-surface/80 hover:text-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring motion-reduce:transition-none",
+                    isAtBottom ? "invisible opacity-0" : "visible opacity-100",
+                  )}
+                >
+                  <ArrowDown className="size-4" />
+                </button>
                 <div className="pointer-events-auto mx-auto max-w-5xl">
                   {shareMode ? (
                     <ShareBar

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -58,6 +58,7 @@
     "hide": "Hide timeline",
     "show": "Show timeline"
   },
+  "jumpToLatest": "Jump to the latest message",
   "roles": {
     "agent": "Assistant"
   },

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -58,6 +58,7 @@
     "hide": "隐藏时间线",
     "show": "显示时间线"
   },
+  "jumpToLatest": "回到最新消息",
   "roles": {
     "agent": "助手"
   },


### PR DESCRIPTION
## What this PR does

The transcript pins itself to the tail, but nothing brings you back once you leave it. Reading back through a long chat — or clicking a timeline dot — drops you upstream with the scrollbar as the only way down, and following stays off until you land within 96px of the bottom by hand.

This adds a control on the composer floor that returns to the live tail and re-engages following.

## Design & Invariants

`useStickToBottom` already exposed `isAtBottom` and `scrollToBottom`; neither had a caller. The control is a button, not new scroll state.

**The jump is instant, never smooth.** `scrollToBottom` re-engages the pin and then animates. A smooth animation emits scroll events while the click is still inside the hook's 300ms user-gesture window, and the first one reports a position short of the bottom — read as the user scrolling away, which releases the pin the call just set. The view lands at the tail with following switched off. One instant jump emits a single event, already at the bottom. A test asserts the argument.

**It rides the sticky floor, not the scroller.** The floor already tracks a composer whose height changes with the draft, so the control needs no measurement of its own. It sits above all three floor states — composer, archived notice, ShareBar — because scrolling is orthogonal to which one holds the floor.

**Fading, not unmounting, so the exit animates.** `visibility` carries the safety: it flips at the end of the transition, so the faded-out button leaves the tab order and stops taking clicks rather than lurking transparent over the transcript.

The dot rail is unaffected — it hugs the right gutter, this is centred.

## Test plan

- [x] `pnpm --filter rome-web exec vitest run` — 1311 tests, including two new ones covering both states and the `auto` argument
- [x] Inverted the visibility condition and switched the jump to `smooth`; both new tests fail, so they hold their subject
- [x] `pnpm test:ui:radius`
- [x] Grepped the built CSS for every utility used here — an arbitrary Tailwind value that does not compile is silent
- [x] Mock mode against a 40-turn transcript: hidden at the tail, fades in on scroll-up, returns and re-pins on click, appears after a timeline jump
- [ ] `pnpm typecheck` — blocked locally on two pre-existing unresolved type deps (`remark-gfm`, `@types/mdx`), unrelated to this change; left to CI

## Not in this PR

- A "new messages" indicator — it needs its own state tracking, and the tail is already reachable without it.
- Placing the control on the timeline rail instead — the rail is hidden under 768px, so that position needs a second layout for small screens.
