### PR TITLE
feat(web): open side widgets full screen in a new tab

### DIFF
--- a/packages/web/src/components/file-browser-page.tsx
+++ b/packages/web/src/components/file-browser-page.tsx
@@ -30,12 +30,14 @@ interface FileBrowserPageProps {
   renderCreateExtra?: (ctx: { type: "file" | "folder"; parentPath: string | null }) => ReactNode;
   /**
    * Fires whenever the user's selection in the browser changes: the file
-   * currently displayed and any multi-select set in the tree. Used by hosts
-   * (e.g. the workspace `ProjectsWidget`) that need to mirror selection
-   * elsewhere — the browser stays the source of truth.
+   * currently displayed, the folder whose contents the browser is showing,
+   * and any multi-select set in the tree. Used by hosts (e.g. the workspace
+   * `ProjectsWidget`) that need to mirror selection elsewhere — the browser
+   * stays the source of truth.
    */
   onSelectionChange?: (selection: {
     selectedPath: string | null;
+    currentFolderPath: string | null;
     selectedTreePaths: string[];
   }) => void;
   rootLabel: string;

--- a/packages/web/src/components/file-browser/Shell.tsx
+++ b/packages/web/src/components/file-browser/Shell.tsx
@@ -47,6 +47,7 @@ interface ShellProps {
   onStartChatFromFolder?: (path: string) => void;
   onSelectionChange?: (selection: {
     selectedPath: string | null;
+    currentFolderPath: string | null;
     selectedTreePaths: string[];
   }) => void;
   folderPanel?: (props: { path: string }) => ReactNode;

--- a/packages/web/src/components/file-browser/hooks/useSelectionChangeBroadcast.ts
+++ b/packages/web/src/components/file-browser/hooks/useSelectionChangeBroadcast.ts
@@ -1,21 +1,32 @@
 import { useEffect, useRef } from "react";
 import { useFileBrowserStore } from "../store/context";
 
-type Callback = (selection: { selectedPath: string | null; selectedTreePaths: string[] }) => void;
+type Callback = (selection: {
+  selectedPath: string | null;
+  currentFolderPath: string | null;
+  selectedTreePaths: string[];
+}) => void;
 
 /**
  * Surface selection upward for embedders that mirror selection elsewhere
  * (the workspace ProjectsWidget). The browser is the source of truth; this
- * just fires the prop callback when selection changes.
+ * just fires the prop callback when selection changes. `currentFolderPath` is
+ * the folder whose contents the browser is showing: pane drilling moves
+ * `filesPaneDrillPath` without touching the selection (the mirror runs the
+ * other way), so the drill path is the fresher signal and the explicit folder
+ * selection is the fallback from before the pane first mounts.
  */
 export function useSelectionChangeBroadcast(onSelectionChange?: Callback) {
   const selectedPath = useFileBrowserStore((s) => s.selection.selectedPath);
+  const selectedFolderPath = useFileBrowserStore((s) => s.selection.selectedFolderPath);
+  const filesPaneDrillPath = useFileBrowserStore((s) => s.ui.filesPaneDrillPath);
   const selectedTreePaths = useFileBrowserStore((s) => s.selection.selectedTreePaths);
+  const currentFolderPath = filesPaneDrillPath ?? selectedFolderPath;
   const callbackRef = useRef(onSelectionChange);
   useEffect(() => {
     callbackRef.current = onSelectionChange;
   }, [onSelectionChange]);
   useEffect(() => {
-    callbackRef.current?.({ selectedPath, selectedTreePaths });
-  }, [selectedPath, selectedTreePaths]);
+    callbackRef.current?.({ selectedPath, currentFolderPath, selectedTreePaths });
+  }, [selectedPath, currentFolderPath, selectedTreePaths]);
 }

--- a/packages/web/src/components/file-browser/store/types.ts
+++ b/packages/web/src/components/file-browser/store/types.ts
@@ -152,6 +152,7 @@ export interface FileBrowserConfig {
   renderCreateExtra?: (ctx: { type: "file" | "folder"; parentPath: string | null }) => ReactNode;
   onSelectionChange?: (selection: {
     selectedPath: string | null;
+    currentFolderPath: string | null;
     selectedTreePaths: string[];
   }) => void;
 }

--- a/packages/web/src/i18n/locales/en/common.json
+++ b/packages/web/src/i18n/locales/en/common.json
@@ -165,6 +165,7 @@
     "back": "Back",
     "noApps": "No apps available",
     "newChat": "New chat",
+    "openWidgetNewTab": "Open in new tab",
     "orPickSession": "or pick an existing session"
   },
   "connectChatApp": {

--- a/packages/web/src/i18n/locales/zh-CN/common.json
+++ b/packages/web/src/i18n/locales/zh-CN/common.json
@@ -165,6 +165,7 @@
     "back": "返回",
     "noApps": "暂无可用应用",
     "newChat": "新对话",
+    "openWidgetNewTab": "在新标签页中打开",
     "orPickSession": "或选择已有对话"
   },
   "connectChatApp": {

--- a/packages/web/src/pages/free/AppWidget.tsx
+++ b/packages/web/src/pages/free/AppWidget.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useApps } from "@/hooks/use-apps";
 import { trackWidgetRender } from "@/lib/analytics";
+import { buildFullAppPath } from "./widget-links";
 import { useWorkspaceContextRegistry } from "./workspace-context";
 
 // Wire contract with the app-web-sdk global-params channel: the app
@@ -60,15 +61,7 @@ export function AppWidget({
     route,
     params,
   }));
-  const query = new URLSearchParams();
-  if (frozen.params) {
-    for (const [k, v] of Object.entries(frozen.params)) query.set(k, String(v));
-  }
-  const qs = query.toString();
-  const routePath = frozen.route
-    ? frozen.route.split("/").filter(Boolean).map(encodeURIComponent).join("/")
-    : "";
-  const src = `/full/apps/${encodeURIComponent(appId)}${routePath ? `/${routePath}` : ""}${qs ? `?${qs}` : ""}`;
+  const src = buildFullAppPath(appId, frozen.route, frozen.params);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const registry = useWorkspaceContextRegistry();
   // The frame's accessible name must match the tile header, which renders the

--- a/packages/web/src/pages/free/FreeGrid.tsx
+++ b/packages/web/src/pages/free/FreeGrid.tsx
@@ -12,6 +12,7 @@ import { horizontalListSortingStrategy, SortableContext, useSortable } from "@dn
 import { CSS } from "@dnd-kit/utilities";
 import {
   Chrome,
+  ExternalLink,
   FolderKanban,
   GripVertical,
   LayoutGrid,
@@ -49,6 +50,7 @@ import { AppWidget } from "./AppWidget";
 import { ChatWidget } from "./ChatWidget";
 import { DesktopWidget } from "./DesktopWidget";
 import { ProjectsWidget } from "./ProjectsWidget";
+import { buildFullAppPath, getWidgetFullHref } from "./widget-links";
 import { WidgetPicker } from "./WidgetPicker";
 import {
   autoPlaceApp,
@@ -65,6 +67,7 @@ import {
 } from "./use-free-cells";
 import {
   createWorkspaceContextRegistry,
+  useWorkspaceContextRegistry,
   WorkspaceContextRegistryContext,
 } from "./workspace-context";
 import { createWorkspaceEventBus, WorkspaceEventBusContext } from "./workspace-event-bus";
@@ -178,11 +181,26 @@ function SortableWidgetCard({
   sessionId?: string;
   interaction?: boolean;
 }) {
+  const { t } = useTranslation("common");
   const prefersReducedMotion = useReducedMotion();
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition } =
     useSortable({ id: widget.id });
 
   const isActive = widget.id === activeId;
+
+  // The full-screen href for this widget. App tiles freeze their iframe src at
+  // mount and navigate internally, so the placement's stored route can trail
+  // the live screen; re-read the iframe's URL at the moments that precede
+  // opening (hover, press, focus) so the link carries where the user actually
+  // is. Builtins derive fully from the placement.
+  const registry = useWorkspaceContextRegistry();
+  const [liveAppHref, setLiveAppHref] = useState<string | null>(null);
+  const fullHref = liveAppHref ?? getWidgetFullHref(widget);
+  const refreshFullHref = useCallback(() => {
+    if (widget.type !== "app" || !widget.targetId) return;
+    const link = registry?.resolveLink(widget.id);
+    if (link) setLiveAppHref(buildFullAppPath(widget.targetId, link.route, link.params));
+  }, [registry, widget]);
 
   return (
     <div
@@ -212,16 +230,35 @@ function SortableWidgetCard({
         {/* The design surface is system-managed while the handoff holds the
             floor: leaving is the chat's "Main" back bar (non-destructive) and
             cancelling is the surface's own Cancel button — so it carries no
-            generic close affordance that could be mistaken for either. */}
+            generic open/close affordances that could be mistaken for either. */}
         {!interaction && (
-          <button
-            type="button"
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={onRemove}
-            className="rounded-4 p-1 text-subtle-foreground hover:bg-surface-hover hover:text-foreground"
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
+          <>
+            {fullHref && (
+              <a
+                href={fullHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={t("chat.openWidgetNewTab")}
+                title={t("chat.openWidgetNewTab")}
+                onPointerDown={(e) => e.stopPropagation()}
+                onPointerEnter={refreshFullHref}
+                onFocus={refreshFullHref}
+                className="rounded-4 p-1 text-subtle-foreground hover:bg-surface-hover hover:text-foreground"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            )}
+            <button
+              type="button"
+              aria-label={t("sidebar.remove")}
+              title={t("sidebar.remove")}
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={onRemove}
+              className="rounded-4 p-1 text-subtle-foreground hover:bg-surface-hover hover:text-foreground"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </>
         )}
       </div>
       <div className="relative min-h-0 flex-1 overflow-auto overscroll-y-contain">

--- a/packages/web/src/pages/free/ProjectsWidget.tsx
+++ b/packages/web/src/pages/free/ProjectsWidget.tsx
@@ -11,7 +11,7 @@ interface ProjectsWidgetProps {
   dragging: boolean;
   /** Placement id — selection changes are persisted back onto this placement. */
   placementId?: string;
-  /** File selected before the last reload, restored once on mount. */
+  /** File or folder selected before the last reload, restored once on mount. */
   initialSelectedPath?: string;
 }
 
@@ -135,9 +135,18 @@ export function ProjectsWidget({
     selectedTreePaths: string[];
   }>({ selectedPath: null, selectedTreePaths: [] });
   const handleSelectionChange = useCallback(
-    (sel: { selectedPath: string | null; selectedTreePaths: string[] }) => {
+    (sel: {
+      selectedPath: string | null;
+      currentFolderPath: string | null;
+      selectedTreePaths: string[];
+    }) => {
       setBrowserSelection(sel);
-      if (placementId) updateProjectsSelection(placementId, sel.selectedPath);
+      // Persist wherever the user is — the open file, or the folder the
+      // browser is showing when no file is open. The restore path already
+      // resolves either kind through `/resolve`.
+      if (placementId) {
+        updateProjectsSelection(placementId, sel.selectedPath ?? sel.currentFolderPath);
+      }
     },
     [placementId],
   );

--- a/packages/web/src/pages/free/use-free-cells.ts
+++ b/packages/web/src/pages/free/use-free-cells.ts
@@ -13,11 +13,12 @@ export interface WidgetPlacement {
   // reload. Set by an agent's `show_app`/`place_widget`.
   route?: string;
   params?: Record<string, string | number | boolean>;
-  // Selected file for a `projects` widget — the file the user (or an agent
-  // link) last opened. Persists with the layout so the addressed file survives
-  // reload; the embedded file browser disables its own URL-as-SSOT sync, so
-  // without this the selection is lost on refresh. A `projects/`-rooted logical
-  // path, matching the browser's own selection space.
+  // Selected file or folder for a `projects` widget — wherever the user (or an
+  // agent link) last navigated. Persists with the layout so the addressed spot
+  // survives reload and rides the open-in-new-tab link; the embedded file
+  // browser disables its own URL-as-SSOT sync, so without this the selection is
+  // lost on refresh. A `projects/`-rooted logical path, matching the browser's
+  // own selection space.
   selectedPath?: string;
 }
 
@@ -273,10 +274,10 @@ export function updatePlacementLink(
 }
 
 /**
- * Persist a `projects` tile's currently-selected file back onto its placement
- * so the addressed file survives reload. In place (id unchanged → no remount);
- * no-ops when unchanged to avoid churning localStorage + the server PUT on every
- * click.
+ * Persist a `projects` tile's currently-selected file or folder back onto its
+ * placement so the addressed spot survives reload. In place (id unchanged → no
+ * remount); no-ops when unchanged to avoid churning localStorage + the server
+ * PUT on every click.
  */
 export function updateProjectsSelection(placementId: string, selectedPath: string | null): void {
   const current = getSnapshot();

--- a/packages/web/src/pages/free/widget-links.test.ts
+++ b/packages/web/src/pages/free/widget-links.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "@rstest/core";
+import type { WidgetPlacement } from "./use-free-cells";
+import { buildFullAppPath, getWidgetFullHref } from "./widget-links";
+
+function placement(overrides: Partial<WidgetPlacement> & { type: WidgetPlacement["type"] }) {
+  return { id: "w1", order: 1, ...overrides } as WidgetPlacement;
+}
+
+describe("buildFullAppPath", () => {
+  it("addresses the app root when no route or params are set", () => {
+    expect(buildFullAppPath("skills")).toBe("/full/apps/skills");
+  });
+
+  it("rides the route on the path and the params on the query", () => {
+    expect(buildFullAppPath("shop", "orders/detail", { orderId: 7, draft: true })).toBe(
+      "/full/apps/shop/orders/detail?orderId=7&draft=true",
+    );
+  });
+
+  it("encodes each route segment and the app id", () => {
+    expect(buildFullAppPath("my app", "a b/c#d")).toBe("/full/apps/my%20app/a%20b/c%23d");
+  });
+});
+
+describe("getWidgetFullHref", () => {
+  it("addresses the projects root when no path is selected", () => {
+    expect(getWidgetFullHref(placement({ type: "projects" }))).toBe("/projects");
+  });
+
+  it("carries the selected file or folder into the projects URL", () => {
+    expect(
+      getWidgetFullHref(placement({ type: "projects", selectedPath: "projects/docs/a b.md" })),
+    ).toBe("/projects/docs/a%20b.md");
+  });
+
+  it("addresses the desktop page for the browser widget", () => {
+    expect(getWidgetFullHref(placement({ type: "desktop" }))).toBe("/desktop");
+  });
+
+  it("addresses the full app view with the stored route and params", () => {
+    expect(
+      getWidgetFullHref(
+        placement({ type: "app", targetId: "shop", route: "orders", params: { orderId: "7" } }),
+      ),
+    ).toBe("/full/apps/shop/orders?orderId=7");
+  });
+
+  it("returns null for widgets with no standalone page", () => {
+    expect(getWidgetFullHref(placement({ type: "chat" }))).toBeNull();
+    expect(getWidgetFullHref(placement({ type: "app" }))).toBeNull();
+  });
+});

--- a/packages/web/src/pages/free/widget-links.ts
+++ b/packages/web/src/pages/free/widget-links.ts
@@ -1,0 +1,51 @@
+// Maps a widget placement to the full-screen route that shows the same
+// surface on its own: the strip card and the full page are two views of one
+// address, so "open in new tab" is a plain link, not a state handoff.
+
+import { getFileBrowserUrlPath } from "@/lib/file-browser-routing";
+import type { WidgetPlacement } from "./use-free-cells";
+
+// Must match the `logicalRootPath` ProjectsWidget passes to FileBrowserPage —
+// both name the same route namespace the full `/projects` page mounts at.
+const PROJECTS_LOGICAL_ROOT = "projects";
+
+/**
+ * Build the `/full/apps/<appId>[/<route>][?<params>]` path — the app's own
+ * route rides the path (per-segment encoded) and its own params ride the
+ * query, mirroring how AppFullPage parses them back apart. Shared by the
+ * widget iframe `src` and the header's open-in-new-tab link so the two
+ * addresses cannot drift.
+ */
+export function buildFullAppPath(
+  appId: string,
+  route?: string,
+  params?: Record<string, string | number | boolean>,
+): string {
+  const query = new URLSearchParams();
+  if (params) {
+    for (const [k, v] of Object.entries(params)) query.set(k, String(v));
+  }
+  const qs = query.toString();
+  const routePath = route ? route.split("/").filter(Boolean).map(encodeURIComponent).join("/") : "";
+  return `/full/apps/${encodeURIComponent(appId)}${routePath ? `/${routePath}` : ""}${qs ? `?${qs}` : ""}`;
+}
+
+/**
+ * The full-screen href for a placement, from its persisted state. `null` when
+ * the widget has no standalone page (chat is the base surface, an app tile
+ * without a target is unaddressable).
+ */
+export function getWidgetFullHref(widget: WidgetPlacement): string | null {
+  switch (widget.type) {
+    case "projects":
+      return getFileBrowserUrlPath(PROJECTS_LOGICAL_ROOT, widget.selectedPath ?? null);
+    case "desktop":
+      return "/desktop";
+    case "app":
+      return widget.targetId
+        ? buildFullAppPath(widget.targetId, widget.route, widget.params)
+        : null;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## What this PR does

A side widget lives only in the strip next to the conversation, with no way to promote it to a full screen, even though every widget already has a full-page twin: `/projects`, `/desktop`, and `/full/apps/<appId>`. The Projects widget also persisted only file selections. Browsing into a folder in its list/grid pane wrote nothing back onto the placement, so the folder was lost on reload and could not ride a link.

This PR adds an "Open in new tab" anchor to each widget card header, next to the close button. It is a real link, so middle-click, Cmd-click, and copy-link behave natively. The link carries the widget's current state:

- Projects opens `/projects/<path>` for the open file, or for the folder the pane is showing.
- An app opens `/full/apps/<appId>/<route>?<params>`. App tiles freeze their iframe `src` at mount, so the anchor re-reads the live iframe URL on hover, press, and focus through the existing `resolveLink`.
- Browser opens `/desktop`.

The close button also gains the `aria-label` its mobile counterpart already has.

## Design & Invariants

The strip card and the full page are two views of one address. "Open in new tab" is a plain link derived from the placement, not a state handoff. `buildFullAppPath` is shared by the iframe `src` and the anchor, so the two constructions cannot drift.

The selection broadcast reports `currentFolderPath`: the folder whose contents the browser is showing. Pane drilling moves `ui.filesPaneDrillPath` without touching the selection (the mirror runs the other way), so the drill path is the fresher signal and the explicit folder selection is the fallback. The placement's persisted `selectedPath` widens from "file" to "file or folder". The restore path already resolves both kinds through `/resolve`, so folder selections now survive reload too.

Interaction surfaces stay free of generic affordances: the anchor is gated with the close button on `!interaction`.

Alternatives considered: a per-widget overflow menu (two clicks for a single action, and the header holds only one action today), a clickable title (collides with the header being the drag activator), and an in-place maximize (not a new tab, and it loses chatting alongside the widget).

## Test plan

- [x] `pnpm --filter rome-web typecheck`
- [x] `pnpm --filter rome-web test` (161 files, 1326 tests, including the new `widget-links.test.ts`)
- [x] Mock-mode browser run (playwright against :3200): the anchor renders before the X with `target="_blank"`, the href follows folder drilling (`/projects/demo-app`) and file selection (`/projects/demo-app/README.md`), the folder path persists onto the placement, the new tab lands on the preserved folder URL, and an app widget links to `/full/apps/recipe-box`.

## Not in this PR

- A mobile affordance: the card header is desktop-only, and the mobile tab pills stay as they are.
- Session context for full-page apps: `chatSessionId` and `interaction` ride postMessage from the workspace, so an app opened full page starts without them, matching the existing "Open full view" menu action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)