### PR TITLE
feat(opencli): add Redfin listing photo download plugin

### DIFF
--- a/opencli-plugins/README.md
+++ b/opencli-plugins/README.md
@@ -93,6 +93,9 @@ Agents pick up new/changed commands automatically: the `browser-automation` skil
   resolves a restaurant name, OpenTable alias, or `/r/` URL and reads its public profile,
   bookable times and booking links, verified reviews, menus, photos, and dining experiences without
   requiring an OpenTable login.
+- `opencli redfin download URL [--output DIR] [--size SIZE] [--limit N]` — downloads every gallery
+  photo of a public Redfin listing into one folder per listing, in gallery order, with captions and
+  room tags in the result rows. `photos URL` lists the same gallery without writing anything.
 
 ## Overriding a built-in command: caveats
 
@@ -367,4 +370,32 @@ opencli opentable reviews lolinda-reservations-san-francisco --sort newest --rat
 opencli opentable menu lolinda-reservations-san-francisco --query steak -f json
 opencli opentable photos lolinda-reservations-san-francisco --category food --limit 10
 opencli opentable experiences lolinda-reservations-san-francisco -f json
+```
+
+### Redfin
+
+The Redfin plugin reads a public listing page and works from the gallery Redfin server-renders into
+the page state (`__reactServerState`), which lists every photo in display order with the CDN URL of
+each size variant, plus Redfin's own captions and room tags per photo. The commands need no Redfin
+account and call no private API. When that state is absent, the commands fall back to the full-size
+CDN URLs present in the HTML.
+
+- `download` saves the gallery to `<output>/<address slug>-<property id>/`, one file per photo named
+  `<gallery position>-<CDN file name>` (for example `01-ML82027150_2.jpg`) so a folder listing
+  matches the order on Redfin. Each result row carries the saved path, byte size, caption, tags,
+  and source URL. A photo that fails to download gets a failed row with the error, and the run
+  continues with the next photo.
+- `photos` returns the same gallery as rows without touching the disk.
+- `--size` picks the variant. `full` (default) is Redfin's uncropped full-screen image, up to 1280px
+  wide. `large` is a fixed 1080×771 crop. `medium`, `small`, and `thumb` are progressively smaller.
+  Files for a non-default size carry the size in their name, so variants never overwrite each other.
+- `--limit` caps the number of photos taken from the front of the gallery.
+
+A Redfin bot-check ("Press & Hold") or a missing listing fails with a typed error instead of an empty
+result.
+
+```bash
+opencli redfin download https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461
+opencli redfin download https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461 --output ~/Pictures --size large --limit 10 -f json
+opencli redfin photos https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461 -f json
 ```

--- a/opencli-plugins/redfin/download.js
+++ b/opencli-plugins/redfin/download.js
@@ -1,0 +1,102 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { httpDownload } from "@jackwener/opencli/download";
+import { CommandExecutionError, getErrorMessage } from "@jackwener/opencli/errors";
+import { cli, Strategy } from "@jackwener/opencli/registry";
+import { readRedfinListingPhotos } from "./redfin-browser.mjs";
+import {
+  canonicalRedfinListingUrl,
+  DEFAULT_REDFIN_EXAMPLE_URL,
+  DEFAULT_REDFIN_OUTPUT,
+  describeRedfinListing,
+  integerInRange,
+  planRedfinDownloads,
+  REDFIN_PHOTO_SIZES,
+  redfinListingSlug,
+  summarizeRedfinDownload,
+} from "./redfin-helpers.mjs";
+
+cli({
+  site: "redfin",
+  name: "download",
+  access: "read",
+  description: "Download every gallery photo of a public Redfin listing",
+  example: `opencli redfin download ${DEFAULT_REDFIN_EXAMPLE_URL} --output ./redfin-downloads`,
+  domain: "redfin.com",
+  strategy: Strategy.PUBLIC,
+  browser: true,
+  args: [
+    {
+      name: "url",
+      type: "string",
+      positional: true,
+      required: true,
+      help: `Redfin listing URL, e.g. ${DEFAULT_REDFIN_EXAMPLE_URL}`,
+    },
+    {
+      name: "output",
+      type: "string",
+      default: DEFAULT_REDFIN_OUTPUT,
+      help: "Directory that receives one <address>-<property id> folder per listing",
+    },
+    {
+      name: "size",
+      type: "string",
+      default: "full",
+      choices: REDFIN_PHOTO_SIZES,
+      help: "Photo variant to download: full (original frame), large, medium, small, or thumb",
+    },
+    {
+      name: "limit",
+      type: "int",
+      default: 0,
+      help: "Maximum photos to download in gallery order (0 = all)",
+    },
+  ],
+  columns: ["index", "status", "size", "file", "caption", "tags", "url"],
+  func: async (page, kwargs) => {
+    if (!page) throw new CommandExecutionError("Browser session required for redfin download");
+    let url;
+    let limit;
+    let output;
+    try {
+      url = canonicalRedfinListingUrl(kwargs.url);
+      limit = integerInRange(kwargs.limit ?? 0, "limit", 0, 1000);
+      output = String(kwargs.output || DEFAULT_REDFIN_OUTPUT).trim() || DEFAULT_REDFIN_OUTPUT;
+      if (!REDFIN_PHOTO_SIZES.includes(kwargs.size)) {
+        throw new Error(`size must be one of: ${REDFIN_PHOTO_SIZES.join(", ")}`);
+      }
+    } catch (error) {
+      throw new CommandExecutionError(error instanceof Error ? error.message : String(error));
+    }
+
+    const { pageData, photos } = await readRedfinListingPhotos(page, url);
+    const listing = describeRedfinListing(pageData, url);
+    const plan = planRedfinDownloads(photos, { size: kwargs.size, limit });
+
+    const outputDir = path.resolve(output, redfinListingSlug(url));
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    const rows = [];
+    for (const item of plan) {
+      if (!item.url) {
+        rows.push(
+          summarizeRedfinDownload(item, { success: false, error: "No photo URL" }, { listing }),
+        );
+        continue;
+      }
+      const file = path.join(outputDir, item.file_name);
+      let result;
+      try {
+        result = await httpDownload(item.url, file, {
+          headers: { Referer: "https://www.redfin.com/" },
+          timeout: 60000,
+        });
+      } catch (error) {
+        result = { success: false, size: 0, error: getErrorMessage(error) };
+      }
+      rows.push(summarizeRedfinDownload(item, result, { listing, file }));
+    }
+    return rows;
+  },
+});

--- a/opencli-plugins/redfin/opencli-plugin.json
+++ b/opencli-plugins/redfin/opencli-plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "rome-redfin",
+  "description": "Public Redfin listing photo commands for OpenCLI",
+  "version": "0.1.0",
+  "opencli": ">=1.8.0"
+}

--- a/opencli-plugins/redfin/package.json
+++ b/opencli-plugins/redfin/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "rome-opencli-redfin",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "../../scripts/test-env.sh node --test redfin-helpers.test.mjs"
+  }
+}

--- a/opencli-plugins/redfin/photos.js
+++ b/opencli-plugins/redfin/photos.js
@@ -1,0 +1,64 @@
+import { CommandExecutionError } from "@jackwener/opencli/errors";
+import { cli, Strategy } from "@jackwener/opencli/registry";
+import { readRedfinListingPhotos } from "./redfin-browser.mjs";
+import {
+  canonicalRedfinListingUrl,
+  DEFAULT_REDFIN_EXAMPLE_URL,
+  describeRedfinListing,
+  integerInRange,
+  normalizePhotoRow,
+  REDFIN_PHOTO_SIZES,
+} from "./redfin-helpers.mjs";
+
+cli({
+  site: "redfin",
+  name: "photos",
+  access: "read",
+  description: "List every gallery photo of a public Redfin listing with captions and CDN URLs",
+  example: `opencli redfin photos ${DEFAULT_REDFIN_EXAMPLE_URL} -f json`,
+  domain: "redfin.com",
+  strategy: Strategy.PUBLIC,
+  browser: true,
+  args: [
+    {
+      name: "url",
+      type: "string",
+      positional: true,
+      required: true,
+      help: `Redfin listing URL, e.g. ${DEFAULT_REDFIN_EXAMPLE_URL}`,
+    },
+    {
+      name: "size",
+      type: "string",
+      default: "full",
+      choices: REDFIN_PHOTO_SIZES,
+      help: "Photo variant reported in the url column: full (original frame), large, medium, small, or thumb",
+    },
+    {
+      name: "limit",
+      type: "int",
+      default: 0,
+      help: "Maximum photos to return in gallery order (0 = all)",
+    },
+  ],
+  columns: ["index", "photo_id", "caption", "tags", "source_width", "source_height", "url"],
+  func: async (page, kwargs) => {
+    if (!page) throw new CommandExecutionError("Browser session required for redfin photos");
+    let url;
+    let limit;
+    try {
+      url = canonicalRedfinListingUrl(kwargs.url);
+      limit = integerInRange(kwargs.limit ?? 0, "limit", 0, 1000);
+      if (!REDFIN_PHOTO_SIZES.includes(kwargs.size)) {
+        throw new Error(`size must be one of: ${REDFIN_PHOTO_SIZES.join(", ")}`);
+      }
+    } catch (error) {
+      throw new CommandExecutionError(error instanceof Error ? error.message : String(error));
+    }
+
+    const { pageData, photos } = await readRedfinListingPhotos(page, url);
+    const listing = describeRedfinListing(pageData, url);
+    const selected = limit > 0 ? photos.slice(0, limit) : photos;
+    return selected.map((photo) => normalizePhotoRow(photo, listing, kwargs.size));
+  },
+});

--- a/opencli-plugins/redfin/redfin-browser.mjs
+++ b/opencli-plugins/redfin/redfin-browser.mjs
@@ -1,0 +1,178 @@
+import { CommandExecutionError } from "@jackwener/opencli/errors";
+import {
+  collectRedfinPhotos,
+  detectRedfinChallenge,
+  detectRedfinNotFound,
+  isRedfinUrl,
+} from "./redfin-helpers.mjs";
+
+/**
+ * Runs inside the listing page, so it must stay self-contained: `page.evaluate`
+ * serializes the function source and cannot carry module-scope bindings along.
+ *
+ * Redfin server-renders every data-API response the page needs into
+ * `window.__reactServerState.InitialContext["ReactServerAgent.cache"].dataCache`,
+ * keyed by API path. The media browser payload there is the complete gallery in
+ * display order, with the CDN URL for every variant of each photo; the photo
+ * tags payload adds captions and room tags per photo id. Only when that state is
+ * absent does the reader fall back to scraping full-size CDN URLs out of the HTML.
+ */
+export function readRedfinListingPage() {
+  var out = {
+    url: location.href,
+    title: document.title || "",
+    body_text: "",
+    hydrated: false,
+    initial_info: null,
+    media_browser_info: null,
+    address_section_info: null,
+    tags_by_photo_id: null,
+    html_photo_urls: [],
+  };
+  try {
+    out.body_text = String((document.body && document.body.innerText) || "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 3000);
+  } catch (_) {
+    out.body_text = "";
+  }
+
+  var state = window.__reactServerState;
+  var context = state && state.InitialContext;
+  var agent = context && context["ReactServerAgent.cache"];
+  var cache = agent && agent.dataCache;
+
+  function payloadOf(pattern) {
+    if (!cache) return null;
+    var keys = Object.keys(cache);
+    for (var i = 0; i < keys.length; i++) {
+      if (!pattern.test(keys[i])) continue;
+      var entry = cache[keys[i]];
+      var body = entry && entry.res && entry.res.body;
+      if (body && body.payload) return body.payload;
+    }
+    return null;
+  }
+
+  if (cache) {
+    out.hydrated = true;
+    var initialInfo = payloadOf(/\/home\/details\/initialInfo(?:\?|$)/);
+    if (initialInfo) {
+      out.initial_info = {
+        listingId: initialInfo.listingId,
+        propertyId: initialInfo.propertyId,
+        dataSourceId: initialInfo.dataSourceId,
+        marketName: initialInfo.marketName,
+        responseCode: initialInfo.responseCode,
+      };
+    }
+    var aboveTheFold = payloadOf(/\/home\/details\/aboveTheFold(?:\?|$)/);
+    var media = aboveTheFold && aboveTheFold.mediaBrowserInfo;
+    if (media) {
+      out.media_browser_info = {
+        photos: Array.isArray(media.photos) ? media.photos : [],
+        assembledAddress: media.assembledAddress,
+        altTextForImage: media.altTextForImage,
+        dataSourceId: media.dataSourceId,
+        previousListingPhotosCount: media.previousListingPhotosCount,
+      };
+    }
+    var address = aboveTheFold && aboveTheFold.addressSectionInfo;
+    if (address) {
+      out.address_section_info = {
+        assembledAddress: address.streetAddress && address.streetAddress.assembledAddress,
+        city: address.city,
+        state: address.state,
+        zip: address.zip,
+        status: address.status && address.status.displayValue,
+        url: address.url,
+      };
+    }
+    var tags = payloadOf(/\/photoTagsAndCaptions\//);
+    out.tags_by_photo_id = (tags && tags.tagsByPhotoId) || null;
+  }
+
+  var hasPhotos =
+    out.media_browser_info &&
+    Array.isArray(out.media_browser_info.photos) &&
+    out.media_browser_info.photos.length > 0;
+  if (!hasPhotos) {
+    var html = document.documentElement ? document.documentElement.outerHTML : "";
+    var matches =
+      html.match(
+        /https?:\\?\/\\?\/ssl\.cdn-redfin\.com\\?\/photo\\?\/\d+\\?\/bigphoto\\?\/[^"'\s\\<>]+/g,
+      ) || [];
+    var seen = {};
+    for (var j = 0; j < matches.length; j++) {
+      var url = matches[j].replace(/\\\//g, "/");
+      if (!seen[url]) {
+        seen[url] = true;
+        out.html_photo_urls.push(url);
+      }
+    }
+  }
+  return out;
+}
+
+function hasReadablePhotos(pageData) {
+  return (
+    (Array.isArray(pageData?.media_browser_info?.photos) &&
+      pageData.media_browser_info.photos.length > 0) ||
+    (Array.isArray(pageData?.html_photo_urls) && pageData.html_photo_urls.length > 0)
+  );
+}
+
+/**
+ * Navigate to the listing and poll until Redfin's server state is present (or
+ * the page has settled on a challenge / not-found screen). Leaving a Redfin page
+ * first keeps the client-side router from swallowing the navigation.
+ */
+export async function loadRedfinListingPage(page, url, { timeoutMs = 20000 } = {}) {
+  const currentUrl = await page.evaluate("window.location.href || ''").catch(() => "");
+  if (isRedfinUrl(currentUrl)) {
+    await page.goto("about:blank", { waitUntil: "none" });
+  }
+  await page.goto(url);
+
+  const deadline = Date.now() + timeoutMs;
+  let pageData = null;
+  for (;;) {
+    pageData = await page.evaluate(readRedfinListingPage);
+    if (
+      pageData?.hydrated ||
+      hasReadablePhotos(pageData) ||
+      detectRedfinChallenge(pageData) ||
+      detectRedfinNotFound(pageData) ||
+      Date.now() >= deadline
+    ) {
+      break;
+    }
+    await page.wait({ time: 0.5 });
+  }
+  return pageData;
+}
+
+export function assertReadableRedfinPage(pageData, url) {
+  if (detectRedfinChallenge(pageData)) {
+    throw new CommandExecutionError(
+      "Redfin served a bot-check or access challenge; clear it in the browser and retry",
+    );
+  }
+  if (detectRedfinNotFound(pageData)) {
+    throw new CommandExecutionError(`Redfin has no listing page at ${url}`);
+  }
+}
+
+/** Load a listing and return its gallery photos plus where they came from. */
+export async function readRedfinListingPhotos(page, url) {
+  const pageData = await loadRedfinListingPage(page, url);
+  assertReadableRedfinPage(pageData, url);
+  const { photos, source } = collectRedfinPhotos(pageData);
+  if (photos.length === 0) {
+    throw new CommandExecutionError(
+      `Redfin exposed no listing photos at ${url}; pass a home listing URL such as https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461`,
+    );
+  }
+  return { pageData, photos, source };
+}

--- a/opencli-plugins/redfin/redfin-helpers.mjs
+++ b/opencli-plugins/redfin/redfin-helpers.mjs
@@ -1,0 +1,372 @@
+// Pure helpers for the Redfin plugin. Nothing here touches the browser or the
+// filesystem, so every function is exercised directly by redfin-helpers.test.mjs.
+
+export const DEFAULT_REDFIN_OUTPUT = "./redfin-downloads";
+export const DEFAULT_REDFIN_EXAMPLE_URL =
+  "https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461";
+
+/**
+ * Redfin's CDN serves each listing photo in fixed variants. `full` is the
+ * uncropped frame from Redfin's full-screen viewer (`bigphoto`, up to 1280px
+ * wide) and the most faithful copy. `large` (`mbphotov3`) is a fixed 1080x771
+ * crop, so it can carry more pixels than `full` on a small source photo while
+ * still losing the frame edges. Redfin's per-photo `width`/`height` describe the
+ * uploaded source, not any served variant, hence the `source_*` row fields.
+ */
+export const REDFIN_PHOTO_SIZES = ["full", "large", "medium", "small", "thumb"];
+
+const PHOTO_URL_PATHS = {
+  full: ["photoUrls", "fullScreenPhotoUrl"],
+  large: ["photoUrls", "nonFullScreenPhotoUrlCompressed"],
+  medium: ["photoUrls", "nonFullScreenPhotoUrl"],
+  small: ["photoUrls", "lightboxListUrl"],
+  thumb: ["thumbnailData", "thumbnailUrl"],
+};
+
+const REDFIN_HOSTNAME = /^(?:[a-z0-9-]+\.)*redfin\.(?:com|ca)$/i;
+
+export function cleanText(value) {
+  return String(value ?? "")
+    .replace(/[\u00a0\u202f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function integerInRange(value, name, minimum, maximum) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return parsed;
+}
+
+function isHttpUrl(value) {
+  return typeof value === "string" && /^https?:\/\//i.test(value);
+}
+
+function urlBasename(url) {
+  try {
+    const segments = new URL(url).pathname.split("/").filter(Boolean);
+    return decodeURIComponent(segments[segments.length - 1] || "");
+  } catch (_) {
+    return "";
+  }
+}
+
+/**
+ * Accept a listing URL with or without a scheme, require a Redfin host, and
+ * drop query/hash so tracking parameters never reach the browser or the output.
+ */
+export function canonicalRedfinListingUrl(input) {
+  const text = cleanText(input);
+  if (!text) throw new Error("url must not be empty");
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(text) ? text : `https://${text}`;
+  let url;
+  try {
+    url = new URL(withScheme);
+  } catch (_) {
+    throw new Error(`url is not a valid URL: ${text}`);
+  }
+  if (!/^https?:$/i.test(url.protocol) || !REDFIN_HOSTNAME.test(url.hostname)) {
+    throw new Error(`url must be a Redfin listing URL such as ${DEFAULT_REDFIN_EXAMPLE_URL}`);
+  }
+  url.protocol = "https:";
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/+$/, "");
+}
+
+export function isRedfinUrl(value) {
+  try {
+    return REDFIN_HOSTNAME.test(new URL(String(value ?? "")).hostname);
+  } catch (_) {
+    return false;
+  }
+}
+
+function sanitizeSegment(value) {
+  return String(value ?? "")
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "");
+}
+
+/**
+ * Folder name for one listing: `<address slug>[-<unit>]-<property id>` from a
+ * canonical URL such as `/CA/Atherton/349-Walsh-Rd-94027/home/1061461`. The id
+ * keeps two listings that share a street address apart.
+ */
+export function redfinListingSlug(url) {
+  let segments;
+  try {
+    segments = new URL(url).pathname.split("/").filter(Boolean);
+  } catch (_) {
+    segments = [];
+  }
+  const homeIndex = segments.findIndex(
+    (segment, index) =>
+      /^(?:home|apartment|building)$/i.test(segment) && /^\d+$/.test(segments[index + 1] || ""),
+  );
+  const parts = [];
+  if (homeIndex >= 0) {
+    let addressIndex = homeIndex - 1;
+    const unit = [];
+    while (addressIndex >= 0 && /^unit-/i.test(segments[addressIndex])) {
+      unit.unshift(segments[addressIndex]);
+      addressIndex -= 1;
+    }
+    if (addressIndex >= 0) parts.push(segments[addressIndex]);
+    parts.push(...unit);
+    if (parts.length === 0) parts.push("redfin");
+    parts.push(segments[homeIndex + 1]);
+  } else {
+    parts.push(...segments);
+  }
+  const slug = sanitizeSegment(parts.join("-"));
+  return slug || "redfin-listing";
+}
+
+/**
+ * Photo position encoded in a CDN file name. Redfin names the first photo
+ * `<MLS>_<version>.jpg` and every later one `<MLS>_<position>_<version>.jpg`.
+ */
+export function redfinPhotoPosition(fileName) {
+  const match = /^(.*?)_(?:(\d+)_)?(\d+)\.[A-Za-z0-9]+$/.exec(cleanText(fileName));
+  if (!match) return null;
+  return match[2] === undefined ? 0 : Number(match[2]);
+}
+
+export function detectRedfinChallenge(pageData) {
+  const title = cleanText(pageData?.title);
+  const body = cleanText(pageData?.body_text);
+  return (
+    /access to this page has been denied|access denied|captcha/i.test(title) ||
+    /press\s*&\s*hold|confirm you are (?:a )?human|verify you are (?:a )?human|are you a robot|unusual (?:traffic|activity)|captcha/i.test(
+      body,
+    )
+  );
+}
+
+export function detectRedfinNotFound(pageData) {
+  const title = cleanText(pageData?.title);
+  const body = cleanText(pageData?.body_text);
+  return (
+    /page not found/i.test(title) ||
+    /lost that one|page (?:you requested )?(?:could not|cannot|can't) be found|no longer available/i.test(
+      body,
+    )
+  );
+}
+
+export function describeRedfinListing(pageData, fallbackUrl = "") {
+  const media = pageData?.media_browser_info || {};
+  const address = pageData?.address_section_info || {};
+  const initial = pageData?.initial_info || {};
+  const assembled = cleanText(
+    media.altTextForImage || media.assembledAddress || address.assembledAddress,
+  );
+  return {
+    url: cleanText(pageData?.url) || cleanText(fallbackUrl),
+    title: cleanText(pageData?.title),
+    address: assembled,
+    city: cleanText(address.city),
+    state: cleanText(address.state),
+    zip: cleanText(address.zip),
+    status: cleanText(address.status),
+    listing_id: initial.listingId != null ? String(initial.listingId) : "",
+    property_id: initial.propertyId != null ? String(initial.propertyId) : "",
+  };
+}
+
+export function normalizeRedfinPhoto(candidate, index, tagsByPhotoId = {}) {
+  const urls = {};
+  for (const size of REDFIN_PHOTO_SIZES) {
+    const [group, key] = PHOTO_URL_PATHS[size];
+    const value = candidate?.[group]?.[key];
+    urls[size] = isHttpUrl(value) ? value : "";
+  }
+  const photoId = candidate?.photoId != null ? String(candidate.photoId) : "";
+  const tagEntry = photoId && tagsByPhotoId ? tagsByPhotoId[photoId] : undefined;
+  const tags = Array.isArray(tagEntry?.tags)
+    ? tagEntry.tags.map(cleanText).filter((tag) => tag && !/^all$/i.test(tag))
+    : [];
+  const sourceWidth = Number(candidate?.width);
+  const sourceHeight = Number(candidate?.height);
+  return {
+    index: index + 1,
+    photo_id: photoId,
+    caption: cleanText(tagEntry?.shortCaption),
+    long_caption: cleanText(tagEntry?.longCaption),
+    tags,
+    source_width: Number.isFinite(sourceWidth) && sourceWidth > 0 ? sourceWidth : null,
+    source_height: Number.isFinite(sourceHeight) && sourceHeight > 0 ? sourceHeight : null,
+    file_name: cleanText(candidate?.fileName) || urlBasename(urls.full),
+    urls,
+  };
+}
+
+function largestGroupInOrder(urls) {
+  const groups = new Map();
+  for (const url of urls) {
+    const key = url.replace(/[^/]*$/, "");
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(url);
+  }
+  let best = [];
+  for (const group of groups.values()) {
+    if (group.length > best.length) best = group;
+  }
+  return best;
+}
+
+/**
+ * Gallery photos for the listing, in Redfin's display order. The server-rendered
+ * media browser payload is authoritative; when it is missing, full-size CDN
+ * URLs scraped from the HTML stand in, narrowed to the single listing directory
+ * that contributes the most photos and ordered by their encoded position.
+ */
+export function collectRedfinPhotos(pageData) {
+  const rawPhotos = Array.isArray(pageData?.media_browser_info?.photos)
+    ? pageData.media_browser_info.photos
+    : [];
+  const tagsByPhotoId =
+    pageData?.tags_by_photo_id && typeof pageData.tags_by_photo_id === "object"
+      ? pageData.tags_by_photo_id
+      : {};
+  const photos = rawPhotos
+    .map((candidate, index) => normalizeRedfinPhoto(candidate, index, tagsByPhotoId))
+    .filter((photo) => Object.values(photo.urls).some(Boolean))
+    .map((photo, index) => ({ ...photo, index: index + 1 }));
+  if (photos.length > 0) return { photos, source: "state" };
+
+  const seen = new Set();
+  const htmlUrls = (Array.isArray(pageData?.html_photo_urls) ? pageData.html_photo_urls : [])
+    .filter(isHttpUrl)
+    .filter((url) => {
+      if (seen.has(url)) return false;
+      seen.add(url);
+      return true;
+    });
+  const ordered = largestGroupInOrder(htmlUrls)
+    .map((url, order) => ({ url, order, position: redfinPhotoPosition(urlBasename(url)) }))
+    .sort((a, b) => {
+      if (a.position === null && b.position === null) return a.order - b.order;
+      if (a.position === null) return 1;
+      if (b.position === null) return -1;
+      return a.position - b.position || a.order - b.order;
+    });
+  return {
+    photos: ordered.map((entry, index) =>
+      normalizeRedfinPhoto(
+        { photoUrls: { fullScreenPhotoUrl: entry.url }, fileName: urlBasename(entry.url) },
+        index,
+      ),
+    ),
+    source: ordered.length > 0 ? "html" : "none",
+  };
+}
+
+/** Requested variant when Redfin published it, else the largest available one. */
+export function selectRedfinPhotoUrl(photo, size) {
+  const order = [size, ...REDFIN_PHOTO_SIZES.filter((candidate) => candidate !== size)];
+  for (const candidate of order) {
+    if (photo?.urls?.[candidate]) return { url: photo.urls[candidate], size: candidate };
+  }
+  return { url: "", size: "" };
+}
+
+/**
+ * `01-ML82027150_2.jpg`: a zero-padded gallery position keeps files sorted the
+ * way Redfin shows them, and the CDN base name keeps the MLS provenance. Sizes
+ * other than `full` carry the size so variants of one photo never overwrite each
+ * other in a shared folder.
+ */
+export function buildRedfinPhotoFilename({ url, index, total, size }) {
+  const width = Math.max(2, String(Math.max(Number(total) || 0, Number(index) || 0)).length);
+  const prefix = String(index).padStart(width, "0");
+  const extension = (/\.([A-Za-z0-9]{2,5})$/.exec(urlBasename(url)) || [])[1] || "jpg";
+  const base = sanitizeSegment(urlBasename(url)) || `photo.${extension.toLowerCase()}`;
+  return size && size !== "full" ? `${prefix}-${size}-${base}` : `${prefix}-${base}`;
+}
+
+/** One download plan entry per photo: which URL to fetch and what to name it. */
+export function planRedfinDownloads(photos, { size = "full", limit = 0 } = {}) {
+  const selected = limit > 0 ? photos.slice(0, limit) : photos;
+  const total = selected.length;
+  return selected.map((photo, order) => {
+    const index = order + 1;
+    const chosen = selectRedfinPhotoUrl(photo, size);
+    return {
+      index,
+      photo_id: photo.photo_id,
+      caption: photo.caption,
+      tags: photo.tags,
+      source_width: photo.source_width,
+      source_height: photo.source_height,
+      size_variant: chosen.size,
+      url: chosen.url,
+      file_name: chosen.url
+        ? buildRedfinPhotoFilename({ url: chosen.url, index, total, size: chosen.size })
+        : "",
+    };
+  });
+}
+
+export function formatBytes(bytes) {
+  const value = Number(bytes);
+  if (!Number.isFinite(value) || value < 0) return "";
+  if (value < 1024) return `${value} B`;
+  const units = ["KB", "MB", "GB"];
+  let scaled = value / 1024;
+  let unit = 0;
+  while (scaled >= 1024 && unit < units.length - 1) {
+    scaled /= 1024;
+    unit += 1;
+  }
+  return `${scaled.toFixed(scaled >= 100 ? 0 : 1)} ${units[unit]}`;
+}
+
+/**
+ * Output row for one planned download. `result` follows opencli's httpDownload
+ * shape (`{ success, size, error }`); `file` is only reported for a file that
+ * exists on disk.
+ */
+export function summarizeRedfinDownload(item, result, { listing = {}, file = "" } = {}) {
+  const success = result?.success === true;
+  return {
+    index: item.index,
+    status: success ? "success" : "failed",
+    size: success ? formatBytes(result.size) : "",
+    bytes: success ? Number(result.size) || 0 : 0,
+    file: success ? file : "",
+    error: success ? "" : cleanText(result?.error) || "unknown error",
+    photo_id: item.photo_id,
+    caption: item.caption,
+    tags: Array.isArray(item.tags) ? item.tags.join(", ") : "",
+    source_width: item.source_width,
+    source_height: item.source_height,
+    size_variant: item.size_variant,
+    url: item.url,
+    address: listing.address || "",
+    listing_url: listing.url || "",
+  };
+}
+
+export function normalizePhotoRow(photo, listing, size) {
+  const chosen = selectRedfinPhotoUrl(photo, size);
+  return {
+    index: photo.index,
+    photo_id: photo.photo_id,
+    caption: photo.caption,
+    tags: photo.tags.join(", "),
+    source_width: photo.source_width,
+    source_height: photo.source_height,
+    url: chosen.url,
+    size_variant: chosen.size,
+    thumbnail_url: photo.urls.thumb,
+    full_url: photo.urls.full,
+    long_caption: photo.long_caption,
+    address: listing.address,
+    listing_url: listing.url,
+  };
+}

--- a/opencli-plugins/redfin/redfin-helpers.test.mjs
+++ b/opencli-plugins/redfin/redfin-helpers.test.mjs
@@ -1,0 +1,485 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildRedfinPhotoFilename,
+  canonicalRedfinListingUrl,
+  collectRedfinPhotos,
+  describeRedfinListing,
+  detectRedfinChallenge,
+  detectRedfinNotFound,
+  formatBytes,
+  integerInRange,
+  isRedfinUrl,
+  normalizePhotoRow,
+  normalizeRedfinPhoto,
+  planRedfinDownloads,
+  REDFIN_PHOTO_SIZES,
+  redfinListingSlug,
+  redfinPhotoPosition,
+  selectRedfinPhotoUrl,
+  summarizeRedfinDownload,
+} from "./redfin-helpers.mjs";
+
+const CDN = "https://ssl.cdn-redfin.com/photo/8";
+
+// Shaped like Redfin's server-rendered aboveTheFold media browser entries.
+function rawPhoto(fileName, photoId, { width = 799, height = 533 } = {}) {
+  return {
+    photoUrls: {
+      nonFullScreenPhotoUrlCompressed: `${CDN}/mbphotov3/150/genMid.${fileName}`,
+      nonFullScreenPhotoUrl: `${CDN}/mbpaddedwide/150/genMid.${fileName}`,
+      fullScreenPhotoUrl: `${CDN}/bigphoto/150/${fileName}`,
+      lightboxListUrl: `${CDN}/bcsphoto/150/genBcs.${fileName}`,
+    },
+    thumbnailData: { thumbnailUrl: `${CDN}/tmbphoto/150/genTmb.${fileName}` },
+    displayLevel: 1,
+    dataSourceId: 8,
+    photoType: "SPRITED",
+    subdirectory: "150",
+    fileName,
+    height,
+    width,
+    photoId,
+  };
+}
+
+function hydratedPageData() {
+  return {
+    url: "https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461",
+    title: "349 Walsh Rd, Atherton, CA 94027 | MLS# ML82027150 | Redfin",
+    body_text: "Buy Rent Sell 34 photos $49,680,000 5 beds 7 baths 11968 sq ft",
+    hydrated: true,
+    initial_info: { listingId: 211307847, propertyId: 1061461, dataSourceId: 8 },
+    media_browser_info: {
+      photos: [
+        rawPhoto("ML82027150_2.jpg", 3108056537),
+        rawPhoto("ML82027150_1_2.jpg", 3108056538),
+        rawPhoto("ML82027150_2_2.jpg", 3108056539, { width: 599, height: 449 }),
+      ],
+      assembledAddress: "349 Walsh Rd",
+      altTextForImage: "349 Walsh Rd, Atherton, CA 94027",
+      dataSourceId: 8,
+      previousListingPhotosCount: 0,
+    },
+    address_section_info: {
+      assembledAddress: "349 Walsh Rd",
+      city: "Atherton",
+      state: "CA",
+      zip: "94027",
+      status: "Active",
+      url: "/CA/Atherton/349-Walsh-Rd-94027/home/1061461",
+    },
+    tags_by_photo_id: {
+      3108056537: {
+        photoId: 3108056537,
+        tags: ["All", "Exterior"],
+        shortCaption: "Modern architectural masterpiece",
+        longCaption: "Modern architectural masterpiece with glass walls and a floating staircase.",
+      },
+      3108056538: {
+        photoId: 3108056538,
+        tags: ["All"],
+        shortCaption: "  Glass entrance   with wooden door ",
+        longCaption: "",
+      },
+    },
+    html_photo_urls: [],
+  };
+}
+
+test("canonicalRedfinListingUrl accepts Redfin hosts and strips tracking noise", () => {
+  assert.equal(
+    canonicalRedfinListingUrl(
+      " https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461/?utm_source=share#photos ",
+    ),
+    "https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461",
+  );
+  assert.equal(
+    canonicalRedfinListingUrl("redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461"),
+    "https://redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461",
+  );
+  assert.equal(
+    canonicalRedfinListingUrl("http://www.redfin.ca/BC/Vancouver/1-Main-St-V5T/home/12345"),
+    "https://www.redfin.ca/BC/Vancouver/1-Main-St-V5T/home/12345",
+  );
+});
+
+test("canonicalRedfinListingUrl rejects empty, malformed, and non-Redfin input", () => {
+  assert.throws(() => canonicalRedfinListingUrl(""), /url must not be empty/);
+  assert.throws(() => canonicalRedfinListingUrl("https://"), /not a valid URL/);
+  assert.throws(() => canonicalRedfinListingUrl("https://www.zillow.com/homedetails/1"), /Redfin/);
+  assert.throws(() => canonicalRedfinListingUrl("https://redfin.com.evil.example/x"), /Redfin/);
+  assert.throws(() => canonicalRedfinListingUrl("ftp://www.redfin.com/CA/x/home/1"), /Redfin/);
+});
+
+test("isRedfinUrl recognizes Redfin origins only", () => {
+  assert.equal(isRedfinUrl("https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1"), true);
+  assert.equal(isRedfinUrl("https://redfin.ca/"), true);
+  assert.equal(isRedfinUrl("about:blank"), false);
+  assert.equal(isRedfinUrl("https://www.redfin.com.example/"), false);
+  assert.equal(isRedfinUrl(""), false);
+});
+
+test("redfinListingSlug names the folder after the address slug and property id", () => {
+  assert.equal(
+    redfinListingSlug("https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461"),
+    "349-Walsh-Rd-94027-1061461",
+  );
+  assert.equal(
+    redfinListingSlug("https://www.redfin.com/CA/San-Francisco/1-Main-St-94105/unit-2B/home/77"),
+    "1-Main-St-94105-unit-2B-77",
+  );
+  assert.equal(redfinListingSlug("https://www.redfin.com/home/1061461"), "redfin-1061461");
+  assert.equal(
+    redfinListingSlug("https://www.redfin.com/city/820/CA/Atherton"),
+    "city-820-CA-Atherton",
+  );
+  assert.equal(redfinListingSlug("https://www.redfin.com/"), "redfin-listing");
+  assert.equal(redfinListingSlug("not a url"), "redfin-listing");
+});
+
+test("redfinPhotoPosition decodes the gallery position from a CDN file name", () => {
+  assert.equal(redfinPhotoPosition("ML82027150_2.jpg"), 0);
+  assert.equal(redfinPhotoPosition("ML82027150_1_2.jpg"), 1);
+  assert.equal(redfinPhotoPosition("ML82027150_33_2.jpg"), 33);
+  assert.equal(redfinPhotoPosition("ML82050172_0.jpg"), 0);
+  assert.equal(redfinPhotoPosition("genMid.ML82050172_12_0.jpg"), 12);
+  assert.equal(redfinPhotoPosition("logo.svg"), null);
+  assert.equal(redfinPhotoPosition(""), null);
+});
+
+test("detectRedfinChallenge and detectRedfinNotFound read the page chrome", () => {
+  assert.equal(detectRedfinChallenge(hydratedPageData()), false);
+  assert.equal(detectRedfinNotFound(hydratedPageData()), false);
+  assert.equal(
+    detectRedfinChallenge({
+      title: "Access to this page has been denied.",
+      body_text: "Press & Hold to confirm you are a human (and not a bot).",
+    }),
+    true,
+  );
+  assert.equal(
+    detectRedfinChallenge({ title: "Redfin", body_text: "Please solve the CAPTCHA" }),
+    true,
+  );
+  assert.equal(
+    detectRedfinNotFound({
+      title: "Page Not Found | Redfin",
+      body_text: "Oops… lost that one. Let's get you home.",
+    }),
+    true,
+  );
+  assert.equal(detectRedfinNotFound({ title: "Redfin", body_text: "Oops… lost that one." }), true);
+  assert.equal(detectRedfinChallenge(null), false);
+  assert.equal(detectRedfinNotFound(undefined), false);
+});
+
+test("describeRedfinListing prefers the media browser address and stringifies ids", () => {
+  assert.deepEqual(describeRedfinListing(hydratedPageData()), {
+    url: "https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461",
+    title: "349 Walsh Rd, Atherton, CA 94027 | MLS# ML82027150 | Redfin",
+    address: "349 Walsh Rd, Atherton, CA 94027",
+    city: "Atherton",
+    state: "CA",
+    zip: "94027",
+    status: "Active",
+    listing_id: "211307847",
+    property_id: "1061461",
+  });
+  assert.deepEqual(describeRedfinListing({}, "https://www.redfin.com/x/home/1"), {
+    url: "https://www.redfin.com/x/home/1",
+    title: "",
+    address: "",
+    city: "",
+    state: "",
+    zip: "",
+    status: "",
+    listing_id: "",
+    property_id: "",
+  });
+});
+
+test("normalizeRedfinPhoto maps every CDN variant and merges tags without the All bucket", () => {
+  const photo = normalizeRedfinPhoto(
+    rawPhoto("ML82027150_2.jpg", 3108056537),
+    0,
+    hydratedPageData().tags_by_photo_id,
+  );
+  assert.deepEqual(photo, {
+    index: 1,
+    photo_id: "3108056537",
+    caption: "Modern architectural masterpiece",
+    long_caption: "Modern architectural masterpiece with glass walls and a floating staircase.",
+    tags: ["Exterior"],
+    source_width: 799,
+    source_height: 533,
+    file_name: "ML82027150_2.jpg",
+    urls: {
+      full: `${CDN}/bigphoto/150/ML82027150_2.jpg`,
+      large: `${CDN}/mbphotov3/150/genMid.ML82027150_2.jpg`,
+      medium: `${CDN}/mbpaddedwide/150/genMid.ML82027150_2.jpg`,
+      small: `${CDN}/bcsphoto/150/genBcs.ML82027150_2.jpg`,
+      thumb: `${CDN}/tmbphoto/150/genTmb.ML82027150_2.jpg`,
+    },
+  });
+});
+
+test("normalizeRedfinPhoto tolerates sparse candidates", () => {
+  const photo = normalizeRedfinPhoto(
+    {
+      photoUrls: {
+        fullScreenPhotoUrl: `${CDN}/bigphoto/150/ML82027150_5_2.jpg`,
+        lightboxListUrl: "x",
+      },
+    },
+    4,
+  );
+  assert.equal(photo.index, 5);
+  assert.equal(photo.photo_id, "");
+  assert.equal(photo.caption, "");
+  assert.deepEqual(photo.tags, []);
+  assert.equal(photo.source_width, null);
+  assert.equal(photo.source_height, null);
+  assert.equal(photo.file_name, "ML82027150_5_2.jpg");
+  assert.equal(photo.urls.full, `${CDN}/bigphoto/150/ML82027150_5_2.jpg`);
+  assert.equal(photo.urls.small, "");
+  assert.equal(photo.urls.thumb, "");
+});
+
+test("collectRedfinPhotos uses the server state gallery in display order", () => {
+  const { photos, source } = collectRedfinPhotos(hydratedPageData());
+  assert.equal(source, "state");
+  assert.deepEqual(
+    photos.map((photo) => [photo.index, photo.file_name, photo.caption, photo.tags]),
+    [
+      [1, "ML82027150_2.jpg", "Modern architectural masterpiece", ["Exterior"]],
+      [2, "ML82027150_1_2.jpg", "Glass entrance with wooden door", []],
+      [3, "ML82027150_2_2.jpg", "", []],
+    ],
+  );
+  assert.deepEqual([photos[2].source_width, photos[2].source_height], [599, 449]);
+});
+
+test("collectRedfinPhotos drops entries without any URL and renumbers the rest", () => {
+  const pageData = hydratedPageData();
+  pageData.media_browser_info.photos.splice(1, 0, { photoId: 1, fileName: "broken.jpg" });
+  const { photos } = collectRedfinPhotos(pageData);
+  assert.deepEqual(
+    photos.map((photo) => [photo.index, photo.file_name]),
+    [
+      [1, "ML82027150_2.jpg"],
+      [2, "ML82027150_1_2.jpg"],
+      [3, "ML82027150_2_2.jpg"],
+    ],
+  );
+});
+
+test("collectRedfinPhotos falls back to HTML CDN URLs, narrowed to one listing and ordered", () => {
+  const { photos, source } = collectRedfinPhotos({
+    hydrated: false,
+    media_browser_info: null,
+    html_photo_urls: [
+      `${CDN}/bigphoto/150/ML82027150_2.jpg`,
+      `${CDN}/bigphoto/150/ML82027150_33_2.jpg`,
+      `${CDN}/bigphoto/150/ML82027150_1_2.jpg`,
+      `${CDN}/bigphoto/150/ML82027150_2.jpg`,
+      "https://ssl.cdn-redfin.com/photo/10/bigphoto/822/ML81911822_0.jpg",
+      `${CDN}/bigphoto/150/ML82027150_2_2.jpg`,
+      "not-a-url",
+    ],
+  });
+  assert.equal(source, "html");
+  assert.deepEqual(
+    photos.map((photo) => [photo.index, photo.file_name]),
+    [
+      [1, "ML82027150_2.jpg"],
+      [2, "ML82027150_1_2.jpg"],
+      [3, "ML82027150_2_2.jpg"],
+      [4, "ML82027150_33_2.jpg"],
+    ],
+  );
+  assert.equal(photos[0].urls.full, `${CDN}/bigphoto/150/ML82027150_2.jpg`);
+  assert.equal(photos[0].urls.large, "");
+  assert.equal(photos[0].photo_id, "");
+});
+
+test("collectRedfinPhotos reports none when nothing is readable", () => {
+  assert.deepEqual(collectRedfinPhotos({ hydrated: true, media_browser_info: { photos: [] } }), {
+    photos: [],
+    source: "none",
+  });
+  assert.deepEqual(collectRedfinPhotos(null), { photos: [], source: "none" });
+});
+
+test("selectRedfinPhotoUrl honors the requested size and falls back to the largest available", () => {
+  const photo = normalizeRedfinPhoto(rawPhoto("ML82027150_2.jpg", 1), 0);
+  assert.deepEqual(selectRedfinPhotoUrl(photo, "thumb"), {
+    url: `${CDN}/tmbphoto/150/genTmb.ML82027150_2.jpg`,
+    size: "thumb",
+  });
+  const fullOnly = normalizeRedfinPhoto(
+    { photoUrls: { fullScreenPhotoUrl: `${CDN}/bigphoto/150/ML82027150_2.jpg` } },
+    0,
+  );
+  assert.deepEqual(selectRedfinPhotoUrl(fullOnly, "large"), {
+    url: `${CDN}/bigphoto/150/ML82027150_2.jpg`,
+    size: "full",
+  });
+  assert.deepEqual(selectRedfinPhotoUrl({ urls: {} }, "full"), { url: "", size: "" });
+  assert.deepEqual(REDFIN_PHOTO_SIZES, ["full", "large", "medium", "small", "thumb"]);
+});
+
+test("buildRedfinPhotoFilename pads by gallery size and marks non-full variants", () => {
+  assert.equal(
+    buildRedfinPhotoFilename({
+      url: `${CDN}/bigphoto/150/ML82027150_2.jpg`,
+      index: 1,
+      total: 34,
+      size: "full",
+    }),
+    "01-ML82027150_2.jpg",
+  );
+  assert.equal(
+    buildRedfinPhotoFilename({
+      url: `${CDN}/bigphoto/150/ML82027150_33_2.jpg`,
+      index: 34,
+      total: 34,
+      size: "full",
+    }),
+    "34-ML82027150_33_2.jpg",
+  );
+  assert.equal(
+    buildRedfinPhotoFilename({
+      url: `${CDN}/bigphoto/150/ML82027150_2.jpg`,
+      index: 7,
+      total: 120,
+      size: "full",
+    }),
+    "007-ML82027150_2.jpg",
+  );
+  assert.equal(
+    buildRedfinPhotoFilename({
+      url: `${CDN}/mbphotov3/150/genMid.ML82027150_2.jpg`,
+      index: 1,
+      total: 3,
+      size: "large",
+    }),
+    "01-large-genMid.ML82027150_2.jpg",
+  );
+  assert.equal(
+    buildRedfinPhotoFilename({
+      url: "https://ssl.cdn-redfin.com/",
+      index: 2,
+      total: 2,
+      size: "full",
+    }),
+    "02-photo.jpg",
+  );
+  assert.equal(
+    buildRedfinPhotoFilename({
+      url: "https://ssl.cdn-redfin.com/photo/8/bigphoto/150/we%20ird%20name.PNG",
+      index: 1,
+      total: 1,
+      size: "full",
+    }),
+    "01-we-ird-name.PNG",
+  );
+});
+
+test("planRedfinDownloads applies the limit and names files consistently", () => {
+  const { photos } = collectRedfinPhotos(hydratedPageData());
+  const plan = planRedfinDownloads(photos, { size: "full", limit: 2 });
+  assert.deepEqual(
+    plan.map((item) => [item.index, item.file_name, item.size_variant, item.url]),
+    [
+      [1, "01-ML82027150_2.jpg", "full", `${CDN}/bigphoto/150/ML82027150_2.jpg`],
+      [2, "02-ML82027150_1_2.jpg", "full", `${CDN}/bigphoto/150/ML82027150_1_2.jpg`],
+    ],
+  );
+  assert.deepEqual(plan[0].tags, ["Exterior"]);
+  assert.equal(plan[0].caption, "Modern architectural masterpiece");
+  const all = planRedfinDownloads(photos, { size: "medium" });
+  assert.equal(all.length, 3);
+  assert.equal(all[2].file_name, "03-medium-genMid.ML82027150_2_2.jpg");
+  const unplannable = planRedfinDownloads([{ ...photos[0], urls: {} }], { size: "full" });
+  assert.deepEqual([unplannable[0].url, unplannable[0].file_name], ["", ""]);
+});
+
+test("formatBytes renders human-friendly sizes", () => {
+  assert.equal(formatBytes(0), "0 B");
+  assert.equal(formatBytes(512), "512 B");
+  assert.equal(formatBytes(68514), "66.9 KB");
+  assert.equal(formatBytes(1048576), "1.0 MB");
+  assert.equal(formatBytes(157286400), "150 MB");
+  assert.equal(formatBytes(-1), "");
+  assert.equal(formatBytes("nope"), "");
+});
+
+test("summarizeRedfinDownload reports success and failure rows", () => {
+  const { photos } = collectRedfinPhotos(hydratedPageData());
+  const listing = describeRedfinListing(hydratedPageData());
+  const [item] = planRedfinDownloads(photos, { size: "full" });
+  assert.deepEqual(
+    summarizeRedfinDownload(
+      item,
+      { success: true, size: 68514 },
+      { listing, file: "/tmp/out/01-ML82027150_2.jpg" },
+    ),
+    {
+      index: 1,
+      status: "success",
+      size: "66.9 KB",
+      bytes: 68514,
+      file: "/tmp/out/01-ML82027150_2.jpg",
+      error: "",
+      photo_id: "3108056537",
+      caption: "Modern architectural masterpiece",
+      tags: "Exterior",
+      source_width: 799,
+      source_height: 533,
+      size_variant: "full",
+      url: `${CDN}/bigphoto/150/ML82027150_2.jpg`,
+      address: "349 Walsh Rd, Atherton, CA 94027",
+      listing_url: "https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461",
+    },
+  );
+  const failed = summarizeRedfinDownload(
+    item,
+    { success: false, size: 0, error: "HTTP 404" },
+    { listing, file: "/tmp/out/01-ML82027150_2.jpg" },
+  );
+  assert.equal(failed.status, "failed");
+  assert.equal(failed.size, "");
+  assert.equal(failed.bytes, 0);
+  assert.equal(failed.file, "");
+  assert.equal(failed.error, "HTTP 404");
+  assert.equal(summarizeRedfinDownload(item, undefined).error, "unknown error");
+});
+
+test("normalizePhotoRow flattens a photo for the photos command", () => {
+  const { photos } = collectRedfinPhotos(hydratedPageData());
+  const listing = describeRedfinListing(hydratedPageData());
+  assert.deepEqual(normalizePhotoRow(photos[0], listing, "large"), {
+    index: 1,
+    photo_id: "3108056537",
+    caption: "Modern architectural masterpiece",
+    tags: "Exterior",
+    source_width: 799,
+    source_height: 533,
+    url: `${CDN}/mbphotov3/150/genMid.ML82027150_2.jpg`,
+    size_variant: "large",
+    thumbnail_url: `${CDN}/tmbphoto/150/genTmb.ML82027150_2.jpg`,
+    full_url: `${CDN}/bigphoto/150/ML82027150_2.jpg`,
+    long_caption: "Modern architectural masterpiece with glass walls and a floating staircase.",
+    address: "349 Walsh Rd, Atherton, CA 94027",
+    listing_url: "https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461",
+  });
+});
+
+test("integerInRange validates command limits", () => {
+  assert.equal(integerInRange("5", "limit", 0, 1000), 5);
+  assert.equal(integerInRange(0, "limit", 0, 1000), 0);
+  assert.throws(() => integerInRange("1.5", "limit", 0, 1000), /limit must be an integer/);
+  assert.throws(() => integerInRange(-1, "limit", 0, 1000), /between 0 and 1000/);
+  assert.throws(() => integerInRange("abc", "limit", 0, 1000), /limit must be an integer/);
+});


### PR DESCRIPTION
## What this PR does

Rome had no OpenCLI command for Redfin, so an agent asked to save a listing's photos had to hand-drive the browser and scrape the gallery each time, with no stable output shape and no reliable way to get every photo at its best served size.

This adds the `rome-redfin` plugin (`opencli-plugins/redfin/`) with two browser-backed, logged-out commands:

- `opencli redfin download URL [--output DIR] [--size SIZE] [--limit N]` saves every gallery photo of a listing to `<output>/<address slug>-<property id>/`, one file per photo in Redfin's display order (`01-ML82027150_2.jpg`, `02-ML82027150_1_2.jpg`, …), and returns one row per photo with the saved path, byte size, caption, room tags, source dimensions, and CDN URL.
- `opencli redfin photos URL [--size SIZE] [--limit N]` returns the same gallery as rows without writing anything.

```bash
opencli redfin download https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461
opencli redfin photos https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461 -f json
```

## Design & Invariants

- **Source of truth is Redfin's server-rendered page state, not the DOM.** Redfin embeds every data-API response the listing page needs in `window.__reactServerState.InitialContext["ReactServerAgent.cache"].dataCache`. The `aboveTheFold` payload's `mediaBrowserInfo.photos` is the complete gallery in display order with the CDN URL of every size variant, and the `photoTagsAndCaptions` payload carries captions and room tags per `photoId`. Reading that state gives all 34 photos of the example listing even though the DOM only renders a handful of `<img>` tags. When the state is absent, the commands fall back to full-size CDN URLs scraped from the HTML, narrowed to the single listing directory that contributes the most photos and ordered by the position encoded in the file name.
- **`full` (Redfin's `bigphoto`) is the default because it is the most faithful served copy.** Redfin caps it at 1280px wide and it keeps the whole frame. `large` (`mbphotov3`) is a fixed 1080×771 crop, so it can carry more pixels than `full` on a small source photo while losing the frame edges. Redfin's per-photo `width`/`height` describe the uploaded source, not any served variant, so rows expose them as `source_width`/`source_height`.
- **Files never collide.** The output folder is derived from the listing URL (`<address slug>[-<unit>]-<property id>`), file names are zero-padded by gallery position, and a non-default `--size` adds the size to the name so two variants of one photo can share a folder.
- **A failed photo is a failed row, not a failed run.** `download` reports each photo's `status`/`error` and continues. A bot-check ("Press & Hold"), a Page Not Found, or a page with no gallery fails the whole command with a typed `CommandExecutionError` instead of returning partial or empty rows.
- **No account, no private API.** Both commands use `Strategy.PUBLIC`, navigate the public listing page, and fetch photos straight from `ssl.cdn-redfin.com`, which serves them without cookies.
- The in-page reader (`readRedfinListingPage`) returns raw payload slices only; all shaping, validation, and naming live in pure helpers (`redfin-helpers.mjs`) that the unit tests cover directly. Alternative considered: calling Redfin's `stingray` API from Node. Rejected because the listing id it needs is only available after the page loads and the page state already holds the same response.

## Test plan

- [x] `npm test` in `opencli-plugins/redfin` — 20 helper tests pass (URL canonicalization, slug naming, position decoding, challenge/not-found detection, state and HTML fallback collection, size selection, file naming, download planning, row shaping).
- [x] `biome check opencli-plugins/` — clean.
- [x] `scripts/check-pr-title.sh` — title accepted.
- [x] Live: `opencli plugin install opencli-plugins/redfin`, then `opencli redfin download https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461 --output /tmp/redfin-test -f json` — 34/34 photos saved (2.0 MB, all valid JPEGs, no leftover `.tmp` files) in ~3 s, rows carry captions and tags.
- [x] Live: a sold listing (`/CA/Atherton/31-Rittenhouse-Ave-94027/home/849653`) with `--size large --limit 2` and a `?utm_source=` suffix — UTM stripped, folder named from the slug, files carry the `-large-` infix.
- [x] Live: `photos --size thumb -f table` renders the declared columns.
- [x] Live: a non-Redfin URL fails with a usage error before any navigation; a bogus listing id fails with "Redfin has no listing page at …" in under 1 s.
- [ ] CI.
