### PR TITLE
feat(chat): add a universal stop command

### DIFF
--- a/packages/app-runtime-sdk/src/chat-stop.test.ts
+++ b/packages/app-runtime-sdk/src/chat-stop.test.ts
@@ -8,7 +8,7 @@ describe("chat stop contract", () => {
     expect(isStopCommand("please /stop")).toBe(false);
   });
 
-  it("reports that interruption was requested without claiming termination", () => {
-    expect(chatStopReceipt("stop_requested")).toBe("Stop requested.");
+  it("confirms the interruption", () => {
+    expect(chatStopReceipt("stop_requested")).toBe("Stopped.");
   });
 });

--- a/packages/app-runtime-sdk/src/chat-stop.test.ts
+++ b/packages/app-runtime-sdk/src/chat-stop.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "@rstest/core";
+import { chatStopReceipt, isStopCommand } from "./index.js";
+
+describe("chat stop contract", () => {
+  it("recognizes only the exact /stop command", () => {
+    expect(isStopCommand(" /STOP ")).toBe(true);
+    expect(isStopCommand("/stop now")).toBe(false);
+    expect(isStopCommand("please /stop")).toBe(false);
+  });
+
+  it("reports that interruption was requested without claiming termination", () => {
+    expect(chatStopReceipt("stop_requested")).toBe("Stop requested.");
+  });
+});

--- a/packages/app-runtime-sdk/src/index.ts
+++ b/packages/app-runtime-sdk/src/index.ts
@@ -1409,7 +1409,7 @@ export interface ChatStopResult {
 export function chatStopReceipt(status: ChatStopStatus): string {
   switch (status) {
     case "stop_requested":
-      return "Stop requested.";
+      return "Stopped.";
     case "forbidden":
       return "You can only stop a response that you started.";
     case "idle":

--- a/packages/app-runtime-sdk/src/index.ts
+++ b/packages/app-runtime-sdk/src/index.ts
@@ -1316,6 +1316,10 @@ export interface MessageRouting {
   agentName?: string;
 }
 
+/** How an inbound message was directed at the bot. Channel control messages
+ * use this provider-normalized signal instead of parsing provider payloads. */
+export type MessageAddressing = "direct" | "mention" | "reply" | "bot_thread" | "ambient";
+
 /** Provider-normalized reference attached to an ordinary inbound reply. */
 export interface MessageReplyReference {
   /** Provider/server id of the referenced message. */
@@ -1350,6 +1354,7 @@ export interface NormalizedMessage {
   attachments: Attachment[];
   replyTo?: MessageReplyReference;
   routing?: MessageRouting;
+  addressing?: MessageAddressing;
   rawEvent: unknown;
 }
 
@@ -1385,8 +1390,41 @@ export interface InboundMessage {
   timestamp: Date;
   replyTo?: MessageReplyReference;
   thread?: { kind: "dm" | "group" | "topic"; name?: string };
+  addressing?: MessageAddressing;
   raw?: unknown;
 }
+
+/** Exact provider-neutral chat command recognized before an agent turn. */
+export function isStopCommand(text: string): boolean {
+  return text.trim().toLowerCase() === "/stop";
+}
+
+export type ChatStopStatus = "stop_requested" | "idle" | "forbidden";
+
+export interface ChatStopResult {
+  status: ChatStopStatus;
+  turnId?: string;
+}
+
+export function chatStopReceipt(status: ChatStopStatus): string {
+  switch (status) {
+    case "stop_requested":
+      return "Stop requested.";
+    case "forbidden":
+      return "You can only stop a response that you started.";
+    case "idle":
+      return "There is no active response to stop.";
+  }
+}
+
+export interface ChatStopInput {
+  ref: ConversationRef;
+  service: string;
+  senderId: string;
+}
+
+/** Stops the active agent turn for a provider conversation. */
+export type ChatStopHandler = (input: ChatStopInput) => Promise<ChatStopResult>;
 
 export interface MessageReceipt {
   messageId?: string;

--- a/packages/core/src/channels/discord-stop.test.ts
+++ b/packages/core/src/channels/discord-stop.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, rs } from "@rstest/core";
+import type { ChatStopHandler, ConversationId } from "@rome-os/app-runtime";
+import type { ChatInputCommandInteraction } from "discord.js";
+import {
+  buildDiscordSlashCommands,
+  DiscordAdapter,
+  normalizeDiscordMessageText,
+} from "./discord.js";
+
+describe("Discord stop command", () => {
+  it("registers /stop as a native command", () => {
+    expect(buildDiscordSlashCommands()).toContainEqual(
+      expect.objectContaining({
+        name: "stop",
+        description: "Stop the active Rome response in this conversation",
+      }),
+    );
+  });
+
+  it("removes the bot mention before command recognition", () => {
+    expect(normalizeDiscordMessageText("  <@123> /stop  ", "123")).toBe("/stop");
+    expect(normalizeDiscordMessageText("<@!123> /STOP", "123")).toBe("/STOP");
+  });
+
+  it("routes native /stop through chat control before the guardian-only config gate", async () => {
+    const stop = rs.fn(async () => ({ status: "stop_requested" as const, turnId: "turn-1" }));
+    const chatStop: ChatStopHandler = stop;
+    const isGuardian = rs.fn(async () => false);
+    const adapter = new DiscordAdapter({
+      botToken: "token",
+      connectionId: "connection:discord",
+      chatStop,
+      isGuardian,
+    });
+    const deferReply = rs.fn(async () => undefined);
+    const editReply = rs.fn(async () => undefined);
+    const interaction = {
+      commandName: "stop",
+      channelId: "channel-1" as ConversationId,
+      user: { id: "user-1" },
+      deferReply,
+      editReply,
+    } as unknown as ChatInputCommandInteraction;
+
+    await (
+      adapter as unknown as {
+        handleSlashCommand(interaction: ChatInputCommandInteraction): Promise<void>;
+      }
+    ).handleSlashCommand(interaction);
+
+    expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(stop).toHaveBeenCalledWith({
+      ref: { connectionId: "connection:discord", conversationId: "channel-1" },
+      service: "discord",
+      senderId: "user-1",
+    });
+    expect(editReply).toHaveBeenCalledWith({ content: "Stop requested." });
+    expect(isGuardian).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/channels/discord-stop.test.ts
+++ b/packages/core/src/channels/discord-stop.test.ts
@@ -54,7 +54,7 @@ describe("Discord stop command", () => {
       service: "discord",
       senderId: "user-1",
     });
-    expect(editReply).toHaveBeenCalledWith({ content: "Stop requested." });
+    expect(editReply).toHaveBeenCalledWith({ content: "Stopped." });
     expect(isGuardian).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/channels/discord.ts
+++ b/packages/core/src/channels/discord.ts
@@ -19,6 +19,7 @@ import {
   type ChatInputCommandInteraction,
   type AutocompleteInteraction,
 } from "discord.js";
+import { chatStopReceipt, isStopCommand } from "@rome-os/app-runtime";
 import type { APIRequest, RateLimitData, RequestMethod, ResponseLike } from "discord.js";
 import { isCoreMainAgentId } from "../apps/artifact-id.js";
 import {
@@ -33,6 +34,8 @@ import type {
   ConversationId,
   ConversationSettingsControl,
   ConversationSettingsSnapshot,
+  ChatStopHandler,
+  MessageAddressing,
 } from "@rome-os/app-runtime";
 import type {
   NormalizedMessage,
@@ -167,7 +170,11 @@ function isThreadType(type: ChannelType): boolean {
   );
 }
 
-function buildSlashCommands() {
+export function buildDiscordSlashCommands() {
+  const stop = new SlashCommandBuilder()
+    .setName("stop")
+    .setDescription("Stop the active Rome response in this conversation");
+
   const channel = new SlashCommandBuilder()
     .setName("channel")
     .setDescription("Configure Rome Bot behavior for this channel")
@@ -277,7 +284,12 @@ function buildSlashCommands() {
     .setName("help")
     .setDescription("Show available Rome Bot commands");
 
-  return [channel.toJSON(), bot.toJSON(), help.toJSON()];
+  return [stop.toJSON(), channel.toJSON(), bot.toJSON(), help.toJSON()];
+}
+
+export function normalizeDiscordMessageText(content: string, botId?: string): string {
+  if (!botId) return content.trim();
+  return content.replace(new RegExp(`<@!?${botId}>`, "g"), "").trim();
 }
 
 /** A guild channel as surfaced to callers resolving a "#name" → snowflake. */
@@ -321,6 +333,7 @@ export class DiscordAdapter implements ProviderAdapter {
    */
   private listAgents?: () => string[];
   private isGuardian?: (channelUserId: string) => Promise<boolean>;
+  private chatStop?: ChatStopHandler;
 
   /**
    * Reports terminal gateway faults so the grant-epoch lifecycle can react:
@@ -345,6 +358,7 @@ export class DiscordAdapter implements ProviderAdapter {
     maxMessagesPerChannel?: number;
     listAgents?: () => string[];
     isGuardian?: (channelUserId: string) => Promise<boolean>;
+    chatStop?: ChatStopHandler;
     onGatewayFault?: (fault: { kind: "credential" | "transport"; cause: unknown }) => void;
   }) {
     this.connectionId = config.connectionId;
@@ -352,6 +366,7 @@ export class DiscordAdapter implements ProviderAdapter {
     this.maxMessagesPerChannel = config.maxMessagesPerChannel ?? 100;
     this.listAgents = config.listAgents;
     this.isGuardian = config.isGuardian;
+    this.chatStop = config.chatStop;
     this.onGatewayFault = config.onGatewayFault;
     this.client = new Client({
       intents: [
@@ -647,7 +662,7 @@ export class DiscordAdapter implements ProviderAdapter {
       if (!this.slashCommandsRegistered) {
         this.slashCommandsRegistered = true;
         try {
-          const commands = buildSlashCommands();
+          const commands = buildDiscordSlashCommands();
           await this.rest.put(Routes.applicationCommands(client.user.id), { body: commands });
           log.info("slash commands registered", { count: commands.length });
         } catch (err) {
@@ -683,6 +698,13 @@ export class DiscordAdapter implements ProviderAdapter {
       const isThread = isThreadType(message.channel.type);
 
       const cfg = this.legacyConfig(await this.settingsForMessage(message));
+      const botId = this.client.user?.id;
+      const botMentioned = botId ? message.mentions.users.has(botId) : false;
+      const isOwnThread =
+        isThread &&
+        !!botId &&
+        "ownerId" in message.channel &&
+        (message.channel as ThreadChannel).ownerId === botId;
 
       // ── Layer 2: Bot filter ───────────────────────────────────────────────
       if (message.author.bot) {
@@ -718,12 +740,32 @@ export class DiscordAdapter implements ProviderAdapter {
 
       // ── DM shortcut: always respond ───────────────────────────────────────
       if (isDm) {
-        await this.dispatchMessage(message, isDm, isThread);
+        await this.dispatchMessage(message, isDm, isThread, "direct");
         return;
       }
 
+      let replyToBot = false;
+      if (!botMentioned && botId && message.reference?.messageId) {
+        try {
+          const refMsg = await message.channel.messages.fetch(message.reference.messageId);
+          replyToBot = refMsg.author.id === botId;
+        } catch {
+          // A missing reference cannot prove that this message addresses Rome.
+        }
+      }
+      const addressing: MessageAddressing = botMentioned
+        ? "mention"
+        : replyToBot
+          ? "reply"
+          : isOwnThread
+            ? "bot_thread"
+            : "ambient";
+      const directedStop =
+        addressing !== "ambient" &&
+        isStopCommand(normalizeDiscordMessageText(message.content, botId));
+
       // ── Layer 4: Channel permission ───────────────────────────────────────
-      if (cfg?.mode === "ignore") {
+      if (cfg?.mode === "ignore" && !directedStop) {
         log.debug("ignoring message in channel with mode=ignore", {
           channelId: message.channelId,
         });
@@ -734,53 +776,33 @@ export class DiscordAdapter implements ProviderAdapter {
       // Threads the bot itself started (e.g. auto-thread replies) are treated
       // as ongoing conversations and skip the mention requirement. Threads
       // created by other users still need an @mention or a reply-to-bot.
-      const botId = this.client.user?.id;
-      const isOwnThread =
-        isThread &&
-        !!botId &&
-        "ownerId" in message.channel &&
-        (message.channel as ThreadChannel).ownerId === botId;
-
       const requireMention = cfg?.requireMention ?? true;
-      if (requireMention && !isOwnThread) {
-        const botMentioned = botId ? message.mentions.users.has(botId) : false;
-
-        let replyToBot = false;
-        if (!botMentioned && message.reference?.messageId) {
-          try {
-            const refMsg = await message.channel.messages.fetch(message.reference.messageId);
-            replyToBot = refMsg.author.id === botId;
-          } catch {
-            // can't fetch reference — skip
-          }
-        }
-
-        if (!botMentioned && !replyToBot) {
-          log.debug("ignoring guild message not directed at bot", {
-            from: message.author.id,
-            channelId: message.channelId,
-            isThread,
-          });
-          return;
-        }
+      if (requireMention && addressing === "ambient") {
+        log.debug("ignoring guild message not directed at bot", {
+          from: message.author.id,
+          channelId: message.channelId,
+          isThread,
+        });
+        return;
       }
 
-      await this.dispatchMessage(message, isDm, isThread);
+      await this.dispatchMessage(message, isDm, isThread, addressing);
     });
 
     await this.client.login(this._botToken);
     log.info("bot logged in", { username: this.client.user?.tag });
   }
 
-  private async dispatchMessage(message: Message, isDm: boolean, isThread: boolean): Promise<void> {
+  private async dispatchMessage(
+    message: Message,
+    isDm: boolean,
+    isThread: boolean,
+    addressing: MessageAddressing,
+  ): Promise<void> {
     if (!this.handler) return;
 
     // Strip the bot @mention from message text so the agent sees clean input
-    let text = message.content;
-    if (this.client.user) {
-      const botId = this.client.user.id;
-      text = text.replace(new RegExp(`<@!?${botId}>`, "g"), "").trim();
-    }
+    const text = normalizeDiscordMessageText(message.content, this.client.user?.id);
 
     let threadName: string | undefined;
     if (!isDm && "name" in message.channel) {
@@ -805,6 +827,7 @@ export class DiscordAdapter implements ProviderAdapter {
       text,
       attachments: this.extractAttachments(message),
       replyTo: replyToMessageId ? { messageId: replyToMessageId } : undefined,
+      addressing,
       rawEvent: message,
     };
 
@@ -830,13 +853,30 @@ export class DiscordAdapter implements ProviderAdapter {
     await interaction.deferReply({ ephemeral: true });
 
     try {
+      const cmd = interaction.commandName;
+      if (cmd === "stop") {
+        if (!this.chatStop || !this.connectionId) {
+          await interaction.editReply({ content: "Stop is unavailable for this connection." });
+          return;
+        }
+        const result = await this.chatStop({
+          ref: {
+            connectionId: this.connectionId,
+            conversationId: interaction.channelId as ConversationId,
+          },
+          service: "discord",
+          senderId: interaction.user.id,
+        });
+        await interaction.editReply({ content: chatStopReceipt(result.status) });
+        return;
+      }
+
       if (this.isGuardian && !(await this.isGuardian(interaction.user.id))) {
         await interaction.editReply({
           content: "Only the linked guardian can configure this Discord conversation.",
         });
         return;
       }
-      const cmd = interaction.commandName;
       const subGroup = interaction.options.getSubcommandGroup(false);
       const sub = interaction.options.getSubcommand(false);
 
@@ -859,6 +899,7 @@ export class DiscordAdapter implements ProviderAdapter {
             "",
             "Global overview:",
             "  `/bot status` — list all channel overrides",
+            "  `/stop` — stop the active Rome response in this conversation",
             "",
             "Tip: you can also tell the bot what you want in plain language",
           ].join("\n"),

--- a/packages/core/src/channels/feishu.test.ts
+++ b/packages/core/src/channels/feishu.test.ts
@@ -253,6 +253,7 @@ describe("FeishuAdapter", () => {
     expect(msg.displayName).toBe("Alice");
     expect(msg.threadId).toBe("oc_chat");
     expect(msg.threadType).toBe("private");
+    expect(msg.addressing).toBe("direct");
     expect(msg.text).toBe("hi there");
     expect(msg.id).toBe("om_123");
   });
@@ -260,6 +261,19 @@ describe("FeishuAdapter", () => {
   it("maps group chat type to a group thread", async () => {
     await channel.emit({ chatType: "group", mentionedBot: true });
     expect(captured[0].threadType).toBe("group");
+    expect(captured[0].addressing).toBe("mention");
+  });
+
+  it("normalizes an addressed group /stop without leaving the bot mention in the command", async () => {
+    await channel.emit({
+      chatType: "group",
+      mentionedBot: true,
+      content: "@_user_1 /stop",
+      mentions: [{ key: "@_user_1", name: "Rome" }],
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({ text: "/stop", addressing: "mention" });
   });
 
   it("delivers an @-only group message as a greeting", async () => {
@@ -391,6 +405,38 @@ describe("FeishuAdapter", () => {
     await channel.emit({ chatType: "group", mentionedBot: true, content: "@_user_1 hello" });
 
     expect(captured).toHaveLength(0);
+  });
+
+  it("delivers an addressed /stop when group policy is disabled", async () => {
+    const conversationSettings = makeConversationSettings({
+      enabled: false,
+      activation: { mode: "all" },
+    });
+    channel = new FakeLarkChannel();
+    adapter = new FeishuAdapter(
+      {
+        appId: "cli_test",
+        appSecret: "secret",
+        connectionId: FEISHU_CONNECTION_ID,
+        conversationSettings: conversationSettings.control,
+      },
+      () => channel as unknown as LarkChannel,
+    );
+    captured = [];
+    adapter.onMessage(async (msg) => {
+      captured.push(msg);
+    });
+    await adapter.start();
+
+    await channel.emit({
+      chatType: "group",
+      mentionedBot: true,
+      content: "@_user_1 /stop",
+      mentions: [{ key: "@_user_1", name: "Rome" }],
+    });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({ text: "/stop", addressing: "mention" });
   });
 
   it("renders current group settings as select field defaults", async () => {

--- a/packages/core/src/channels/feishu.ts
+++ b/packages/core/src/channels/feishu.ts
@@ -7,6 +7,7 @@ import {
   LoggerLevel,
   type NormalizedMessage as LarkMessage,
 } from "@larksuiteoapi/node-sdk";
+import { isStopCommand } from "@rome-os/app-runtime";
 import type { ProviderAdapter } from "./adapter.js";
 import type { NormalizedMessage, OutgoingMessage } from "./types.js";
 import { createLogger } from "../logger.js";
@@ -15,6 +16,7 @@ import type {
   ConversationDescriptor,
   ConversationId,
   ConversationSettingsControl,
+  MessageAddressing,
 } from "@rome-os/app-runtime";
 
 const log = createLogger("feishu");
@@ -225,10 +227,17 @@ export class FeishuAdapter implements ProviderAdapter {
 
     // MVP: text-bearing messages only. Media-only messages arrive with empty
     // content and are dropped until attachment support lands.
+    const commandText = stripMentionPlaceholders(m.content ?? "", m.mentions);
     const resolvedText = resolveMentions(m.content ?? "", m.mentions);
-    const text = resolvedText || (m.rawContentType === "text" && m.mentionedBot ? "hello" : "");
+    const text =
+      m.mentionedBot && isStopCommand(commandText)
+        ? "/stop"
+        : resolvedText || (m.rawContentType === "text" && m.mentionedBot ? "hello" : "");
     if (!text) return;
     const threadType = m.chatType === "p2p" ? "private" : "group";
+    const addressing: MessageAddressing =
+      threadType === "private" ? "direct" : m.mentionedBot ? "mention" : "ambient";
+    const directedStop = addressing !== "ambient" && isStopCommand(text);
     if (threadType === "group") {
       this.observedConversations.set(m.chatId, {
         id: m.chatId,
@@ -245,7 +254,7 @@ export class FeishuAdapter implements ProviderAdapter {
       }
 
       const cfg = await this.getChannelConfig(m.chatId);
-      if (cfg.mode === "ignore") {
+      if (cfg.mode === "ignore" && !directedStop) {
         log.debug("ignoring Feishu group message because group policy is disabled", {
           from: m.senderId,
           threadId: m.chatId,
@@ -275,6 +284,7 @@ export class FeishuAdapter implements ProviderAdapter {
       attachments: [],
       replyTo: m.replyToMessageId ? { messageId: m.replyToMessageId } : undefined,
       routing: cfg.agentName ? { agentName: cfg.agentName } : undefined,
+      addressing,
       rawEvent: m.raw ?? m,
     };
 
@@ -537,6 +547,17 @@ export function resolveMentions(
   let text = content;
   for (const mention of mentions ?? []) {
     if (mention.key && mention.name) text = text.split(mention.key).join(mention.name);
+  }
+  return text.trim();
+}
+
+function stripMentionPlaceholders(
+  content: string,
+  mentions: Array<{ key?: string; name?: string }>,
+): string {
+  let text = content;
+  for (const mention of mentions ?? []) {
+    if (mention.key) text = text.split(mention.key).join("");
   }
   return text.trim();
 }

--- a/packages/core/src/channels/wechat.test.ts
+++ b/packages/core/src/channels/wechat.test.ts
@@ -55,6 +55,7 @@ describe("normalizeWechatMessage", () => {
       timestamp: new Date(1700000000000),
       text: "hello from wechat",
       attachments: [],
+      addressing: "direct",
       rawEvent: expect.any(Object),
     });
   });
@@ -238,6 +239,7 @@ describe("normalizeWechatMessage", () => {
     expect(msg?.threadId).toBe("bob@im.wechat");
     expect(msg?.threadType).toBe("group");
     expect(msg?.threadName).toBe("room-1@chatroom");
+    expect(msg?.addressing).toBe("direct");
   });
 
   it("treats empty group id as private metadata", () => {

--- a/packages/core/src/channels/wechat.ts
+++ b/packages/core/src/channels/wechat.ts
@@ -951,6 +951,9 @@ export function normalizeWechatMessage(msg: WechatMessage): NormalizedMessage | 
     text: extracted.text,
     attachments: extracted.attachments.filter((att) => att.url || att.fileName || att.mimeType),
     ...(extracted.replyTo ? { replyTo: extracted.replyTo } : {}),
+    // WeChat group traffic is partitioned by senderId, so a command can only
+    // address that sender's Rome conversation, never another group member's.
+    addressing: "direct",
     rawEvent: msg,
   };
 }

--- a/packages/core/src/connections/integrations/discord.ts
+++ b/packages/core/src/connections/integrations/discord.ts
@@ -16,6 +16,7 @@
 import { DiscordjsError, DiscordjsErrorCodes } from "discord.js";
 import { z } from "zod";
 import type {
+  ChatStopHandler,
   TalkActivity,
   TalkDirectory,
   TalkFeatureMap,
@@ -117,6 +118,7 @@ export function isDiscordAuthError(err: unknown): boolean {
  */
 export interface DiscordDeps {
   conversationSettings: ConversationSettingsService;
+  chatStop?: ChatStopHandler;
   personMappingRepo: PersonMappingRepository;
   listAgents: () => string[];
   /** Injectable token validator so the connect route / tests can drive the
@@ -381,6 +383,7 @@ export function makeDiscordDescriptor(deps: DiscordDeps): ConnectionDescriptor {
             botToken: token.token,
             connectionId: kit.connectionId,
             conversationSettings: deps.conversationSettings,
+            chatStop: deps.chatStop,
             listAgents: deps.listAgents,
             isGuardian: async (channelUserId) =>
               (await deps.personMappingRepo.findByChannelUser("discord", channelUserId))

--- a/packages/core/src/connections/integrations/index.ts
+++ b/packages/core/src/connections/integrations/index.ts
@@ -17,6 +17,7 @@ import {
 import { credentialFromBundle, grantProfileFromBundle } from "../providers-import.js";
 import type { ConnectionRegistry } from "../registry.js";
 import type { ConversationSettingsService } from "../../conversation-settings/service.js";
+import type { ChatStopHandler } from "@rome-os/app-runtime";
 import { makeDiscordDescriptor } from "./discord.js";
 import { makeEmailDescriptor } from "./email.js";
 import { createFeishuDescriptor } from "./feishu.js";
@@ -47,6 +48,7 @@ export { makeOAuthProviderDescriptor, OAUTH_PROVIDER_GRANTS } from "./oauth-prov
 export interface BuiltinConnectionDeps {
   settingsRepo: SettingsRepository;
   conversationSettings: ConversationSettingsService;
+  chatStop: ChatStopHandler;
   personMappingRepo: PersonMappingRepository;
   webchatRepo: WebChatRepository;
   whatsAppSyncSink: WhatsAppSyncSink;
@@ -85,6 +87,7 @@ export function registerBuiltinConnections(
   registry.register(
     makeDiscordDescriptor({
       conversationSettings: deps.conversationSettings,
+      chatStop: deps.chatStop,
       personMappingRepo: deps.personMappingRepo,
       listAgents: deps.listAgents,
     }),

--- a/packages/core/src/connections/integrations/talk-features.ts
+++ b/packages/core/src/connections/integrations/talk-features.ts
@@ -25,6 +25,7 @@ export function toInboundMessage(message: NormalizedMessage): InboundMessage {
     attachments: message.attachments,
     timestamp: message.timestamp,
     replyTo: message.replyTo,
+    ...(message.addressing ? { addressing: message.addressing } : {}),
     thread: {
       kind: message.threadType === "private" ? "dm" : message.parentThreadId ? "topic" : "group",
       ...(message.threadName ? { name: message.threadName } : {}),

--- a/packages/core/src/core/agent-session-bridge.test.ts
+++ b/packages/core/src/core/agent-session-bridge.test.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { describe, expect, it, rs } from "@rstest/core";
+import type { ConversationId, StreamAgentMessage } from "@rome-os/app-runtime";
+import { createAgentTurnStreamRegistry } from "./agent-turn-stream-registry.js";
+import type { AgentSession, AgentSessionManager, AgentTurnHandle } from "./agent-session.js";
+import { AgentSessionBridge } from "./agent-session-bridge.js";
+
+class FakeChild extends EventEmitter {
+  connected = true;
+  sent: unknown[] = [];
+
+  send(message: unknown): boolean {
+    this.sent.push(message);
+    return true;
+  }
+}
+
+describe("AgentSessionBridge turn routing", () => {
+  it("routes a started provider conversation to its exact interruptible turn", async () => {
+    let startTurn!: () => void;
+    const start = new Promise<void>((resolve) => {
+      startTurn = resolve;
+    });
+    let finishTurn!: () => void;
+    const finish = new Promise<void>((resolve) => {
+      finishTurn = resolve;
+    });
+    const interrupt = rs.fn(async () => undefined);
+    const events = (async function* (): AsyncIterable<StreamAgentMessage> {
+      await start;
+      yield {
+        type: "turn_start",
+        turnId: "turn-1",
+        sessionId: "session-1",
+        userPrompt: "hello",
+      };
+      await finish;
+      yield { type: "turn_end", turnId: "turn-1", status: "completed", durationMs: 1 };
+    })();
+    const session = {
+      key: { agentName: "main", channelThreadKey: "discord:channel-1" },
+      sessionId: "session-1",
+      romeSessionId: "channel:discord:channel-1",
+      sendTurn: () => ({ turnId: "turn-1", events, interrupt }) as unknown as AgentTurnHandle,
+    } as unknown as AgentSession;
+    const manager = {
+      acquire: async () => session,
+      peek: () => session,
+    } as unknown as AgentSessionManager;
+    const turns = createAgentTurnStreamRegistry();
+    const child = new FakeChild();
+    new AgentSessionBridge(manager, undefined, undefined, turns).attach(
+      child as unknown as ChildProcess,
+    );
+
+    child.emit("message", {
+      type: "rpc_request",
+      reqId: "request-1",
+      method: "agent.session.runTurn",
+      params: {
+        key: session.key,
+        input: { prompt: "hello" },
+        init: {
+          threadContext: {
+            channel: "discord",
+            connectionId: "connection:discord",
+            threadId: "channel-1",
+            channelUserId: "user-1",
+          },
+        },
+      },
+    });
+
+    const ref = {
+      connectionId: "connection:discord",
+      conversationId: "channel-1" as ConversationId,
+    };
+    await rs.waitFor(() =>
+      expect(child.sent).toContainEqual(expect.objectContaining({ type: "rpc_response" })),
+    );
+    expect(turns.getActiveByConversation(ref)).toBeUndefined();
+
+    startTurn();
+    await rs.waitFor(() => expect(turns.getActiveByConversation(ref)?.turnId).toBe("turn-1"));
+    const active = turns.getActiveByConversation(ref)!;
+    expect(active.initiatorId).toBe("user-1");
+
+    await active.interrupt?.("chat-stop");
+    expect(interrupt).toHaveBeenCalledWith("chat-stop");
+
+    finishTurn();
+    await rs.waitFor(() => expect(turns.getActiveByConversation(ref)).toBeUndefined());
+  });
+});

--- a/packages/core/src/core/agent-session-bridge.ts
+++ b/packages/core/src/core/agent-session-bridge.ts
@@ -6,6 +6,7 @@
 import type { ChildProcess } from "node:child_process";
 import { IpcRpc, createChildProcessTransport } from "../actions/ipc.js";
 import type {
+  ConversationId,
   CurrentActionContext,
   MessageReplyReference,
   RomeSessionRef,
@@ -34,6 +35,7 @@ import {
 } from "../actions/action-subprocess.js";
 import { actionExecutionContext } from "../actions/context.js";
 import { replayContext } from "../actions/replay.js";
+import type { AgentTurnStreamRegistry } from "./agent-turn-stream-registry.js";
 
 const log = createLogger("agent-session-bridge");
 
@@ -75,6 +77,7 @@ export class AgentSessionBridge implements AgentSessionChildBridge {
     private manager: AgentSessionManager,
     private webchatRepo?: WebChatRepository,
     private actionWorkerCoordinator?: ActionWorkerCoordinator,
+    private turnStreams?: AgentTurnStreamRegistry,
   ) {}
 
   attach(child: ChildProcess): IpcRpc {
@@ -194,8 +197,35 @@ export class AgentSessionBridge implements AgentSessionChildBridge {
         const stream = ctx.openStream<StreamAgentMessage>(`agent.turn:${handle.turnId}`);
         // Drain the per-turn events into the IPC stream.
         void (async () => {
+          let liveStream: ReturnType<AgentTurnStreamRegistry["register"]> | null = null;
           try {
             for await (const msg of handle.events) {
+              if (!liveStream && msg.type === "turn_start" && this.turnStreams) {
+                const thread = req.init?.threadContext;
+                try {
+                  liveStream = this.turnStreams.register({
+                    sessionId: msg.sessionId,
+                    turnId: msg.turnId,
+                    agentName: session.key.agentName,
+                    ...(thread?.connectionId
+                      ? {
+                          conversation: {
+                            connectionId: thread.connectionId,
+                            conversationId: thread.threadId as ConversationId,
+                          },
+                        }
+                      : {}),
+                    ...(thread?.channelUserId ? { initiatorId: thread.channelUserId } : {}),
+                    interrupt: handle.interrupt,
+                  });
+                } catch (err) {
+                  log.warn("failed to register agent turn stream", {
+                    turnId: handle.turnId,
+                    error: err instanceof Error ? err.message : String(err),
+                  });
+                }
+              }
+              liveStream?.publish(msg);
               if (recorder) {
                 await recordAgentTraceBestEffort(recorder, msg, log, {
                   turnId: handle.turnId,
@@ -211,6 +241,8 @@ export class AgentSessionBridge implements AgentSessionChildBridge {
               error: err instanceof Error ? err.message : String(err),
             });
             stream.close({ error: err instanceof Error ? err : new Error(String(err)) });
+          } finally {
+            liveStream?.finish();
           }
         })();
 

--- a/packages/core/src/core/agent-turn-stream-registry.test.ts
+++ b/packages/core/src/core/agent-turn-stream-registry.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, rs } from "@rstest/core";
+import type { ConversationId } from "@rome-os/app-runtime";
+import { createAgentTurnStreamRegistry } from "./agent-turn-stream-registry.js";
+
+const conversation = {
+  connectionId: "connection:discord",
+  conversationId: "channel-1" as ConversationId,
+};
+
+describe("AgentTurnStreamRegistry conversation routing", () => {
+  it("resolves the active turn for a provider conversation", () => {
+    const registry = createAgentTurnStreamRegistry();
+    const interrupt = rs.fn(async () => undefined);
+    const stream = registry.register({
+      sessionId: "session-1",
+      turnId: "turn-1",
+      agentName: "main",
+      conversation,
+      initiatorId: "user-1",
+      interrupt,
+    });
+
+    expect(registry.getActiveByConversation(conversation)).toBe(stream);
+    expect(stream.initiatorId).toBe("user-1");
+    expect(stream.interrupt).toBe(interrupt);
+
+    stream.finish();
+    expect(registry.getActiveByConversation(conversation)).toBeUndefined();
+  });
+
+  it("does not let an older turn clear a newer conversation route", () => {
+    const registry = createAgentTurnStreamRegistry();
+    const older = registry.register({
+      sessionId: "session-1",
+      turnId: "turn-1",
+      agentName: "main",
+      conversation,
+    });
+    const newer = registry.register({
+      sessionId: "session-2",
+      turnId: "turn-2",
+      agentName: "main",
+      conversation,
+    });
+
+    older.finish();
+    expect(registry.getActiveByConversation(conversation)).toBe(newer);
+  });
+});

--- a/packages/core/src/core/agent-turn-stream-registry.ts
+++ b/packages/core/src/core/agent-turn-stream-registry.ts
@@ -1,9 +1,12 @@
+import type { ConversationRef } from "@rome-os/app-runtime";
 import type { StreamAgentMessage } from "./agent-session.js";
 
 export interface ActiveAgentTurnStream {
   sessionId: string;
   turnId: string;
   agentName: string;
+  conversation?: ConversationRef;
+  initiatorId?: string;
   startedAt: string;
   finished: boolean;
   messages(): readonly StreamAgentMessage[];
@@ -23,16 +26,24 @@ export interface AgentTurnStreamRegistry {
     sessionId: string;
     turnId: string;
     agentName: string;
+    conversation?: ConversationRef;
+    initiatorId?: string;
     interrupt?(reason?: string): Promise<void>;
   }): MutableAgentTurnStream;
   get(turnId: string): ActiveAgentTurnStream | undefined;
+  getActiveByConversation(ref: ConversationRef): ActiveAgentTurnStream | undefined;
   listBySession(sessionId: string): ActiveAgentTurnStream[];
 }
 
 const FINISHED_STREAM_TTL_MS = 30_000;
 
+function conversationKey(ref: ConversationRef): string {
+  return `${ref.connectionId}\u0000${ref.conversationId}`;
+}
+
 export function createAgentTurnStreamRegistry(): AgentTurnStreamRegistry {
   const streams = new Map<string, MutableAgentTurnStream>();
+  const activeByConversation = new Map<string, MutableAgentTurnStream>();
 
   return {
     register(input) {
@@ -49,6 +60,8 @@ export function createAgentTurnStreamRegistry(): AgentTurnStreamRegistry {
         sessionId: input.sessionId,
         turnId: input.turnId,
         agentName: input.agentName,
+        conversation: input.conversation,
+        initiatorId: input.initiatorId,
         startedAt: new Date().toISOString(),
         finished: false,
         messages: () => values,
@@ -66,6 +79,12 @@ export function createAgentTurnStreamRegistry(): AgentTurnStreamRegistry {
         finish() {
           if (stream.finished) return;
           stream.finished = true;
+          if (
+            input.conversation &&
+            activeByConversation.get(conversationKey(input.conversation)) === stream
+          ) {
+            activeByConversation.delete(conversationKey(input.conversation));
+          }
           resolveFinished();
           setTimeout(() => {
             if (streams.get(input.turnId) === stream) streams.delete(input.turnId);
@@ -73,11 +92,19 @@ export function createAgentTurnStreamRegistry(): AgentTurnStreamRegistry {
         },
       };
       streams.set(input.turnId, stream);
+      if (input.conversation) {
+        activeByConversation.set(conversationKey(input.conversation), stream);
+      }
       return stream;
     },
 
     get(turnId) {
       return streams.get(turnId);
+    },
+
+    getActiveByConversation(ref) {
+      const stream = activeByConversation.get(conversationKey(ref));
+      return stream && !stream.finished ? stream : undefined;
     },
 
     listBySession(sessionId) {

--- a/packages/core/src/core/chat-stop.test.ts
+++ b/packages/core/src/core/chat-stop.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, rs } from "@rstest/core";
+import type { ConversationId } from "@rome-os/app-runtime";
+import { createAgentTurnStreamRegistry } from "./agent-turn-stream-registry.js";
+import { stopActiveConversationTurn } from "./chat-stop.js";
+
+const ref = {
+  connectionId: "connection:discord",
+  conversationId: "channel-1" as ConversationId,
+};
+
+function activeTurn(initiatorId = "user-1") {
+  const turns = createAgentTurnStreamRegistry();
+  const interrupt = rs.fn(async () => undefined);
+  const stream = turns.register({
+    sessionId: "session-1",
+    turnId: "turn-1",
+    agentName: "main",
+    conversation: ref,
+    initiatorId,
+    interrupt,
+  });
+  return { turns, interrupt, stream };
+}
+
+describe("stopActiveConversationTurn", () => {
+  it("interrupts the active conversation turn for its initiator", async () => {
+    const { turns, interrupt } = activeTurn();
+    const isGuardian = rs.fn(async () => false);
+
+    await expect(
+      stopActiveConversationTurn(
+        { ref, service: "discord", senderId: "user-1" },
+        { turns, isGuardian },
+      ),
+    ).resolves.toEqual({ status: "stop_requested", turnId: "turn-1" });
+    expect(interrupt).toHaveBeenCalledWith("chat-stop");
+    expect(isGuardian).not.toHaveBeenCalled();
+  });
+
+  it("allows a guardian to stop another sender's turn", async () => {
+    const { turns, interrupt } = activeTurn("owner");
+
+    await expect(
+      stopActiveConversationTurn(
+        { ref, service: "discord", senderId: "guardian" },
+        { turns, isGuardian: async () => true },
+      ),
+    ).resolves.toMatchObject({ status: "stop_requested", turnId: "turn-1" });
+    expect(interrupt).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects another sender and reports an idle conversation", async () => {
+    const { turns, interrupt, stream } = activeTurn("owner");
+    const options = { turns, isGuardian: async () => false };
+
+    await expect(
+      stopActiveConversationTurn({ ref, service: "discord", senderId: "other" }, options),
+    ).resolves.toEqual({ status: "forbidden" });
+    expect(interrupt).not.toHaveBeenCalled();
+
+    stream.finish();
+    await expect(
+      stopActiveConversationTurn({ ref, service: "discord", senderId: "owner" }, options),
+    ).resolves.toEqual({ status: "idle" });
+  });
+});

--- a/packages/core/src/core/chat-stop.ts
+++ b/packages/core/src/core/chat-stop.ts
@@ -1,0 +1,21 @@
+import type { ChatStopInput, ChatStopResult } from "@rome-os/app-runtime";
+import type { AgentTurnStreamRegistry } from "./agent-turn-stream-registry.js";
+
+export async function stopActiveConversationTurn(
+  input: ChatStopInput,
+  options: {
+    turns: AgentTurnStreamRegistry;
+    isGuardian: (service: string, senderId: string) => Promise<boolean>;
+  },
+): Promise<ChatStopResult> {
+  const turn = options.turns.getActiveByConversation(input.ref);
+  if (!turn?.interrupt) return { status: "idle" };
+
+  if (turn.initiatorId !== input.senderId) {
+    const guardian = await options.isGuardian(input.service, input.senderId);
+    if (!guardian) return { status: "forbidden" };
+  }
+
+  await turn.interrupt("chat-stop");
+  return { status: "stop_requested", turnId: turn.turnId };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ import { getConfiguredInstanceOrigin } from "./lib/rome-cloud-origin.js";
 import { reportBootVersion, commitBootVersion } from "./lib/boot-version-report.js";
 import { getBuildInfo } from "./build-info.js";
 import { initTelemetry, getTracer, shutdown as shutdownTelemetry } from "./telemetry.js";
+import type { ChatStopHandler } from "@rome-os/app-runtime";
 
 const log = createLogger("startup");
 
@@ -93,6 +94,7 @@ import { createAgentSessionManager } from "./core/agent-session.js";
 import { createAgentLifecycleDispatcher } from "./core/agent-lifecycle.js";
 import { createTurnMiddlewareChain } from "./core/turn-middleware.js";
 import { AgentSessionBridge } from "./core/agent-session-bridge.js";
+import { stopActiveConversationTurn } from "./core/chat-stop.js";
 import { CapabilityDiscovery } from "./core/capability-discovery.js";
 import { EventBus } from "./events/event-bus.js";
 import { EventService } from "./events/event-service.js";
@@ -623,6 +625,12 @@ async function main() {
 
   const activeSubagentRegistry = createActiveSubagentRegistry();
   const agentTurnStreamRegistry = createAgentTurnStreamRegistry();
+  const chatStop: ChatStopHandler = (input) =>
+    stopActiveConversationTurn(input, {
+      turns: agentTurnStreamRegistry,
+      isGuardian: async (service, senderId) =>
+        (await personMappingRepo.findByChannelUser(service, senderId))?.bondLevel === "guardian",
+    });
   const subagentExecutionService = createSubagentExecutionService({
     webchatRepo,
     activeRegistry: activeSubagentRegistry,
@@ -655,6 +663,7 @@ async function main() {
     agentSessionManager,
     webchatRepo,
     actionWorkerCoordinator,
+    agentTurnStreamRegistry,
   );
   actionEngine.setAgentSessionBridge(agentSessionBridge);
 
@@ -941,6 +950,7 @@ async function main() {
   registerBuiltinConnections(connectionRegistry, {
     settingsRepo,
     conversationSettings,
+    chatStop,
     personMappingRepo,
     webchatRepo,
     whatsAppSyncSink: whatsAppStoreRepo,
@@ -979,6 +989,7 @@ async function main() {
         actionEngine,
         talkRouter,
         conversationSettings,
+        chatStop,
       });
       if (loadedHook) {
         messageHook = loadedHook;
@@ -1013,7 +1024,7 @@ async function main() {
   const reloadChannelMessageHook = messageHandlerRegistered
     ? createChannelMessageHookReloader({
         catalog: appCatalog,
-        deps: { actionEngine, talkRouter, conversationSettings },
+        deps: { actionEngine, talkRouter, conversationSettings, chatStop },
         getCurrent: () => messageHook,
         setCurrent: (hook) => {
           messageHook = hook;

--- a/rome_apps/inbox/src/hooks/channel-message/channel-message.test.ts
+++ b/rome_apps/inbox/src/hooks/channel-message/channel-message.test.ts
@@ -153,7 +153,7 @@ describe("ChannelMessageHook", () => {
       senderId: "user-1",
     });
     expect(harness.send).toHaveBeenCalledWith(TELEGRAM_ID, "chat-1", {
-      text: "Stop requested.",
+      text: "Stopped.",
     });
     expect(harness.get).not.toHaveBeenCalled();
     expect(harness.run).not.toHaveBeenCalled();

--- a/rome_apps/inbox/src/hooks/channel-message/channel-message.test.ts
+++ b/rome_apps/inbox/src/hooks/channel-message/channel-message.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, rs } from "@rstest/core";
 import type {
   ActionEngineLike,
+  ChatStopHandler,
   ConversationId,
   ConversationSettingsControl,
   InboundMessage,
@@ -64,6 +65,11 @@ function createHarness() {
     snapshot(connectionId, conversationId),
   );
   const conversationSettings = { get } as unknown as ConversationSettingsControl;
+  const stop = rs.fn(async () => ({ status: "stop_requested" as const, turnId: "turn-1" }));
+  const chatStop: ChatStopHandler = stop;
+  const send = rs.fn(async (_connectionId: string, conversationId: ConversationId) => ({
+    conversationId,
+  }));
   const talkRouter: TalkRouter = {
     list: async () => [
       { connectionId: TELEGRAM_ID, service: "telegram" },
@@ -73,21 +79,19 @@ function createHarness() {
       handlers.set(connectionId, handler);
       return () => handlers.delete(connectionId);
     },
-    async send(_connectionId, conversationId) {
-      return { conversationId };
-    },
+    send,
     feature<K extends TalkFeatureName>(connectionId: string, name: K) {
       return (features.get(connectionId)?.[name] ?? null) as TalkFeatureMap[K] | null;
     },
   };
-  const hook = new ChannelMessageHook(actionEngine, talkRouter, conversationSettings);
+  const hook = new ChannelMessageHook(actionEngine, talkRouter, conversationSettings, chatStop);
   const emit = async (connectionId: string, incoming: InboundMessage) => {
     const handler = handlers.get(connectionId);
     if (!handler) throw new Error(`no subscription for ${connectionId}`);
     await handler(incoming);
   };
 
-  return { hook, run, get, features, emit };
+  return { hook, run, get, features, emit, stop, send };
 }
 
 describe("ChannelMessageHook", () => {
@@ -135,6 +139,50 @@ describe("ChannelMessageHook", () => {
         }),
       }),
     );
+  });
+
+  it("handles a direct /stop before settings or message_handler", async () => {
+    await harness.emit(
+      TELEGRAM_ID,
+      message({ text: "/STOP", thread: { kind: "dm", name: "Alice" } }),
+    );
+
+    expect(harness.stop).toHaveBeenCalledWith({
+      ref: { connectionId: TELEGRAM_ID, conversationId: "chat-1" },
+      service: "telegram",
+      senderId: "user-1",
+    });
+    expect(harness.send).toHaveBeenCalledWith(TELEGRAM_ID, "chat-1", {
+      text: "Stop requested.",
+    });
+    expect(harness.get).not.toHaveBeenCalled();
+    expect(harness.run).not.toHaveBeenCalled();
+  });
+
+  it("accepts an addressed group /stop even when the conversation is disabled", async () => {
+    harness.get.mockImplementation(async ({ connectionId, conversationId }) =>
+      snapshot(connectionId, conversationId, { enabled: false }),
+    );
+
+    await harness.emit(
+      TELEGRAM_ID,
+      message({ text: "/stop", addressing: "mention", thread: { kind: "group" } }),
+    );
+
+    expect(harness.stop).toHaveBeenCalledTimes(1);
+    expect(harness.get).not.toHaveBeenCalled();
+    expect(harness.run).not.toHaveBeenCalled();
+  });
+
+  it("swallows an ambient group /stop instead of sending it to the model", async () => {
+    await harness.emit(
+      TELEGRAM_ID,
+      message({ text: "/stop", addressing: "ambient", thread: { kind: "group" } }),
+    );
+
+    expect(harness.stop).not.toHaveBeenCalled();
+    expect(harness.send).not.toHaveBeenCalled();
+    expect(harness.run).not.toHaveBeenCalled();
   });
 
   it("honors disabled conversations and routed agents from shared settings", async () => {

--- a/rome_apps/inbox/src/hooks/channel-message/index.ts
+++ b/rome_apps/inbox/src/hooks/channel-message/index.ts
@@ -1,6 +1,7 @@
-import { createAppLogger } from "@rome-os/app-runtime";
+import { chatStopReceipt, createAppLogger, isStopCommand } from "@rome-os/app-runtime";
 import type {
   ActionEngineLike,
+  ChatStopHandler,
   ChannelMessageHook as ChannelMessageHookInterface,
   ConversationSettingsControl,
   InboundMessage,
@@ -16,6 +17,7 @@ export class ChannelMessageHook implements ChannelMessageHookInterface {
     private readonly actionEngine: ActionEngineLike,
     private readonly talkRouter: TalkRouter,
     private readonly conversationSettings: ConversationSettingsControl,
+    private readonly chatStop: ChatStopHandler,
   ) {}
 
   async register(): Promise<void> {
@@ -50,6 +52,38 @@ export class ChannelMessageHook implements ChannelMessageHookInterface {
     }
 
     const ref = { connectionId, conversationId: message.conversationId };
+    if (isStopCommand(message.text)) {
+      const addressing =
+        message.addressing ?? (message.thread?.kind === "dm" ? "direct" : "ambient");
+      if (addressing === "ambient") {
+        log.debug("ignoring group stop command not directed at the bot", {
+          service,
+          messageId: message.messageId,
+        });
+        return;
+      }
+      try {
+        const result = await this.chatStop({
+          ref,
+          service,
+          senderId: message.senderId,
+        });
+        await this.talkRouter.send(connectionId, message.conversationId, {
+          text: chatStopReceipt(result.status),
+        });
+      } catch (err) {
+        log.error("stop command failed", {
+          service,
+          messageId: message.messageId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        await this.talkRouter.send(connectionId, message.conversationId, {
+          text: "Stop could not be requested. Please try again.",
+        });
+      }
+      return;
+    }
+
     let enabled = true;
     let routedAgentName: string | undefined;
     const snapshot = await this.conversationSettings.get(ref);
@@ -151,6 +185,12 @@ export function createHook(deps: {
   actionEngine: ActionEngineLike;
   talkRouter: TalkRouter;
   conversationSettings: ConversationSettingsControl;
+  chatStop: ChatStopHandler;
 }): ChannelMessageHookInterface {
-  return new ChannelMessageHook(deps.actionEngine, deps.talkRouter, deps.conversationSettings);
+  return new ChannelMessageHook(
+    deps.actionEngine,
+    deps.talkRouter,
+    deps.conversationSettings,
+    deps.chatStop,
+  );
 }


### PR DESCRIPTION
## What this PR does

External chat conversations can start an agent turn, but they had no provider-neutral way to stop the active response. This adds `/stop` handling for Discord, Feishu/Lark, and WeChat, including addressed group commands and Discord's native slash command.

## Design and invariants

The existing agent turn stream registry owns the live `ConversationRef` to turn mapping. It registers a conversation only after `turn_start`, so `/stop` cannot target queued input. The stop handler interrupts that exact active turn and leaves the conversation available for later messages.

Channel adapters normalize command addressing and can bypass disabled admission only for a directed `/stop`. The sender who started the turn or the Guardian can stop it.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit`
- [x] Stop command, turn registry, session bridge, provider, and inbox unit coverage
- [ ] `pnpm dev:all` — blocked because `/Users/ray/Projects/rome-internal-3` is already running the same Compose project name (`main`)
