### PR TITLE
docs(skills): let a reconcile run file work and a report together

### DIFF
--- a/.claude/skills/loop-northstar/SKILL.md
+++ b/.claude/skills/loop-northstar/SKILL.md
@@ -21,6 +21,7 @@ Admission rules for every statement:
 - Declarative present tense. No "currently", no "we will", no "migrate from", no milestone names.
 - Checkable: an agent can verify compliance by reading the code.
 - Open: more than one implementation can satisfy it. The test: the statement stands without naming a file, function, or type. A statement only one implementation satisfies is code transcribed into prose.
+- A statement asserting that something is answered one way, or once, names the question it answers. Compliance turns on which reads count as the same question, so a uniqueness claim without its question cannot be checked.
 
 Content that never enters the doc:
 
@@ -42,8 +43,9 @@ A milestone is an intermediate ideal state. Its description is a Statements list
 
 1. Orient. Read the existing doc if there is one, the repository's open milestones and `loop-reconcile` issues, and the code the doc covers.
 2. Discuss to consensus. Draft in chat and iterate with the user. Push back on any statement that fails an admission rule.
-3. Check consistency. Walk the full Statements list — new and existing statements together — and surface any two that cannot both hold. A revision session checks against the whole doc, not only the edited part.
-4. Land the artifacts, only after the user's go-ahead in chat:
+3. Name each statement's decider. For every statement the session lands, new and existing, name the code a reader opens to decide compliance. A statement whose decider you cannot name is not checkable, and it does not land. This is the step that catches a statement describing a question the code does not ask.
+4. Check consistency. Walk the full Statements list — new and existing statements together — and surface any two that cannot both hold. A revision session checks against the whole doc, not only the edited part.
+5. Land the artifacts, only after the user's go-ahead in chat:
    1. The doc: open a branch and a PR. The user merges.
    2. The milestones: create each on GitHub with `gh api repos/{owner}/{repo}/milestones -f title=... -f description=...` — the title names the slice, the description holds its Statements list. Create layers in build order.
 

--- a/.claude/skills/loop-reconcile/SKILL.md
+++ b/.claude/skills/loop-reconcile/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: loop-reconcile
-description: Autonomously compute the gap between an ideal-state doc and the codebase, then file the next work issues — or a loop-complete or loop-needs-discussion report.
+description: Autonomously compute the gap between an ideal-state doc and the codebase, then file the next work issues, a report on what needs discussion, or both.
 disable-model-invocation: true
 ---
 
 # Loop: reconcile
 
-Goal end-state: the next deliverable chunk of the gap between the doc and the codebase exists as issues, awaiting `ready-for-agent`, or one report explains why not.
+Goal end-state: every deliverable chunk the run can scope exists as issues, awaiting `ready-for-agent`, and one report explains whatever it could not scope.
 
-This is the autonomous half of the reconciliation loop. When launched from a session, run it in a background agent. It runs headless: never ask the user a question mid-run. Every ambiguity resolves to "stop and file a report", never "do something plausible". Every report reads standalone on GitHub and never depends on chat context.
+This is the autonomous half of the reconciliation loop. When launched from a session, run it in a background agent. It runs headless: never ask the user a question mid-run. Every ambiguity resolves to a report, never to something plausible. Every report reads standalone on GitHub and never depends on chat context.
 
-All work state lives in the GitHub repository itself: issues, labels, and milestones. No project board. Every issue this skill files carries two labels: `loop-reconcile`, the mark that the loop owns it, and a scope label `loop:<doc-stem>` naming its source doc — `loop:people` for `docs/northstars/people.md`. Reports also carry `loop-complete` or `loop-needs-discussion`. If a label is missing from the repository, create it.
+All work state lives in the GitHub repository itself: issues, labels, and milestones. No project board. Every issue this skill files carries two labels: `loop-reconcile`, the mark that the loop owns it, and a scope label `loop:<doc-stem>` naming its source doc — `loop:people` for `docs/northstars/people.md`. A report is an issue too, and it carries `loop-complete` or `loop-needs-discussion` on top of those two. If a label is missing from the repository, create it.
 
 Args: an ideal-state doc under `docs/northstars/`, and optionally a repository milestone.
 
@@ -42,11 +42,22 @@ Args: an ideal-state doc under `docs/northstars/`, and optionally a repository m
    - If one is labeled `ready-for-agent` or is in progress, file nothing. Print a pointer to it and stop.
    - If none carries `ready-for-agent`, re-check each against the gap computed below. If they hold, stop. If they are stale, revise or withdraw them, then continue.
 2. Compute the gap. Walk the Statements list one claim at a time against the code. Record each as holds, with evidence, or fails, with the shortest path to make it hold.
-3. Exit by what the walk found.
+3. Exit by what the walk found. A run files at most one report.
    - A statement cannot be checked, or two statements cannot both hold: the doc is broken. File a `loop-needs-discussion` report naming the statements, and file nothing else. The doc gets fixed in a `loop-northstar` session, never by this run.
    - Zero gap: file a `loop-complete` report walking each statement with its evidence and naming what it checked — the doc, or the milestone. Never advance to the next milestone.
-   - More than about four chunks, or crossing a contract boundary: file a `loop-needs-discussion` report calling for a milestone session and sketching a possible slicing. Never scope and plan in the same run.
-   - Otherwise: scope chunks by the rules below and file them as issues.
+   - Otherwise: scope chunks by the rules below and file them as issues, up to about four. Alongside them file a `loop-needs-discussion` report for every question the walk could not answer and every chunk the cap left out. Chunks and a report are one run's ordinary output, not alternatives.
+
+The size of a gap decides how much of it a run files. It never decides whether the run files anything.
+
+## Open questions
+
+A report names the statements it questions. Every other statement the walk covered is unquestioned, and a chunk serving only unquestioned statements is filable while that report is open.
+
+- The report enumerates the live resolutions of each question it raises. A chunk is filable when every one of those resolutions still needs it. A chunk that some resolutions need and others do not belongs to the report.
+- A filable chunk touches no file the contested fix would touch. This is the mechanical check when the resolutions are hard to enumerate.
+- A filable chunk names the report, states the open question in one line, and states which resolutions it survives. That claim is what a human checks before applying `ready-for-agent`.
+- Its Scope names the contested area as out of scope, so the boundary is written down rather than inferred.
+- A report questioning a statement carries the replacement text it proposes. A `loop-northstar` session then reviews a draft rather than redesigning from the problem.
 
 ## Scoping rules
 
@@ -57,7 +68,3 @@ Args: an ideal-state doc under `docs/northstars/`, and optionally a repository m
 - File several issues only when the chunks are parallel: disjoint files, no shared contract. Never file a dependency chain — a chained issue is a stored prediction that goes stale.
 - Issues follow [the issue format](../../../docs/authoring/github-issues.md), attach to the milestone when one is given, and stand alone without the doc.
 - Never apply `ready-for-agent`.
-
-## Exits
-
-Every run ends in exactly one: issues filed, a `loop-complete` report, or a `loop-needs-discussion` report. A report is an issue carrying its label.


### PR DESCRIPTION
## What this PR does

`loop-reconcile` ended every run in exactly one of three outcomes: issues, a completion report, or a discussion report. Two runs against `docs/northstars/channels.md` both ended in a discussion report, and neither filed any work. The chunks they dropped were not blocked by anything either report raised. One of them, the timeline-accounts fold, was needed under every slicing anyone might have chosen, and it only got filed because a human asked for it by hand.

The rule stopped for two unrelated reasons and treated them the same. A broken doc is a correctness risk, and filing work against it can aim at the wrong goal. A gap larger than one run is the loop's ordinary condition, and stopping there protects nothing. This splits the two apart.

## Design & Invariants

A run now files the chunks no open question blocks, plus at most one report for what stays blocked. The report names the statements it questions. A chunk serving only unquestioned statements is filable while that report is open, and the report enumerates the live resolutions so the claim can be checked rather than trusted.

The broken-doc exit is unchanged and still absolute. When two statements cannot both hold, or one cannot be checked, the run files a report and nothing else.

Filing a chunk was never the moment work commits. `ready-for-agent` is, and only a human applies it. The old rule defended a door the label already locks, and paid for it by dropping work that no question threatened. What the new rules add is the obligation for a co-filed chunk to state its own invariance, so the human gate is cheap to operate rather than requiring the analysis to be re-derived.

`## Exits` is deleted rather than rewritten. It restated the branches in `Procedure` step 3, and it was the place that said "exactly one". Its one non-redundant sentence, that a report is an issue carrying its label, moves to the paragraph that defines the labels.

`loop-northstar` gains the prevention half. A statement now has to name the code that decides its compliance before it lands, and a statement claiming something is answered "one way" has to name the question. Both doc revisions this loop needed trace to statements written without walking the code. One asserted that every channel sends, which no reading of the code supported. The other asserted a history is answered one way, which passed all three admission rules and still named two different questions rather than two answers to one.

Alternatives considered. Keeping the exclusive exit and raising the chunk cap would have filed more per run, and it would still have dropped everything whenever any question was open. Letting the run resolve its own open questions was the other option, and it fails the skill's headless rule: a run that guesses an intent has no human to correct it before the issue is written.

## Test plan

- [x] Replayed both channels runs against the new rules. Run 2 files the timeline fold and its report. Run 4 files the Discord and email history stores and its report. Both match what was filed by hand afterwards.
- [x] Confirmed the broken-doc branch still reads as file-nothing-else.
- [x] Checked the new prose against `docs/authoring/WRITING.md` by hand. `scripts/check-prose.mjs` scopes markdown to `docs/*.md`, so Vale does not reach `.claude/skills/`.
- [x] `scripts/check-pr-title.sh "docs(skills): let a reconcile run file work and a report together"`.

## Not in this PR

- Extending the Vale pathspec to `.claude/skills/`. It would gate these files, and it would surface findings in the other skills that this change did not touch.
- The guard in step 1. It still stops a run when open unapproved issues hold, so this gives more work per run rather than more runs. Changing that is a separate question about how much unapproved work should sit in one scope.
