### PR TITLE
core: let a channel answer for what a conversation holds

### DIFF
--- a/packages/core/src/channels/linkedin-messages.test.ts
+++ b/packages/core/src/channels/linkedin-messages.test.ts
@@ -44,11 +44,17 @@ const threads: ThreadSeed[] = [
     ],
   },
   // Three on the thread: nobody's direct history, whatever LinkedIn's own flag
-  // says about it.
+  // says about it — and all of it is what the thread holds.
   {
     thread: "t-room",
     participants: [SELF, MEMBER, OTHER],
-    messages: [{ id: "f", at: 700, text: "in the room" }],
+    messages: [
+      { id: "f", at: 700, text: "in the room" },
+      { id: "f2", at: 720, self: true, text: "said back" },
+      // The same second as `f2`; the direction settles the tie.
+      { id: "f3", at: 720, text: "crossed in flight" },
+      { id: "f4", at: 900, text: "newest in the room" },
+    ],
   },
   // Two on the thread, but LinkedIn calls it a group.
   {
@@ -172,6 +178,89 @@ describe("linkedInMessages", () => {
     expect(await messages.count(twins)).toBe(1);
   });
 
+  // The acceptance the milestone turns on: the mirror already held these rows
+  // and nothing asked for them.
+  it("answers a group thread's messages when asked for that thread", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const page = await messages.readConversation({
+      conversation: { channel: "linkedin", id: "t-room" },
+      limit: WHOLE_HISTORY,
+    });
+    expect(refs(page)).toEqual(["t-room:f4", "t-room:f2", "t-room:f3", "t-room:f"]);
+    expect(page[0]).toEqual({
+      source: "linkedin",
+      timestamp: 900,
+      direction: "inbound",
+      ref: "t-room:f4",
+      body: "newest in the room",
+    });
+  });
+
+  it("answers none of a group thread's messages to any account read", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const held = await messages.readConversation({
+      conversation: { channel: "linkedin", id: "t-room" },
+      limit: WHOLE_HISTORY,
+    });
+    expect(held.length).toBeGreaterThan(0);
+
+    // Every member of the room asked for as an account, and the thread id
+    // handed over as if it were one.
+    for (const address of [MEMBER, OTHER, SELF, "t-room"]) {
+      const scope: MessageAccount[] = [{ channel: "linkedin", addresses: [address] }];
+      expect(refs(await messages.read({ accounts: scope, limit: WHOLE_HISTORY }))).not.toContain(
+        "t-room:f4",
+      );
+    }
+    const asThread: MessageAccount[] = [{ channel: "linkedin", addresses: ["t-room"] }];
+    expect(await messages.latest(asThread)).toBeNull();
+    expect(await messages.count(asThread)).toBe(0);
+  });
+
+  // LinkedIn's own flag is the other way a thread is a group, and it settles
+  // threads the participant count would call direct.
+  it("answers a thread LinkedIn calls a group when asked for that thread", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const page = await messages.readConversation({
+      conversation: { channel: "linkedin", id: "t-flagged" },
+      limit: WHOLE_HISTORY,
+    });
+    expect(refs(page)).toEqual(["t-flagged:g"]);
+    expect(refs(await messages.read({ accounts, limit: WHOLE_HISTORY }))).not.toContain(
+      "t-flagged:g",
+    );
+  });
+
+  it("answers a direct thread asked for as a conversation exactly as its account reads it", async () => {
+    const messages = linkedInMessages(testDb.db);
+    const byConversation = await messages.readConversation({
+      conversation: { channel: "linkedin", id: "t-direct" },
+      limit: WHOLE_HISTORY,
+    });
+    expect(byConversation).toEqual(await messages.read({ accounts, limit: WHOLE_HISTORY }));
+  });
+
+  it("holds nothing for a conversation on another channel", async () => {
+    const messages = linkedInMessages(testDb.db);
+    expect(
+      await messages.readConversation({
+        conversation: { channel: "whatsapp", id: "t-room" },
+        limit: WHOLE_HISTORY,
+      }),
+    ).toEqual([]);
+  });
+
+  // The store takes the database and nothing else, so the read that reaches a
+  // group answers with no LinkedIn session open.
+  it("answers a conversation from the database alone", async () => {
+    expect(linkedInMessages.length).toBe(1);
+    const page = await linkedInMessages(testDb.db).readConversation({
+      conversation: { channel: "linkedin", id: "t-room" },
+      limit: 1,
+    });
+    expect(refs(page)).toEqual(["t-room:f4"]);
+  });
+
   it("holds nothing for an account on another channel", async () => {
     const messages = linkedInMessages(testDb.db);
     const elsewhere: MessageAccount[] = [{ channel: "whatsapp", addresses: [MEMBER] }];
@@ -265,5 +354,11 @@ describe("linkedInMessages", () => {
 testMessagesContract("linkedInMessages", () => {
   const testDb = createTestDb();
   seedMirror(testDb);
-  return { messages: linkedInMessages(testDb.db), accounts, silent };
+  return {
+    messages: linkedInMessages(testDb.db),
+    accounts,
+    silent,
+    conversation: { channel: "linkedin", id: "t-room" },
+    silentConversation: { channel: "linkedin", id: "t-nobody" },
+  };
 });

--- a/packages/core/src/channels/linkedin-messages.ts
+++ b/packages/core/src/channels/linkedin-messages.ts
@@ -1,18 +1,20 @@
 import { sql } from "drizzle-orm";
 import type { DrizzleDb } from "../db/index.js";
 import type { Messages } from "./messages.js";
-import { addressesIn, inList, sqlMessages } from "./messages-sql.js";
+import { inList, scopeColumn, scopeValues, sqlMessages } from "./messages-sql.js";
 
 /**
- * `Messages` over the LinkedIn inbox mirror (`linkedin_messages`), restricted
- * to threads that are a conversation between two people.
+ * `Messages` over the LinkedIn inbox mirror (`linkedin_messages`).
  *
- * A LinkedIn message hangs off a thread rather than off a member, so the scope
- * is reached through the thread's membership: a member's history is the
- * messages of the threads they are on. Two conditions keep that to a direct
- * conversation, and both are needed — LinkedIn's own group flag is null until
- * a thread has been snapshotted, so the membership decides the threads it has
- * not answered for yet.
+ * A LinkedIn message hangs off a thread rather than off a member, so the two
+ * questions reach it two ways rather than by one scope with a condition on it.
+ *
+ * A member's history goes through the thread's membership — a member's history
+ * is the messages of the threads they are on — restricted to threads that are
+ * a conversation between two people. Two conditions keep it there, and both
+ * are needed: LinkedIn's own group flag is null until a thread has been
+ * snapshotted, so the membership decides the threads it has not answered for
+ * yet.
  *
  * A message is answered once for each scoped member of its thread, and the
  * read above folds those together. That is what makes a person holding two
@@ -20,19 +22,39 @@ import { addressesIn, inList, sqlMessages } from "./messages-sql.js";
  * twice — and, unlike picking a single member per thread, it holds however
  * many members of however many people the scope names at once, which a read
  * grouping a whole directory into one pass depends on.
+ *
+ * A conversation is the thread itself, so nothing is reached through: the
+ * thread id is on the message row. Nor is anything restricted — a thread of
+ * three, and a thread LinkedIn flags as a group, are exactly the conversations
+ * no member's history can reach, and answering them is what this read is for.
+ * One member per message rather than one row per participant, since a thread
+ * named once is a thread answered once.
  */
 export function linkedInMessages(db: DrizzleDb): Messages {
   return sqlMessages({
     channel: "linkedin",
     db,
     view(scope) {
-      const addresses = addressesIn(scope);
-      const members = inList(sql`tp.participant_id`, addresses);
+      if (scope.by === "conversation") {
+        const threads = inList(sql`m.thread_id`, scopeValues(scope));
+        if (threads === null) return null;
+        return sql`
+          SELECT
+            'linkedin' AS source,
+            m.thread_id AS ${scopeColumn(scope)},
+            coalesce(m.sent_at, m.created_at) AS at,
+            CASE WHEN m.sender_is_self THEN 1 ELSE 0 END AS outbound,
+            m.thread_id || ':' || m.message_id AS ref,
+            m.text AS body
+          FROM linkedin_messages m
+          WHERE ${threads}`;
+      }
+      const members = inList(sql`tp.participant_id`, scopeValues(scope));
       if (members === null) return null;
       return sql`
         SELECT
           'linkedin' AS source,
-          tp.participant_id AS address,
+          tp.participant_id AS ${scopeColumn(scope)},
           coalesce(m.sent_at, m.created_at) AS at,
           CASE WHEN m.sender_is_self THEN 1 ELSE 0 END AS outbound,
           m.thread_id || ':' || m.message_id AS ref,

--- a/packages/core/src/channels/messages-agent.test.ts
+++ b/packages/core/src/channels/messages-agent.test.ts
@@ -85,15 +85,25 @@ async function seed(db: DrizzleDb) {
 
   // Out of scope, each for its own reason.
   await message(db, "m-trace", { sessionId: "s-direct", role: "trace", at: 400 });
-  // Sent by the account, but into a thread the group addresses.
+  await message(db, "m-webchat", { sessionId: "s-webchat", role: "user", at: 600 });
+  await message(db, "m-elsewhere", { sessionId: "s-elsewhere", role: "user", at: 550 });
+
+  // The group's own session. No account addresses it, so none of this reaches
+  // an account read — and all of it is the transcript of that thread.
+  // `m-group` is sent by the account itself, which changes nothing: the line
+  // belongs to the group's thread.
   await message(db, "m-group", {
     sessionId: "s-group",
     role: "user",
     at: 500,
     senderId: DIRECT,
   });
-  await message(db, "m-webchat", { sessionId: "s-webchat", role: "user", at: 600 });
-  await message(db, "m-elsewhere", { sessionId: "s-elsewhere", role: "user", at: 550 });
+  await message(db, "m-group-reply", { sessionId: "s-group", role: "assistant", at: 520 });
+  // The same second as the reply; the direction settles the tie.
+  await message(db, "m-group-crossed", { sessionId: "s-group", role: "user", at: 520 });
+  await message(db, "m-group-later", { sessionId: "s-group", role: "notification", at: 620 });
+  // A turn's own machinery belongs to no conversation, the group's included.
+  await message(db, "m-group-trace", { sessionId: "s-group", role: "trace", at: 640 });
 }
 
 describe("agentMessages", () => {
@@ -140,6 +150,80 @@ describe("agentMessages", () => {
 
   it("leaves out a session that is not a channel's", async () => {
     expect(await refs()).not.toContain("agent:m-webchat");
+  });
+
+  describe("read as a conversation", () => {
+    const inGroup = () =>
+      agentMessages(db).readConversation({
+        conversation: { channel: CHANNEL, id: GROUP },
+        limit: WHOLE_HISTORY,
+      });
+
+    it("answers the group's session when asked for its thread", async () => {
+      expect((await inGroup()).map((entry) => entry.ref)).toEqual([
+        "agent:m-group-later",
+        "agent:m-group-reply",
+        "agent:m-group-crossed",
+        "agent:m-group",
+      ]);
+    });
+
+    it("leaves out a trace row, which belongs to no conversation", async () => {
+      expect((await inGroup()).map((entry) => entry.ref)).not.toContain("agent:m-group-trace");
+    });
+
+    it("leaves out a session that is not a channel's", async () => {
+      const webchat = await agentMessages(db).readConversation({
+        conversation: { channel: CHANNEL, id: "s-webchat" },
+        limit: WHOLE_HISTORY,
+      });
+      expect(webchat).toEqual([]);
+    });
+
+    it("scopes a thread id to its own channel", async () => {
+      const here = await agentMessages(db).readConversation({
+        conversation: { channel: CHANNEL, id: DIRECT },
+        limit: WHOLE_HISTORY,
+      });
+      const there = await agentMessages(db).readConversation({
+        conversation: { channel: OTHER_CHANNEL, id: DIRECT },
+        limit: WHOLE_HISTORY,
+      });
+      expect(here.map((entry) => entry.ref)).not.toContain("agent:m-elsewhere");
+      expect(there.map((entry) => entry.ref)).toEqual(["agent:m-elsewhere"]);
+    });
+
+    it("answers a direct thread exactly as the account read answers it", async () => {
+      const byConversation = await agentMessages(db).readConversation({
+        conversation: { channel: CHANNEL, id: DIRECT },
+        limit: WHOLE_HISTORY,
+      });
+      const byAccount = await agentMessages(db).read({
+        accounts: [{ channel: CHANNEL, addresses: [DIRECT] }],
+        limit: WHOLE_HISTORY,
+      });
+      expect(byConversation).toEqual(byAccount);
+    });
+
+    it("costs one pass per round of conversation calls", async () => {
+      const counted = countingDb(db);
+      const messages = agentMessages(counted.db);
+      const before = counted.passes();
+
+      await Promise.all([
+        messages.readConversation({ conversation: { channel: CHANNEL, id: GROUP }, limit: 2 }),
+        messages.readConversation({
+          conversation: { channel: CHANNEL, id: DIRECT },
+          limit: WHOLE_HISTORY,
+        }),
+        messages.readConversation({
+          conversation: { channel: OTHER_CHANNEL, id: DIRECT },
+          limit: WHOLE_HISTORY,
+        }),
+      ]);
+
+      expect(counted.passes() - before).toBe(1);
+    });
   });
 
   it("names the channel as the source and the direction by the role", async () => {
@@ -300,7 +384,13 @@ testMessagesContract("agentMessages", () => {
   enrolled ??= (async () => {
     const { db } = createTestDb();
     await seed(db);
-    return { messages: agentMessages(db), accounts: [account], silent };
+    return {
+      messages: agentMessages(db),
+      accounts: [account],
+      silent,
+      conversation: { channel: CHANNEL, id: GROUP },
+      silentConversation: { channel: CHANNEL, id: "tg-no-such-thread" },
+    };
   })();
   return enrolled;
 });

--- a/packages/core/src/channels/messages-agent.ts
+++ b/packages/core/src/channels/messages-agent.ts
@@ -5,7 +5,7 @@ import { sql, type SQL } from "drizzle-orm";
 import type { DrizzleDb } from "../db/index.js";
 import type { MessagePart } from "../types.js";
 import type { Messages } from "./messages.js";
-import { scopePairs, sqlMessages } from "./messages-sql.js";
+import { scopeColumn, scopePairs, sqlMessages } from "./messages-sql.js";
 
 /**
  * The sender id Rome stamps on a message it sent itself.
@@ -48,12 +48,17 @@ export function agentMessageOutbound(role: SQL, senderId: SQL): SQL {
 /**
  * Rome's own transcript of a channel conversation.
  *
- * Reached through the session's channel address: a channel session is keyed by
- * the thread it belongs to, so a session addressed by the account is that
- * account's direct conversation, and a group's session — addressed by the
- * group rather than by anyone on it — is named by no account and never
- * matches. Which sender a message carries makes no difference: a line the
- * account wrote into a group belongs to the group's thread.
+ * A channel session is keyed by the thread it belongs to, so the session's
+ * thread id is what both questions reach a message through — and the same
+ * column answers each, since a direct conversation is addressed by the account
+ * whose thread it is.
+ *
+ * What differs is which threads each may select. An account read takes the
+ * ones an account addresses, so a group's session — addressed by the group
+ * rather than by anyone on it — is named by no account and never matches.
+ * Which sender a message carries makes no difference either way: a line the
+ * account wrote into a group belongs to the group's thread, and that thread is
+ * what a conversation read asks for.
  */
 export function agentMessages(db: DrizzleDb): Messages {
   // No `channel`: the transcript holds every channel that has no mirror of its
@@ -61,12 +66,18 @@ export function agentMessages(db: DrizzleDb): Messages {
   return sqlMessages({
     db,
     view(scope) {
-      const addressed = scopePairs(scope, sql`s.source_channel`, sql`s.source_thread_id`);
-      if (addressed === null) return null;
+      const named = scopePairs(scope, sql`s.source_channel`, sql`s.source_thread_id`);
+      if (named === null) return null;
+      // Addressing already leaves a group out of an account read, since a
+      // group's session is keyed by the group and no account answers to that.
+      // Said again on the store's own terms so the guarantee survives a caller
+      // that hands over a group id as if it were an account's address.
+      const direct =
+        scope.by === "address" ? sql` AND coalesce(s.source_thread_type, '') <> 'group'` : sql``;
       return sql`
         SELECT
           s.source_channel AS source,
-          s.source_thread_id AS address,
+          s.source_thread_id AS ${scopeColumn(scope)},
           m.created_at AS at,
           ${agentMessageOutbound(sql`m.role`, sql`m.sender_id`)} AS outbound,
           'agent:' || m.id AS ref,
@@ -74,17 +85,12 @@ export function agentMessages(db: DrizzleDb): Messages {
         FROM rome_agent_messages m
         JOIN rome_sessions s ON s.id = m.session_id
         WHERE s.type = 'channel'
-          AND ${addressed}
-          -- Addressing already leaves a group out, since a group's session is
-          -- keyed by the group and no account answers to that. Said again on
-          -- the store's own terms so the guarantee survives a caller that
-          -- hands over a group id as if it were an account's address.
-          AND coalesce(s.source_thread_type, '') <> 'group'
+          AND ${named}${direct}
           -- 'notification' is a line that passed outside a turn — something
           -- the person said without waking the agent, or something Rome sent
           -- untied to one. Either way it is conversation, and the direction
           -- above is what tells the two apart. 'trace' is the turn's own
-          -- machinery and belongs to no conversation.
+          -- machinery and belongs to no conversation, a group's included.
           AND m.role IN ('user', 'assistant', 'notification')`;
     },
     body: messageContentText,

--- a/packages/core/src/channels/messages-contract.ts
+++ b/packages/core/src/channels/messages-contract.ts
@@ -10,7 +10,7 @@ import {
   timelineCursor,
   type TimelineEntry,
 } from "@rome/api-types/people";
-import type { MessageAccount, Messages } from "./messages.js";
+import type { MessageAccount, MessageConversation, Messages } from "./messages.js";
 
 /** A limit large enough to hold any history a store can answer — what
  *  messages.ts calls the full read. */
@@ -29,6 +29,17 @@ export interface MessagesContractSubject {
   accounts: MessageAccount[];
   /** Accounts on the store's own channels that it holds nothing for. */
   silent: MessageAccount[];
+  /**
+   * A conversation the store holds messages of, and which none of `accounts`
+   * reaches — a group, since a group is addressed by nobody on it.
+   *
+   * Enroll with at least four messages, two of them in the same second, for
+   * the reason `accounts` gives: a conversation that fits in one page never
+   * pages, and one whose timestamps are all distinct settles no tie.
+   */
+  conversation: MessageConversation;
+  /** A conversation on the store's own channels that it holds nothing of. */
+  silentConversation: MessageConversation;
 }
 
 /** Page size the paging assertions walk with. Smaller than the history the
@@ -139,6 +150,130 @@ export function testMessagesContract(
       expect(await store.messages.read({ accounts: store.silent, limit: WHOLE_HISTORY })).toEqual(
         [],
       );
+    });
+
+    // What a conversation holds, which is the other question a store is asked.
+    // The obligations are `read`'s, restated over a conversation rather than
+    // re-derived: a store that ordered or paged the two differently would
+    // answer one message two ways.
+    describe("read as a conversation", () => {
+      const wholeConversation = async ({ messages, conversation }: MessagesContractSubject) =>
+        messages.readConversation({ conversation, limit: WHOLE_HISTORY });
+
+      it("holds enough of a conversation to prove the law", async () => {
+        const store = await subject();
+        const full = await wholeConversation(store);
+        expect(full.length).toBeGreaterThanOrEqual(4);
+        expect(new Set(full.map((entry) => entry.timestamp)).size).toBeLessThan(full.length);
+      });
+
+      // The whole of it: a conversation nobody is addressed on is reachable
+      // here and nowhere else. A store answering these through an account read
+      // too would have made the new verb a second name for the old one.
+      it("answers a conversation no account read reaches", async () => {
+        const store = await subject();
+        const conversation = await wholeConversation(store);
+        const accounts = await store.messages.read({
+          accounts: store.accounts,
+          limit: WHOLE_HISTORY,
+        });
+        const reached = new Set(accounts.map((entry) => entry.ref));
+        expect(conversation.every((entry) => !reached.has(entry.ref))).toBe(true);
+      });
+
+      it("answers a page newest first, no longer than its limit", async () => {
+        const store = await subject();
+        const page = await store.messages.readConversation({
+          conversation: store.conversation,
+          limit: PAGE,
+        });
+        expect(page.length).toBeLessThanOrEqual(PAGE);
+        expect(page).toEqual([...page].sort(compareTimelineEntries));
+      });
+
+      it("answers only messages strictly after the cursor", async () => {
+        const store = await subject();
+        const first = await store.messages.readConversation({
+          conversation: store.conversation,
+          limit: PAGE,
+        });
+        const cursor = first.at(-1);
+        if (!cursor) throw new Error("the store answered no first page to resume from");
+        const next = await store.messages.readConversation({
+          conversation: store.conversation,
+          after: cursor,
+          limit: WHOLE_HISTORY,
+        });
+        expect(next.every((entry) => isAfterTimelineCursor(entry, cursor))).toBe(true);
+      });
+
+      it("pages to exhaustion over exactly the whole conversation", async () => {
+        const store = await subject();
+        const full = await wholeConversation(store);
+
+        const walked: TimelineEntry[] = [];
+        let after: TimelineEntry | null = null;
+        // Bounded for the reason the account walk above is.
+        for (let page = 0; page <= Math.ceil(full.length / PAGE); page++) {
+          const entries: TimelineEntry[] = await store.messages.readConversation({
+            conversation: store.conversation,
+            after,
+            limit: PAGE,
+          });
+          if (entries.length === 0) break;
+          walked.push(...entries);
+          after = entries[entries.length - 1] ?? null;
+        }
+
+        expect(walked).toEqual(full);
+      });
+
+      it("answers nothing after the conversation's oldest message", async () => {
+        const store = await subject();
+        const full = await wholeConversation(store);
+        const oldest = full.at(-1);
+        expect(oldest).toBeDefined();
+        const past = await store.messages.readConversation({
+          conversation: store.conversation,
+          after: oldest,
+          limit: WHOLE_HISTORY,
+        });
+        expect(past).toEqual([]);
+      });
+
+      it("gives every message its own cursor position", async () => {
+        const store = await subject();
+        const full = await wholeConversation(store);
+        expect(new Set(full.map(timelineCursor)).size).toBe(full.length);
+      });
+
+      // The settled answer for a conversation a store holds nothing of: an
+      // empty page, which is what a store holding the conversation but nothing
+      // said in it answers too. No store needs to tell those apart, and a
+      // second answer for one of them is a case every caller would have to
+      // branch on.
+      it("answers an empty page for a conversation it holds nothing of", async () => {
+        const store = await subject();
+        expect(
+          await store.messages.readConversation({
+            conversation: store.silentConversation,
+            limit: WHOLE_HISTORY,
+          }),
+        ).toEqual([]);
+      });
+
+      it("answers an empty page for a silent conversation resumed from a cursor", async () => {
+        const store = await subject();
+        const cursor = (await wholeConversation(store))[0];
+        if (!cursor) throw new Error("the store answered no entry to resume from");
+        expect(
+          await store.messages.readConversation({
+            conversation: store.silentConversation,
+            after: cursor,
+            limit: WHOLE_HISTORY,
+          }),
+        ).toEqual([]);
+      });
     });
   });
 }

--- a/packages/core/src/channels/messages-memory.test.ts
+++ b/packages/core/src/channels/messages-memory.test.ts
@@ -9,6 +9,12 @@ import { testMessagesContract, WHOLE_HISTORY } from "./messages-contract.js";
 const PHONE = "1555@s.whatsapp.net";
 const LID = "77@lid";
 const MEMBER = "ACoAA1";
+// A thread the accounts below are not on, carrying messages from two addresses
+// — the shape a LinkedIn thread has, where what addresses a message and what
+// names the conversation it was said in are two different things.
+const ROOM = "li-thread-room";
+const ROOM_A = "ACoAAROOMA";
+const ROOM_B = "ACoAAROOMB";
 
 const entry = (
   source: string,
@@ -30,6 +36,35 @@ const held: HeldMessage[] = [
   // same string as a WhatsApp address on a channel that is not WhatsApp.
   { channel: "whatsapp", address: "9999@s.whatsapp.net", entry: entry("whatsapp", 600, "wa:x") },
   { channel: "linkedin", address: PHONE, entry: entry("linkedin", 700, "li:x") },
+
+  // The room. Every message names its own sender and the one conversation they
+  // were all said in, and no account below is addressed on it.
+  {
+    channel: "linkedin",
+    address: ROOM_A,
+    conversation: ROOM,
+    entry: entry("linkedin", 800, "li:r1"),
+  },
+  {
+    channel: "linkedin",
+    address: ROOM_B,
+    conversation: ROOM,
+    entry: entry("linkedin", 900, "li:r2", "outbound"),
+  },
+  // The same second as li:r2, from the other member: the direction settles the
+  // tie, and both have to survive a page boundary.
+  {
+    channel: "linkedin",
+    address: ROOM_A,
+    conversation: ROOM,
+    entry: entry("linkedin", 900, "li:r3"),
+  },
+  {
+    channel: "linkedin",
+    address: ROOM_B,
+    conversation: ROOM,
+    entry: entry("linkedin", 1000, "li:r4"),
+  },
 ];
 
 const accounts = [
@@ -41,6 +76,8 @@ testMessagesContract("memoryMessages", () => ({
   messages: memoryMessages(held),
   accounts,
   silent: [{ channel: "whatsapp", addresses: ["4444@s.whatsapp.net"] }],
+  conversation: { channel: "linkedin", id: ROOM },
+  silentConversation: { channel: "linkedin", id: "li-thread-nobody" },
 }));
 
 describe("memoryMessages", () => {
@@ -71,5 +108,37 @@ describe("memoryMessages", () => {
     expect(await messages.latest([])).toBeNull();
     expect(await messages.count([])).toBe(0);
     expect(await messages.read({ accounts: [], limit: WHOLE_HISTORY })).toEqual([]);
+  });
+
+  it("merges every address of a conversation into one newest-first history", async () => {
+    const page = await messages.readConversation({
+      conversation: { channel: "linkedin", id: ROOM },
+      limit: WHOLE_HISTORY,
+    });
+    expect(page.map((e) => e.ref)).toEqual(["li:r4", "li:r2", "li:r3", "li:r1"]);
+  });
+
+  // A message held with no conversation of its own was said in the one the
+  // person on it addresses, so asking for that conversation answers exactly
+  // what the person's account read answers.
+  it("names a direct conversation by the address it arrived at", async () => {
+    const byConversation = await messages.readConversation({
+      conversation: { channel: "whatsapp", id: PHONE },
+      limit: WHOLE_HISTORY,
+    });
+    const byAccount = await messages.read({
+      accounts: [{ channel: "whatsapp", addresses: [PHONE] }],
+      limit: WHOLE_HISTORY,
+    });
+    expect(byConversation).toEqual(byAccount);
+  });
+
+  it("scopes a conversation by the channel and the id together", async () => {
+    expect(
+      await messages.readConversation({
+        conversation: { channel: "whatsapp", id: ROOM },
+        limit: WHOLE_HISTORY,
+      }),
+    ).toEqual([]);
   });
 });

--- a/packages/core/src/channels/messages-memory.ts
+++ b/packages/core/src/channels/messages-memory.ts
@@ -7,44 +7,63 @@ import {
   isAfterTimelineCursor,
   type TimelineEntry,
 } from "@rome/api-types/people";
-import type { MessageAccount, MessageRead, Messages } from "./messages.js";
+import type { ConversationRead, MessageAccount, MessageRead, Messages } from "./messages.js";
 
-/** One message the store holds, at the address it arrived on. */
+/** One message the store holds, at the address it arrived on and in the
+ *  conversation it was said in. */
 export interface HeldMessage {
   channel: string;
   address: string;
   entry: TimelineEntry;
+  /**
+   * The thread the message was said in, when that is not the address itself.
+   *
+   * Absent for a direct conversation, which is addressed by the person on it —
+   * so a message held at an address and nothing more is a message in that
+   * person's own thread. A store where the two genuinely differ says so: a
+   * LinkedIn thread is named by the thread and addressed by each member on it,
+   * and a group is named by the group and addressed by nobody.
+   */
+  conversation?: string;
 }
 
 /**
- * `Messages` over `held`, scoped by the `(channel, address)` pair — an address
- * on one channel never selects a message another channel stores under the same
- * string.
+ * `Messages` over `held`, scoped by the `(channel, address)` pair for an
+ * account read and the `(channel, conversation)` pair for a conversation read.
+ * Either way it is the pair — a value on one channel never selects a message
+ * another channel stores under the same string.
  *
  * A message is answered once however many of the given accounts name its
  * address, because a read filters the list rather than making a pass per
  * address.
  */
 export function memoryMessages(held: readonly HeldMessage[]): Messages {
+  const sorted = (messages: readonly HeldMessage[]): TimelineEntry[] =>
+    messages.map((message) => message.entry).sort(compareTimelineEntries);
+
   const full = (accounts: readonly MessageAccount[]): TimelineEntry[] => {
     const scope = new Set(
       accounts.flatMap((account) =>
-        account.addresses.map((address) => addressKey(account.channel, address)),
+        account.addresses.map((address) => key(account.channel, address)),
       ),
     );
-    return held
-      .filter((message) => scope.has(addressKey(message.channel, message.address)))
-      .map((message) => message.entry)
-      .sort(compareTimelineEntries);
+    return sorted(held.filter((message) => scope.has(key(message.channel, message.address))));
   };
+
+  // Newest first, then everything strictly after the cursor, then the page —
+  // the one shape both reads answer in, stated once so neither can drift.
+  const page = (
+    entries: TimelineEntry[],
+    after: TimelineEntry | null,
+    limit: number,
+  ): TimelineEntry[] =>
+    entries
+      .filter((entry) => after === null || isAfterTimelineCursor(entry, after))
+      .slice(0, Math.max(1, Math.floor(limit)));
 
   return {
     async read(request: MessageRead) {
-      const after = request.after ?? null;
-      const limit = Math.max(1, Math.floor(request.limit));
-      return full(request.accounts)
-        .filter((entry) => after === null || isAfterTimelineCursor(entry, after))
-        .slice(0, limit);
+      return page(full(request.accounts), request.after ?? null, request.limit);
     },
 
     async count(accounts) {
@@ -54,7 +73,15 @@ export function memoryMessages(held: readonly HeldMessage[]): Messages {
     async latest(accounts) {
       return full(accounts)[0] ?? null;
     },
+
+    async readConversation(request: ConversationRead) {
+      const wanted = key(request.conversation.channel, request.conversation.id);
+      const inThread = held.filter(
+        (message) => key(message.channel, message.conversation ?? message.address) === wanted,
+      );
+      return page(sorted(inThread), request.after ?? null, request.limit);
+    },
   };
 }
 
-const addressKey = (channel: string, address: string) => `${channel}\n${address}`;
+const key = (channel: string, value: string) => `${channel}\n${value}`;

--- a/packages/core/src/channels/messages-sentinel.test.ts
+++ b/packages/core/src/channels/messages-sentinel.test.ts
@@ -73,9 +73,15 @@ async function seed(db: DrizzleDb) {
   // An empty reply is no reply.
   await row(db, "quiet", { at: 1200, text: "hm", response: "", threadId: "tg-quiet-thread" });
 
-  // Out of scope: the thread a group session covers, and another sender.
-  await row(db, "in-group", { at: 900, text: "hi all", response: "hello", threadId: GROUP });
+  // Out of scope: another sender.
   await row(db, "stranger", { at: 1300, text: "who?", channelUserId: "tg-stranger" });
+
+  // The thread a group session covers. No account read reaches it — the
+  // subtraction above takes it out however the row names its sender — and all
+  // of it is what the sentinel logged of that thread. Two rows, each read as
+  // the two lines it records, which is four entries and two ties.
+  await row(db, "in-group", { at: 900, text: "hi all", response: "hello", threadId: GROUP });
+  await row(db, "in-group-2", { at: 950, text: "still here", response: "ack", threadId: GROUP });
 }
 
 describe("sentinelLogMessages", () => {
@@ -152,6 +158,44 @@ describe("sentinelLogMessages", () => {
     expect(await messages.count([])).toBe(0);
     expect(await messages.read({ accounts: [], limit: WHOLE_HISTORY })).toEqual([]);
   });
+
+  describe("read as a conversation", () => {
+    const inThread = (id: string) =>
+      sentinelLogMessages(db).readConversation({
+        conversation: { channel: CHANNEL, id },
+        limit: WHOLE_HISTORY,
+      });
+
+    it("answers a group thread's rows when asked for that thread", async () => {
+      expect((await inThread(GROUP)).map((entry) => entry.ref)).toEqual([
+        "sentinel:in-group-2:reply",
+        "sentinel:in-group-2",
+        "sentinel:in-group:reply",
+        "sentinel:in-group",
+      ]);
+    });
+
+    it("answers none of a group thread's rows to the account read", async () => {
+      const held = await inThread(GROUP);
+      expect(held.length).toBeGreaterThan(0);
+      expect(await refs()).not.toContain("sentinel:in-group");
+      expect(await refs()).not.toContain("sentinel:in-group:reply");
+    });
+
+    it("reads a row with no reply as the inbound message alone", async () => {
+      const entries = (await inThread("tg-unknown-thread")).map((entry) => entry.ref);
+      expect(entries).toContain("sentinel:unheard");
+      expect(entries).not.toContain("sentinel:unheard:reply");
+    });
+
+    it("scopes a thread id to its own channel", async () => {
+      const elsewhere = await sentinelLogMessages(db).readConversation({
+        conversation: { channel: "discord", id: GROUP },
+        limit: WHOLE_HISTORY,
+      });
+      expect(elsewhere).toEqual([]);
+    });
+  });
 });
 
 // One seeded database for the whole suite: every assertion in it reads, so a
@@ -162,7 +206,13 @@ testMessagesContract("sentinelLogMessages", () => {
   enrolled ??= (async () => {
     const { db } = createTestDb();
     await seed(db);
-    return { messages: sentinelLogMessages(db), accounts: [account], silent };
+    return {
+      messages: sentinelLogMessages(db),
+      accounts: [account],
+      silent,
+      conversation: { channel: CHANNEL, id: GROUP },
+      silentConversation: { channel: CHANNEL, id: "tg-no-such-thread" },
+    };
   })();
   return enrolled;
 });

--- a/packages/core/src/channels/messages-sentinel.ts
+++ b/packages/core/src/channels/messages-sentinel.ts
@@ -4,7 +4,7 @@
 import { sql } from "drizzle-orm";
 import type { DrizzleDb } from "../db/index.js";
 import type { Messages } from "./messages.js";
-import { scopePairs, sqlMessages } from "./messages-sql.js";
+import { scopeColumn, scopePairs, sqlMessages } from "./messages-sql.js";
 
 /**
  * What the sentinel logged, one row read as the two lines it records: what the
@@ -13,6 +13,10 @@ import { scopePairs, sqlMessages } from "./messages-sql.js";
  * Both halves share the row's one timestamp, and the ordering puts the reply
  * above the line it answers. Each carries its own `ref`, so the two never
  * collapse to one cursor position.
+ *
+ * A row names both the sender it came from and the thread it was said in, so
+ * the two questions read two different columns of it rather than one column
+ * two ways.
  */
 export function sentinelLogMessages(db: DrizzleDb): Messages {
   // No `channel`: the log holds every channel's triage side by side, so it is
@@ -20,14 +24,20 @@ export function sentinelLogMessages(db: DrizzleDb): Messages {
   return sqlMessages({
     db,
     view(scope) {
-      const addressed = scopePairs(scope, sql`l.channel`, sql`l.channel_user_id`);
-      if (addressed === null) return null;
+      const key = scope.by === "address" ? sql`l.channel_user_id` : sql`l.thread_id`;
+      const named = scopePairs(scope, sql`l.channel`, key);
+      if (named === null) return null;
       // A log row names its sender but not whether they were alone. The
       // session that recorded the same thread does, so a thread Rome knows to
-      // be a group is what the scope subtracts — a row whose thread no session
-      // covers is a direct exchange until something says otherwise.
-      const direct = sql`
-        ${addressed}
+      // be a group is what an account read subtracts — a row whose thread no
+      // session covers is a direct exchange until something says otherwise. A
+      // conversation read subtracts nothing: the thread named is the thread
+      // answered, group or not.
+      const held =
+        scope.by === "conversation"
+          ? named
+          : sql`
+        ${named}
         AND NOT EXISTS (
           SELECT 1 FROM rome_sessions s
           WHERE s.type = 'channel'
@@ -38,23 +48,23 @@ export function sentinelLogMessages(db: DrizzleDb): Messages {
       return sql`
         SELECT
           l.channel AS source,
-          l.channel_user_id AS address,
+          ${key} AS ${scopeColumn(scope)},
           l.created_at AS at,
           0 AS outbound,
           'sentinel:' || l.id AS ref,
           l.text AS body
         FROM sentinel_log l
-        WHERE ${direct}
+        WHERE ${held}
         UNION ALL
         SELECT
           l.channel,
-          l.channel_user_id,
+          ${key},
           l.created_at,
           1,
           'sentinel:' || l.id || ':reply',
           l.response
         FROM sentinel_log l
-        WHERE ${direct} AND l.response IS NOT NULL AND l.response <> ''`;
+        WHERE ${held} AND l.response IS NOT NULL AND l.response <> ''`;
     },
   });
 }

--- a/packages/core/src/channels/messages-sql.ts
+++ b/packages/core/src/channels/messages-sql.ts
@@ -12,14 +12,23 @@
 import { sql, type SQL } from "drizzle-orm";
 import type { TimelineEntry } from "@rome/api-types/people";
 import type { DrizzleDb } from "../db/index.js";
-import type { MessageAccount, MessageRead, Messages } from "./messages.js";
+import type {
+  ConversationRead,
+  MessageAccount,
+  MessageConversation,
+  MessageRead,
+  Messages,
+} from "./messages.js";
 
 /**
  * A store's rows as timeline entries: a SELECT producing exactly the columns
- * `source`, `address`, `at`, `outbound`, `ref`, `body`.
+ * `source`, `at`, `outbound`, `ref`, `body`, and the one column naming what
+ * the view was scoped by — `address` for an address scope, `conversation` for
+ * a conversation scope, which is what {@link scopeColumn} spells.
  *
- * - `source` is the channel an entry arrived on, and `address` an address of
- *   the account it belongs to — one of the addresses the view was given.
+ * - `source` is the channel an entry arrived on. `address` is an address of
+ *   the account it belongs to and `conversation` the platform's id for the
+ *   thread it was said in — in each case one of the values the view was given.
  * - `at` is epoch seconds, `outbound` is 1 for something Rome said and 0 for
  *   something it was told, `body` is the line to render or NULL.
  * - `ref` must be unique across everything the store can put on one person's
@@ -32,12 +41,52 @@ import type { MessageAccount, MessageRead, Messages } from "./messages.js";
  */
 export type MessageViewSql = SQL;
 
-/** One address, on the channel that holds it. What a store is scoped by, since
- *  the pair is what names a conversation: two channels are free to spell an
- *  address the same way and mean two different people. */
+/** One address, on the channel that holds it. What a store's account reads are
+ *  scoped by, since the pair is what names a person: two channels are free to
+ *  spell an address the same way and mean two different people. */
 export interface MessageAddress {
   channel: string;
   address: string;
+}
+
+/**
+ * What a view is scoped to, and which of the store's two questions asked it.
+ *
+ * One scope holds one kind. The two select different rows — a group thread is
+ * out of every address scope and in a conversation scope naming it — so a view
+ * handed both at once could not say which condition each value belonged to.
+ * A tick raising both kinds is answered by one statement per kind.
+ */
+export type MessageScope =
+  | { by: "address"; addresses: readonly MessageAddress[] }
+  | { by: "conversation"; conversations: readonly MessageConversation[] };
+
+/** Every value in a scope, each once — the addresses of an address scope, the
+ *  conversation ids of a conversation scope. What a view on a single channel
+ *  needs, the channel being its own. */
+export function scopeValues(scope: MessageScope): string[] {
+  return [...new Set(scopeEntries(scope).map((entry) => entry.value))];
+}
+
+/** The column a view answers under for `scope`. Two names because each is true
+ *  of what it holds, and a view spelling the other one is a read that selects
+ *  nothing rather than one that quietly answers the wrong rows. */
+export function scopeColumn(scope: MessageScope): SQL {
+  return sql.raw(scope.by === "address" ? "address" : "conversation");
+}
+
+/** A scope as the `(channel, value)` pairs it names, in the order given. */
+function scopeEntries(scope: MessageScope): ScopeEntry[] {
+  return scope.by === "address"
+    ? scope.addresses.map((entry) => ({ channel: entry.channel, value: entry.address }))
+    : scope.conversations.map((entry) => ({ channel: entry.channel, value: entry.id }));
+}
+
+/** One thing a job asked about, on the channel that holds it — an address or a
+ *  conversation id, depending on which question raised the job. */
+interface ScopeEntry {
+  channel: string;
+  value: string;
 }
 
 export interface SqlMessagesOptions {
@@ -54,13 +103,14 @@ export interface SqlMessagesOptions {
   channel?: string;
   db: DrizzleDb;
   /**
-   * The store's rows, scoped to every address of every account a batch of
-   * calls named, deduplicated.
+   * The store's rows, scoped to everything a batch of calls named,
+   * deduplicated — every address of every account for an address scope, every
+   * conversation id for a conversation scope.
    *
    * Null when the request can hold nothing, and the store then answers empty
    * without a query.
    */
-  view(scope: readonly MessageAddress[]): MessageViewSql | null;
+  view(scope: MessageScope): MessageViewSql | null;
   /**
    * The view's `body` column mapped to the line to render, for a store whose
    * text is not stored as text — Rome's transcript keeps a JSON array of
@@ -87,10 +137,16 @@ export interface SqlMessagesOptions {
  * because both are read off the same ranking of the same rows.
  */
 export function sqlMessages(options: SqlMessagesOptions): Messages {
-  const submit = batched<Job, JobResult>((jobs) => runBatch(options, jobs));
+  // One queue per question. A batch is one statement and a statement scopes
+  // its view one way, so the two kinds of job are gathered apart — each still
+  // answering a whole round of its own calls in a single pass.
+  const submitAddresses = batched<Job, JobResult>((jobs) => runBatch(options, "address", jobs));
+  const submitConversations = batched<Job, JobResult>((jobs) =>
+    runBatch(options, "conversation", jobs),
+  );
 
   const job = (accounts: readonly MessageAccount[], after: TimelineEntry | null, limit: number) =>
-    submit({ scope: scopeOf(accounts, options.channel), after, limit });
+    submitAddresses({ scope: addressScope(accounts, options.channel), after, limit });
 
   return {
     async read(request: MessageRead) {
@@ -105,6 +161,17 @@ export function sqlMessages(options: SqlMessagesOptions): Messages {
     async latest(accounts) {
       return (await job(accounts, null, 1)).entries[0] ?? null;
     },
+
+    async readConversation(request: ConversationRead) {
+      const limit = Math.max(1, Math.floor(request.limit));
+      return (
+        await submitConversations({
+          scope: conversationScope(request.conversation, options.channel),
+          after: request.after ?? null,
+          limit,
+        })
+      ).entries;
+    },
   };
 }
 
@@ -116,30 +183,35 @@ export function sqlMessages(options: SqlMessagesOptions): Messages {
  * one channel drops the accounts on every other here; a store that serves them
  * all keeps the channel beside each address and matches on both.
  */
-function scopeOf(
+function addressScope(
   accounts: readonly MessageAccount[],
   channel: string | undefined,
-): MessageAddress[] {
-  const scope = new Map<string, MessageAddress>();
+): ScopeEntry[] {
+  const scope = new Map<string, ScopeEntry>();
   for (const account of accounts) {
     if (channel !== undefined && account.channel !== channel) continue;
     for (const address of account.addresses) {
-      scope.set(`${account.channel}\n${address}`, { channel: account.channel, address });
+      scope.set(`${account.channel}\n${address}`, { channel: account.channel, value: address });
     }
   }
   return [...scope.values()];
 }
 
-/** Every address in a scope, each once — what a view on a single channel needs,
- *  the channel being its own. */
-export function addressesIn(scope: readonly MessageAddress[]): string[] {
-  return [...new Set(scope.map((entry) => entry.address))];
+/** The conversation a read named, or nothing when it belongs to a channel this
+ *  store does not serve — the rule the address scope applies, applied to the
+ *  other question. */
+function conversationScope(
+  conversation: MessageConversation,
+  channel: string | undefined,
+): ScopeEntry[] {
+  if (channel !== undefined && conversation.channel !== channel) return [];
+  return [{ channel: conversation.channel, value: conversation.id }];
 }
 
 /** One call, as the batch sees it. `limit` of {@link COUNT_ONLY} is a job that
  *  wants the length of a history and none of it. */
 interface Job {
-  scope: readonly MessageAddress[];
+  scope: readonly ScopeEntry[];
   after: TimelineEntry | null;
   limit: number;
 }
@@ -165,21 +237,32 @@ const nothing = (): JobResult => ({ entries: [], total: 0 });
  * wants — so the rows are scoped, ranked and cut per job inside a single pass
  * rather than once per job.
  */
-async function runBatch(options: SqlMessagesOptions, jobs: Job[]): Promise<JobResult[]> {
+async function runBatch(
+  options: SqlMessagesOptions,
+  by: MessageScope["by"],
+  jobs: Job[],
+): Promise<JobResult[]> {
   const asked = jobs.flatMap((job, index) => job.scope.map((entry) => ({ index, ...entry })));
   if (asked.length === 0) return jobs.map(nothing);
 
-  const wanted = new Map(asked.map((entry) => [`${entry.channel}\n${entry.address}`, entry]));
-  const rows = options.view(
-    [...wanted.values()].map(({ channel, address }) => ({
-      channel,
-      address,
-    })),
-  );
+  const wanted = new Map(asked.map((entry) => [`${entry.channel}\n${entry.value}`, entry]));
+  const scoped = [...wanted.values()];
+  const scope: MessageScope =
+    by === "address"
+      ? {
+          by,
+          addresses: scoped.map(({ channel, value }) => ({ channel, address: value })),
+        }
+      : { by, conversations: scoped.map(({ channel, value }) => ({ channel, id: value })) };
+  const rows = options.view(scope);
   if (rows === null) return jobs.map(nothing);
 
-  const scope = sql.join(
-    asked.map((entry) => sql`(${entry.index}, ${entry.channel}, ${entry.address})`),
+  // Whichever column the view answered under. The join below is otherwise the
+  // same either way: the rows are one store's, and only the question of which
+  // of them a job asked about differs.
+  const held = sql`held.${scopeColumn(scope)}`;
+  const asking = sql.join(
+    asked.map((entry) => sql`(${entry.index}, ${entry.channel}, ${entry.value})`),
     sql`, `,
   );
   const ask = sql.join(
@@ -188,7 +271,7 @@ async function runBatch(options: SqlMessagesOptions, jobs: Job[]): Promise<JobRe
   );
 
   const answered = (await options.db.all(sql`
-    WITH scope(rq, source, address) AS (VALUES ${scope}),
+    WITH scope(rq, source, val) AS (VALUES ${asking}),
     ask(rq, cap, has_cursor, c_at, c_outbound, c_source, c_ref) AS (VALUES ${ask}),
     -- One row per (job, message). DISTINCT because a view may attribute one
     -- message to several of a job's addresses — a LinkedIn thread carrying two
@@ -203,10 +286,10 @@ async function runBatch(options: SqlMessagesOptions, jobs: Job[]): Promise<JobRe
         held.ref AS ref,
         held.body AS body
       FROM (${rows}) held
-      -- The pair, never the address alone: a store holding several channels
-      -- side by side would otherwise hand one channel's message to a job that
-      -- asked about the same string on another.
-      JOIN scope ON scope.source = held.source AND scope.address = held.address
+      -- The pair, never the value alone: a store holding several channels side
+      -- by side would otherwise hand one channel's message to a job that asked
+      -- about the same string on another.
+      JOIN scope ON scope.source = held.source AND scope.val = ${held}
     ),
     -- Each job's own history, ranked and measured in one pass. One named
     -- window rather than two inline ones: SQLite shares a partition pass only
@@ -341,27 +424,27 @@ function batched<J, R>(run: (jobs: J[]) => Promise<R[]>): (job: J) => Promise<R>
 }
 
 /**
- * A whole scope as a WHERE clause: `(channel = … AND address IN (…))` per
+ * A whole scope as a WHERE clause: `(channel = … AND value IN (…))` per
  * channel, or'd together, and null when the scope is empty.
  *
  * What a store holding several channels side by side scopes itself with. The
- * pair rather than the address alone, for the reason the batch's join gives:
- * two channels may spell an address the same way and mean two people.
+ * pair rather than the value alone, for the reason the batch's join gives: two
+ * channels may spell an address — or a thread id — the same way and mean two
+ * different things.
+ *
+ * `valueColumn` is whichever column answers the question that raised the
+ * scope: the address a row arrived at, or the thread it was said in.
  */
-export function scopePairs(
-  scope: readonly MessageAddress[],
-  channelColumn: SQL,
-  addressColumn: SQL,
-): SQL | null {
+export function scopePairs(scope: MessageScope, channelColumn: SQL, valueColumn: SQL): SQL | null {
   const byChannel = new Map<string, string[]>();
-  for (const { channel, address } of scope) {
-    const addresses = byChannel.get(channel);
-    if (addresses) addresses.push(address);
-    else byChannel.set(channel, [address]);
+  for (const { channel, value } of scopeEntries(scope)) {
+    const values = byChannel.get(channel);
+    if (values) values.push(value);
+    else byChannel.set(channel, [value]);
   }
   const clauses = [...byChannel]
-    .map(([channel, addresses]) => {
-      const held = inList(addressColumn, addresses);
+    .map(([channel, values]) => {
+      const held = inList(valueColumn, values);
       return held === null ? null : sql`(${channelColumn} = ${channel} AND ${held})`;
     })
     .filter((clause): clause is SQL => clause !== null);

--- a/packages/core/src/channels/messages.ts
+++ b/packages/core/src/channels/messages.ts
@@ -1,11 +1,21 @@
 /**
- * What was said to a channel's accounts, as one store holds it. `Accounts` (accounts.ts) answers who a channel can reach, and this
- * answers what passed between Rome and them.
+ * What was said on a channel, as one store holds it. `Accounts` (accounts.ts)
+ * answers who a channel can reach; this answers what passed between Rome and
+ * them, and what a conversation holds — including one nobody in particular is
+ * addressed on.
  *
- * A message is a {@link TimelineEntry}. The shape, the ordering and the cursor
- * belong to the People contract (`@rome/api-types/people`), because what a
- * store answers here is what a person's timeline pages. A second definition of
- * either is a page boundary the two ends disagree about.
+ * A message is a {@link TimelineEntry}, whichever question reached it. The
+ * shape, the ordering and the cursor belong to the People contract
+ * (`@rome/api-types/people`), because what an account read answers here is
+ * what a person's timeline pages. A second definition of either is a page
+ * boundary the two ends disagree about.
+ *
+ * A conversation read is not a person's timeline, and it answers the same type
+ * anyway — not by reusing what was to hand, but because it is the same rows of
+ * the same store, and every message a direct conversation holds is a message
+ * that person's timeline pages. Given a second shape, one message read two
+ * ways would carry two orderings and two cursors, and the store that holds it
+ * would owe both of them. The type is one because the history is one.
  */
 
 import type { TimelineEntry } from "@rome/api-types/people";
@@ -38,13 +48,44 @@ export interface MessageRead {
 }
 
 /**
- * One message store, read for a set of accounts at once.
+ * One conversation a store reads for: the thread a message was said in, named
+ * by the platform's own id for it.
  *
- * The set is read as one history: a person holds several accounts and an
- * account several addresses, and the caller wants the messages merged, not one
- * sequence per address.
+ * The pair rather than the id alone, for the reason {@link MessageAccount}
+ * carries a channel: two platforms are free to spell a thread id the same way
+ * and mean two different conversations, and a store holding several channels
+ * side by side would otherwise hand one channel's thread to a caller asking
+ * about another's.
  *
- * One law binds the three verbs. Call the *full read* of a set of accounts the
+ * A direct conversation is addressed by the person on it, so the same messages
+ * reach {@link Messages.read} through that person's account. A group
+ * conversation is addressed by the group and by nobody on it, so this is the
+ * only way to ask for it.
+ */
+export interface MessageConversation {
+  channel: string;
+  /** The platform's own id for the thread — a WhatsApp chat JID, a LinkedIn
+   *  thread id, the thread a channel session is keyed by. */
+  id: string;
+}
+
+export interface ConversationRead {
+  conversation: MessageConversation;
+  /** The entry the previous page ended on. Null or absent for the first page. */
+  after?: TimelineEntry | null;
+  limit: number;
+}
+
+/**
+ * One message store, asked either what passed between Rome and a set of
+ * accounts or what a conversation holds.
+ *
+ * A set of accounts is read as one history: a person holds several accounts
+ * and an account several addresses, and the caller wants the messages merged,
+ * not one sequence per address.
+ *
+ * One law binds the three account verbs. Call the *full read* of a set of
+ * accounts the
  * `read` with no cursor and a limit large enough to hold everything the store
  * can answer for them:
  *
@@ -60,9 +101,17 @@ export interface MessageRead {
  * an account. There is no `holds` verb — a second way to ask the same question
  * is a second answer to disagree with.
  *
- * Direct threads only. A group conversation is addressed by the group rather
- * than by any person on it, so no address of an account names it and none of
- * its messages reaches these reads.
+ * Those three are direct threads only. A group conversation is addressed by
+ * the group rather than by any person on it, so no address of an account names
+ * it and none of its messages reaches them. `readConversation` is how a caller
+ * asks for one, and it reaches every conversation the store holds.
+ *
+ * The two questions are one store asked two ways rather than two histories. So
+ * a message is the same {@link TimelineEntry} however it was reached, in the
+ * same `compareTimelineEntries` order, resumed by the same cursor: a direct
+ * conversation read through its person's account and read through its own id
+ * answers the same entries, and neither page boundary is a position the other
+ * cannot name.
  */
 export interface Messages {
   /**
@@ -89,4 +138,21 @@ export interface Messages {
    * it in one pass over a whole directory rather than one page per row.
    */
   latest(accounts: readonly MessageAccount[]): Promise<TimelineEntry | null>;
+
+  /**
+   * The store's newest messages of one conversation, under the obligations
+   * `read` carries: at most `limit` of them, every one strictly after `after`,
+   * in `compareTimelineEntries` order.
+   *
+   * Every store owes this verb. It is not optional and it never refuses: a
+   * store holding nothing of the conversation answers an empty page, which is
+   * the same answer as one holding a conversation nothing was ever said in.
+   *
+   * So a store whose platform names no thread it can be asked for answers
+   * empty for every conversation, and a caller reads that as "nothing here"
+   * rather than as a case to branch on. Carving out an unanswerable case would
+   * invent a state no store is in today; forbidding one would deny it to a
+   * store that turns out to be in it.
+   */
+  readConversation(request: ConversationRead): Promise<TimelineEntry[]>;
 }

--- a/packages/core/src/channels/whatsapp-messages.test.ts
+++ b/packages/core/src/channels/whatsapp-messages.test.ts
@@ -38,8 +38,16 @@ const seeds: Seed[] = [
   { id: "e", chat: PHONE, at: 500, text: "latest" },
   // Out of scope, each for its own reason.
   { id: "r", chat: PHONE, at: 600, type: "reaction", text: "👍" },
-  { id: "g", chat: GROUP, at: 700, text: "in the group" },
   { id: "o", chat: OTHER, at: 800, text: "another contact" },
+  // The group. No account is addressed on it, so nothing here reaches an
+  // account read — and all of it is what the chat holds.
+  { id: "g", chat: GROUP, at: 700, text: "in the group" },
+  { id: "g2", chat: GROUP, at: 720, fromMe: true, text: "said back" },
+  // The same second as `g2`; the direction settles the tie.
+  { id: "g3", chat: GROUP, at: 720, text: "crossed in flight" },
+  { id: "g4", chat: GROUP, at: 900, text: "newest in the group" },
+  // A reaction answers a line rather than being one, in a group as in a chat.
+  { id: "gr", chat: GROUP, at: 950, type: "reaction", text: "👍" },
 ];
 
 function seedMirror(testDb: TestDb): void {
@@ -100,6 +108,86 @@ describe("whatsAppMessages", () => {
     const group: MessageAccount[] = [{ channel: "whatsapp", addresses: [GROUP] }];
     expect(await messages.latest(group)).toBeNull();
     expect(await messages.count(group)).toBe(0);
+  });
+
+  // The acceptance the milestone turns on: the mirror already held these rows
+  // and nothing asked for them.
+  it("answers a group chat's messages when asked for that chat", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    const page = await messages.readConversation({
+      conversation: { channel: "whatsapp", id: GROUP },
+      limit: WHOLE_HISTORY,
+    });
+    expect(refs(page)).toEqual([`${GROUP}:g4`, `${GROUP}:g2`, `${GROUP}:g3`, `${GROUP}:g`]);
+    expect(page[0]).toEqual({
+      source: "whatsapp",
+      timestamp: 900,
+      direction: "inbound",
+      ref: `${GROUP}:g4`,
+      body: "newest in the group",
+    });
+  });
+
+  it("answers none of a group chat's messages to any account read", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    const held = await messages.readConversation({
+      conversation: { channel: "whatsapp", id: GROUP },
+      limit: WHOLE_HISTORY,
+    });
+    expect(held.length).toBeGreaterThan(0);
+
+    // Every way an account read can be asked for the group: as the account's
+    // own history, and as an account naming the group's JID as an address.
+    const asGroup: MessageAccount[] = [{ channel: "whatsapp", addresses: [GROUP] }];
+    expect(await messages.latest(asGroup)).toBeNull();
+    expect(await messages.count(asGroup)).toBe(0);
+    expect(await messages.read({ accounts: asGroup, limit: WHOLE_HISTORY })).toEqual([]);
+    expect(refs(await messages.read({ accounts, limit: WHOLE_HISTORY }))).not.toContain(
+      `${GROUP}:g4`,
+    );
+  });
+
+  it("leaves out reactions in a group too", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    const page = await messages.readConversation({
+      conversation: { channel: "whatsapp", id: GROUP },
+      limit: WHOLE_HISTORY,
+    });
+    expect(refs(page)).not.toContain(`${GROUP}:gr`);
+  });
+
+  it("answers a direct chat asked for as a conversation exactly as its account reads it", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    const byConversation = await messages.readConversation({
+      conversation: { channel: "whatsapp", id: PHONE },
+      limit: WHOLE_HISTORY,
+    });
+    const byAccount = await messages.read({
+      accounts: [{ channel: "whatsapp", addresses: [PHONE] }],
+      limit: WHOLE_HISTORY,
+    });
+    expect(byConversation).toEqual(byAccount);
+  });
+
+  it("holds nothing for a conversation on another channel", async () => {
+    const messages = whatsAppMessages(testDb.db);
+    expect(
+      await messages.readConversation({
+        conversation: { channel: "linkedin", id: GROUP },
+        limit: WHOLE_HISTORY,
+      }),
+    ).toEqual([]);
+  });
+
+  // The store takes the database and nothing else, so the read that reaches a
+  // group answers with no WhatsApp connection open.
+  it("answers a conversation from the database alone", async () => {
+    expect(whatsAppMessages.length).toBe(1);
+    const page = await whatsAppMessages(testDb.db).readConversation({
+      conversation: { channel: "whatsapp", id: GROUP },
+      limit: 1,
+    });
+    expect(refs(page)).toEqual([`${GROUP}:g4`]);
   });
 
   it("holds nothing for an account on another channel", async () => {
@@ -188,5 +276,11 @@ describe("whatsAppMessages", () => {
 testMessagesContract("whatsAppMessages", () => {
   const testDb = createTestDb();
   seedMirror(testDb);
-  return { messages: whatsAppMessages(testDb.db), accounts, silent };
+  return {
+    messages: whatsAppMessages(testDb.db),
+    accounts,
+    silent,
+    conversation: { channel: "whatsapp", id: GROUP },
+    silentConversation: { channel: "whatsapp", id: "1299999@g.us" },
+  };
 });

--- a/packages/core/src/channels/whatsapp-messages.ts
+++ b/packages/core/src/channels/whatsapp-messages.ts
@@ -1,49 +1,55 @@
 import { sql } from "drizzle-orm";
 import type { DrizzleDb } from "../db/index.js";
 import type { Messages } from "./messages.js";
-import { addressesIn, inList, sqlMessages } from "./messages-sql.js";
+import { inList, scopeColumn, scopeValues, sqlMessages } from "./messages-sql.js";
 
 /**
  * `Messages` over the WhatsApp message mirror (`wa_messages`) — the thread as
  * the channel has it, which is the fullest record of a WhatsApp conversation
  * Rome holds.
  *
- * Scoped by chat: a WhatsApp message hangs off the chat it was said in, and a
- * direct chat is addressed by the contact, so the account's own addresses are
- * the whole scope. A contact reachable both as a phone JID and as a `@lid` JID
- * has a chat under each, and `WhatsAppAccounts` folds both onto one account —
- * so a caller that passes the account's addresses reads one history rather
- * than whichever half its person mapping happened to name.
+ * Scoped by chat either way it is asked. A WhatsApp message hangs off the chat
+ * it was said in, and the chat JID is both what names a conversation and what
+ * addresses a direct one — so the same `IN` answers both questions, and only
+ * what it is allowed to select differs.
  *
- * Two things the mirror holds are left out:
+ * For an account read, the account's own addresses are the whole scope. A
+ * contact reachable both as a phone JID and as a `@lid` JID has a chat under
+ * each, and `WhatsAppAccounts` folds both onto one account — so a caller that
+ * passes the account's addresses reads one history rather than whichever half
+ * its person mapping happened to name.
  *
- * - Group chats (`@g.us`). A group is addressed by the group rather than by
- *   anyone on it, so no address of an account names one — the `NOT LIKE` is
- *   belt and braces against a group JID arriving as an address.
- * - Reactions. A reaction answers a line rather than being one, and the
- *   address book's own activity already leaves it out of what an account last
- *   did. Carrying it here would let a directory row preview a thumbs-up and
- *   open on the message it was aimed at.
+ * Two things the mirror holds are treated apart from the rest:
+ *
+ * - Group chats (`@g.us`), which an account read leaves out. A group is
+ *   addressed by the group rather than by anyone on it, so no address of an
+ *   account names one and the `NOT LIKE` is belt and braces against a group
+ *   JID arriving as an address. A conversation read is how a caller asks for
+ *   one, and it carries no such condition: the chat named is the chat answered.
+ * - Reactions, which neither read carries. A reaction answers a line rather
+ *   than being one, and the address book's own activity already leaves it out
+ *   of what an account last did. Carrying it would let a directory row preview
+ *   a thumbs-up and open on the message it was aimed at, and it is no more a
+ *   line of a group's conversation than of a contact's.
  */
 export function whatsAppMessages(db: DrizzleDb): Messages {
   return sqlMessages({
     channel: "whatsapp",
     db,
     view(scope) {
-      const addresses = addressesIn(scope);
-      const chats = inList(sql`m.chat_jid`, addresses);
+      const chats = inList(sql`m.chat_jid`, scopeValues(scope));
       if (chats === null) return null;
+      const direct = scope.by === "address" ? sql` AND m.chat_jid NOT LIKE '%@g.us'` : sql``;
       return sql`
         SELECT
           'whatsapp' AS source,
-          m.chat_jid AS address,
+          m.chat_jid AS ${scopeColumn(scope)},
           m.timestamp AS at,
           CASE WHEN m.from_me THEN 1 ELSE 0 END AS outbound,
           m.chat_jid || ':' || m.id AS ref,
           m.text AS body
         FROM wa_messages m
-        WHERE ${chats}
-          AND m.chat_jid NOT LIKE '%@g.us'
+        WHERE ${chats}${direct}
           AND coalesce(m.type, '') <> 'reaction'`;
     },
   });


### PR DESCRIPTION
## Summary

Rome asked a channel two questions about its history and a channel could only answer one. What passed between Rome and a person went through `Messages`; what a conversation holds went to a live connection, so it failed whenever the transport was down and was not asked through the one interface every channel is read through. Both answers come from one store, so this adds the conversation read to that same contract rather than giving it a port of its own.

`Messages` (`packages/core/src/channels/messages.ts`) grows `readConversation` beside `read`, `count` and `latest`. Expand only: the three account verbs keep their signatures, and the diff changes no call site of any of them. That file's "Direct threads only" paragraph now scopes those three rather than the interface.

All five stores implement the verb, and the two channel stores reach the group rows their mirrors already held and nothing asked for:

- `whatsAppMessages` drops the `chat_jid NOT LIKE '%@g.us'` exclusion for a conversation read. Reactions stay out either way — a reaction answers a line rather than being one, in a group as in a chat.
- `linkedInMessages` reads the thread off the message row rather than through its membership, so neither the group flag nor the participant count restricts it.
- `agentMessages` drops the `source_thread_type <> 'group'` condition; `sentinelLogMessages` scopes by `thread_id` instead of `channel_user_id` and subtracts no group session.
- `memoryMessages` gains an optional `conversation` on `HeldMessage`, absent for a direct conversation — which is addressed by the person on it.

`sqlMessages` can now scope a view either way. `view(scope)` takes a `MessageScope` that is a list of addresses or a list of conversation ids, and answers under `address` or `conversation` accordingly (`scopeColumn`). One batching queue per kind, so a round of conversation calls still costs a single pass.

### The two decisions this PR settles

**What the read returns.** `TimelineEntry`, in `compareTimelineEntries` order, resumed by the same cursor — not because the type was to hand, but because it is the same rows of the same store, and every message a direct conversation holds is a message that person's timeline pages. Given a second shape, one message read two ways would carry two orderings and two cursors and the store would owe both. The reasoning is written down in `messages.ts` rather than inherited silently.

**What a store answers when it holds no conversation read.** An empty page — the same answer as a store holding a conversation nothing was ever said in. The verb is required and never refuses. A store whose platform names no thread it can be asked for answers empty for every conversation, and a caller reads that as "nothing here". An optional verb would carve out a case no store is in today; a refusal would deny the case to a store that turns out to be in it.

## Test plan

Tests were written first, against the acceptance criteria, and failed with `readConversation is not a function` before the implementation landed.

- [x] The contract suite (`messages-contract.ts`) states the new verb's obligations once — enough history to prove the law, newest-first order, strictly-after cursor, paging to exhaustion over exactly the full read, distinct cursor positions, and an empty page for a conversation the store holds nothing of (first page and resumed from a cursor). All five enrolled stores pass it: `agentMessages`, `sentinelLogMessages`, `linkedInMessages`, `memoryMessages`, `whatsAppMessages`.
- [x] A contract obligation asserts the enrolled conversation is one **no account read reaches**, which is the point of the milestone stated once for every store.
- [x] `whatsAppMessages` answers a group chat's messages when asked for that chat, and its account reads answer none of them — as the account's own history and with the group JID handed over as an address.
- [x] `linkedInMessages` answers a group thread's messages when asked for that thread, and no member's account read reaches them; a thread LinkedIn flags as a group is covered too.
- [x] Both channel stores answer a conversation from the database alone (arity asserted), so the read works with no connection open.
- [x] A direct conversation read through its own id equals the same conversation read through its person's account, in all four stores that can be asked both ways.
- [x] `pnpm --filter @rome/core typecheck` passes; `biome check` is clean on the touched files.
- [x] `src/channels` and `src/people` suites pass. Three files (`whatsapp.test.ts`, `wechat.test.ts`, `attachment-files.test.ts`) fail identically on the untouched base commit in this environment and are unrelated to the diff.

Closes rome-os/rome#162

🤖 Generated with [Claude Code](https://claude.com/claude-code)