### PR TITLE
feat(opencli): add Zillow listing photo download plugin

### DIFF
--- a/opencli-plugins/README.md
+++ b/opencli-plugins/README.md
@@ -96,6 +96,9 @@ Agents pick up new/changed commands automatically: the `browser-automation` skil
 - `opencli redfin download URL [--output DIR] [--size SIZE] [--limit N]` — downloads every gallery
   photo of a public Redfin listing into one folder per listing, in gallery order, with captions and
   room tags in the result rows. `photos URL` lists the same gallery without writing anything.
+- `opencli zillow download URL [--output DIR] [--size SIZE] [--limit N]` — downloads every gallery
+  photo of a public Zillow listing into one folder per listing, in gallery order, at the widest
+  original-ratio size Zillow serves. `photos URL` lists the same gallery without writing anything.
 
 ## Overriding a built-in command: caveats
 
@@ -398,4 +401,42 @@ result.
 opencli redfin download https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461
 opencli redfin download https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461 --output ~/Pictures --size large --limit 10 -f json
 opencli redfin photos https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461 -f json
+```
+
+### Zillow
+
+The Zillow plugin reads a public home details page and works from the Next.js page state Zillow
+server-renders into `<script id="__NEXT_DATA__">`. The `gdpClientCache` entry there holds the
+listing's `responsivePhotosOriginalRatio` list: every photo in display order with the CDN URL of
+each width bucket, plus a caption and subject type when the listing has them. The commands need no
+Zillow account and call no private API. When that state is absent, the commands fall back to the
+CDN URLs present in the HTML.
+
+- `download` saves the gallery to `<output>/<address slug>-<zpid>/`, one file per photo named
+  `<gallery position>-<photo key>.jpg` (for example `01-40a2df03a9e1e7ce67de59c614683f5f.jpg`) so
+  a folder listing matches the order on Zillow. Each result row carries the saved path, byte size,
+  caption, subject type, served width, and source URL. A photo that fails to download gets a failed
+  row with the error, and the run continues with the next photo.
+- `photos` returns the same gallery as rows without touching the disk.
+- `--size` picks the width bucket. `full` (default) is the widest original-ratio bucket, up to
+  1536px wide, which Zillow scales down from the source photo and never scales up. `large` (1344),
+  `medium` (1024), and `small` (800) are the narrower original-ratio buckets. `thumb` is Zillow's
+  384px crop. A bucket the listing does not publish falls back to the nearest one it does. Files
+  for a non-default size carry the size in their name, so variants never overwrite each other.
+- `--limit` caps the number of photos taken from the front of the gallery.
+
+Both a canonical `/homedetails/<address>/<zpid>_zpid/` URL and a `/homes/<address>_rb/` address
+URL work. The address form resolves through a Zillow redirect, so the canonical form is faster.
+
+Zillow's PerimeterX sensor scores each page load and stores its verdict in the `_px*` and `pxcts`
+cookies. A verdict written during an automated load blocks the next load with a "Press & Hold"
+wall or a bare HTTP 5xx. When a command hits either, it deletes only those PerimeterX cookies from
+the browser, which resets the verdict, and loads the page once more. Every other Zillow cookie,
+including a signed-in session, stays in place. A wall that survives the retry fails with a typed
+error, as does a missing listing.
+
+```bash
+opencli zillow download https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/
+opencli zillow download https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/ --output ~/Pictures --size large --limit 10 -f json
+opencli zillow photos https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/ -f json
 ```

--- a/opencli-plugins/zillow/download.js
+++ b/opencli-plugins/zillow/download.js
@@ -1,0 +1,102 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { httpDownload } from "@jackwener/opencli/download";
+import { CommandExecutionError, getErrorMessage } from "@jackwener/opencli/errors";
+import { cli, Strategy } from "@jackwener/opencli/registry";
+import { readZillowListingPhotos } from "./zillow-browser.mjs";
+import {
+  canonicalZillowListingUrl,
+  DEFAULT_ZILLOW_EXAMPLE_URL,
+  DEFAULT_ZILLOW_OUTPUT,
+  describeZillowListing,
+  integerInRange,
+  planZillowDownloads,
+  summarizeZillowDownload,
+  ZILLOW_PHOTO_SIZES,
+  zillowListingSlug,
+} from "./zillow-helpers.mjs";
+
+cli({
+  site: "zillow",
+  name: "download",
+  access: "read",
+  description: "Download every gallery photo of a public Zillow listing",
+  example: `opencli zillow download ${DEFAULT_ZILLOW_EXAMPLE_URL} --output ./zillow-downloads`,
+  domain: "zillow.com",
+  strategy: Strategy.PUBLIC,
+  browser: true,
+  args: [
+    {
+      name: "url",
+      type: "string",
+      positional: true,
+      required: true,
+      help: `Zillow listing URL, e.g. ${DEFAULT_ZILLOW_EXAMPLE_URL}`,
+    },
+    {
+      name: "output",
+      type: "string",
+      default: DEFAULT_ZILLOW_OUTPUT,
+      help: "Directory that receives one <address>-<zpid> folder per listing",
+    },
+    {
+      name: "size",
+      type: "string",
+      default: "full",
+      choices: ZILLOW_PHOTO_SIZES,
+      help: "Photo variant to download: full (widest original-ratio bucket, up to 1536px), large (1344px), medium (1024px), small (800px), or thumb (384px crop)",
+    },
+    {
+      name: "limit",
+      type: "int",
+      default: 0,
+      help: "Maximum photos to download in gallery order (0 = all)",
+    },
+  ],
+  columns: ["index", "status", "size", "file", "caption", "width", "url"],
+  func: async (page, kwargs) => {
+    if (!page) throw new CommandExecutionError("Browser session required for zillow download");
+    let url;
+    let limit;
+    let output;
+    try {
+      url = canonicalZillowListingUrl(kwargs.url);
+      limit = integerInRange(kwargs.limit ?? 0, "limit", 0, 1000);
+      output = String(kwargs.output || DEFAULT_ZILLOW_OUTPUT).trim() || DEFAULT_ZILLOW_OUTPUT;
+      if (!ZILLOW_PHOTO_SIZES.includes(kwargs.size)) {
+        throw new Error(`size must be one of: ${ZILLOW_PHOTO_SIZES.join(", ")}`);
+      }
+    } catch (error) {
+      throw new CommandExecutionError(error instanceof Error ? error.message : String(error));
+    }
+
+    const { pageData, photos } = await readZillowListingPhotos(page, url);
+    const listing = describeZillowListing(pageData, url);
+    const plan = planZillowDownloads(photos, { size: kwargs.size, limit });
+
+    const outputDir = path.resolve(output, zillowListingSlug(listing.url || url));
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    const rows = [];
+    for (const item of plan) {
+      if (!item.url) {
+        rows.push(
+          summarizeZillowDownload(item, { success: false, error: "No photo URL" }, { listing }),
+        );
+        continue;
+      }
+      const file = path.join(outputDir, item.file_name);
+      let result;
+      try {
+        result = await httpDownload(item.url, file, {
+          headers: { Referer: "https://www.zillow.com/" },
+          timeout: 60000,
+        });
+      } catch (error) {
+        result = { success: false, size: 0, error: getErrorMessage(error) };
+      }
+      rows.push(summarizeZillowDownload(item, result, { listing, file }));
+    }
+    return rows;
+  },
+});

--- a/opencli-plugins/zillow/opencli-plugin.json
+++ b/opencli-plugins/zillow/opencli-plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "rome-zillow",
+  "description": "Public Zillow listing photo commands for OpenCLI",
+  "version": "0.1.0",
+  "opencli": ">=1.8.0"
+}

--- a/opencli-plugins/zillow/package.json
+++ b/opencli-plugins/zillow/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "rome-opencli-zillow",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "../../scripts/test-env.sh node --test zillow-helpers.test.mjs"
+  }
+}

--- a/opencli-plugins/zillow/photos.js
+++ b/opencli-plugins/zillow/photos.js
@@ -1,0 +1,64 @@
+import { CommandExecutionError } from "@jackwener/opencli/errors";
+import { cli, Strategy } from "@jackwener/opencli/registry";
+import { readZillowListingPhotos } from "./zillow-browser.mjs";
+import {
+  canonicalZillowListingUrl,
+  DEFAULT_ZILLOW_EXAMPLE_URL,
+  describeZillowListing,
+  integerInRange,
+  normalizePhotoRow,
+  ZILLOW_PHOTO_SIZES,
+} from "./zillow-helpers.mjs";
+
+cli({
+  site: "zillow",
+  name: "photos",
+  access: "read",
+  description: "List every gallery photo of a public Zillow listing with captions and CDN URLs",
+  example: `opencli zillow photos ${DEFAULT_ZILLOW_EXAMPLE_URL} -f json`,
+  domain: "zillow.com",
+  strategy: Strategy.PUBLIC,
+  browser: true,
+  args: [
+    {
+      name: "url",
+      type: "string",
+      positional: true,
+      required: true,
+      help: `Zillow listing URL, e.g. ${DEFAULT_ZILLOW_EXAMPLE_URL}`,
+    },
+    {
+      name: "size",
+      type: "string",
+      default: "full",
+      choices: ZILLOW_PHOTO_SIZES,
+      help: "Photo variant reported in the url column: full (widest original-ratio bucket, up to 1536px), large (1344px), medium (1024px), small (800px), or thumb (384px crop)",
+    },
+    {
+      name: "limit",
+      type: "int",
+      default: 0,
+      help: "Maximum photos to return in gallery order (0 = all)",
+    },
+  ],
+  columns: ["index", "photo_key", "caption", "subject_type", "width", "url"],
+  func: async (page, kwargs) => {
+    if (!page) throw new CommandExecutionError("Browser session required for zillow photos");
+    let url;
+    let limit;
+    try {
+      url = canonicalZillowListingUrl(kwargs.url);
+      limit = integerInRange(kwargs.limit ?? 0, "limit", 0, 1000);
+      if (!ZILLOW_PHOTO_SIZES.includes(kwargs.size)) {
+        throw new Error(`size must be one of: ${ZILLOW_PHOTO_SIZES.join(", ")}`);
+      }
+    } catch (error) {
+      throw new CommandExecutionError(error instanceof Error ? error.message : String(error));
+    }
+
+    const { pageData, photos } = await readZillowListingPhotos(page, url);
+    const listing = describeZillowListing(pageData, url);
+    const selected = limit > 0 ? photos.slice(0, limit) : photos;
+    return selected.map((photo) => normalizePhotoRow(photo, listing, kwargs.size));
+  },
+});

--- a/opencli-plugins/zillow/zillow-browser.mjs
+++ b/opencli-plugins/zillow/zillow-browser.mjs
@@ -1,0 +1,259 @@
+import { CommandExecutionError } from "@jackwener/opencli/errors";
+import {
+  collectZillowPhotos,
+  detectZillowChallenge,
+  detectZillowNotFound,
+  detectZillowUnavailable,
+  isPerimeterXCookie,
+  isZillowUrl,
+} from "./zillow-helpers.mjs";
+
+/**
+ * Runs inside the listing page, so it must stay self-contained: `page.evaluate`
+ * serializes the function source and cannot carry module-scope bindings along.
+ *
+ * Zillow renders its home details page with Next.js and embeds the GraphQL
+ * response the page was built from in `<script id="__NEXT_DATA__">`, under
+ * `props.pageProps.componentProps.gdpClientCache` (a JSON string keyed by
+ * query name, `ForSalePriorityQuery{...}` or `NotForSalePriorityQuery{...}`).
+ * The entry's `property.responsivePhotosOriginalRatio` is the complete gallery
+ * in display order with the CDN URL of every width bucket of each photo, and
+ * `property.responsivePhotos` is the cropped ladder of the same photos. A 404
+ * renders the same script with `pageProps.errorMessage` instead. Only when
+ * that state is absent does the reader fall back to scraping CDN URLs out of
+ * the HTML.
+ */
+export function readZillowListingPage() {
+  var out = {
+    url: location.href,
+    title: document.title || "",
+    body_text: "",
+    hydrated: false,
+    challenge: false,
+    error_message: "",
+    sub_app: "",
+    property: null,
+    html_photo_urls: [],
+  };
+  try {
+    out.body_text = String((document.body && document.body.innerText) || "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 3000);
+  } catch (_) {
+    out.body_text = "";
+  }
+  try {
+    out.challenge = !!document.querySelector("#px-captcha");
+  } catch (_) {
+    out.challenge = false;
+  }
+
+  var nextData = null;
+  try {
+    var script = document.getElementById("__NEXT_DATA__");
+    nextData = script && script.textContent ? JSON.parse(script.textContent) : null;
+  } catch (_) {
+    nextData = null;
+  }
+  if (!nextData && window.__NEXT_DATA__ && typeof window.__NEXT_DATA__ === "object") {
+    nextData = window.__NEXT_DATA__;
+  }
+
+  function sources(entry) {
+    var list = entry && entry.mixedSources && entry.mixedSources.jpeg;
+    if (!Array.isArray(list)) return [];
+    var result = [];
+    for (var i = 0; i < list.length; i++) {
+      if (list[i] && list[i].url) result.push({ url: list[i].url, width: list[i].width });
+    }
+    return result;
+  }
+  function photoSlice(list) {
+    if (!Array.isArray(list)) return null;
+    var result = [];
+    for (var i = 0; i < list.length; i++) {
+      var entry = list[i] || {};
+      result.push({
+        caption: entry.caption,
+        subjectType: entry.subjectType,
+        key: entry.key,
+        url: entry.url,
+        mixedSources: { jpeg: sources(entry) },
+      });
+    }
+    return result;
+  }
+
+  var pageProps = nextData && nextData.props && nextData.props.pageProps;
+  if (pageProps) {
+    out.hydrated = true;
+    out.error_message = pageProps.errorMessage ? String(pageProps.errorMessage) : "";
+    out.sub_app = pageProps.subAppName ? String(pageProps.subAppName) : "";
+    var componentProps = pageProps.componentProps;
+    var cache = componentProps && componentProps.gdpClientCache;
+    if (typeof cache === "string") {
+      try {
+        cache = JSON.parse(cache);
+      } catch (_) {
+        cache = null;
+      }
+    }
+    if (cache && typeof cache === "object") {
+      var keys = Object.keys(cache);
+      for (var k = 0; k < keys.length; k++) {
+        var property = cache[keys[k]] && cache[keys[k]].property;
+        if (!property || typeof property !== "object") continue;
+        out.property = {
+          zpid: property.zpid,
+          streetAddress: property.streetAddress,
+          city: property.city,
+          state: property.state,
+          zipcode: property.zipcode,
+          address: property.address,
+          homeStatus: property.homeStatus,
+          hdpUrl: property.hdpUrl,
+          photoCount: property.photoCount,
+          mlsid: property.mlsid,
+          hiResImageLink: property.hiResImageLink,
+          responsivePhotosOriginalRatio: photoSlice(property.responsivePhotosOriginalRatio),
+          responsivePhotos: photoSlice(property.responsivePhotos),
+        };
+        break;
+      }
+    }
+  }
+
+  var hasPhotos =
+    out.property &&
+    ((Array.isArray(out.property.responsivePhotosOriginalRatio) &&
+      out.property.responsivePhotosOriginalRatio.length > 0) ||
+      (Array.isArray(out.property.responsivePhotos) && out.property.responsivePhotos.length > 0));
+  if (!hasPhotos) {
+    var html = document.documentElement ? document.documentElement.outerHTML : "";
+    var matches =
+      html.match(
+        /https?:\\?\/\\?\/photos\.zillowstatic\.com\\?\/fp\\?\/[0-9a-f]{32}-[^"'\s\\<>)]+/gi,
+      ) || [];
+    var seen = {};
+    for (var j = 0; j < matches.length; j++) {
+      var url = matches[j].replace(/\\\//g, "/");
+      if (!seen[url]) {
+        seen[url] = true;
+        out.html_photo_urls.push(url);
+      }
+    }
+  }
+  return out;
+}
+
+function hasReadablePhotos(pageData) {
+  return collectZillowPhotos(pageData).photos.length > 0;
+}
+
+async function navigateAndRead(page, url, timeoutMs) {
+  const currentUrl = await page.evaluate("window.location.href || ''").catch(() => "");
+  if (isZillowUrl(currentUrl)) {
+    await page.goto("about:blank", { waitUntil: "none" });
+  }
+  await page.goto(url);
+
+  const deadline = Date.now() + timeoutMs;
+  let pageData = null;
+  for (;;) {
+    pageData = await page.evaluate(readZillowListingPage);
+    if (
+      pageData?.hydrated ||
+      hasReadablePhotos(pageData) ||
+      detectZillowChallenge(pageData) ||
+      detectZillowUnavailable(pageData) ||
+      detectZillowNotFound(pageData) ||
+      Date.now() >= deadline
+    ) {
+      break;
+    }
+    await page.wait({ time: 0.5 });
+  }
+  return pageData;
+}
+
+/**
+ * Zillow's PerimeterX sensor scores every page load and stores its verdict in
+ * the `_px*`/`pxcts` cookies. A verdict written during an automated load blocks
+ * the next navigation with a "Press & Hold" wall, while a visitor without those
+ * cookies gets the page. Deleting only those cookies resets the verdict and
+ * leaves the rest of the guardian's Zillow session alone. Returns the number of
+ * cookies deleted.
+ */
+export async function resetPerimeterXCookies(page) {
+  let cookies;
+  try {
+    cookies = await page.getCookies({ url: "https://www.zillow.com/" });
+  } catch (_) {
+    return 0;
+  }
+  const targets = (Array.isArray(cookies) ? cookies : []).filter(isPerimeterXCookie);
+  let deleted = 0;
+  for (const cookie of targets) {
+    try {
+      await page.cdp("Network.deleteCookies", {
+        name: cookie.name,
+        domain: cookie.domain,
+        path: cookie.path || "/",
+      });
+      deleted += 1;
+    } catch (_) {
+      // A cookie the browser refuses to delete leaves the verdict in place; the
+      // retry then reports the wall instead of looping.
+    }
+  }
+  return deleted;
+}
+
+function isRefusedLoad(pageData) {
+  return detectZillowChallenge(pageData) || detectZillowUnavailable(pageData);
+}
+
+/**
+ * Navigate to the listing and poll until Zillow's page state is present (or
+ * the page has settled on a challenge, error, or not-found screen). A refused
+ * load is retried once after resetting the PerimeterX cookies. Leaving a Zillow
+ * page first keeps the client-side router from swallowing the navigation.
+ */
+export async function loadZillowListingPage(page, url, { timeoutMs = 20000 } = {}) {
+  let pageData = await navigateAndRead(page, url, timeoutMs);
+  if (isRefusedLoad(pageData)) {
+    await resetPerimeterXCookies(page);
+    pageData = await navigateAndRead(page, url, timeoutMs);
+  }
+  return pageData;
+}
+
+export function assertReadableZillowPage(pageData, url) {
+  if (detectZillowChallenge(pageData)) {
+    throw new CommandExecutionError(
+      "Zillow served a bot-check or access challenge; clear it in the browser and retry",
+    );
+  }
+  if (detectZillowUnavailable(pageData)) {
+    throw new CommandExecutionError(
+      `Zillow refused to serve ${url} (HTTP error page); wait a moment and retry`,
+    );
+  }
+  if (detectZillowNotFound(pageData)) {
+    throw new CommandExecutionError(`Zillow has no listing page at ${url}`);
+  }
+}
+
+/** Load a listing and return its gallery photos plus where they came from. */
+export async function readZillowListingPhotos(page, url) {
+  const pageData = await loadZillowListingPage(page, url);
+  assertReadableZillowPage(pageData, url);
+  const { photos, source } = collectZillowPhotos(pageData);
+  if (photos.length === 0) {
+    throw new CommandExecutionError(
+      `Zillow exposed no listing photos at ${url}; pass a home details URL such as https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/`,
+    );
+  }
+  return { pageData, photos, source };
+}

--- a/opencli-plugins/zillow/zillow-helpers.mjs
+++ b/opencli-plugins/zillow/zillow-helpers.mjs
@@ -1,0 +1,439 @@
+// Pure helpers for the Zillow plugin. Nothing here touches the browser or the
+// filesystem, so every function is exercised directly by zillow-helpers.test.mjs.
+
+export const DEFAULT_ZILLOW_OUTPUT = "./zillow-downloads";
+export const DEFAULT_ZILLOW_EXAMPLE_URL =
+  "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/";
+
+/**
+ * Zillow publishes each listing photo as a fixed ladder of width buckets. The
+ * original-ratio ladder (`d_d` 800, `o_a` 1024, `uncropped_scaled_within_1344_1008`,
+ * `uncropped_scaled_within_1536_1152`) scales the source photo down to fit the
+ * bucket and never scales it up, so the widest bucket is the most faithful
+ * served copy. The cropped ladder (`cc_ft_<width>`, 192 to 1536) trims the frame
+ * to a fixed aspect ratio at small widths and only serves `thumb`. The listing's
+ * `hiResImageLink` (`p_f`) is not on either ladder: it resizes every photo to
+ * 1024px wide, upscaling small sources, so no size maps to it.
+ */
+export const ZILLOW_PHOTO_SIZES = ["full", "large", "medium", "small", "thumb"];
+
+const SIZE_TARGET_WIDTH = {
+  full: Number.POSITIVE_INFINITY,
+  large: 1344,
+  medium: 1024,
+  small: 800,
+  thumb: 384,
+};
+
+const ZILLOW_HOSTNAME = /^(?:[a-z0-9-]+\.)*zillow\.com$/i;
+const PX_COOKIE_NAME = /^(?:_px[a-z0-9]*|pxcts)$/i;
+const PHOTO_KEY = /^[0-9a-f]{32}$/i;
+
+export function cleanText(value) {
+  return String(value ?? "")
+    .replace(/[\u00a0\u202f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function integerInRange(value, name, minimum, maximum) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return parsed;
+}
+
+function isHttpUrl(value) {
+  return typeof value === "string" && /^https?:\/\//i.test(value);
+}
+
+function urlBasename(url) {
+  try {
+    const segments = new URL(url).pathname.split("/").filter(Boolean);
+    return decodeURIComponent(segments[segments.length - 1] || "");
+  } catch (_) {
+    return "";
+  }
+}
+
+/**
+ * Accept a listing URL with or without a scheme, require a Zillow host, and
+ * drop query/hash so tracking parameters never reach the browser or the output.
+ */
+export function canonicalZillowListingUrl(input) {
+  const text = cleanText(input);
+  if (!text) throw new Error("url must not be empty");
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(text) ? text : `https://${text}`;
+  let url;
+  try {
+    url = new URL(withScheme);
+  } catch (_) {
+    throw new Error(`url is not a valid URL: ${text}`);
+  }
+  if (!/^https?:$/i.test(url.protocol) || !ZILLOW_HOSTNAME.test(url.hostname)) {
+    throw new Error(`url must be a Zillow listing URL such as ${DEFAULT_ZILLOW_EXAMPLE_URL}`);
+  }
+  url.protocol = "https:";
+  url.search = "";
+  url.hash = "";
+  const canonical = url.toString();
+  return canonical.endsWith("/") ? canonical : `${canonical}/`;
+}
+
+export function isZillowUrl(value) {
+  try {
+    return ZILLOW_HOSTNAME.test(new URL(String(value ?? "")).hostname);
+  } catch (_) {
+    return false;
+  }
+}
+
+/** PerimeterX cookies carry Zillow's bot verdict; nothing else on the site does. */
+export function isPerimeterXCookie(cookie) {
+  return PX_COOKIE_NAME.test(cleanText(cookie?.name));
+}
+
+function sanitizeSegment(value) {
+  return String(value ?? "")
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "");
+}
+
+/** The zpid encoded in a home details path such as `/homedetails/<slug>/15598337_zpid/`. */
+export function zillowZpidFromUrl(url) {
+  let pathname;
+  try {
+    pathname = new URL(url).pathname;
+  } catch (_) {
+    return "";
+  }
+  const match = /\/(\d+)_zpid(?:\/|$)/i.exec(pathname);
+  return match ? match[1] : "";
+}
+
+/**
+ * Folder name for one listing: `<address slug>-<zpid>` from a canonical home
+ * details URL such as `/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/`.
+ * The zpid keeps two listings that share a street address apart.
+ */
+export function zillowListingSlug(url) {
+  let segments;
+  try {
+    segments = new URL(url).pathname.split("/").filter(Boolean);
+  } catch (_) {
+    segments = [];
+  }
+  const zpidIndex = segments.findIndex((segment) => /^\d+_zpid$/i.test(segment));
+  const parts = [];
+  if (zpidIndex >= 0) {
+    const address = segments[zpidIndex - 1];
+    if (address && !/^homedetails$/i.test(address)) parts.push(address);
+    if (parts.length === 0) parts.push("zillow");
+    parts.push(segments[zpidIndex].replace(/_zpid$/i, ""));
+  } else {
+    parts.push(...segments.filter((segment) => !/^homedetails$/i.test(segment)));
+  }
+  const slug = sanitizeSegment(parts.join("-"));
+  return slug || "zillow-listing";
+}
+
+export function detectZillowChallenge(pageData) {
+  const title = cleanText(pageData?.title);
+  const body = cleanText(pageData?.body_text);
+  return (
+    pageData?.challenge === true ||
+    /access to this page has been denied|access denied|captcha/i.test(title) ||
+    /press\s*&\s*hold|confirm you are (?:a )?human|verify you are (?:a )?human|are you a robot|unusual (?:traffic|activity)|captcha/i.test(
+      body,
+    )
+  );
+}
+
+export function detectZillowNotFound(pageData) {
+  const title = cleanText(pageData?.title);
+  const body = cleanText(pageData?.body_text);
+  const error = cleanText(pageData?.error_message);
+  return (
+    /page not found|not found/i.test(error) ||
+    /page not found/i.test(title) ||
+    /error 404|page not found/i.test(body)
+  );
+}
+
+/**
+ * Zillow answers some automated loads with a bare HTTP 5xx and no page at all,
+ * which Chrome renders as its own error page. That load is a refusal, not a
+ * listing, so the loader treats it like a challenge and retries once.
+ */
+export function detectZillowUnavailable(pageData) {
+  const url = cleanText(pageData?.url);
+  const body = cleanText(pageData?.body_text);
+  return (
+    /^chrome-error:/i.test(url) ||
+    /http error 5\d\d|is currently unable to handle this request|this page isn.t working/i.test(
+      body,
+    )
+  );
+}
+
+export function describeZillowListing(pageData, fallbackUrl = "") {
+  const property = pageData?.property || {};
+  const address = property.address && typeof property.address === "object" ? property.address : {};
+  const street = cleanText(property.streetAddress || address.streetAddress);
+  const city = cleanText(property.city || address.city);
+  const state = cleanText(property.state || address.state);
+  const zip = cleanText(property.zipcode || address.zipcode);
+  const locality = [city, [state, zip].filter(Boolean).join(" ")].filter(Boolean).join(", ");
+  const assembled = [street, locality].filter(Boolean).join(", ");
+  let url = cleanText(pageData?.url) || cleanText(fallbackUrl);
+  const hdpUrl = cleanText(property.hdpUrl);
+  if (hdpUrl.startsWith("/")) url = `https://www.zillow.com${hdpUrl}`;
+  return {
+    url,
+    title: cleanText(pageData?.title),
+    address: assembled,
+    street,
+    city,
+    state,
+    zip,
+    status: cleanText(property.homeStatus).toLowerCase().replace(/_/g, " "),
+    zpid: property.zpid != null ? String(property.zpid) : zillowZpidFromUrl(url),
+    mls_id: cleanText(property.mlsid),
+    photo_count: Number.isInteger(property.photoCount) ? property.photoCount : null,
+  };
+}
+
+/** Photo key encoded in a CDN URL such as `.../fp/<32 hex>-o_a.jpg`. */
+export function zillowPhotoKey(url) {
+  const match = /^([0-9a-f]{32})(?:-|\.|$)/i.exec(urlBasename(url));
+  return match ? match[1].toLowerCase() : "";
+}
+
+/** The JPEG sources of one ladder entry, widest first. */
+function jpegSources(entry) {
+  const list = entry?.mixedSources?.jpeg;
+  if (!Array.isArray(list)) return [];
+  return list
+    .filter((source) => isHttpUrl(source?.url))
+    .map((source) => ({ url: source.url, width: Number(source.width) || 0 }))
+    .sort((a, b) => b.width - a.width);
+}
+
+/**
+ * One gallery entry from Zillow's `responsivePhotosOriginalRatio` list, joined
+ * with the cropped ladder of the same position from `responsivePhotos`. Both
+ * lists come from the same page state in the same order.
+ */
+export function normalizeZillowPhoto(candidate, index, cropped = null) {
+  const original = jpegSources(candidate);
+  const croppedSources = jpegSources(cropped);
+  const anyUrl = original[0]?.url || croppedSources[0]?.url || candidate?.url || "";
+  const key = PHOTO_KEY.test(String(candidate?.key ?? ""))
+    ? String(candidate.key).toLowerCase()
+    : zillowPhotoKey(anyUrl);
+  return {
+    index: index + 1,
+    photo_key: key,
+    caption: cleanText(candidate?.caption ?? cropped?.caption),
+    subject_type: cleanText(candidate?.subjectType ?? cropped?.subjectType),
+    original,
+    cropped: croppedSources,
+  };
+}
+
+function uniqueInOrder(values) {
+  const seen = new Set();
+  return values.filter((value) => {
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return true;
+  });
+}
+
+/**
+ * Gallery photos for the listing, in Zillow's display order. The page state's
+ * original-ratio list is authoritative. When it is missing, CDN URLs scraped
+ * from the HTML stand in, grouped by photo key in order of first appearance,
+ * with only the widest variant of each key kept.
+ */
+export function collectZillowPhotos(pageData) {
+  const property = pageData?.property || {};
+  const originals = Array.isArray(property.responsivePhotosOriginalRatio)
+    ? property.responsivePhotosOriginalRatio
+    : [];
+  const cropped = Array.isArray(property.responsivePhotos) ? property.responsivePhotos : [];
+  const fromState = originals
+    .map((candidate, index) => normalizeZillowPhoto(candidate, index, cropped[index] || null))
+    .filter((photo) => photo.original.length > 0 || photo.cropped.length > 0)
+    .map((photo, index) => ({ ...photo, index: index + 1 }));
+  if (fromState.length > 0) return { photos: fromState, source: "state" };
+
+  const croppedOnly = cropped
+    .map((candidate, index) => normalizeZillowPhoto(null, index, candidate))
+    .filter((photo) => photo.cropped.length > 0)
+    .map((photo, index) => ({ ...photo, index: index + 1 }));
+  if (croppedOnly.length > 0) return { photos: croppedOnly, source: "state" };
+
+  const htmlUrls = uniqueInOrder(
+    (Array.isArray(pageData?.html_photo_urls) ? pageData.html_photo_urls : []).filter(isHttpUrl),
+  );
+  const byKey = new Map();
+  for (const url of htmlUrls) {
+    const key = zillowPhotoKey(url);
+    if (!key) continue;
+    if (!byKey.has(key)) byKey.set(key, []);
+    byKey.get(key).push(url);
+  }
+  const photos = [...byKey.entries()].map(([key, urls], index) => {
+    const ranked = urls
+      .map((url) => ({ url, width: zillowVariantWidth(url) }))
+      .sort((a, b) => b.width - a.width);
+    return {
+      index: index + 1,
+      photo_key: key,
+      caption: "",
+      subject_type: "",
+      original: ranked.filter((entry) => !/-cc_ft_\d+\./i.test(entry.url)),
+      cropped: ranked.filter((entry) => /-cc_ft_\d+\./i.test(entry.url)),
+    };
+  });
+  return { photos, source: photos.length > 0 ? "html" : "none" };
+}
+
+/** Width bucket encoded in a CDN variant name, for ranking scraped URLs. */
+export function zillowVariantWidth(url) {
+  const name = urlBasename(url);
+  let match = /-uncropped_scaled_within_(\d+)_\d+\./i.exec(name);
+  if (match) return Number(match[1]);
+  match = /-cc_ft_(\d+)\./i.exec(name);
+  if (match) return Number(match[1]);
+  if (/-o_a\./i.test(name)) return 1024;
+  if (/-d_d\./i.test(name)) return 800;
+  if (/-p_f\./i.test(name)) return 1024;
+  if (/-p_h\./i.test(name)) return 550;
+  if (/-p_e\./i.test(name)) return 596;
+  if (/-p_d\./i.test(name)) return 400;
+  return 0;
+}
+
+/**
+ * The variant for a requested size: the widest original-ratio bucket that fits
+ * the size's target width, else the narrowest bucket above it. `thumb` reads
+ * the cropped ladder instead, because the original-ratio ladder stops at 800.
+ * A photo with no usable bucket at all yields an empty URL.
+ */
+export function selectZillowPhotoUrl(photo, size) {
+  const target = SIZE_TARGET_WIDTH[size] ?? Number.POSITIVE_INFINITY;
+  const ladder = size === "thumb" ? photo?.cropped : photo?.original;
+  const fallback = size === "thumb" ? photo?.original : photo?.cropped;
+  const chosen = pickWidth(ladder, target) || pickWidth(fallback, target);
+  return chosen ? { url: chosen.url, width: chosen.width } : { url: "", width: 0 };
+}
+
+function pickWidth(sources, target) {
+  if (!Array.isArray(sources) || sources.length === 0) return null;
+  const fitting = sources.filter((entry) => entry.width <= target);
+  if (fitting.length > 0) return fitting[0];
+  return sources[sources.length - 1];
+}
+
+/**
+ * `01-40a2df03a9e1e7ce67de59c614683f5f.jpg`: a zero-padded gallery position
+ * keeps files sorted the way Zillow shows them, and the CDN photo key keeps
+ * the asset provenance. Sizes other than `full` carry the size so variants of
+ * one photo never overwrite each other in a shared folder.
+ */
+export function buildZillowPhotoFilename({ url, key, index, total, size }) {
+  const width = Math.max(2, String(Math.max(Number(total) || 0, Number(index) || 0)).length);
+  const prefix = String(index).padStart(width, "0");
+  const extension = (
+    (/\.([A-Za-z0-9]{2,5})$/.exec(urlBasename(url)) || [])[1] || "jpg"
+  ).toLowerCase();
+  const base = PHOTO_KEY.test(String(key ?? ""))
+    ? String(key).toLowerCase()
+    : sanitizeSegment(urlBasename(url).replace(/\.[A-Za-z0-9]{2,5}$/, "")) || "photo";
+  return size && size !== "full"
+    ? `${prefix}-${size}-${base}.${extension}`
+    : `${prefix}-${base}.${extension}`;
+}
+
+/** One download plan entry per photo: which URL to fetch and what to name it. */
+export function planZillowDownloads(photos, { size = "full", limit = 0 } = {}) {
+  const selected = limit > 0 ? photos.slice(0, limit) : photos;
+  const total = selected.length;
+  return selected.map((photo, order) => {
+    const index = order + 1;
+    const chosen = selectZillowPhotoUrl(photo, size);
+    return {
+      index,
+      photo_key: photo.photo_key,
+      caption: photo.caption,
+      subject_type: photo.subject_type,
+      width: chosen.width,
+      url: chosen.url,
+      file_name: chosen.url
+        ? buildZillowPhotoFilename({ url: chosen.url, key: photo.photo_key, index, total, size })
+        : "",
+    };
+  });
+}
+
+export function formatBytes(bytes) {
+  const value = Number(bytes);
+  if (!Number.isFinite(value) || value < 0) return "";
+  if (value < 1024) return `${value} B`;
+  const units = ["KB", "MB", "GB"];
+  let scaled = value / 1024;
+  let unit = 0;
+  while (scaled >= 1024 && unit < units.length - 1) {
+    scaled /= 1024;
+    unit += 1;
+  }
+  return `${scaled.toFixed(scaled >= 100 ? 0 : 1)} ${units[unit]}`;
+}
+
+/**
+ * Output row for one planned download. `result` follows opencli's httpDownload
+ * shape (`{ success, size, error }`); `file` is only reported for a file that
+ * exists on disk.
+ */
+export function summarizeZillowDownload(item, result, { listing = {}, file = "" } = {}) {
+  const success = result?.success === true;
+  return {
+    index: item.index,
+    status: success ? "success" : "failed",
+    size: success ? formatBytes(result.size) : "",
+    bytes: success ? Number(result.size) || 0 : 0,
+    file: success ? file : "",
+    error: success ? "" : cleanText(result?.error) || "unknown error",
+    photo_key: item.photo_key,
+    caption: item.caption,
+    subject_type: item.subject_type,
+    width: item.width,
+    url: item.url,
+    address: listing.address || "",
+    zpid: listing.zpid || "",
+    listing_url: listing.url || "",
+  };
+}
+
+export function normalizePhotoRow(photo, listing, size) {
+  const chosen = selectZillowPhotoUrl(photo, size);
+  const full = selectZillowPhotoUrl(photo, "full");
+  const thumb = selectZillowPhotoUrl(photo, "thumb");
+  return {
+    index: photo.index,
+    photo_key: photo.photo_key,
+    caption: photo.caption,
+    subject_type: photo.subject_type,
+    width: chosen.width,
+    url: chosen.url,
+    thumbnail_url: thumb.url,
+    full_url: full.url,
+    address: listing.address,
+    zpid: listing.zpid,
+    listing_url: listing.url,
+  };
+}

--- a/opencli-plugins/zillow/zillow-helpers.test.mjs
+++ b/opencli-plugins/zillow/zillow-helpers.test.mjs
@@ -1,0 +1,652 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildZillowPhotoFilename,
+  canonicalZillowListingUrl,
+  collectZillowPhotos,
+  describeZillowListing,
+  detectZillowChallenge,
+  detectZillowNotFound,
+  detectZillowUnavailable,
+  formatBytes,
+  integerInRange,
+  isPerimeterXCookie,
+  isZillowUrl,
+  normalizePhotoRow,
+  normalizeZillowPhoto,
+  planZillowDownloads,
+  selectZillowPhotoUrl,
+  summarizeZillowDownload,
+  ZILLOW_PHOTO_SIZES,
+  zillowListingSlug,
+  zillowPhotoKey,
+  zillowVariantWidth,
+  zillowZpidFromUrl,
+} from "./zillow-helpers.mjs";
+
+const CDN = "https://photos.zillowstatic.com/fp";
+const KEY_1 = "40a2df03a9e1e7ce67de59c614683f5f";
+const KEY_2 = "daad1a3d4a0c9190ab21e0a88199523b";
+const KEY_3 = "255bf622fd4c024591f530b133942a65";
+
+// Shaped like Zillow's `responsivePhotosOriginalRatio` entries.
+function rawOriginal(key, { caption = "", subjectType = null, withUrl = true } = {}) {
+  const entry = {
+    caption,
+    subjectType,
+    mixedSources: {
+      jpeg: [
+        { url: `${CDN}/${key}-d_d.jpg`, width: 800 },
+        { url: `${CDN}/${key}-o_a.jpg`, width: 1024 },
+        { url: `${CDN}/${key}-uncropped_scaled_within_1344_1008.jpg`, width: 1344 },
+        { url: `${CDN}/${key}-uncropped_scaled_within_1536_1152.jpg`, width: 1536 },
+      ],
+    },
+    key,
+  };
+  if (withUrl) entry.url = `${CDN}/${key}-p_d.jpg`;
+  return entry;
+}
+
+// Shaped like Zillow's `responsivePhotos` entries (the cropped ladder).
+function rawCropped(key, { caption = "" } = {}) {
+  return {
+    caption,
+    subjectType: null,
+    url: `${CDN}/${key}-p_d.jpg`,
+    mixedSources: {
+      jpeg: [192, 384, 576, 768, 960, 1152, 1344, 1536].map((width) => ({
+        url: `${CDN}/${key}-cc_ft_${width}.jpg`,
+        width,
+      })),
+    },
+  };
+}
+
+function hydratedPageData() {
+  return {
+    url: "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+    title: "349 Walsh Rd, Atherton, CA 94027 | MLS #ML82027150 | Zillow",
+    body_text: "Skip main navigation Buy Rent Sell See all 34 photos $49,680,000 349 Walsh Rd",
+    hydrated: true,
+    challenge: false,
+    error_message: "",
+    sub_app: "for-sale-page-sub-app",
+    property: {
+      zpid: 15598337,
+      streetAddress: "349 Walsh Rd",
+      city: "Atherton",
+      state: "CA",
+      zipcode: "94027",
+      address: { streetAddress: "349 Walsh Rd", zipcode: "94027", city: "Atherton", state: "CA" },
+      homeStatus: "FOR_SALE",
+      hdpUrl: "/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+      photoCount: 3,
+      mlsid: "ML82027150",
+      hiResImageLink: `${CDN}/${KEY_1}-p_f.jpg`,
+      responsivePhotosOriginalRatio: [
+        rawOriginal(KEY_1, {
+          caption: "Modern architectural masterpiece",
+          subjectType: "EXTERIOR",
+        }),
+        rawOriginal(KEY_2, { caption: "  Glass entrance   with wooden door " }),
+        rawOriginal(KEY_3, { withUrl: false }),
+      ],
+      responsivePhotos: [rawCropped(KEY_1), rawCropped(KEY_2), rawCropped(KEY_3)],
+    },
+    html_photo_urls: [],
+  };
+}
+
+test("canonicalZillowListingUrl accepts Zillow hosts and strips tracking noise", () => {
+  assert.equal(
+    canonicalZillowListingUrl(
+      " https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/?utm_source=share#photos ",
+    ),
+    "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+  );
+  assert.equal(
+    canonicalZillowListingUrl(
+      "zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid",
+    ),
+    "https://zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+  );
+  assert.equal(
+    canonicalZillowListingUrl(
+      "http://www.zillow.com/homes/31-Rittenhouse-Ave-Atherton-CA-94027_rb",
+    ),
+    "https://www.zillow.com/homes/31-Rittenhouse-Ave-Atherton-CA-94027_rb/",
+  );
+});
+
+test("canonicalZillowListingUrl rejects empty, malformed, and non-Zillow input", () => {
+  assert.throws(() => canonicalZillowListingUrl(""), /url must not be empty/);
+  assert.throws(() => canonicalZillowListingUrl("https://"), /not a valid URL/);
+  assert.throws(
+    () => canonicalZillowListingUrl("https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1"),
+    /Zillow/,
+  );
+  assert.throws(() => canonicalZillowListingUrl("https://zillow.com.evil.example/x"), /Zillow/);
+  assert.throws(
+    () => canonicalZillowListingUrl("ftp://www.zillow.com/homedetails/1_zpid/"),
+    /Zillow/,
+  );
+});
+
+test("isZillowUrl recognizes Zillow origins only", () => {
+  assert.equal(isZillowUrl("https://www.zillow.com/homedetails/x/15598337_zpid/"), true);
+  assert.equal(isZillowUrl("https://zillow.com/"), true);
+  assert.equal(isZillowUrl("about:blank"), false);
+  assert.equal(isZillowUrl("https://www.zillow.com.example/"), false);
+  assert.equal(isZillowUrl("https://photos.zillowstatic.com/fp/x.jpg"), false);
+  assert.equal(isZillowUrl(""), false);
+});
+
+test("isPerimeterXCookie matches only the PerimeterX cookie family", () => {
+  for (const name of ["_px3", "_pxvid", "pxcts", "_pxhd", "_pxde", "_pxff"]) {
+    assert.equal(isPerimeterXCookie({ name }), true, name);
+  }
+  for (const name of ["zguid", "zgsession", "JSESSIONID", "AWSALB", "px", "", undefined]) {
+    assert.equal(isPerimeterXCookie({ name }), false, String(name));
+  }
+  assert.equal(isPerimeterXCookie(null), false);
+});
+
+test("zillowZpidFromUrl reads the zpid segment", () => {
+  assert.equal(
+    zillowZpidFromUrl(
+      "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+    ),
+    "15598337",
+  );
+  assert.equal(zillowZpidFromUrl("https://www.zillow.com/homedetails/1_zpid"), "1");
+  assert.equal(zillowZpidFromUrl("https://www.zillow.com/homes/31-Rittenhouse-Ave_rb/"), "");
+  assert.equal(zillowZpidFromUrl("not a url"), "");
+});
+
+test("zillowListingSlug names the folder after the address slug and zpid", () => {
+  assert.equal(
+    zillowListingSlug(
+      "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+    ),
+    "349-Walsh-Rd-Atherton-CA-94027-15598337",
+  );
+  assert.equal(
+    zillowListingSlug(
+      "https://www.zillow.com/homedetails/1-Main-St-APT-2B-San-Francisco-CA-94105/77_zpid/",
+    ),
+    "1-Main-St-APT-2B-San-Francisco-CA-94105-77",
+  );
+  assert.equal(
+    zillowListingSlug("https://www.zillow.com/homedetails/15598337_zpid/"),
+    "zillow-15598337",
+  );
+  assert.equal(
+    zillowListingSlug("https://www.zillow.com/homes/31-Rittenhouse-Ave-Atherton-CA-94027_rb/"),
+    "homes-31-Rittenhouse-Ave-Atherton-CA-94027_rb",
+  );
+  assert.equal(zillowListingSlug("https://www.zillow.com/"), "zillow-listing");
+  assert.equal(zillowListingSlug("not a url"), "zillow-listing");
+});
+
+test("zillowPhotoKey and zillowVariantWidth decode CDN file names", () => {
+  assert.equal(zillowPhotoKey(`${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`), KEY_1);
+  assert.equal(zillowPhotoKey(`${CDN}/${KEY_1.toUpperCase()}-p_f.jpg`), KEY_1);
+  assert.equal(zillowPhotoKey(`${CDN}/${KEY_1}.jpg`), KEY_1);
+  assert.equal(zillowPhotoKey("https://photos.zillowstatic.com/fp/logo.svg"), "");
+  assert.equal(zillowPhotoKey(""), "");
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`), 1536);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-uncropped_scaled_within_1344_1008.webp`), 1344);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-cc_ft_768.jpg`), 768);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-o_a.jpg`), 1024);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-d_d.jpg`), 800);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-p_f.jpg`), 1024);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-p_d.jpg`), 400);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-unknown.jpg`), 0);
+});
+
+test("detectZillowChallenge and detectZillowNotFound read the page chrome and state", () => {
+  assert.equal(detectZillowChallenge(hydratedPageData()), false);
+  assert.equal(detectZillowNotFound(hydratedPageData()), false);
+  assert.equal(
+    detectZillowChallenge({
+      title: "Access to this page has been denied",
+      body_text: "Press & Hold to confirm you are a human (and not a bot). Reference ID a18b9dc0",
+    }),
+    true,
+  );
+  assert.equal(detectZillowChallenge({ title: "", body_text: "", challenge: true }), true);
+  assert.equal(
+    detectZillowChallenge({ title: "Zillow", body_text: "Please solve the CAPTCHA" }),
+    true,
+  );
+  assert.equal(
+    detectZillowNotFound({
+      title: "",
+      body_text:
+        "Skip main navigation Buy Rent Sell Uh oh, something broke. Error 404 - page not found.",
+      hydrated: true,
+      error_message: "Error 404 - page not found.",
+      sub_app: "error-page-subapp",
+    }),
+    true,
+  );
+  assert.equal(detectZillowNotFound({ title: "Page Not Found | Zillow", body_text: "" }), true);
+  assert.equal(
+    detectZillowNotFound({ title: "", body_text: "", error_message: "Not Found" }),
+    true,
+  );
+  assert.equal(detectZillowChallenge(null), false);
+  assert.equal(detectZillowNotFound(undefined), false);
+});
+
+test("detectZillowUnavailable recognizes Chrome's error page for a refused load", () => {
+  assert.equal(detectZillowUnavailable(hydratedPageData()), false);
+  assert.equal(
+    detectZillowUnavailable({
+      url: "chrome-error://chromewebdata/",
+      title: "www.zillow.com",
+      body_text:
+        "This page isn’t working www.zillow.com is currently unable to handle this request. HTTP ERROR 503 Reload",
+    }),
+    true,
+  );
+  assert.equal(
+    detectZillowUnavailable({ url: "https://www.zillow.com/x/", body_text: "HTTP ERROR 502" }),
+    true,
+  );
+  assert.equal(
+    detectZillowUnavailable({ url: "https://www.zillow.com/x/", body_text: "HTTP ERROR 404" }),
+    false,
+  );
+  assert.equal(detectZillowUnavailable(null), false);
+});
+
+test("describeZillowListing assembles the address and prefers the canonical hdpUrl", () => {
+  assert.deepEqual(describeZillowListing(hydratedPageData()), {
+    url: "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+    title: "349 Walsh Rd, Atherton, CA 94027 | MLS #ML82027150 | Zillow",
+    address: "349 Walsh Rd, Atherton, CA 94027",
+    street: "349 Walsh Rd",
+    city: "Atherton",
+    state: "CA",
+    zip: "94027",
+    status: "for sale",
+    zpid: "15598337",
+    mls_id: "ML82027150",
+    photo_count: 3,
+  });
+  assert.deepEqual(
+    describeZillowListing(
+      {
+        url: "https://www.zillow.com/homes/31-Rittenhouse-Ave_rb/",
+        property: { hdpUrl: "/homedetails/31-Rittenhouse-Ave-Atherton-CA-94027/15580183_zpid/" },
+      },
+      "https://www.zillow.com/x/",
+    ).url,
+    "https://www.zillow.com/homedetails/31-Rittenhouse-Ave-Atherton-CA-94027/15580183_zpid/",
+  );
+  assert.deepEqual(describeZillowListing({}, "https://www.zillow.com/homedetails/77_zpid/"), {
+    url: "https://www.zillow.com/homedetails/77_zpid/",
+    title: "",
+    address: "",
+    street: "",
+    city: "",
+    state: "",
+    zip: "",
+    status: "",
+    zpid: "77",
+    mls_id: "",
+    photo_count: null,
+  });
+});
+
+test("normalizeZillowPhoto orders both ladders widest first and keeps the key", () => {
+  const photo = normalizeZillowPhoto(
+    rawOriginal(KEY_1, { caption: "Modern architectural masterpiece", subjectType: "EXTERIOR" }),
+    0,
+    rawCropped(KEY_1),
+  );
+  assert.equal(photo.index, 1);
+  assert.equal(photo.photo_key, KEY_1);
+  assert.equal(photo.caption, "Modern architectural masterpiece");
+  assert.equal(photo.subject_type, "EXTERIOR");
+  assert.deepEqual(
+    photo.original.map((source) => source.width),
+    [1536, 1344, 1024, 800],
+  );
+  assert.equal(photo.original[0].url, `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`);
+  assert.deepEqual(
+    photo.cropped.map((source) => source.width),
+    [1536, 1344, 1152, 960, 768, 576, 384, 192],
+  );
+});
+
+test("normalizeZillowPhoto tolerates sparse candidates", () => {
+  const photo = normalizeZillowPhoto(
+    { mixedSources: { jpeg: [{ url: `${CDN}/${KEY_2}-o_a.jpg`, width: 1024 }, { url: "x" }] } },
+    4,
+  );
+  assert.equal(photo.index, 5);
+  assert.equal(photo.photo_key, KEY_2);
+  assert.equal(photo.caption, "");
+  assert.equal(photo.subject_type, "");
+  assert.deepEqual(photo.original, [{ url: `${CDN}/${KEY_2}-o_a.jpg`, width: 1024 }]);
+  assert.deepEqual(photo.cropped, []);
+  const croppedOnly = normalizeZillowPhoto(null, 0, rawCropped(KEY_3, { caption: "Kitchen" }));
+  assert.equal(croppedOnly.photo_key, KEY_3);
+  assert.equal(croppedOnly.caption, "Kitchen");
+  assert.deepEqual(croppedOnly.original, []);
+  assert.equal(croppedOnly.cropped.length, 8);
+});
+
+test("collectZillowPhotos uses the page state gallery in display order", () => {
+  const { photos, source } = collectZillowPhotos(hydratedPageData());
+  assert.equal(source, "state");
+  assert.deepEqual(
+    photos.map((photo) => [photo.index, photo.photo_key, photo.caption, photo.subject_type]),
+    [
+      [1, KEY_1, "Modern architectural masterpiece", "EXTERIOR"],
+      [2, KEY_2, "Glass entrance with wooden door", ""],
+      [3, KEY_3, "", ""],
+    ],
+  );
+  assert.equal(photos[2].cropped[0].url, `${CDN}/${KEY_3}-cc_ft_1536.jpg`);
+});
+
+test("collectZillowPhotos drops entries without any URL and renumbers the rest", () => {
+  const pageData = hydratedPageData();
+  pageData.property.responsivePhotosOriginalRatio.splice(1, 0, { caption: "broken", key: "nope" });
+  pageData.property.responsivePhotos.splice(1, 0, {});
+  const { photos } = collectZillowPhotos(pageData);
+  assert.deepEqual(
+    photos.map((photo) => [photo.index, photo.photo_key]),
+    [
+      [1, KEY_1],
+      [2, KEY_2],
+      [3, KEY_3],
+    ],
+  );
+});
+
+test("collectZillowPhotos falls back to the cropped ladder when the original-ratio list is absent", () => {
+  const pageData = hydratedPageData();
+  pageData.property.responsivePhotosOriginalRatio = null;
+  const { photos, source } = collectZillowPhotos(pageData);
+  assert.equal(source, "state");
+  assert.deepEqual(
+    photos.map((photo) => [
+      photo.index,
+      photo.photo_key,
+      photo.original.length,
+      photo.cropped.length,
+    ]),
+    [
+      [1, KEY_1, 0, 8],
+      [2, KEY_2, 0, 8],
+      [3, KEY_3, 0, 8],
+    ],
+  );
+});
+
+test("collectZillowPhotos falls back to HTML CDN URLs, one photo per key in order of appearance", () => {
+  const { photos, source } = collectZillowPhotos({
+    hydrated: false,
+    property: null,
+    html_photo_urls: [
+      `${CDN}/${KEY_1}-cc_ft_384.jpg`,
+      `${CDN}/${KEY_1}-p_d.jpg`,
+      `${CDN}/${KEY_2}-cc_ft_768.jpg`,
+      `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`,
+      `${CDN}/${KEY_1}-cc_ft_384.jpg`,
+      `${CDN}/${KEY_2}-o_a.jpg`,
+      "https://photos.zillowstatic.com/fp/logo.svg",
+      "not-a-url",
+    ],
+  });
+  assert.equal(source, "html");
+  assert.deepEqual(
+    photos.map((photo) => [photo.index, photo.photo_key, photo.caption]),
+    [
+      [1, KEY_1, ""],
+      [2, KEY_2, ""],
+    ],
+  );
+  assert.deepEqual(photos[0].original, [
+    { url: `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`, width: 1536 },
+    { url: `${CDN}/${KEY_1}-p_d.jpg`, width: 400 },
+  ]);
+  assert.deepEqual(photos[0].cropped, [{ url: `${CDN}/${KEY_1}-cc_ft_384.jpg`, width: 384 }]);
+  assert.deepEqual(photos[1].original, [{ url: `${CDN}/${KEY_2}-o_a.jpg`, width: 1024 }]);
+});
+
+test("collectZillowPhotos reports none when nothing is readable", () => {
+  assert.deepEqual(collectZillowPhotos({ hydrated: true, property: { responsivePhotos: [] } }), {
+    photos: [],
+    source: "none",
+  });
+  assert.deepEqual(collectZillowPhotos({ hydrated: true, property: null, html_photo_urls: [] }), {
+    photos: [],
+    source: "none",
+  });
+  assert.deepEqual(collectZillowPhotos(null), { photos: [], source: "none" });
+});
+
+test("selectZillowPhotoUrl maps each size to its width bucket and falls back sensibly", () => {
+  const photo = normalizeZillowPhoto(rawOriginal(KEY_1), 0, rawCropped(KEY_1));
+  assert.deepEqual(selectZillowPhotoUrl(photo, "full"), {
+    url: `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`,
+    width: 1536,
+  });
+  assert.deepEqual(selectZillowPhotoUrl(photo, "large"), {
+    url: `${CDN}/${KEY_1}-uncropped_scaled_within_1344_1008.jpg`,
+    width: 1344,
+  });
+  assert.deepEqual(selectZillowPhotoUrl(photo, "medium"), {
+    url: `${CDN}/${KEY_1}-o_a.jpg`,
+    width: 1024,
+  });
+  assert.deepEqual(selectZillowPhotoUrl(photo, "small"), {
+    url: `${CDN}/${KEY_1}-d_d.jpg`,
+    width: 800,
+  });
+  assert.deepEqual(selectZillowPhotoUrl(photo, "thumb"), {
+    url: `${CDN}/${KEY_1}-cc_ft_384.jpg`,
+    width: 384,
+  });
+
+  // Only a 1024 bucket published: small takes the narrowest bucket above its target.
+  const mediumOnly = normalizeZillowPhoto(
+    { mixedSources: { jpeg: [{ url: `${CDN}/${KEY_1}-o_a.jpg`, width: 1024 }] } },
+    0,
+  );
+  assert.deepEqual(selectZillowPhotoUrl(mediumOnly, "full"), {
+    url: `${CDN}/${KEY_1}-o_a.jpg`,
+    width: 1024,
+  });
+  assert.deepEqual(selectZillowPhotoUrl(mediumOnly, "small"), {
+    url: `${CDN}/${KEY_1}-o_a.jpg`,
+    width: 1024,
+  });
+  // No cropped ladder: thumb falls back to the original-ratio ladder.
+  assert.deepEqual(selectZillowPhotoUrl(mediumOnly, "thumb"), {
+    url: `${CDN}/${KEY_1}-o_a.jpg`,
+    width: 1024,
+  });
+  // No original-ratio ladder: full falls back to the widest crop.
+  const croppedOnly = normalizeZillowPhoto(null, 0, rawCropped(KEY_1));
+  assert.deepEqual(selectZillowPhotoUrl(croppedOnly, "full"), {
+    url: `${CDN}/${KEY_1}-cc_ft_1536.jpg`,
+    width: 1536,
+  });
+  assert.deepEqual(selectZillowPhotoUrl({ original: [], cropped: [] }, "full"), {
+    url: "",
+    width: 0,
+  });
+  assert.deepEqual(ZILLOW_PHOTO_SIZES, ["full", "large", "medium", "small", "thumb"]);
+});
+
+test("buildZillowPhotoFilename pads by gallery size and marks non-full variants", () => {
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`,
+      key: KEY_1,
+      index: 1,
+      total: 34,
+      size: "full",
+    }),
+    `01-${KEY_1}.jpg`,
+  );
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: `${CDN}/${KEY_1}-o_a.jpg`,
+      key: KEY_1,
+      index: 34,
+      total: 34,
+      size: "full",
+    }),
+    `34-${KEY_1}.jpg`,
+  );
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: `${CDN}/${KEY_1}-o_a.jpg`,
+      key: KEY_1,
+      index: 7,
+      total: 120,
+      size: "full",
+    }),
+    `007-${KEY_1}.jpg`,
+  );
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: `${CDN}/${KEY_1}-uncropped_scaled_within_1344_1008.webp`,
+      key: KEY_1,
+      index: 1,
+      total: 3,
+      size: "large",
+    }),
+    `01-large-${KEY_1}.webp`,
+  );
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: "https://photos.zillowstatic.com/fp/we%20ird%20name.PNG",
+      key: "",
+      index: 1,
+      total: 1,
+      size: "full",
+    }),
+    "01-we-ird-name.png",
+  );
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: "https://photos.zillowstatic.com/",
+      key: "",
+      index: 2,
+      total: 2,
+      size: "full",
+    }),
+    "02-photo.jpg",
+  );
+});
+
+test("planZillowDownloads applies the limit and names files consistently", () => {
+  const { photos } = collectZillowPhotos(hydratedPageData());
+  const plan = planZillowDownloads(photos, { size: "full", limit: 2 });
+  assert.deepEqual(
+    plan.map((item) => [item.index, item.file_name, item.width, item.url]),
+    [
+      [1, `01-${KEY_1}.jpg`, 1536, `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`],
+      [2, `02-${KEY_2}.jpg`, 1536, `${CDN}/${KEY_2}-uncropped_scaled_within_1536_1152.jpg`],
+    ],
+  );
+  assert.equal(plan[0].caption, "Modern architectural masterpiece");
+  assert.equal(plan[0].subject_type, "EXTERIOR");
+  const all = planZillowDownloads(photos, { size: "medium" });
+  assert.equal(all.length, 3);
+  assert.equal(all[2].file_name, `03-medium-${KEY_3}.jpg`);
+  assert.equal(all[2].url, `${CDN}/${KEY_3}-o_a.jpg`);
+  const thumbs = planZillowDownloads(photos, { size: "thumb", limit: 1 });
+  assert.equal(thumbs[0].file_name, `01-thumb-${KEY_1}.jpg`);
+  assert.equal(thumbs[0].width, 384);
+  const unplannable = planZillowDownloads([{ ...photos[0], original: [], cropped: [] }], {
+    size: "full",
+  });
+  assert.deepEqual([unplannable[0].url, unplannable[0].file_name], ["", ""]);
+});
+
+test("formatBytes renders human-friendly sizes", () => {
+  assert.equal(formatBytes(0), "0 B");
+  assert.equal(formatBytes(512), "512 B");
+  assert.equal(formatBytes(85171), "83.2 KB");
+  assert.equal(formatBytes(1048576), "1.0 MB");
+  assert.equal(formatBytes(157286400), "150 MB");
+  assert.equal(formatBytes(-1), "");
+  assert.equal(formatBytes("nope"), "");
+});
+
+test("summarizeZillowDownload reports success and failure rows", () => {
+  const { photos } = collectZillowPhotos(hydratedPageData());
+  const listing = describeZillowListing(hydratedPageData());
+  const [item] = planZillowDownloads(photos, { size: "full" });
+  assert.deepEqual(
+    summarizeZillowDownload(
+      item,
+      { success: true, size: 85171 },
+      { listing, file: `/tmp/out/01-${KEY_1}.jpg` },
+    ),
+    {
+      index: 1,
+      status: "success",
+      size: "83.2 KB",
+      bytes: 85171,
+      file: `/tmp/out/01-${KEY_1}.jpg`,
+      error: "",
+      photo_key: KEY_1,
+      caption: "Modern architectural masterpiece",
+      subject_type: "EXTERIOR",
+      width: 1536,
+      url: `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`,
+      address: "349 Walsh Rd, Atherton, CA 94027",
+      zpid: "15598337",
+      listing_url:
+        "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+    },
+  );
+  const failed = summarizeZillowDownload(
+    item,
+    { success: false, size: 0, error: "HTTP 404" },
+    { listing, file: `/tmp/out/01-${KEY_1}.jpg` },
+  );
+  assert.equal(failed.status, "failed");
+  assert.equal(failed.size, "");
+  assert.equal(failed.bytes, 0);
+  assert.equal(failed.file, "");
+  assert.equal(failed.error, "HTTP 404");
+  assert.equal(summarizeZillowDownload(item, undefined).error, "unknown error");
+});
+
+test("normalizePhotoRow flattens a photo for the photos command", () => {
+  const { photos } = collectZillowPhotos(hydratedPageData());
+  const listing = describeZillowListing(hydratedPageData());
+  assert.deepEqual(normalizePhotoRow(photos[0], listing, "large"), {
+    index: 1,
+    photo_key: KEY_1,
+    caption: "Modern architectural masterpiece",
+    subject_type: "EXTERIOR",
+    width: 1344,
+    url: `${CDN}/${KEY_1}-uncropped_scaled_within_1344_1008.jpg`,
+    thumbnail_url: `${CDN}/${KEY_1}-cc_ft_384.jpg`,
+    full_url: `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`,
+    address: "349 Walsh Rd, Atherton, CA 94027",
+    zpid: "15598337",
+    listing_url: "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+  });
+});
+
+test("integerInRange validates command limits", () => {
+  assert.equal(integerInRange("5", "limit", 0, 1000), 5);
+  assert.equal(integerInRange(0, "limit", 0, 1000), 0);
+  assert.throws(() => integerInRange("1.5", "limit", 0, 1000), /limit must be an integer/);
+  assert.throws(() => integerInRange(-1, "limit", 0, 1000), /between 0 and 1000/);
+  assert.throws(() => integerInRange("abc", "limit", 0, 1000), /limit must be an integer/);
+});


### PR DESCRIPTION
## What this PR does

Rome had no OpenCLI command for Zillow, so an agent asked to save a listing's photos had to hand-drive the browser and scrape the gallery each time, with no stable output shape and no reliable way to get every photo at its best served size. Zillow also blocks the second automated page load in a session with a PerimeterX "Press & Hold" wall, so a hand-driven session stalls after one page.

This adds the `rome-zillow` plugin (`opencli-plugins/zillow/`) with two browser-backed, logged-out commands:

- `opencli zillow download URL [--output DIR] [--size SIZE] [--limit N]` saves every gallery photo of a listing to `<output>/<address slug>-<zpid>/`, one file per photo in Zillow's display order (`01-40a2df03a9e1e7ce67de59c614683f5f.jpg`, `02-daad1a3d4a0c9190ab21e0a88199523b.jpg`, …), and returns one row per photo with the saved path, byte size, caption, subject type, served width, and CDN URL.
- `opencli zillow photos URL [--size SIZE] [--limit N]` returns the same gallery as rows without writing anything.

```bash
opencli zillow download https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/
opencli zillow photos https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/ -f json
```

## Design & Invariants

- **Source of truth is Zillow's server-rendered page state, not the DOM.** Zillow renders the home details page with Next.js and embeds the GraphQL response it was built from in `<script id="__NEXT_DATA__">`, under `props.pageProps.componentProps.gdpClientCache`. That cache is keyed by query name (`ForSalePriorityQuery{…}` for an active listing, `NotForSalePriorityQuery{…}` for a sold one), so the reader scans for the entry that carries a `property` instead of matching a key. `property.responsivePhotosOriginalRatio` is the complete gallery in display order with the CDN URL of every width bucket, and `property.responsivePhotos` is the cropped ladder of the same photos. Reading that state gives all 34 photos of the example listing even though the DOM only renders a handful of `<img>` tags. When the state is absent, the commands fall back to CDN URLs scraped from the HTML, one photo per 32-hex photo key in order of first appearance.
- **`full` is the widest original-ratio bucket (`uncropped_scaled_within_1536_1152`) because it is the most faithful served copy.** Zillow scales the source photo down to fit the bucket and never scales it up: a 1440px source comes back at 1440×959 and a 799px source at 799×533. The listing's `hiResImageLink` (`p_f`) is deliberately not used — it resizes every photo to 1024px wide, upscaling small sources. Rows expose the served `width` so a caller can tell which bucket it got.
- **A refused load is retried once after resetting only the PerimeterX cookies.** Zillow's sensor stores its verdict in `_px3`/`_pxvid`/`pxcts`. A verdict written during an automated load blocks the next navigation with the "Press & Hold" wall or a bare HTTP 503, while a visitor without those cookies gets the page (verified deterministic across a dozen loads). On a refused load the loader deletes those cookies through `page.cdp("Network.deleteCookies")` and navigates again. Every other Zillow cookie, including a signed-in session, is left alone. A wall that survives the retry, an HTTP error page, or a missing listing fails with a typed `CommandExecutionError` instead of returning partial or empty rows. Alternative considered: failing on the wall and asking the guardian to clear it, as the Redfin plugin does. Rejected because Zillow blocks every load after the first in an automated session, so the command would fail on effectively every run.
- **Files never collide.** The output folder is derived from the listing's canonical `hdpUrl` (`<address slug>-<zpid>`), so a `/homes/<address>_rb/` input still lands in the canonical folder. File names are zero-padded by gallery position and keyed by Zillow's photo hash, and a non-default `--size` adds the size to the name so two variants of one photo can share a folder.
- **A failed photo is a failed row, not a failed run.** `download` reports each photo's `status`/`error` and continues.
- **No account, no private API.** Both commands use `Strategy.PUBLIC`, navigate the public listing page, and fetch photos straight from `photos.zillowstatic.com`, which serves them without cookies.
- The in-page reader (`readZillowListingPage`) returns raw payload slices only; all shaping, validation, and naming live in pure helpers (`zillow-helpers.mjs`) that the unit tests cover directly.

## Test plan

- [x] `npm test` in `opencli-plugins/zillow` — 24 helper tests pass (URL canonicalization, slug and zpid parsing, PerimeterX cookie matching, challenge/not-found/unavailable detection, state, cropped-only, and HTML fallback collection, size selection, file naming, download planning, row shaping).
- [x] `biome check opencli-plugins/` — clean.
- [x] `scripts/check-pr-title.sh` — title accepted.
- [x] Offline: the helpers replayed against the captured page state of the example listing and of a sold listing — 34 and 30 photos, every key unique, canonical folder names.
- [x] Live: `opencli plugin install opencli-plugins/zillow`, then `opencli zillow download https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/ --output /tmp/zillow-test -f json` — 34/34 photos saved (2.45 MB, all valid JPEGs, no leftover `.tmp` files) in under 9 s, through the PerimeterX wall on an already-flagged session.
- [x] Live: a sold listing via `https://www.zillow.com/homes/31-Rittenhouse-Ave-Atherton-CA-94027_rb/?utm_source=share` with `--size large --limit 2` — UTM stripped, redirect followed, folder named from the canonical `hdpUrl`, files carry the `-large-` infix at 1344px.
- [x] Live: `photos --size thumb --limit 3` reports the 384px crop with `full_url` alongside.
- [x] Live: two back-to-back runs both succeed (the second always starts on a flagged session).
- [x] Live: a non-Zillow URL fails with a usage error before any navigation; a bogus zpid fails with "Zillow has no listing page at …" in about 3 s.
- [ ] CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
