### PR TITLE
chore: upgrade opencli to 1.8.8 and port its twitter follow fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -211,7 +211,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # top-level --registry (the mirror), producing a 404.
 RUN --mount=type=cache,target=/root/.npm \
     npm install -g ${NPM_REGISTRY:+--registry "$NPM_REGISTRY"} @anthropic-ai/claude-code@2.1.251 @openai/codex@0.144.5 && \
-    npm install -g @yunfanye/opencli@1.8.7
+    npm install -g @yunfanye/opencli@1.8.8
 
 RUN curl -fsSL --retry 5 --retry-delay 2 https://composio.dev/install | COMPOSIO_INSTALL_DIR=/usr/local/lib/composio bash -s -- "$COMPOSIO_CLI_VERSION" && \
     ln -sf /usr/local/lib/composio/composio /usr/local/bin/composio && \

--- a/infra/rome/Dockerfile
+++ b/infra/rome/Dockerfile
@@ -52,7 +52,7 @@ RUN mkdir -p /rome-home && chmod 0777 /rome-home
 # terminal-server (claude /login, codex login, opencli usage) finds them on
 # PATH inside the dev container.
 RUN --mount=type=cache,target=/root/.npm \
-    npm install -g @anthropic-ai/claude-code@2.1.251 @openai/codex@0.144.5 @yunfanye/opencli@1.8.7
+    npm install -g @anthropic-ai/claude-code@2.1.251 @openai/codex@0.144.5 @yunfanye/opencli@1.8.8
 
 # The container's browser is the server-side Chrome (the `chrome` sidecar,
 # which shares this container's network namespace — compose.dev.yml): BROWSER

--- a/opencli-plugins/linkedin/thread-snapshot.js
+++ b/opencli-plugins/linkedin/thread-snapshot.js
@@ -1,4 +1,4 @@
-// Overrides clis/linkedin/thread-snapshot.js from @yunfanye/opencli 1.8.7.
+// Overrides clis/linkedin/thread-snapshot.js from @yunfanye/opencli 1.8.8.
 // Keep the API URL discovery in sync when upstream changes LinkedIn messaging queries.
 import { ArgumentError, CommandExecutionError } from "@jackwener/opencli/errors";
 import { cli, Strategy } from "@jackwener/opencli/registry";

--- a/opencli-plugins/twitter/follow.js
+++ b/opencli-plugins/twitter/follow.js
@@ -1,10 +1,10 @@
-import { CommandExecutionError } from "@jackwener/opencli/errors";
+import { CommandExecutionError, TimeoutError } from "@jackwener/opencli/errors";
 import { cli, Strategy } from "@jackwener/opencli/registry";
 
 // Overrides the built-in twitter/follow: plugins are discovered last at opencli
 // startup, so this cli() call wins the "twitter/follow" registry key while every
 // other twitter command stays built-in. Diff base: clis/twitter/follow.js in
-// @yunfanye/opencli@1.8.6 - the only addition is the --only-follow-back gate.
+// @yunfanye/opencli@1.8.8 - the only addition is the --only-follow-back gate.
 cli({
   site: "twitter",
   name: "follow",
@@ -36,6 +36,7 @@ cli({
     await page.goto(`https://x.com/${username}`);
     await page.wait({ selector: '[data-testid="primaryColumn"]' });
     const result = await page.evaluate(`(async () => {
+        let writeStarted = false;
         try {
             let attempts = 0;
             let followBtn = null;
@@ -67,6 +68,7 @@ cli({
                 }
             }
 
+            writeStarted = true;
             followBtn.click();
             await new Promise(r => setTimeout(r, 1500));
 
@@ -75,17 +77,30 @@ cli({
             if (verify) {
                 return { ok: true, message: 'Successfully followed @${username}.' };
             } else {
-                return { ok: false, message: 'Follow action initiated but UI did not update.' };
+                return { ok: false, unconfirmed: true, message: 'Follow action initiated but UI did not update.' };
             }
         } catch (e) {
-            return { ok: false, message: e.toString() };
+            return { ok: false, unconfirmed: writeStarted, message: e.toString() };
         }
     })()`);
     if (result.refused) throw new CommandExecutionError(result.message);
-    if (result.ok) await page.wait(2);
+    if (result.unconfirmed) {
+      throw new TimeoutError(
+        "twitter follow confirmation",
+        1.5,
+        `${result.message} Check the profile before retrying; the follow may already have succeeded.`,
+      );
+    }
+    if (!result.ok) {
+      throw new CommandExecutionError(
+        result.message,
+        "Nothing changed. Open the profile in the browser and retry.",
+      );
+    }
+    await page.wait(2);
     return [
       {
-        status: result.ok ? "success" : "failed",
+        status: "success",
         message: result.message,
       },
     ];


### PR DESCRIPTION
## What this PR does

The containers install @yunfanye/opencli 1.8.7, one release behind the fork. Overrides shadow upstream silently after a version bump, so this PR follows the [opencli-plugins README](opencli-plugins/README.md) procedure: bump the pin in both images, then diff each override file against its new upstream source and port relevant fixes.

- `Dockerfile` and `infra/rome/Dockerfile`: bump `@yunfanye/opencli` 1.8.7 → 1.8.8.
- `opencli-plugins/twitter/follow.js`: port upstream 1.8.8's unconfirmed-write handling. A follow click whose UI confirmation never arrives now throws `TimeoutError` (the follow may have landed, so the caller is told to check before retrying), and a clean failure throws `CommandExecutionError` instead of returning a `failed` row. The Rome-only `--only-follow-back` gate is unchanged. `TimeoutError` also exists in 1.8.7, so dev containers that have not rebuilt yet still load the plugin.
- `opencli-plugins/linkedin/thread-snapshot.js`: comment-only diff-base update. Upstream 1.8.8 replaced its DOM scrape with the same messengerMessages API approach the Rome override already uses, and the discovery patterns (GraphQL path, `queryId` regexes, `uas` authwall path) already match, so nothing needed porting.

1.8.8's new upstream commands (twitter `archive`/`collection`/`mute-word`/`user-timeline`, linkedin `company`/`connections`, google `images`) do not collide with any Rome-owned plugin command, so no new silent shadowing is introduced.

## Test plan

- [x] Diffed `clis/twitter/follow.js` and `clis/linkedin/thread-snapshot.js` between the 1.8.7 and 1.8.8 npm tarballs; the ported change matches upstream 1.8.8 exactly aside from the `--only-follow-back` gate.
- [x] Verified `@yunfanye/opencli@1.8.8` exists on npm and exports `TimeoutError` from `./errors` (in 1.8.7 as well).
- [x] `node --check` on the edited plugin file; biome ran via the pre-commit hook.
- [ ] Container image rebuild with the new pin (CI docker build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)