### PR TITLE
docs(concepts): split the conversation entry's semicolon into two sentences

### DIFF
--- a/docs/concepts/messaging.md
+++ b/docs/concepts/messaging.md
@@ -29,7 +29,7 @@ A conversation is the thread a [message](#message) was said in, named by the pla
 
 **Not to be confused with:**
 
-- **[Account](people.md#account)** — the account is who Rome is talking to. The conversation is where they said it. On a direct thread the two are named by one string; on a group they are not.
+- **[Account](people.md#account)** — the account is who Rome is talking to. The conversation is where they said it. On a direct thread the two are named by one string. On a group they are not.
 - **Session** — a session is Rome's own working context for a thread. The conversation is the thread itself, which exists whether or not Rome ever opened a session on it.
 
 ## Channels


### PR DESCRIPTION
## What this PR does

`pnpm lint:prose` fails on `main`. The conversation entry in `docs/concepts/messaging.md` (#163) merged one commit before the prose gate (#170), so its semicolon is not in the baseline and the check reports `Rome.Semicolons 0 → 1` on that file.

WRITING.md's rule for a semicolon is to split the sentence, and that is the whole change.

## Test plan

- [x] `pnpm lint:prose` — "Prose matches the baseline." It failed on `main` at fb1b302 with the same command.
- [x] `scripts/check-pr-title.sh "docs(concepts): split the conversation entry's semicolon into two sentences"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)