### PR TITLE
docs(authoring): name the mechanism, not a picture of it

### DIFF
--- a/docs/authoring/WRITING.md
+++ b/docs/authoring/WRITING.md
@@ -26,7 +26,7 @@ A project-specific term earns admission only with a one-line separation from its
   > Prefer: "install" always means the daemon operation, "set up" covers the dev environment.
   > Over: "install" means the daemon operation in one section and the dev-environment steps in another.
 
-- Name the mechanism, not a picture of it. A description states what is true, not what it is like.
+- Name the thing, not a picture of it. A description states what is true, not what it is like.
 
   > Prefer: "a group has several people on it, and every line any of them sent reads the same way."
   > Over: "a group conversation has more than two ends, and three people talking are one undifferentiated voice."

--- a/docs/authoring/WRITING.md
+++ b/docs/authoring/WRITING.md
@@ -26,6 +26,11 @@ A project-specific term earns admission only with a one-line separation from its
   > Prefer: "install" always means the daemon operation, "set up" covers the dev environment.
   > Over: "install" means the daemon operation in one section and the dev-environment steps in another.
 
+- Name the mechanism, not a picture of it. A description states what is true, not what it is like.
+
+  > Prefer: "a group has several people on it, and every line any of them sent reads the same way."
+  > Over: "a group conversation has more than two ends, and three people talking are one undifferentiated voice."
+
 <!-- vale Rome.WordChoice = NO -->
 <!-- vale Rome.Marketing = NO -->
 <!-- vale Rome.History = NO -->
@@ -119,7 +124,7 @@ If a concept has a canonical home, link to it instead of re-explaining it.
 
 ## Checking
 
-`pnpm lint:prose` runs [Vale](https://vale.sh) over `docs/` and over the comments in `.ts` and `.tsx` sources. The rules it can decide live in [`.vale/styles/Rome`](../../.vale/styles/Rome), one file per section above. The rest — one name per thing, one meaning per word, one topic per paragraph — stay with the reader.
+`pnpm lint:prose` runs [Vale](https://vale.sh) over `docs/` and over the comments in `.ts` and `.tsx` sources. The rules it can decide live in [`.vale/styles/Rome`](../../.vale/styles/Rome), one file per section above. The rest — one name per thing, one meaning per word, the mechanism over a picture of it, one topic per paragraph — stay with the reader.
 
 Four words on the lists above are deliberately absent from the gate: *begin*, *initiate*, *acquire*, and *robust*. Each carries a technical sense a word list cannot tell from the prose one, so checking them would report more wrong answers than right ones. Apply them by reading.
 


### PR DESCRIPTION
## What this PR does

Word choice bans a coined name for a thing that has a standard one, and a fancy synonym for a plain word. Neither reaches a figure of speech that renames nothing.

This sentence, from an issue draft, passes every rule in the file today:

> A group conversation has more than two ends, and three people talking are one undifferentiated voice.

It says less than the sentence it replaced — that a message carries a direction and no sender, so in a group every participant's line reads the same way — and a reader has to decode the image before reaching the mechanism. The rule that would have caught it is not written down, so this writes it down.

## Design & Invariants

The bullet sits with "one name per thing" and "one meaning per word" rather than with the word lists below them, because those three are the Word choice rules no word list can decide. Checking names that set, so the sentence naming it grows the new rule too. Vale gains no style file here: metaphor is not detectable by a word list, and a gate that pretended otherwise would report the wrong sentences.

Rejected: a second bullet for saying each fact once, which is the redundancy half of the same paragraph. "One topic per paragraph" and the six-sentence cap already cover it, and a rule that duplicates two others earns less than it costs.

## Test plan

- [x] `pnpm lint:prose` — "Prose matches the baseline."
- [x] `vale docs/authoring/WRITING.md` — 0 errors, 0 warnings, 0 suggestions, so the new example clears the gate it is written against.
- [x] `scripts/check-pr-title.sh "docs(authoring): name the mechanism, not a picture of it"`.

## Not in this PR

- A Vale rule for the new bullet. No word list decides whether a sentence pictures a mechanism or states it.

Stacked on #174, which unbreaks `pnpm lint:prose` on `main`. Review that one first — GitHub retargets this to `main` when it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)