### PR TITLE
feat(core): default Fable to Claude Fable 5.1 and price its cache reads

### DIFF
--- a/packages/core/src/core/agent-runner.test.ts
+++ b/packages/core/src/core/agent-runner.test.ts
@@ -3763,7 +3763,7 @@ describe("AgentRunner", () => {
   });
 
   describe("session model pin resolution", () => {
-    const FABLE_MODEL = "claude-fable-5[1m]";
+    const FABLE_MODEL = "claude-fable-5-1[1m]";
 
     // Records every open and echoes the resolved model back as the turn result,
     // so a test can assert which concrete model actually ran.

--- a/packages/core/src/core/model-resolver.test.ts
+++ b/packages/core/src/core/model-resolver.test.ts
@@ -95,13 +95,13 @@ describe("ModelResolver", () => {
 
     await expect(r.getModelProvider({ tier: "large" })).resolves.toMatchObject({
       modelProvider: claude,
-      model: "claude-fable-5[1m]",
+      model: "claude-fable-5-1[1m]",
     });
     await expect(
       r.getModelProvider({ tier: "large", providerId: "anthropic" }),
     ).resolves.toMatchObject({
       modelProvider: claude,
-      model: "claude-fable-5[1m]",
+      model: "claude-fable-5-1[1m]",
     });
     await expect(r.getModelProvider({ tier: "medium" })).resolves.toMatchObject({
       modelProvider: codex,
@@ -302,9 +302,9 @@ describe("ModelResolver", () => {
     // enableFable is off: tier resolution would never produce Fable, the pin still runs it.
     await expect(
       resolver().getModelProvider({
-        exact: { providerId: "anthropic", model: "claude-fable-5[1m]" },
+        exact: { providerId: "anthropic", model: "claude-fable-5-1[1m]" },
       }),
-    ).resolves.toMatchObject({ modelProvider: claude, model: "claude-fable-5[1m]" });
+    ).resolves.toMatchObject({ modelProvider: claude, model: "claude-fable-5-1[1m]" });
     // enableFable is on: an exact non-Fable pin is not rerouted to Fable.
     await expect(
       resolver({}, { enableFable: true }).getModelProvider({

--- a/packages/core/src/core/model-resolver.ts
+++ b/packages/core/src/core/model-resolver.ts
@@ -119,7 +119,7 @@ const TEST_TIER_TO_MODEL: Record<ModelTier, string> = {
   small: "claude-haiku-4-5-20251001",
 };
 
-const FABLE_MODEL = "claude-fable-5[1m]";
+const FABLE_MODEL = "claude-fable-5-1[1m]";
 
 function providerQuotaExhausted(providerId: ProviderId, state: ProviderState): boolean {
   return state.quotaExhausted && !(providerId === "anthropic" && claudeUsesApiKey(state));

--- a/packages/core/src/core/model-selector.test.ts
+++ b/packages/core/src/core/model-selector.test.ts
@@ -34,7 +34,7 @@ describe("webchat model selector", () => {
     });
     expect(resolveWebchatLargeModelSelection("claude-fable")).toMatchObject({
       providerId: "anthropic",
-      model: "claude-fable-5[1m]",
+      model: "claude-fable-5-1[1m]",
     });
   });
 

--- a/packages/core/src/core/model-selector.ts
+++ b/packages/core/src/core/model-selector.ts
@@ -59,7 +59,7 @@ export const WEBCHAT_LARGE_MODEL_SELECTIONS: Record<ModelSelectionId, WebchatLar
     "claude-fable": {
       id: "claude-fable",
       providerId: "anthropic",
-      model: "claude-fable-5[1m]",
+      model: "claude-fable-5-1[1m]",
     },
     "gpt-5-6-sol": {
       id: "gpt-5-6-sol",

--- a/packages/core/src/core/provider-accounting.test.ts
+++ b/packages/core/src/core/provider-accounting.test.ts
@@ -2,21 +2,21 @@ import { describe, expect, it } from "vitest";
 import { buildAgentAccounting, calculateImpliedCostUsd } from "./provider-accounting.js";
 
 describe("provider-accounting", () => {
-  it("calculates Anthropic Fable 5 costs using cache read and 5-minute cache write rates", () => {
-    const impliedCostUsd = calculateImpliedCostUsd("anthropic", "claude-fable-5[1m]", {
+  it("calculates Anthropic Fable 5.1 costs using cache read and 5-minute cache write rates", () => {
+    const impliedCostUsd = calculateImpliedCostUsd("anthropic", "claude-fable-5-1[1m]", {
       inputTokens: 1_000_000,
       outputTokens: 1_000_000,
       cacheReadTokens: 1_000_000,
       cacheWriteTokens: 1_000_000,
     });
 
-    expect(impliedCostUsd).toBeCloseTo(73.5);
+    expect(impliedCostUsd).toBeCloseTo(72.75);
   });
 
-  it("uses Anthropic Fable 5 1-hour cache write pricing when reported by usage metadata", () => {
+  it("uses Anthropic Fable 5.1 1-hour cache write pricing when reported by usage metadata", () => {
     const accounting = buildAgentAccounting({
       provider: "anthropic",
-      model: "claude-fable-5[1m]",
+      model: "claude-fable-5-1[1m]",
       usage: {
         inputTokens: 0,
         outputTokens: 0,
@@ -29,6 +29,17 @@ describe("provider-accounting", () => {
     });
 
     expect(accounting.costUsd).toBeCloseTo(20);
+  });
+
+  it("keeps the Fable 5 cache read rate for sessions recorded on the legacy model", () => {
+    const impliedCostUsd = calculateImpliedCostUsd("anthropic", "claude-fable-5[1m]", {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      cacheWriteTokens: 1_000_000,
+    });
+
+    expect(impliedCostUsd).toBeCloseTo(73.5);
   });
 
   it("calculates Anthropic Sonnet 5 costs using cache read and 5-minute cache write rates", () => {

--- a/packages/core/src/core/provider-accounting.ts
+++ b/packages/core/src/core/provider-accounting.ts
@@ -94,6 +94,18 @@ function openAi56Rates(
 const PRICING_RULES: PricingRule[] = [
   {
     provider: "anthropic",
+    // Fable 5.1 discounts cache reads to 0.025x the input rate; every other
+    // Anthropic model reads at 0.1x.
+    matchesModel: (model) => hasPrefix(model, "claude-fable-5-1"),
+    resolveRates: (rawUsage) => ({
+      inputUsdPerMillion: 10,
+      outputUsdPerMillion: 50,
+      cacheReadUsdPerMillion: 0.25,
+      cacheWriteUsdPerMillion: 10 * getAnthropicCacheWriteMultiplier(rawUsage),
+    }),
+  },
+  {
+    provider: "anthropic",
     matchesModel: (model) => hasPrefix(model, "claude-fable-5[1m]"),
     resolveRates: (rawUsage) => ({
       inputUsdPerMillion: 10,


### PR DESCRIPTION
### What this PR does

Rome's Fable routing still pointed at `claude-fable-5[1m]`, and Anthropic has shipped Claude Fable 5.1 (`claude-fable-5-1`), which also reprices prompt-cache reads. Sessions routed to Fable were running the older model, and any cost math written for 5.1 would have overcharged cache reads by 4x.

The Fable setting, the webchat Fable selection, and large-tier resolution now target `claude-fable-5-1[1m]`. Cost accounting gains a Fable 5.1 rule from the [current pricing page](https://platform.claude.com/docs/en/about-claude/pricing): input and output stay at $10 and $50 per MTok with the standard 1.25x/2x cache-write multipliers, and cache reads drop to $0.25 per MTok (0.025x the input rate, versus the 0.1x every other Anthropic model uses).

### Design & Invariants

A pinned session keeps its model regardless of settings or lineup changes ([ADR: pinned-session-model-fails-closed](docs/adrs/pinned-session-model-fails-closed.md)). Sessions pinned to `claude-fable-5[1m]` therefore still resolve, and their usage rows still price at the legacy 0.1x cache-read rate, so the Fable 5 pricing rule stays alongside the new one rather than being rewritten.

### Test plan

- [x] `pnpm --filter @rome/core typecheck`
- [x] `pnpm vitest run src/core/provider-accounting.test.ts src/core/model-resolver.test.ts src/core/model-selector.test.ts src/core/agent-runner.test.ts` (142 tests, including new Fable 5.1 rate assertions and legacy Fable 5 coverage)
- [ ] Exercise the Fable toggle against a live Claude login on the dev stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)