### PR TITLE
feat(opencli): add Gemini video generation plugin with image upload

### DIFF
--- a/opencli-plugins/README.md
+++ b/opencli-plugins/README.md
@@ -96,6 +96,9 @@ Agents pick up new/changed commands automatically: the `browser-automation` skil
 - `opencli redfin download URL [--output DIR] [--size SIZE] [--limit N]` — downloads every gallery
   photo of a public Redfin listing into one folder per listing, in gallery order, with captions and
   room tags in the result rows. `photos URL` lists the same gallery without writing anything.
+- `opencli zillow download URL [--output DIR] [--size SIZE] [--limit N]` — downloads every gallery
+  photo of a public Zillow listing into one folder per listing, in gallery order, at the widest
+  original-ratio size Zillow serves. `photos URL` lists the same gallery without writing anything.
 
 ## Overriding a built-in command: caveats
 
@@ -398,4 +401,42 @@ result.
 opencli redfin download https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461
 opencli redfin download https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461 --output ~/Pictures --size large --limit 10 -f json
 opencli redfin photos https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1061461 -f json
+```
+
+### Zillow
+
+The Zillow plugin reads a public home details page and works from the Next.js page state Zillow
+server-renders into `<script id="__NEXT_DATA__">`. The `gdpClientCache` entry there holds the
+listing's `responsivePhotosOriginalRatio` list: every photo in display order with the CDN URL of
+each width bucket, plus a caption and subject type when the listing has them. The commands need no
+Zillow account and call no private API. When that state is absent, the commands fall back to the
+CDN URLs present in the HTML.
+
+- `download` saves the gallery to `<output>/<address slug>-<zpid>/`, one file per photo named
+  `<gallery position>-<photo key>.jpg` (for example `01-40a2df03a9e1e7ce67de59c614683f5f.jpg`) so
+  a folder listing matches the order on Zillow. Each result row carries the saved path, byte size,
+  caption, subject type, served width, and source URL. A photo that fails to download gets a failed
+  row with the error, and the run continues with the next photo.
+- `photos` returns the same gallery as rows without touching the disk.
+- `--size` picks the width bucket. `full` (default) is the widest original-ratio bucket, up to
+  1536px wide, which Zillow scales down from the source photo and never scales up. `large` (1344),
+  `medium` (1024), and `small` (800) are the narrower original-ratio buckets. `thumb` is Zillow's
+  384px crop. A bucket the listing does not publish falls back to the nearest one it does. Files
+  for a non-default size carry the size in their name, so variants never overwrite each other.
+- `--limit` caps the number of photos taken from the front of the gallery.
+
+Both a canonical `/homedetails/<address>/<zpid>_zpid/` URL and a `/homes/<address>_rb/` address
+URL work. The address form resolves through a Zillow redirect, so the canonical form is faster.
+
+Zillow's PerimeterX sensor scores each page load and stores its verdict in the `_px*` and `pxcts`
+cookies. A verdict written during an automated load blocks the next load with a "Press & Hold"
+wall or a bare HTTP 5xx. When a command hits either, it deletes only those PerimeterX cookies from
+the browser, which resets the verdict, and loads the page once more. Every other Zillow cookie,
+including a signed-in session, stays in place. A wall that survives the retry fails with a typed
+error, as does a missing listing.
+
+```bash
+opencli zillow download https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/
+opencli zillow download https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/ --output ~/Pictures --size large --limit 10 -f json
+opencli zillow photos https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/ -f json
 ```

--- a/opencli-plugins/README.md
+++ b/opencli-plugins/README.md
@@ -99,6 +99,9 @@ Agents pick up new/changed commands automatically: the `browser-automation` skil
 - `opencli zillow download URL [--output DIR] [--size SIZE] [--limit N]` — downloads every gallery
   photo of a public Zillow listing into one folder per listing, in gallery order, at the widest
   original-ratio size Zillow serves. `photos URL` lists the same gallery without writing anything.
+- `opencli gemini video PROMPT [--image A.jpg,B.jpg] [--ratio 16:9|9:16] [--output DIR] [--name FILE]`
+  — generates a clip in the signed-in Gemini web session's video composer, optionally animating
+  uploaded photos, waits for the render, and saves the MP4 with the browser's session cookies.
 
 ## Overriding a built-in command: caveats
 
@@ -439,4 +442,31 @@ error, as does a missing listing.
 opencli zillow download https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/
 opencli zillow download https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/ --output ~/Pictures --size large --limit 10 -f json
 opencli zillow photos https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/ -f json
+```
+
+### Gemini video
+
+The Gemini plugin adds `video` next to the built-in `ask` and `image` commands. It opens
+`gemini.google.com/videos`, where Gemini pre-selects its Videos tool, picks the aspect ratio,
+attaches any `--image` files, submits the prompt, polls the newest model turn until a player
+renders or Gemini reports a failure, then downloads the MP4. The clip host refuses anonymous
+requests, so the download forwards the browser's Google session cookies for that host only.
+
+- `--image` takes a comma-separated list of local paths (up to 10). Gemini builds its file input
+  on demand and only a trusted pointer click opens it, so the command intercepts the file chooser
+  over CDP and hands Chrome the paths. That needs the direct CDP backend
+  (`opencli --cdp-endpoint http://127.0.0.1:9222 …`); the Browser Bridge extension does not
+  relay CDP events. The command waits for every attachment tile to finish uploading before it
+  sends, because a message sent mid-upload is dropped without an error.
+- One prompt yields one clip of roughly 8 to 10 seconds at 1280×720 with generated ambient
+  audio. Longer films are several runs stitched together.
+- Gemini enforces a daily video allowance per account (Google AI Pro: 3 videos a day). Once it is
+  spent, Gemini locks the video composer without a message; the command reports that state as a
+  typed error instead of waiting for a clip.
+- A refusal ("I can't generate that video") is returned as a typed error with Gemini's wording.
+  Refusals are often transient; a retry with a simpler prompt usually works.
+
+```bash
+opencli --cdp-endpoint http://127.0.0.1:9222 gemini video "Slow cinematic dolly toward the house at dusk, subtle motion" --image ./front.jpg --output ./clips --name front-dusk
+opencli --cdp-endpoint http://127.0.0.1:9222 gemini video "A paper boat drifting on a pond at sunrise" --ratio 9:16 -f json
 ```

--- a/opencli-plugins/gemini/gemini-video-browser.mjs
+++ b/opencli-plugins/gemini/gemini-video-browser.mjs
@@ -1,0 +1,331 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { CommandExecutionError } from "@jackwener/opencli/errors";
+import {
+  buildGeminiVideoCookieHeader,
+  classifyGeminiVideoState,
+  GEMINI_VIDEO_URL,
+  isVideoContentType,
+} from "./gemini-video-helpers.mjs";
+
+const BROWSER_USER_AGENT =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36";
+
+/**
+ * Runs inside the Gemini page, so it must stay self-contained: `page.evaluate`
+ * serializes the function source and cannot carry module-scope bindings along.
+ *
+ * Describes the video composer: whether the prompt editor and the Videos tool
+ * chip are present, which aspect ratio is active, where the upload button sits
+ * (a trusted pointer click there opens the file chooser), and how many image
+ * attachments the composer currently shows.
+ */
+export function readGeminiVideoComposer() {
+  var editor = document.querySelector(
+    '[contenteditable="true"][aria-label="Enter a prompt for Gemini"], div.ql-editor[contenteditable="true"]',
+  );
+  // Once the daily video allowance is spent Gemini keeps the composer on
+  // screen but locks it: the editor turns contenteditable="false" and its
+  // container gains ql-disabled, with no message anywhere on the page.
+  var lockedEditor = document.querySelector(
+    'div.ql-editor[contenteditable="false"][aria-label="Enter a prompt for Gemini"]',
+  );
+  var editorLocked =
+    !editor &&
+    !!lockedEditor &&
+    !!(lockedEditor.closest("rich-textarea") || lockedEditor.parentElement) &&
+    String(
+      (lockedEditor.closest("rich-textarea") || lockedEditor.parentElement).className || "",
+    ).indexOf("ql-disabled") !== -1;
+  var upload = document.querySelector('button[aria-label="File upload"]');
+  var ratio = document.querySelector('button[aria-label^="Aspect ratio"]');
+  var send = document.querySelector('button[aria-label="Send message"]');
+  var uploadPoint = null;
+  if (upload) {
+    var rect = upload.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      uploadPoint = {
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
+      };
+    }
+  }
+  // Each attachment renders as a tile that keeps a progress spinner until the
+  // bytes reach Gemini; sending before that drops the message.
+  var tiles = document.querySelectorAll("gem-media-attachment");
+  var attachments = tiles.length;
+  var uploading = 0;
+  for (var i = 0; i < tiles.length; i++) {
+    if (tiles[i].querySelector('[role="progressbar"], .gem-attachment-content.loading')) {
+      uploading++;
+    }
+  }
+  if (attachments === 0) {
+    var images = document.querySelectorAll("img");
+    for (var j = 0; j < images.length; j++) {
+      var src = String(images[j].getAttribute("src") || "");
+      if (src.indexOf("blob:") === 0) attachments++;
+    }
+  }
+  return {
+    url: location.href,
+    hasEditor: !!editor,
+    editorLocked: editorLocked,
+    editorText: editor ? String(editor.innerText || "").trim() : "",
+    videosToolSelected: !!document.querySelector('button[aria-label="Deselect Videos"]'),
+    ratioLabel: ratio ? String(ratio.innerText || "").trim() : "",
+    uploadPoint: uploadPoint,
+    attachments: attachments,
+    uploading: uploading,
+    sendEnabled: !!send && !send.disabled,
+  };
+}
+
+/** Self-contained for `page.evaluate`: the state of the newest model turn. */
+export function readGeminiVideoTurn() {
+  var responses = document.querySelectorAll("model-response");
+  var last = responses.length ? responses[responses.length - 1] : null;
+  var videos = [];
+  var players = document.querySelectorAll("video");
+  for (var i = 0; i < players.length; i++) {
+    videos.push({
+      src: String(players[i].currentSrc || players[i].getAttribute("src") || ""),
+      duration: players[i].duration,
+    });
+  }
+  var body = String((document.body && document.body.innerText) || "");
+  return {
+    url: location.href,
+    videos: videos,
+    responseText: last ? String(last.innerText || "") : "",
+    bodyTail: body.slice(-600),
+  };
+}
+
+function scriptClickRatioMenuItem(label) {
+  return `(() => {
+    const items = [...document.querySelectorAll('[role="menuitemradio"], [role="menuitem"]')];
+    const wanted = ${JSON.stringify(label)};
+    const item = items.find((el) => (el.innerText || el.getAttribute('aria-label') || '').trim() === wanted);
+    if (!item) return items.map((el) => (el.innerText || '').trim()).filter(Boolean);
+    item.click();
+    return true;
+  })()`;
+}
+
+const SCRIPT_OPEN_RATIO_MENU = `(() => {
+  const btn = document.querySelector('button[aria-label^="Aspect ratio"]');
+  if (!btn) return false;
+  btn.click();
+  return true;
+})()`;
+
+const SCRIPT_FOCUS_EDITOR = `(() => {
+  const editor = document.querySelector('[contenteditable="true"][aria-label="Enter a prompt for Gemini"], div.ql-editor[contenteditable="true"]');
+  if (!editor) return false;
+  editor.focus();
+  return true;
+})()`;
+
+const SCRIPT_CLICK_SEND = `(() => {
+  const btn = document.querySelector('button[aria-label="Send message"]');
+  if (!btn || btn.disabled) return false;
+  btn.click();
+  return true;
+})()`;
+
+async function pollComposer(page, predicate, { timeoutMs = 15000, intervalSeconds = 0.5 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let state = null;
+  for (;;) {
+    state = await page.evaluate(readGeminiVideoComposer);
+    if (predicate(state) || Date.now() >= deadline) return state;
+    await page.wait(intervalSeconds);
+  }
+}
+
+/**
+ * Open the video composer. Gemini pre-selects its Videos tool on `/videos`, so
+ * the page itself carries the mode instead of a menu click that can drift.
+ */
+export async function openGeminiVideoComposer(page) {
+  await page.goto(GEMINI_VIDEO_URL, { waitUntil: "load", settleMs: 2500 });
+  const state = await pollComposer(
+    page,
+    (s) => (s.hasEditor && s.videosToolSelected) || s.editorLocked,
+    { timeoutMs: 20000 },
+  );
+  if (state.editorLocked) {
+    throw new CommandExecutionError(
+      "Gemini has locked its video composer for this account, which is how it shows a spent daily video allowance (Google AI Pro: 3 videos a day); retry after the daily reset",
+    );
+  }
+  if (!state.hasEditor) {
+    throw new CommandExecutionError(
+      "Gemini video composer did not load; sign in at https://gemini.google.com and retry",
+    );
+  }
+  if (!state.videosToolSelected) {
+    throw new CommandExecutionError(
+      "Gemini did not select its Videos tool on /videos; video generation may be unavailable for this account",
+    );
+  }
+  return state;
+}
+
+export async function selectGeminiVideoRatio(page, label) {
+  const current = await page.evaluate(readGeminiVideoComposer);
+  if (current.ratioLabel === label) return label;
+  const opened = await page.evaluate(SCRIPT_OPEN_RATIO_MENU);
+  if (!opened) throw new CommandExecutionError("Gemini aspect ratio control was not found");
+  await page.wait(0.7);
+  const picked = await page.evaluate(scriptClickRatioMenuItem(label));
+  if (picked !== true) {
+    const seen =
+      Array.isArray(picked) && picked.length ? ` (menu shows: ${picked.join(", ")})` : "";
+    throw new CommandExecutionError(`Gemini aspect ratio "${label}" was not offered${seen}`);
+  }
+  const state = await pollComposer(page, (s) => s.ratioLabel === label, {
+    timeoutMs: 5000,
+  });
+  if (state.ratioLabel !== label) {
+    throw new CommandExecutionError(
+      `Gemini kept aspect ratio "${state.ratioLabel}" after selecting "${label}"`,
+    );
+  }
+  return label;
+}
+
+/**
+ * Attach reference images. Gemini builds its file input on demand, so the flow
+ * intercepts the file chooser the upload button opens and hands Chrome the local
+ * paths for that node. Only a trusted pointer click opens the chooser, and the
+ * interception needs CDP events, which the direct `--cdp-endpoint` backend
+ * exposes as `page.bridge`.
+ */
+export async function attachGeminiVideoImages(page, files) {
+  if (!files.length) return 0;
+  const bridge = page.bridge;
+  if (typeof page.cdp !== "function" || !bridge || typeof bridge.waitForEvent !== "function") {
+    throw new CommandExecutionError(
+      "Image upload needs the direct CDP backend; rerun with --cdp-endpoint http://127.0.0.1:9222",
+    );
+  }
+  const before = await page.evaluate(readGeminiVideoComposer);
+  if (!before.uploadPoint) {
+    throw new CommandExecutionError("Gemini video composer has no visible File upload button");
+  }
+  await page.cdp("Page.enable", {}).catch(() => undefined);
+  await page.cdp("DOM.enable", {}).catch(() => undefined);
+  await page.cdp("Page.setInterceptFileChooserDialog", { enabled: true });
+  try {
+    const chooser = bridge.waitForEvent("Page.fileChooserOpened", 15000);
+    await page.nativeClick(before.uploadPoint.x, before.uploadPoint.y);
+    let opened;
+    try {
+      opened = await chooser;
+    } catch {
+      throw new CommandExecutionError(
+        "Gemini did not open a file chooser for the File upload button",
+      );
+    }
+    await page.cdp("DOM.setFileInputFiles", {
+      files,
+      backendNodeId: opened.backendNodeId,
+    });
+  } finally {
+    await page.cdp("Page.setInterceptFileChooserDialog", { enabled: false }).catch(() => undefined);
+  }
+  const wanted = before.attachments + files.length;
+  const state = await pollComposer(page, (s) => s.attachments >= wanted && s.uploading === 0, {
+    timeoutMs: 90000,
+  });
+  if (state.attachments < wanted) {
+    throw new CommandExecutionError(
+      `Gemini shows ${state.attachments - before.attachments} of ${files.length} uploaded images; retry with fewer or smaller files`,
+    );
+  }
+  if (state.uploading > 0) {
+    throw new CommandExecutionError(
+      `Gemini is still uploading ${state.uploading} of ${files.length} images after 90s; retry with smaller files`,
+    );
+  }
+  // Let the composer settle before typing so the focus stays in the editor.
+  await page.wait({ time: 0.5 });
+  return files.length;
+}
+
+export async function submitGeminiVideoPrompt(page, prompt) {
+  const focused = await page.evaluate(SCRIPT_FOCUS_EDITOR);
+  if (!focused) throw new CommandExecutionError("Gemini prompt editor was not found");
+  await page.nativeType(prompt);
+  const typed = await pollComposer(page, (s) => s.editorText.length > 0 && s.sendEnabled, {
+    timeoutMs: 5000,
+  });
+  if (!typed.editorText) throw new CommandExecutionError("Failed to insert the prompt into Gemini");
+  if (!typed.sendEnabled) throw new CommandExecutionError("Gemini send button stayed disabled");
+  const sent = await page.evaluate(SCRIPT_CLICK_SEND);
+  if (!sent) throw new CommandExecutionError("Gemini send button could not be clicked");
+  // A accepted submission clears the editor and opens a conversation URL; a
+  // dropped one leaves the prompt in place, which must fail fast instead of
+  // waiting the whole generation timeout for a clip that never comes.
+  const after = await pollComposer(
+    page,
+    (s) => s.editorText.length === 0 && /\/app\/[a-z0-9]+/i.test(s.url),
+    { timeoutMs: 30000 },
+  );
+  if (after.editorText.length > 0) {
+    throw new CommandExecutionError(
+      "Gemini did not accept the prompt; the composer still holds it",
+    );
+  }
+}
+
+/**
+ * Poll the newest model turn until a clip renders, Gemini reports a failure, or
+ * the deadline passes. Generation takes one to several minutes.
+ */
+export async function waitForGeminiVideo(page, timeoutSeconds, { intervalSeconds = 5 } = {}) {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let last = { status: "pending" };
+  for (;;) {
+    let snapshot = await page.evaluate(readGeminiVideoTurn);
+    last = classifyGeminiVideoState(snapshot);
+    if (last.status === "ready" && last.source.duration === null) {
+      // The player reports its length once metadata arrives, shortly after mount.
+      await page.wait({ time: 2 });
+      snapshot = await page.evaluate(readGeminiVideoTurn);
+      last = classifyGeminiVideoState(snapshot);
+    }
+    if (last.status === "ready") return { ...last.source, link: snapshot.url };
+    if (last.status === "error") {
+      throw new CommandExecutionError(`Gemini did not generate the video: ${last.message}`);
+    }
+    if (Date.now() >= deadline) return null;
+    await page.wait(Math.min(intervalSeconds, Math.max(0.5, (deadline - Date.now()) / 1000)));
+  }
+}
+
+/** Download the clip with the browser session's cookies; Gemini's media host refuses anonymous requests. */
+export async function downloadGeminiVideo(page, src, filePath, { fetchImpl = fetch } = {}) {
+  const cookies = await page.getCookies({ url: src });
+  const cookie = buildGeminiVideoCookieHeader(cookies, src);
+  const response = await fetchImpl(src, {
+    redirect: "follow",
+    headers: {
+      ...(cookie ? { cookie } : {}),
+      "user-agent": BROWSER_USER_AGENT,
+      referer: "https://gemini.google.com/",
+    },
+  });
+  const type = response.headers.get("content-type") || "";
+  if (!response.ok || !isVideoContentType(type)) {
+    throw new CommandExecutionError(
+      `Gemini video download returned ${response.status} ${type || "unknown type"}; open the conversation and download it manually`,
+    );
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, bytes);
+  return bytes.length;
+}

--- a/opencli-plugins/gemini/gemini-video-helpers.mjs
+++ b/opencli-plugins/gemini/gemini-video-helpers.mjs
@@ -1,0 +1,203 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export const GEMINI_VIDEO_URL = "https://gemini.google.com/videos";
+export const GEMINI_VIDEO_DEFAULT_OUTPUT = "~/tmp/gemini-videos";
+export const GEMINI_VIDEO_RATIOS = ["16:9", "9:16"];
+export const GEMINI_VIDEO_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".gif", ".heic"];
+export const GEMINI_VIDEO_MAX_IMAGES = 10;
+
+const RATIO_MENU_LABELS = {
+  "16:9": "Landscape (16:9)",
+  "9:16": "Portrait (9:16)",
+};
+
+/** Menu entry Gemini shows for an aspect ratio in the video composer. */
+export function geminiVideoRatioLabel(ratio) {
+  const label = RATIO_MENU_LABELS[String(ratio ?? "").trim()];
+  if (!label) throw new Error(`ratio must be one of: ${GEMINI_VIDEO_RATIOS.join(", ")}`);
+  return label;
+}
+
+export function integerInRange(value, name, min, max) {
+  const num = Number(value);
+  if (!Number.isInteger(num) || num < min || num > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  }
+  return num;
+}
+
+export function expandHomePath(value) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return "";
+  if (raw === "~") return os.homedir();
+  if (raw.startsWith("~/")) return path.join(os.homedir(), raw.slice(2));
+  return path.resolve(raw);
+}
+
+export function resolveGeminiVideoOutputDir(value) {
+  const expanded = expandHomePath(value);
+  return expanded || expandHomePath(GEMINI_VIDEO_DEFAULT_OUTPUT);
+}
+
+/**
+ * `--image` carries a comma-separated list because OpenCLI options are single
+ * valued. Paths are resolved against the working directory and must exist, so a
+ * typo fails before the browser session is touched.
+ */
+export function parseGeminiVideoImages(value, { exists = fs.existsSync } = {}) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return [];
+  const files = raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map((item) => expandHomePath(item));
+  if (files.length > GEMINI_VIDEO_MAX_IMAGES) {
+    throw new Error(`image accepts at most ${GEMINI_VIDEO_MAX_IMAGES} files`);
+  }
+  for (const file of files) {
+    const ext = path.extname(file).toLowerCase();
+    if (!GEMINI_VIDEO_IMAGE_EXTENSIONS.includes(ext)) {
+      throw new Error(`image ${file} must be one of: ${GEMINI_VIDEO_IMAGE_EXTENSIONS.join(", ")}`);
+    }
+    if (!exists(file)) throw new Error(`image not found: ${file}`);
+  }
+  return files;
+}
+
+const SAFE_NAME = /[^a-z0-9._-]+/gi;
+
+/** File name for the saved clip: explicit `--name` wins, else a timestamp. */
+export function buildGeminiVideoFileName(name, stamp = Date.now()) {
+  const raw = String(name ?? "").trim();
+  if (!raw) return `gemini_video_${stamp}.mp4`;
+  const cleaned = raw.replace(SAFE_NAME, "_").replace(/^_+|_+$/g, "");
+  if (!cleaned) return `gemini_video_${stamp}.mp4`;
+  return cleaned.toLowerCase().endsWith(".mp4") ? cleaned : `${cleaned}.mp4`;
+}
+
+const ERROR_PATTERNS = [
+  /couldn['’]t (?:generate|create)/i,
+  /can['’]t (?:generate|create)/i,
+  /unable to (?:generate|create)/i,
+  /daily limit/i,
+  /reached your limit/i,
+  /limit for (?:today|video)/i,
+  /not available/i,
+  /something went wrong/i,
+  /wasn['’]t able to/i,
+  /violat/i,
+];
+
+const GENERATING_PATTERNS = [/generating your video/i, /could take a few minutes/i];
+
+/** The part of the page that describes the current turn, without the sidebar. */
+export function geminiVideoStatusText(snapshot) {
+  const text = String(snapshot?.responseText ?? snapshot?.bodyTail ?? "");
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/** Pick the generated clip: the first `<video>` with a fetchable http(s) source. */
+export function pickGeminiVideoSource(videos) {
+  if (!Array.isArray(videos)) return null;
+  for (const video of videos) {
+    const src = String(video?.src ?? "").trim();
+    if (/^https?:\/\//i.test(src)) {
+      const duration = Number(video?.duration);
+      return {
+        src,
+        duration: Number.isFinite(duration) && duration > 0 ? duration : null,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Reduce a page snapshot to one of `ready`, `error`, `generating`, or `pending`.
+ * A rendered video wins over any wording because Gemini keeps the earlier
+ * progress copy on screen while the player mounts.
+ */
+export function classifyGeminiVideoState(snapshot) {
+  const source = pickGeminiVideoSource(snapshot?.videos);
+  if (source) return { status: "ready", source };
+  const text = geminiVideoStatusText(snapshot);
+  for (const pattern of ERROR_PATTERNS) {
+    const match = text.match(pattern);
+    if (match) {
+      const start = Math.max(0, match.index - 80);
+      return {
+        status: "error",
+        message: text.slice(start, match.index + 160).trim(),
+      };
+    }
+  }
+  if (GENERATING_PATTERNS.some((pattern) => pattern.test(text))) {
+    return { status: "generating" };
+  }
+  return { status: "pending" };
+}
+
+function cookieDomainMatches(cookieDomain, hostname) {
+  const domain = String(cookieDomain ?? "")
+    .replace(/^\./, "")
+    .toLowerCase();
+  if (!domain) return false;
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+/**
+ * Gemini serves clips from a usercontent host that redirects anonymous
+ * requests to a sign-in page, so the download needs the session cookies the
+ * browser would send. Only cookies whose domain covers the host are forwarded.
+ */
+export function buildGeminiVideoCookieHeader(cookies, url) {
+  let hostname;
+  try {
+    hostname = new URL(url).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+  const parts = [];
+  for (const cookie of Array.isArray(cookies) ? cookies : []) {
+    if (!cookie || typeof cookie.name !== "string" || typeof cookie.value !== "string") continue;
+    if (!cookieDomainMatches(cookie.domain, hostname)) continue;
+    parts.push(`${cookie.name}=${cookie.value}`);
+  }
+  return parts.join("; ");
+}
+
+export function isVideoContentType(value) {
+  const type = String(value ?? "").toLowerCase();
+  return type.startsWith("video/") || type.includes("octet-stream");
+}
+
+export function formatDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "";
+  return `${seconds.toFixed(1)}s`;
+}
+
+export function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+export function displayPath(filePath) {
+  const home = os.homedir();
+  return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+}
+
+export function summarizeGeminiVideoResult({ status, file, bytes, duration, link, images }) {
+  return {
+    status,
+    file: file ? displayPath(file) : "-",
+    size: bytes ? formatBytes(bytes) : "",
+    duration: formatDuration(duration),
+    images: Array.isArray(images) ? images.length : 0,
+    link: link || "",
+  };
+}

--- a/opencli-plugins/gemini/gemini-video-helpers.test.mjs
+++ b/opencli-plugins/gemini/gemini-video-helpers.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import {
+  buildGeminiVideoCookieHeader,
+  buildGeminiVideoFileName,
+  classifyGeminiVideoState,
+  expandHomePath,
+  formatBytes,
+  formatDuration,
+  GEMINI_VIDEO_DEFAULT_OUTPUT,
+  geminiVideoRatioLabel,
+  geminiVideoStatusText,
+  integerInRange,
+  isVideoContentType,
+  parseGeminiVideoImages,
+  pickGeminiVideoSource,
+  resolveGeminiVideoOutputDir,
+  summarizeGeminiVideoResult,
+} from "./gemini-video-helpers.mjs";
+
+const CLIP_URL =
+  "https://contribution-rt.usercontent.google.com/download?c=CgxiYXJk&filename=video.mp4&opi=103135050";
+
+test("geminiVideoRatioLabel maps ratios to Gemini menu entries", () => {
+  assert.equal(geminiVideoRatioLabel("16:9"), "Landscape (16:9)");
+  assert.equal(geminiVideoRatioLabel("9:16"), "Portrait (9:16)");
+  assert.throws(() => geminiVideoRatioLabel("4:3"), /ratio must be one of: 16:9, 9:16/);
+});
+
+test("integerInRange accepts integers inside the range only", () => {
+  assert.equal(integerInRange("600", "timeout", 30, 3600), 600);
+  assert.throws(() => integerInRange(10, "timeout", 30, 3600), /timeout must be an integer/);
+  assert.throws(() => integerInRange("1.5", "timeout", 30, 3600), /timeout must be an integer/);
+});
+
+test("expandHomePath resolves tilde and relative paths", () => {
+  assert.equal(expandHomePath("~"), os.homedir());
+  assert.equal(expandHomePath("~/tmp/x"), path.join(os.homedir(), "tmp", "x"));
+  assert.equal(expandHomePath("clips"), path.resolve("clips"));
+  assert.equal(expandHomePath("   "), "");
+});
+
+test("resolveGeminiVideoOutputDir falls back to the default directory", () => {
+  assert.equal(resolveGeminiVideoOutputDir(""), expandHomePath(GEMINI_VIDEO_DEFAULT_OUTPUT));
+  assert.equal(resolveGeminiVideoOutputDir("/tmp/out"), "/tmp/out");
+});
+
+test("parseGeminiVideoImages splits, resolves, and validates paths", () => {
+  const exists = (file) => file.endsWith("a.jpg") || file.endsWith("b.png");
+  assert.deepEqual(parseGeminiVideoImages("", { exists }), []);
+  assert.deepEqual(parseGeminiVideoImages(" /x/a.jpg , /y/b.png ", { exists }), [
+    "/x/a.jpg",
+    "/y/b.png",
+  ]);
+  assert.throws(() => parseGeminiVideoImages("/x/missing.jpg", { exists }), /image not found/);
+  assert.throws(() => parseGeminiVideoImages("/x/a.txt", { exists }), /must be one of/);
+  const many = Array.from({ length: 11 }, (_, i) => `/x/${i}a.jpg`).join(",");
+  assert.throws(() => parseGeminiVideoImages(many, { exists }), /at most 10 files/);
+});
+
+test("buildGeminiVideoFileName sanitizes names and appends .mp4", () => {
+  assert.equal(buildGeminiVideoFileName("", 42), "gemini_video_42.mp4");
+  assert.equal(buildGeminiVideoFileName("01 exterior dusk", 42), "01_exterior_dusk.mp4");
+  assert.equal(buildGeminiVideoFileName("clip.MP4", 42), "clip.MP4");
+  assert.equal(buildGeminiVideoFileName("///", 42), "gemini_video_42.mp4");
+});
+
+test("pickGeminiVideoSource returns the first http source with its duration", () => {
+  assert.equal(pickGeminiVideoSource([]), null);
+  assert.equal(pickGeminiVideoSource([{ src: "blob:https://gemini.google.com/x" }]), null);
+  assert.deepEqual(pickGeminiVideoSource([{ src: "" }, { src: CLIP_URL, duration: 10.005 }]), {
+    src: CLIP_URL,
+    duration: 10.005,
+  });
+  assert.deepEqual(pickGeminiVideoSource([{ src: CLIP_URL, duration: Number.NaN }]), {
+    src: CLIP_URL,
+    duration: null,
+  });
+});
+
+test("geminiVideoStatusText prefers the model turn over the body tail", () => {
+  assert.equal(
+    geminiVideoStatusText({
+      responseText: "Gemini said\n\nYour  video is ready!",
+      bodyTail: "x",
+    }),
+    "Gemini said Your video is ready!",
+  );
+  assert.equal(geminiVideoStatusText({ bodyTail: " tail " }), "tail");
+});
+
+test("classifyGeminiVideoState reports ready when a clip has rendered", () => {
+  const state = classifyGeminiVideoState({
+    videos: [{ src: CLIP_URL, duration: 10 }],
+    responseText: "I'm generating your video. This could take a few minutes.",
+  });
+  assert.equal(state.status, "ready");
+  assert.equal(state.source.src, CLIP_URL);
+});
+
+test("classifyGeminiVideoState reports generating and pending phases", () => {
+  assert.equal(
+    classifyGeminiVideoState({
+      videos: [],
+      responseText: "Generating your video… This could take a few minutes.",
+    }).status,
+    "generating",
+  );
+  assert.equal(classifyGeminiVideoState({ videos: [], responseText: "" }).status, "pending");
+});
+
+test("classifyGeminiVideoState surfaces Gemini failure copy", () => {
+  const state = classifyGeminiVideoState({
+    videos: [],
+    responseText:
+      "Gemini said I couldn't generate that video because it may violate our policies. Try a different prompt.",
+  });
+  assert.equal(state.status, "error");
+  assert.match(state.message, /couldn't generate that video/);
+  assert.equal(
+    classifyGeminiVideoState({
+      videos: [],
+      responseText: "You've reached your daily limit.",
+    }).status,
+    "error",
+  );
+});
+
+test("buildGeminiVideoCookieHeader forwards only cookies scoped to the host", () => {
+  const cookies = [
+    { name: "SID", value: "a", domain: ".google.com" },
+    { name: "_ga", value: "b", domain: ".gemini.google.com" },
+    { name: "bad", domain: ".google.com" },
+    { name: "x", value: "c", domain: "example.com" },
+  ];
+  assert.equal(buildGeminiVideoCookieHeader(cookies, CLIP_URL), "SID=a");
+  assert.equal(buildGeminiVideoCookieHeader(cookies, "not a url"), "");
+  assert.equal(buildGeminiVideoCookieHeader(null, CLIP_URL), "");
+});
+
+test("isVideoContentType accepts video and binary responses only", () => {
+  assert.equal(isVideoContentType("video/mp4"), true);
+  assert.equal(isVideoContentType("application/octet-stream"), true);
+  assert.equal(isVideoContentType("text/html; charset=utf-8"), false);
+  assert.equal(isVideoContentType(""), false);
+});
+
+test("formatters render durations and sizes", () => {
+  assert.equal(formatDuration(10.005), "10.0s");
+  assert.equal(formatDuration(Number.NaN), "");
+  assert.equal(formatBytes(4661590), "4.45 MB");
+  assert.equal(formatBytes(512), "512 B");
+  assert.equal(formatBytes(0), "0 B");
+});
+
+test("summarizeGeminiVideoResult builds the output row", () => {
+  const home = os.homedir();
+  const row = summarizeGeminiVideoResult({
+    status: "saved",
+    file: path.join(home, "tmp", "clip.mp4"),
+    bytes: 4661590,
+    duration: 10,
+    link: "https://gemini.google.com/app/abc",
+    images: ["/x/a.jpg"],
+  });
+  assert.deepEqual(row, {
+    status: "saved",
+    file: "~/tmp/clip.mp4",
+    size: "4.45 MB",
+    duration: "10.0s",
+    images: 1,
+    link: "https://gemini.google.com/app/abc",
+  });
+  assert.equal(summarizeGeminiVideoResult({ status: "generated" }).file, "-");
+});

--- a/opencli-plugins/gemini/opencli-plugin.json
+++ b/opencli-plugins/gemini/opencli-plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "rome-gemini",
+  "description": "Gemini web video generation commands for OpenCLI",
+  "version": "0.1.0",
+  "opencli": ">=1.8.0"
+}

--- a/opencli-plugins/gemini/package.json
+++ b/opencli-plugins/gemini/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "rome-opencli-gemini",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "../../scripts/test-env.sh node --test gemini-video-helpers.test.mjs"
+  }
+}

--- a/opencli-plugins/gemini/video.js
+++ b/opencli-plugins/gemini/video.js
@@ -1,0 +1,136 @@
+import * as path from "node:path";
+import { CommandExecutionError } from "@jackwener/opencli/errors";
+import { cli, Strategy } from "@jackwener/opencli/registry";
+import {
+  attachGeminiVideoImages,
+  downloadGeminiVideo,
+  openGeminiVideoComposer,
+  selectGeminiVideoRatio,
+  submitGeminiVideoPrompt,
+  waitForGeminiVideo,
+} from "./gemini-video-browser.mjs";
+import {
+  buildGeminiVideoFileName,
+  GEMINI_VIDEO_DEFAULT_OUTPUT,
+  GEMINI_VIDEO_RATIOS,
+  geminiVideoRatioLabel,
+  integerInRange,
+  parseGeminiVideoImages,
+  resolveGeminiVideoOutputDir,
+  summarizeGeminiVideoResult,
+} from "./gemini-video-helpers.mjs";
+
+cli({
+  site: "gemini",
+  name: "video",
+  access: "write",
+  description:
+    "Generate a video with Gemini web, optionally animating uploaded reference images, and save it locally",
+  example:
+    'opencli --cdp-endpoint http://127.0.0.1:9222 gemini video "Slow cinematic dolly toward the house at dusk" --image ./front.jpg --output ./clips --name front-dusk',
+  domain: "gemini.google.com",
+  strategy: Strategy.COOKIE,
+  browser: true,
+  siteSession: "persistent",
+  navigateBefore: false,
+  defaultFormat: "plain",
+  args: [
+    {
+      name: "prompt",
+      type: "string",
+      positional: true,
+      required: true,
+      help: "Describe the video; with --image, describe how the photo should move",
+    },
+    {
+      name: "image",
+      type: "string",
+      default: "",
+      help: "Comma-separated local image paths to attach as reference or start frames (needs --cdp-endpoint)",
+    },
+    {
+      name: "ratio",
+      type: "string",
+      default: "16:9",
+      choices: GEMINI_VIDEO_RATIOS,
+      help: "Aspect ratio: 16:9 (landscape) or 9:16 (portrait)",
+    },
+    {
+      name: "output",
+      type: "string",
+      default: GEMINI_VIDEO_DEFAULT_OUTPUT,
+      help: "Directory that receives the saved clip",
+    },
+    {
+      name: "name",
+      type: "string",
+      default: "",
+      help: "File name for the clip (default: gemini_video_<timestamp>.mp4)",
+    },
+    {
+      name: "timeout",
+      type: "int",
+      default: 600,
+      help: "Max seconds to wait for the generation (default: 600)",
+    },
+    {
+      name: "sd",
+      type: "boolean",
+      default: false,
+      help: "Skip the download; only report the conversation link",
+    },
+  ],
+  columns: ["status", "file", "size", "duration", "images", "link"],
+  func: async (page, kwargs) => {
+    if (!page) throw new CommandExecutionError("Browser session required for gemini video");
+    let images;
+    let ratioLabel;
+    let timeout;
+    let outputDir;
+    const prompt = String(kwargs.prompt ?? "").trim();
+    try {
+      if (!prompt) throw new Error("prompt must not be empty");
+      images = parseGeminiVideoImages(kwargs.image);
+      ratioLabel = geminiVideoRatioLabel(kwargs.ratio ?? "16:9");
+      timeout = integerInRange(kwargs.timeout ?? 600, "timeout", 30, 3600);
+      outputDir = resolveGeminiVideoOutputDir(kwargs.output);
+    } catch (error) {
+      throw new CommandExecutionError(error instanceof Error ? error.message : String(error));
+    }
+
+    await openGeminiVideoComposer(page);
+    await selectGeminiVideoRatio(page, ratioLabel);
+    await attachGeminiVideoImages(page, images);
+    await submitGeminiVideoPrompt(page, prompt);
+
+    const video = await waitForGeminiVideo(page, timeout);
+    if (!video) {
+      const link = await page.evaluate("window.location.href").catch(() => "");
+      throw new CommandExecutionError(
+        `No video appeared within ${timeout}s; Gemini may still be generating at ${link || "https://gemini.google.com/app"}`,
+      );
+    }
+    if (kwargs.sd === true) {
+      return [
+        summarizeGeminiVideoResult({
+          status: "generated",
+          duration: video.duration,
+          link: video.link,
+          images,
+        }),
+      ];
+    }
+    const file = path.join(outputDir, buildGeminiVideoFileName(kwargs.name));
+    const bytes = await downloadGeminiVideo(page, video.src, file);
+    return [
+      summarizeGeminiVideoResult({
+        status: "saved",
+        file,
+        bytes,
+        duration: video.duration,
+        link: video.link,
+        images,
+      }),
+    ];
+  },
+});

--- a/opencli-plugins/zillow/download.js
+++ b/opencli-plugins/zillow/download.js
@@ -1,0 +1,102 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { httpDownload } from "@jackwener/opencli/download";
+import { CommandExecutionError, getErrorMessage } from "@jackwener/opencli/errors";
+import { cli, Strategy } from "@jackwener/opencli/registry";
+import { readZillowListingPhotos } from "./zillow-browser.mjs";
+import {
+  canonicalZillowListingUrl,
+  DEFAULT_ZILLOW_EXAMPLE_URL,
+  DEFAULT_ZILLOW_OUTPUT,
+  describeZillowListing,
+  integerInRange,
+  planZillowDownloads,
+  summarizeZillowDownload,
+  ZILLOW_PHOTO_SIZES,
+  zillowListingSlug,
+} from "./zillow-helpers.mjs";
+
+cli({
+  site: "zillow",
+  name: "download",
+  access: "read",
+  description: "Download every gallery photo of a public Zillow listing",
+  example: `opencli zillow download ${DEFAULT_ZILLOW_EXAMPLE_URL} --output ./zillow-downloads`,
+  domain: "zillow.com",
+  strategy: Strategy.PUBLIC,
+  browser: true,
+  args: [
+    {
+      name: "url",
+      type: "string",
+      positional: true,
+      required: true,
+      help: `Zillow listing URL, e.g. ${DEFAULT_ZILLOW_EXAMPLE_URL}`,
+    },
+    {
+      name: "output",
+      type: "string",
+      default: DEFAULT_ZILLOW_OUTPUT,
+      help: "Directory that receives one <address>-<zpid> folder per listing",
+    },
+    {
+      name: "size",
+      type: "string",
+      default: "full",
+      choices: ZILLOW_PHOTO_SIZES,
+      help: "Photo variant to download: full (widest original-ratio bucket, up to 1536px), large (1344px), medium (1024px), small (800px), or thumb (384px crop)",
+    },
+    {
+      name: "limit",
+      type: "int",
+      default: 0,
+      help: "Maximum photos to download in gallery order (0 = all)",
+    },
+  ],
+  columns: ["index", "status", "size", "file", "caption", "width", "url"],
+  func: async (page, kwargs) => {
+    if (!page) throw new CommandExecutionError("Browser session required for zillow download");
+    let url;
+    let limit;
+    let output;
+    try {
+      url = canonicalZillowListingUrl(kwargs.url);
+      limit = integerInRange(kwargs.limit ?? 0, "limit", 0, 1000);
+      output = String(kwargs.output || DEFAULT_ZILLOW_OUTPUT).trim() || DEFAULT_ZILLOW_OUTPUT;
+      if (!ZILLOW_PHOTO_SIZES.includes(kwargs.size)) {
+        throw new Error(`size must be one of: ${ZILLOW_PHOTO_SIZES.join(", ")}`);
+      }
+    } catch (error) {
+      throw new CommandExecutionError(error instanceof Error ? error.message : String(error));
+    }
+
+    const { pageData, photos } = await readZillowListingPhotos(page, url);
+    const listing = describeZillowListing(pageData, url);
+    const plan = planZillowDownloads(photos, { size: kwargs.size, limit });
+
+    const outputDir = path.resolve(output, zillowListingSlug(listing.url || url));
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    const rows = [];
+    for (const item of plan) {
+      if (!item.url) {
+        rows.push(
+          summarizeZillowDownload(item, { success: false, error: "No photo URL" }, { listing }),
+        );
+        continue;
+      }
+      const file = path.join(outputDir, item.file_name);
+      let result;
+      try {
+        result = await httpDownload(item.url, file, {
+          headers: { Referer: "https://www.zillow.com/" },
+          timeout: 60000,
+        });
+      } catch (error) {
+        result = { success: false, size: 0, error: getErrorMessage(error) };
+      }
+      rows.push(summarizeZillowDownload(item, result, { listing, file }));
+    }
+    return rows;
+  },
+});

--- a/opencli-plugins/zillow/opencli-plugin.json
+++ b/opencli-plugins/zillow/opencli-plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "rome-zillow",
+  "description": "Public Zillow listing photo commands for OpenCLI",
+  "version": "0.1.0",
+  "opencli": ">=1.8.0"
+}

--- a/opencli-plugins/zillow/package.json
+++ b/opencli-plugins/zillow/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "rome-opencli-zillow",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "../../scripts/test-env.sh node --test zillow-helpers.test.mjs"
+  }
+}

--- a/opencli-plugins/zillow/photos.js
+++ b/opencli-plugins/zillow/photos.js
@@ -1,0 +1,64 @@
+import { CommandExecutionError } from "@jackwener/opencli/errors";
+import { cli, Strategy } from "@jackwener/opencli/registry";
+import { readZillowListingPhotos } from "./zillow-browser.mjs";
+import {
+  canonicalZillowListingUrl,
+  DEFAULT_ZILLOW_EXAMPLE_URL,
+  describeZillowListing,
+  integerInRange,
+  normalizePhotoRow,
+  ZILLOW_PHOTO_SIZES,
+} from "./zillow-helpers.mjs";
+
+cli({
+  site: "zillow",
+  name: "photos",
+  access: "read",
+  description: "List every gallery photo of a public Zillow listing with captions and CDN URLs",
+  example: `opencli zillow photos ${DEFAULT_ZILLOW_EXAMPLE_URL} -f json`,
+  domain: "zillow.com",
+  strategy: Strategy.PUBLIC,
+  browser: true,
+  args: [
+    {
+      name: "url",
+      type: "string",
+      positional: true,
+      required: true,
+      help: `Zillow listing URL, e.g. ${DEFAULT_ZILLOW_EXAMPLE_URL}`,
+    },
+    {
+      name: "size",
+      type: "string",
+      default: "full",
+      choices: ZILLOW_PHOTO_SIZES,
+      help: "Photo variant reported in the url column: full (widest original-ratio bucket, up to 1536px), large (1344px), medium (1024px), small (800px), or thumb (384px crop)",
+    },
+    {
+      name: "limit",
+      type: "int",
+      default: 0,
+      help: "Maximum photos to return in gallery order (0 = all)",
+    },
+  ],
+  columns: ["index", "photo_key", "caption", "subject_type", "width", "url"],
+  func: async (page, kwargs) => {
+    if (!page) throw new CommandExecutionError("Browser session required for zillow photos");
+    let url;
+    let limit;
+    try {
+      url = canonicalZillowListingUrl(kwargs.url);
+      limit = integerInRange(kwargs.limit ?? 0, "limit", 0, 1000);
+      if (!ZILLOW_PHOTO_SIZES.includes(kwargs.size)) {
+        throw new Error(`size must be one of: ${ZILLOW_PHOTO_SIZES.join(", ")}`);
+      }
+    } catch (error) {
+      throw new CommandExecutionError(error instanceof Error ? error.message : String(error));
+    }
+
+    const { pageData, photos } = await readZillowListingPhotos(page, url);
+    const listing = describeZillowListing(pageData, url);
+    const selected = limit > 0 ? photos.slice(0, limit) : photos;
+    return selected.map((photo) => normalizePhotoRow(photo, listing, kwargs.size));
+  },
+});

--- a/opencli-plugins/zillow/zillow-browser.mjs
+++ b/opencli-plugins/zillow/zillow-browser.mjs
@@ -1,0 +1,259 @@
+import { CommandExecutionError } from "@jackwener/opencli/errors";
+import {
+  collectZillowPhotos,
+  detectZillowChallenge,
+  detectZillowNotFound,
+  detectZillowUnavailable,
+  isPerimeterXCookie,
+  isZillowUrl,
+} from "./zillow-helpers.mjs";
+
+/**
+ * Runs inside the listing page, so it must stay self-contained: `page.evaluate`
+ * serializes the function source and cannot carry module-scope bindings along.
+ *
+ * Zillow renders its home details page with Next.js and embeds the GraphQL
+ * response the page was built from in `<script id="__NEXT_DATA__">`, under
+ * `props.pageProps.componentProps.gdpClientCache` (a JSON string keyed by
+ * query name, `ForSalePriorityQuery{...}` or `NotForSalePriorityQuery{...}`).
+ * The entry's `property.responsivePhotosOriginalRatio` is the complete gallery
+ * in display order with the CDN URL of every width bucket of each photo, and
+ * `property.responsivePhotos` is the cropped ladder of the same photos. A 404
+ * renders the same script with `pageProps.errorMessage` instead. Only when
+ * that state is absent does the reader fall back to scraping CDN URLs out of
+ * the HTML.
+ */
+export function readZillowListingPage() {
+  var out = {
+    url: location.href,
+    title: document.title || "",
+    body_text: "",
+    hydrated: false,
+    challenge: false,
+    error_message: "",
+    sub_app: "",
+    property: null,
+    html_photo_urls: [],
+  };
+  try {
+    out.body_text = String((document.body && document.body.innerText) || "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 3000);
+  } catch (_) {
+    out.body_text = "";
+  }
+  try {
+    out.challenge = !!document.querySelector("#px-captcha");
+  } catch (_) {
+    out.challenge = false;
+  }
+
+  var nextData = null;
+  try {
+    var script = document.getElementById("__NEXT_DATA__");
+    nextData = script && script.textContent ? JSON.parse(script.textContent) : null;
+  } catch (_) {
+    nextData = null;
+  }
+  if (!nextData && window.__NEXT_DATA__ && typeof window.__NEXT_DATA__ === "object") {
+    nextData = window.__NEXT_DATA__;
+  }
+
+  function sources(entry) {
+    var list = entry && entry.mixedSources && entry.mixedSources.jpeg;
+    if (!Array.isArray(list)) return [];
+    var result = [];
+    for (var i = 0; i < list.length; i++) {
+      if (list[i] && list[i].url) result.push({ url: list[i].url, width: list[i].width });
+    }
+    return result;
+  }
+  function photoSlice(list) {
+    if (!Array.isArray(list)) return null;
+    var result = [];
+    for (var i = 0; i < list.length; i++) {
+      var entry = list[i] || {};
+      result.push({
+        caption: entry.caption,
+        subjectType: entry.subjectType,
+        key: entry.key,
+        url: entry.url,
+        mixedSources: { jpeg: sources(entry) },
+      });
+    }
+    return result;
+  }
+
+  var pageProps = nextData && nextData.props && nextData.props.pageProps;
+  if (pageProps) {
+    out.hydrated = true;
+    out.error_message = pageProps.errorMessage ? String(pageProps.errorMessage) : "";
+    out.sub_app = pageProps.subAppName ? String(pageProps.subAppName) : "";
+    var componentProps = pageProps.componentProps;
+    var cache = componentProps && componentProps.gdpClientCache;
+    if (typeof cache === "string") {
+      try {
+        cache = JSON.parse(cache);
+      } catch (_) {
+        cache = null;
+      }
+    }
+    if (cache && typeof cache === "object") {
+      var keys = Object.keys(cache);
+      for (var k = 0; k < keys.length; k++) {
+        var property = cache[keys[k]] && cache[keys[k]].property;
+        if (!property || typeof property !== "object") continue;
+        out.property = {
+          zpid: property.zpid,
+          streetAddress: property.streetAddress,
+          city: property.city,
+          state: property.state,
+          zipcode: property.zipcode,
+          address: property.address,
+          homeStatus: property.homeStatus,
+          hdpUrl: property.hdpUrl,
+          photoCount: property.photoCount,
+          mlsid: property.mlsid,
+          hiResImageLink: property.hiResImageLink,
+          responsivePhotosOriginalRatio: photoSlice(property.responsivePhotosOriginalRatio),
+          responsivePhotos: photoSlice(property.responsivePhotos),
+        };
+        break;
+      }
+    }
+  }
+
+  var hasPhotos =
+    out.property &&
+    ((Array.isArray(out.property.responsivePhotosOriginalRatio) &&
+      out.property.responsivePhotosOriginalRatio.length > 0) ||
+      (Array.isArray(out.property.responsivePhotos) && out.property.responsivePhotos.length > 0));
+  if (!hasPhotos) {
+    var html = document.documentElement ? document.documentElement.outerHTML : "";
+    var matches =
+      html.match(
+        /https?:\\?\/\\?\/photos\.zillowstatic\.com\\?\/fp\\?\/[0-9a-f]{32}-[^"'\s\\<>)]+/gi,
+      ) || [];
+    var seen = {};
+    for (var j = 0; j < matches.length; j++) {
+      var url = matches[j].replace(/\\\//g, "/");
+      if (!seen[url]) {
+        seen[url] = true;
+        out.html_photo_urls.push(url);
+      }
+    }
+  }
+  return out;
+}
+
+function hasReadablePhotos(pageData) {
+  return collectZillowPhotos(pageData).photos.length > 0;
+}
+
+async function navigateAndRead(page, url, timeoutMs) {
+  const currentUrl = await page.evaluate("window.location.href || ''").catch(() => "");
+  if (isZillowUrl(currentUrl)) {
+    await page.goto("about:blank", { waitUntil: "none" });
+  }
+  await page.goto(url);
+
+  const deadline = Date.now() + timeoutMs;
+  let pageData = null;
+  for (;;) {
+    pageData = await page.evaluate(readZillowListingPage);
+    if (
+      pageData?.hydrated ||
+      hasReadablePhotos(pageData) ||
+      detectZillowChallenge(pageData) ||
+      detectZillowUnavailable(pageData) ||
+      detectZillowNotFound(pageData) ||
+      Date.now() >= deadline
+    ) {
+      break;
+    }
+    await page.wait({ time: 0.5 });
+  }
+  return pageData;
+}
+
+/**
+ * Zillow's PerimeterX sensor scores every page load and stores its verdict in
+ * the `_px*`/`pxcts` cookies. A verdict written during an automated load blocks
+ * the next navigation with a "Press & Hold" wall, while a visitor without those
+ * cookies gets the page. Deleting only those cookies resets the verdict and
+ * leaves the rest of the guardian's Zillow session alone. Returns the number of
+ * cookies deleted.
+ */
+export async function resetPerimeterXCookies(page) {
+  let cookies;
+  try {
+    cookies = await page.getCookies({ url: "https://www.zillow.com/" });
+  } catch (_) {
+    return 0;
+  }
+  const targets = (Array.isArray(cookies) ? cookies : []).filter(isPerimeterXCookie);
+  let deleted = 0;
+  for (const cookie of targets) {
+    try {
+      await page.cdp("Network.deleteCookies", {
+        name: cookie.name,
+        domain: cookie.domain,
+        path: cookie.path || "/",
+      });
+      deleted += 1;
+    } catch (_) {
+      // A cookie the browser refuses to delete leaves the verdict in place; the
+      // retry then reports the wall instead of looping.
+    }
+  }
+  return deleted;
+}
+
+function isRefusedLoad(pageData) {
+  return detectZillowChallenge(pageData) || detectZillowUnavailable(pageData);
+}
+
+/**
+ * Navigate to the listing and poll until Zillow's page state is present (or
+ * the page has settled on a challenge, error, or not-found screen). A refused
+ * load is retried once after resetting the PerimeterX cookies. Leaving a Zillow
+ * page first keeps the client-side router from swallowing the navigation.
+ */
+export async function loadZillowListingPage(page, url, { timeoutMs = 20000 } = {}) {
+  let pageData = await navigateAndRead(page, url, timeoutMs);
+  if (isRefusedLoad(pageData)) {
+    await resetPerimeterXCookies(page);
+    pageData = await navigateAndRead(page, url, timeoutMs);
+  }
+  return pageData;
+}
+
+export function assertReadableZillowPage(pageData, url) {
+  if (detectZillowChallenge(pageData)) {
+    throw new CommandExecutionError(
+      "Zillow served a bot-check or access challenge; clear it in the browser and retry",
+    );
+  }
+  if (detectZillowUnavailable(pageData)) {
+    throw new CommandExecutionError(
+      `Zillow refused to serve ${url} (HTTP error page); wait a moment and retry`,
+    );
+  }
+  if (detectZillowNotFound(pageData)) {
+    throw new CommandExecutionError(`Zillow has no listing page at ${url}`);
+  }
+}
+
+/** Load a listing and return its gallery photos plus where they came from. */
+export async function readZillowListingPhotos(page, url) {
+  const pageData = await loadZillowListingPage(page, url);
+  assertReadableZillowPage(pageData, url);
+  const { photos, source } = collectZillowPhotos(pageData);
+  if (photos.length === 0) {
+    throw new CommandExecutionError(
+      `Zillow exposed no listing photos at ${url}; pass a home details URL such as https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/`,
+    );
+  }
+  return { pageData, photos, source };
+}

--- a/opencli-plugins/zillow/zillow-helpers.mjs
+++ b/opencli-plugins/zillow/zillow-helpers.mjs
@@ -1,0 +1,439 @@
+// Pure helpers for the Zillow plugin. Nothing here touches the browser or the
+// filesystem, so every function is exercised directly by zillow-helpers.test.mjs.
+
+export const DEFAULT_ZILLOW_OUTPUT = "./zillow-downloads";
+export const DEFAULT_ZILLOW_EXAMPLE_URL =
+  "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/";
+
+/**
+ * Zillow publishes each listing photo as a fixed ladder of width buckets. The
+ * original-ratio ladder (`d_d` 800, `o_a` 1024, `uncropped_scaled_within_1344_1008`,
+ * `uncropped_scaled_within_1536_1152`) scales the source photo down to fit the
+ * bucket and never scales it up, so the widest bucket is the most faithful
+ * served copy. The cropped ladder (`cc_ft_<width>`, 192 to 1536) trims the frame
+ * to a fixed aspect ratio at small widths and only serves `thumb`. The listing's
+ * `hiResImageLink` (`p_f`) is not on either ladder: it resizes every photo to
+ * 1024px wide, upscaling small sources, so no size maps to it.
+ */
+export const ZILLOW_PHOTO_SIZES = ["full", "large", "medium", "small", "thumb"];
+
+const SIZE_TARGET_WIDTH = {
+  full: Number.POSITIVE_INFINITY,
+  large: 1344,
+  medium: 1024,
+  small: 800,
+  thumb: 384,
+};
+
+const ZILLOW_HOSTNAME = /^(?:[a-z0-9-]+\.)*zillow\.com$/i;
+const PX_COOKIE_NAME = /^(?:_px[a-z0-9]*|pxcts)$/i;
+const PHOTO_KEY = /^[0-9a-f]{32}$/i;
+
+export function cleanText(value) {
+  return String(value ?? "")
+    .replace(/[\u00a0\u202f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function integerInRange(value, name, minimum, maximum) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return parsed;
+}
+
+function isHttpUrl(value) {
+  return typeof value === "string" && /^https?:\/\//i.test(value);
+}
+
+function urlBasename(url) {
+  try {
+    const segments = new URL(url).pathname.split("/").filter(Boolean);
+    return decodeURIComponent(segments[segments.length - 1] || "");
+  } catch (_) {
+    return "";
+  }
+}
+
+/**
+ * Accept a listing URL with or without a scheme, require a Zillow host, and
+ * drop query/hash so tracking parameters never reach the browser or the output.
+ */
+export function canonicalZillowListingUrl(input) {
+  const text = cleanText(input);
+  if (!text) throw new Error("url must not be empty");
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(text) ? text : `https://${text}`;
+  let url;
+  try {
+    url = new URL(withScheme);
+  } catch (_) {
+    throw new Error(`url is not a valid URL: ${text}`);
+  }
+  if (!/^https?:$/i.test(url.protocol) || !ZILLOW_HOSTNAME.test(url.hostname)) {
+    throw new Error(`url must be a Zillow listing URL such as ${DEFAULT_ZILLOW_EXAMPLE_URL}`);
+  }
+  url.protocol = "https:";
+  url.search = "";
+  url.hash = "";
+  const canonical = url.toString();
+  return canonical.endsWith("/") ? canonical : `${canonical}/`;
+}
+
+export function isZillowUrl(value) {
+  try {
+    return ZILLOW_HOSTNAME.test(new URL(String(value ?? "")).hostname);
+  } catch (_) {
+    return false;
+  }
+}
+
+/** PerimeterX cookies carry Zillow's bot verdict; nothing else on the site does. */
+export function isPerimeterXCookie(cookie) {
+  return PX_COOKIE_NAME.test(cleanText(cookie?.name));
+}
+
+function sanitizeSegment(value) {
+  return String(value ?? "")
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "");
+}
+
+/** The zpid encoded in a home details path such as `/homedetails/<slug>/15598337_zpid/`. */
+export function zillowZpidFromUrl(url) {
+  let pathname;
+  try {
+    pathname = new URL(url).pathname;
+  } catch (_) {
+    return "";
+  }
+  const match = /\/(\d+)_zpid(?:\/|$)/i.exec(pathname);
+  return match ? match[1] : "";
+}
+
+/**
+ * Folder name for one listing: `<address slug>-<zpid>` from a canonical home
+ * details URL such as `/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/`.
+ * The zpid keeps two listings that share a street address apart.
+ */
+export function zillowListingSlug(url) {
+  let segments;
+  try {
+    segments = new URL(url).pathname.split("/").filter(Boolean);
+  } catch (_) {
+    segments = [];
+  }
+  const zpidIndex = segments.findIndex((segment) => /^\d+_zpid$/i.test(segment));
+  const parts = [];
+  if (zpidIndex >= 0) {
+    const address = segments[zpidIndex - 1];
+    if (address && !/^homedetails$/i.test(address)) parts.push(address);
+    if (parts.length === 0) parts.push("zillow");
+    parts.push(segments[zpidIndex].replace(/_zpid$/i, ""));
+  } else {
+    parts.push(...segments.filter((segment) => !/^homedetails$/i.test(segment)));
+  }
+  const slug = sanitizeSegment(parts.join("-"));
+  return slug || "zillow-listing";
+}
+
+export function detectZillowChallenge(pageData) {
+  const title = cleanText(pageData?.title);
+  const body = cleanText(pageData?.body_text);
+  return (
+    pageData?.challenge === true ||
+    /access to this page has been denied|access denied|captcha/i.test(title) ||
+    /press\s*&\s*hold|confirm you are (?:a )?human|verify you are (?:a )?human|are you a robot|unusual (?:traffic|activity)|captcha/i.test(
+      body,
+    )
+  );
+}
+
+export function detectZillowNotFound(pageData) {
+  const title = cleanText(pageData?.title);
+  const body = cleanText(pageData?.body_text);
+  const error = cleanText(pageData?.error_message);
+  return (
+    /page not found|not found/i.test(error) ||
+    /page not found/i.test(title) ||
+    /error 404|page not found/i.test(body)
+  );
+}
+
+/**
+ * Zillow answers some automated loads with a bare HTTP 5xx and no page at all,
+ * which Chrome renders as its own error page. That load is a refusal, not a
+ * listing, so the loader treats it like a challenge and retries once.
+ */
+export function detectZillowUnavailable(pageData) {
+  const url = cleanText(pageData?.url);
+  const body = cleanText(pageData?.body_text);
+  return (
+    /^chrome-error:/i.test(url) ||
+    /http error 5\d\d|is currently unable to handle this request|this page isn.t working/i.test(
+      body,
+    )
+  );
+}
+
+export function describeZillowListing(pageData, fallbackUrl = "") {
+  const property = pageData?.property || {};
+  const address = property.address && typeof property.address === "object" ? property.address : {};
+  const street = cleanText(property.streetAddress || address.streetAddress);
+  const city = cleanText(property.city || address.city);
+  const state = cleanText(property.state || address.state);
+  const zip = cleanText(property.zipcode || address.zipcode);
+  const locality = [city, [state, zip].filter(Boolean).join(" ")].filter(Boolean).join(", ");
+  const assembled = [street, locality].filter(Boolean).join(", ");
+  let url = cleanText(pageData?.url) || cleanText(fallbackUrl);
+  const hdpUrl = cleanText(property.hdpUrl);
+  if (hdpUrl.startsWith("/")) url = `https://www.zillow.com${hdpUrl}`;
+  return {
+    url,
+    title: cleanText(pageData?.title),
+    address: assembled,
+    street,
+    city,
+    state,
+    zip,
+    status: cleanText(property.homeStatus).toLowerCase().replace(/_/g, " "),
+    zpid: property.zpid != null ? String(property.zpid) : zillowZpidFromUrl(url),
+    mls_id: cleanText(property.mlsid),
+    photo_count: Number.isInteger(property.photoCount) ? property.photoCount : null,
+  };
+}
+
+/** Photo key encoded in a CDN URL such as `.../fp/<32 hex>-o_a.jpg`. */
+export function zillowPhotoKey(url) {
+  const match = /^([0-9a-f]{32})(?:-|\.|$)/i.exec(urlBasename(url));
+  return match ? match[1].toLowerCase() : "";
+}
+
+/** The JPEG sources of one ladder entry, widest first. */
+function jpegSources(entry) {
+  const list = entry?.mixedSources?.jpeg;
+  if (!Array.isArray(list)) return [];
+  return list
+    .filter((source) => isHttpUrl(source?.url))
+    .map((source) => ({ url: source.url, width: Number(source.width) || 0 }))
+    .sort((a, b) => b.width - a.width);
+}
+
+/**
+ * One gallery entry from Zillow's `responsivePhotosOriginalRatio` list, joined
+ * with the cropped ladder of the same position from `responsivePhotos`. Both
+ * lists come from the same page state in the same order.
+ */
+export function normalizeZillowPhoto(candidate, index, cropped = null) {
+  const original = jpegSources(candidate);
+  const croppedSources = jpegSources(cropped);
+  const anyUrl = original[0]?.url || croppedSources[0]?.url || candidate?.url || "";
+  const key = PHOTO_KEY.test(String(candidate?.key ?? ""))
+    ? String(candidate.key).toLowerCase()
+    : zillowPhotoKey(anyUrl);
+  return {
+    index: index + 1,
+    photo_key: key,
+    caption: cleanText(candidate?.caption ?? cropped?.caption),
+    subject_type: cleanText(candidate?.subjectType ?? cropped?.subjectType),
+    original,
+    cropped: croppedSources,
+  };
+}
+
+function uniqueInOrder(values) {
+  const seen = new Set();
+  return values.filter((value) => {
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return true;
+  });
+}
+
+/**
+ * Gallery photos for the listing, in Zillow's display order. The page state's
+ * original-ratio list is authoritative. When it is missing, CDN URLs scraped
+ * from the HTML stand in, grouped by photo key in order of first appearance,
+ * with only the widest variant of each key kept.
+ */
+export function collectZillowPhotos(pageData) {
+  const property = pageData?.property || {};
+  const originals = Array.isArray(property.responsivePhotosOriginalRatio)
+    ? property.responsivePhotosOriginalRatio
+    : [];
+  const cropped = Array.isArray(property.responsivePhotos) ? property.responsivePhotos : [];
+  const fromState = originals
+    .map((candidate, index) => normalizeZillowPhoto(candidate, index, cropped[index] || null))
+    .filter((photo) => photo.original.length > 0 || photo.cropped.length > 0)
+    .map((photo, index) => ({ ...photo, index: index + 1 }));
+  if (fromState.length > 0) return { photos: fromState, source: "state" };
+
+  const croppedOnly = cropped
+    .map((candidate, index) => normalizeZillowPhoto(null, index, candidate))
+    .filter((photo) => photo.cropped.length > 0)
+    .map((photo, index) => ({ ...photo, index: index + 1 }));
+  if (croppedOnly.length > 0) return { photos: croppedOnly, source: "state" };
+
+  const htmlUrls = uniqueInOrder(
+    (Array.isArray(pageData?.html_photo_urls) ? pageData.html_photo_urls : []).filter(isHttpUrl),
+  );
+  const byKey = new Map();
+  for (const url of htmlUrls) {
+    const key = zillowPhotoKey(url);
+    if (!key) continue;
+    if (!byKey.has(key)) byKey.set(key, []);
+    byKey.get(key).push(url);
+  }
+  const photos = [...byKey.entries()].map(([key, urls], index) => {
+    const ranked = urls
+      .map((url) => ({ url, width: zillowVariantWidth(url) }))
+      .sort((a, b) => b.width - a.width);
+    return {
+      index: index + 1,
+      photo_key: key,
+      caption: "",
+      subject_type: "",
+      original: ranked.filter((entry) => !/-cc_ft_\d+\./i.test(entry.url)),
+      cropped: ranked.filter((entry) => /-cc_ft_\d+\./i.test(entry.url)),
+    };
+  });
+  return { photos, source: photos.length > 0 ? "html" : "none" };
+}
+
+/** Width bucket encoded in a CDN variant name, for ranking scraped URLs. */
+export function zillowVariantWidth(url) {
+  const name = urlBasename(url);
+  let match = /-uncropped_scaled_within_(\d+)_\d+\./i.exec(name);
+  if (match) return Number(match[1]);
+  match = /-cc_ft_(\d+)\./i.exec(name);
+  if (match) return Number(match[1]);
+  if (/-o_a\./i.test(name)) return 1024;
+  if (/-d_d\./i.test(name)) return 800;
+  if (/-p_f\./i.test(name)) return 1024;
+  if (/-p_h\./i.test(name)) return 550;
+  if (/-p_e\./i.test(name)) return 596;
+  if (/-p_d\./i.test(name)) return 400;
+  return 0;
+}
+
+/**
+ * The variant for a requested size: the widest original-ratio bucket that fits
+ * the size's target width, else the narrowest bucket above it. `thumb` reads
+ * the cropped ladder instead, because the original-ratio ladder stops at 800.
+ * A photo with no usable bucket at all yields an empty URL.
+ */
+export function selectZillowPhotoUrl(photo, size) {
+  const target = SIZE_TARGET_WIDTH[size] ?? Number.POSITIVE_INFINITY;
+  const ladder = size === "thumb" ? photo?.cropped : photo?.original;
+  const fallback = size === "thumb" ? photo?.original : photo?.cropped;
+  const chosen = pickWidth(ladder, target) || pickWidth(fallback, target);
+  return chosen ? { url: chosen.url, width: chosen.width } : { url: "", width: 0 };
+}
+
+function pickWidth(sources, target) {
+  if (!Array.isArray(sources) || sources.length === 0) return null;
+  const fitting = sources.filter((entry) => entry.width <= target);
+  if (fitting.length > 0) return fitting[0];
+  return sources[sources.length - 1];
+}
+
+/**
+ * `01-40a2df03a9e1e7ce67de59c614683f5f.jpg`: a zero-padded gallery position
+ * keeps files sorted the way Zillow shows them, and the CDN photo key keeps
+ * the asset provenance. Sizes other than `full` carry the size so variants of
+ * one photo never overwrite each other in a shared folder.
+ */
+export function buildZillowPhotoFilename({ url, key, index, total, size }) {
+  const width = Math.max(2, String(Math.max(Number(total) || 0, Number(index) || 0)).length);
+  const prefix = String(index).padStart(width, "0");
+  const extension = (
+    (/\.([A-Za-z0-9]{2,5})$/.exec(urlBasename(url)) || [])[1] || "jpg"
+  ).toLowerCase();
+  const base = PHOTO_KEY.test(String(key ?? ""))
+    ? String(key).toLowerCase()
+    : sanitizeSegment(urlBasename(url).replace(/\.[A-Za-z0-9]{2,5}$/, "")) || "photo";
+  return size && size !== "full"
+    ? `${prefix}-${size}-${base}.${extension}`
+    : `${prefix}-${base}.${extension}`;
+}
+
+/** One download plan entry per photo: which URL to fetch and what to name it. */
+export function planZillowDownloads(photos, { size = "full", limit = 0 } = {}) {
+  const selected = limit > 0 ? photos.slice(0, limit) : photos;
+  const total = selected.length;
+  return selected.map((photo, order) => {
+    const index = order + 1;
+    const chosen = selectZillowPhotoUrl(photo, size);
+    return {
+      index,
+      photo_key: photo.photo_key,
+      caption: photo.caption,
+      subject_type: photo.subject_type,
+      width: chosen.width,
+      url: chosen.url,
+      file_name: chosen.url
+        ? buildZillowPhotoFilename({ url: chosen.url, key: photo.photo_key, index, total, size })
+        : "",
+    };
+  });
+}
+
+export function formatBytes(bytes) {
+  const value = Number(bytes);
+  if (!Number.isFinite(value) || value < 0) return "";
+  if (value < 1024) return `${value} B`;
+  const units = ["KB", "MB", "GB"];
+  let scaled = value / 1024;
+  let unit = 0;
+  while (scaled >= 1024 && unit < units.length - 1) {
+    scaled /= 1024;
+    unit += 1;
+  }
+  return `${scaled.toFixed(scaled >= 100 ? 0 : 1)} ${units[unit]}`;
+}
+
+/**
+ * Output row for one planned download. `result` follows opencli's httpDownload
+ * shape (`{ success, size, error }`); `file` is only reported for a file that
+ * exists on disk.
+ */
+export function summarizeZillowDownload(item, result, { listing = {}, file = "" } = {}) {
+  const success = result?.success === true;
+  return {
+    index: item.index,
+    status: success ? "success" : "failed",
+    size: success ? formatBytes(result.size) : "",
+    bytes: success ? Number(result.size) || 0 : 0,
+    file: success ? file : "",
+    error: success ? "" : cleanText(result?.error) || "unknown error",
+    photo_key: item.photo_key,
+    caption: item.caption,
+    subject_type: item.subject_type,
+    width: item.width,
+    url: item.url,
+    address: listing.address || "",
+    zpid: listing.zpid || "",
+    listing_url: listing.url || "",
+  };
+}
+
+export function normalizePhotoRow(photo, listing, size) {
+  const chosen = selectZillowPhotoUrl(photo, size);
+  const full = selectZillowPhotoUrl(photo, "full");
+  const thumb = selectZillowPhotoUrl(photo, "thumb");
+  return {
+    index: photo.index,
+    photo_key: photo.photo_key,
+    caption: photo.caption,
+    subject_type: photo.subject_type,
+    width: chosen.width,
+    url: chosen.url,
+    thumbnail_url: thumb.url,
+    full_url: full.url,
+    address: listing.address,
+    zpid: listing.zpid,
+    listing_url: listing.url,
+  };
+}

--- a/opencli-plugins/zillow/zillow-helpers.test.mjs
+++ b/opencli-plugins/zillow/zillow-helpers.test.mjs
@@ -1,0 +1,652 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildZillowPhotoFilename,
+  canonicalZillowListingUrl,
+  collectZillowPhotos,
+  describeZillowListing,
+  detectZillowChallenge,
+  detectZillowNotFound,
+  detectZillowUnavailable,
+  formatBytes,
+  integerInRange,
+  isPerimeterXCookie,
+  isZillowUrl,
+  normalizePhotoRow,
+  normalizeZillowPhoto,
+  planZillowDownloads,
+  selectZillowPhotoUrl,
+  summarizeZillowDownload,
+  ZILLOW_PHOTO_SIZES,
+  zillowListingSlug,
+  zillowPhotoKey,
+  zillowVariantWidth,
+  zillowZpidFromUrl,
+} from "./zillow-helpers.mjs";
+
+const CDN = "https://photos.zillowstatic.com/fp";
+const KEY_1 = "40a2df03a9e1e7ce67de59c614683f5f";
+const KEY_2 = "daad1a3d4a0c9190ab21e0a88199523b";
+const KEY_3 = "255bf622fd4c024591f530b133942a65";
+
+// Shaped like Zillow's `responsivePhotosOriginalRatio` entries.
+function rawOriginal(key, { caption = "", subjectType = null, withUrl = true } = {}) {
+  const entry = {
+    caption,
+    subjectType,
+    mixedSources: {
+      jpeg: [
+        { url: `${CDN}/${key}-d_d.jpg`, width: 800 },
+        { url: `${CDN}/${key}-o_a.jpg`, width: 1024 },
+        { url: `${CDN}/${key}-uncropped_scaled_within_1344_1008.jpg`, width: 1344 },
+        { url: `${CDN}/${key}-uncropped_scaled_within_1536_1152.jpg`, width: 1536 },
+      ],
+    },
+    key,
+  };
+  if (withUrl) entry.url = `${CDN}/${key}-p_d.jpg`;
+  return entry;
+}
+
+// Shaped like Zillow's `responsivePhotos` entries (the cropped ladder).
+function rawCropped(key, { caption = "" } = {}) {
+  return {
+    caption,
+    subjectType: null,
+    url: `${CDN}/${key}-p_d.jpg`,
+    mixedSources: {
+      jpeg: [192, 384, 576, 768, 960, 1152, 1344, 1536].map((width) => ({
+        url: `${CDN}/${key}-cc_ft_${width}.jpg`,
+        width,
+      })),
+    },
+  };
+}
+
+function hydratedPageData() {
+  return {
+    url: "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+    title: "349 Walsh Rd, Atherton, CA 94027 | MLS #ML82027150 | Zillow",
+    body_text: "Skip main navigation Buy Rent Sell See all 34 photos $49,680,000 349 Walsh Rd",
+    hydrated: true,
+    challenge: false,
+    error_message: "",
+    sub_app: "for-sale-page-sub-app",
+    property: {
+      zpid: 15598337,
+      streetAddress: "349 Walsh Rd",
+      city: "Atherton",
+      state: "CA",
+      zipcode: "94027",
+      address: { streetAddress: "349 Walsh Rd", zipcode: "94027", city: "Atherton", state: "CA" },
+      homeStatus: "FOR_SALE",
+      hdpUrl: "/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+      photoCount: 3,
+      mlsid: "ML82027150",
+      hiResImageLink: `${CDN}/${KEY_1}-p_f.jpg`,
+      responsivePhotosOriginalRatio: [
+        rawOriginal(KEY_1, {
+          caption: "Modern architectural masterpiece",
+          subjectType: "EXTERIOR",
+        }),
+        rawOriginal(KEY_2, { caption: "  Glass entrance   with wooden door " }),
+        rawOriginal(KEY_3, { withUrl: false }),
+      ],
+      responsivePhotos: [rawCropped(KEY_1), rawCropped(KEY_2), rawCropped(KEY_3)],
+    },
+    html_photo_urls: [],
+  };
+}
+
+test("canonicalZillowListingUrl accepts Zillow hosts and strips tracking noise", () => {
+  assert.equal(
+    canonicalZillowListingUrl(
+      " https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/?utm_source=share#photos ",
+    ),
+    "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+  );
+  assert.equal(
+    canonicalZillowListingUrl(
+      "zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid",
+    ),
+    "https://zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+  );
+  assert.equal(
+    canonicalZillowListingUrl(
+      "http://www.zillow.com/homes/31-Rittenhouse-Ave-Atherton-CA-94027_rb",
+    ),
+    "https://www.zillow.com/homes/31-Rittenhouse-Ave-Atherton-CA-94027_rb/",
+  );
+});
+
+test("canonicalZillowListingUrl rejects empty, malformed, and non-Zillow input", () => {
+  assert.throws(() => canonicalZillowListingUrl(""), /url must not be empty/);
+  assert.throws(() => canonicalZillowListingUrl("https://"), /not a valid URL/);
+  assert.throws(
+    () => canonicalZillowListingUrl("https://www.redfin.com/CA/Atherton/349-Walsh-Rd-94027/home/1"),
+    /Zillow/,
+  );
+  assert.throws(() => canonicalZillowListingUrl("https://zillow.com.evil.example/x"), /Zillow/);
+  assert.throws(
+    () => canonicalZillowListingUrl("ftp://www.zillow.com/homedetails/1_zpid/"),
+    /Zillow/,
+  );
+});
+
+test("isZillowUrl recognizes Zillow origins only", () => {
+  assert.equal(isZillowUrl("https://www.zillow.com/homedetails/x/15598337_zpid/"), true);
+  assert.equal(isZillowUrl("https://zillow.com/"), true);
+  assert.equal(isZillowUrl("about:blank"), false);
+  assert.equal(isZillowUrl("https://www.zillow.com.example/"), false);
+  assert.equal(isZillowUrl("https://photos.zillowstatic.com/fp/x.jpg"), false);
+  assert.equal(isZillowUrl(""), false);
+});
+
+test("isPerimeterXCookie matches only the PerimeterX cookie family", () => {
+  for (const name of ["_px3", "_pxvid", "pxcts", "_pxhd", "_pxde", "_pxff"]) {
+    assert.equal(isPerimeterXCookie({ name }), true, name);
+  }
+  for (const name of ["zguid", "zgsession", "JSESSIONID", "AWSALB", "px", "", undefined]) {
+    assert.equal(isPerimeterXCookie({ name }), false, String(name));
+  }
+  assert.equal(isPerimeterXCookie(null), false);
+});
+
+test("zillowZpidFromUrl reads the zpid segment", () => {
+  assert.equal(
+    zillowZpidFromUrl(
+      "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+    ),
+    "15598337",
+  );
+  assert.equal(zillowZpidFromUrl("https://www.zillow.com/homedetails/1_zpid"), "1");
+  assert.equal(zillowZpidFromUrl("https://www.zillow.com/homes/31-Rittenhouse-Ave_rb/"), "");
+  assert.equal(zillowZpidFromUrl("not a url"), "");
+});
+
+test("zillowListingSlug names the folder after the address slug and zpid", () => {
+  assert.equal(
+    zillowListingSlug(
+      "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+    ),
+    "349-Walsh-Rd-Atherton-CA-94027-15598337",
+  );
+  assert.equal(
+    zillowListingSlug(
+      "https://www.zillow.com/homedetails/1-Main-St-APT-2B-San-Francisco-CA-94105/77_zpid/",
+    ),
+    "1-Main-St-APT-2B-San-Francisco-CA-94105-77",
+  );
+  assert.equal(
+    zillowListingSlug("https://www.zillow.com/homedetails/15598337_zpid/"),
+    "zillow-15598337",
+  );
+  assert.equal(
+    zillowListingSlug("https://www.zillow.com/homes/31-Rittenhouse-Ave-Atherton-CA-94027_rb/"),
+    "homes-31-Rittenhouse-Ave-Atherton-CA-94027_rb",
+  );
+  assert.equal(zillowListingSlug("https://www.zillow.com/"), "zillow-listing");
+  assert.equal(zillowListingSlug("not a url"), "zillow-listing");
+});
+
+test("zillowPhotoKey and zillowVariantWidth decode CDN file names", () => {
+  assert.equal(zillowPhotoKey(`${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`), KEY_1);
+  assert.equal(zillowPhotoKey(`${CDN}/${KEY_1.toUpperCase()}-p_f.jpg`), KEY_1);
+  assert.equal(zillowPhotoKey(`${CDN}/${KEY_1}.jpg`), KEY_1);
+  assert.equal(zillowPhotoKey("https://photos.zillowstatic.com/fp/logo.svg"), "");
+  assert.equal(zillowPhotoKey(""), "");
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`), 1536);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-uncropped_scaled_within_1344_1008.webp`), 1344);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-cc_ft_768.jpg`), 768);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-o_a.jpg`), 1024);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-d_d.jpg`), 800);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-p_f.jpg`), 1024);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-p_d.jpg`), 400);
+  assert.equal(zillowVariantWidth(`${CDN}/${KEY_1}-unknown.jpg`), 0);
+});
+
+test("detectZillowChallenge and detectZillowNotFound read the page chrome and state", () => {
+  assert.equal(detectZillowChallenge(hydratedPageData()), false);
+  assert.equal(detectZillowNotFound(hydratedPageData()), false);
+  assert.equal(
+    detectZillowChallenge({
+      title: "Access to this page has been denied",
+      body_text: "Press & Hold to confirm you are a human (and not a bot). Reference ID a18b9dc0",
+    }),
+    true,
+  );
+  assert.equal(detectZillowChallenge({ title: "", body_text: "", challenge: true }), true);
+  assert.equal(
+    detectZillowChallenge({ title: "Zillow", body_text: "Please solve the CAPTCHA" }),
+    true,
+  );
+  assert.equal(
+    detectZillowNotFound({
+      title: "",
+      body_text:
+        "Skip main navigation Buy Rent Sell Uh oh, something broke. Error 404 - page not found.",
+      hydrated: true,
+      error_message: "Error 404 - page not found.",
+      sub_app: "error-page-subapp",
+    }),
+    true,
+  );
+  assert.equal(detectZillowNotFound({ title: "Page Not Found | Zillow", body_text: "" }), true);
+  assert.equal(
+    detectZillowNotFound({ title: "", body_text: "", error_message: "Not Found" }),
+    true,
+  );
+  assert.equal(detectZillowChallenge(null), false);
+  assert.equal(detectZillowNotFound(undefined), false);
+});
+
+test("detectZillowUnavailable recognizes Chrome's error page for a refused load", () => {
+  assert.equal(detectZillowUnavailable(hydratedPageData()), false);
+  assert.equal(
+    detectZillowUnavailable({
+      url: "chrome-error://chromewebdata/",
+      title: "www.zillow.com",
+      body_text:
+        "This page isn’t working www.zillow.com is currently unable to handle this request. HTTP ERROR 503 Reload",
+    }),
+    true,
+  );
+  assert.equal(
+    detectZillowUnavailable({ url: "https://www.zillow.com/x/", body_text: "HTTP ERROR 502" }),
+    true,
+  );
+  assert.equal(
+    detectZillowUnavailable({ url: "https://www.zillow.com/x/", body_text: "HTTP ERROR 404" }),
+    false,
+  );
+  assert.equal(detectZillowUnavailable(null), false);
+});
+
+test("describeZillowListing assembles the address and prefers the canonical hdpUrl", () => {
+  assert.deepEqual(describeZillowListing(hydratedPageData()), {
+    url: "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+    title: "349 Walsh Rd, Atherton, CA 94027 | MLS #ML82027150 | Zillow",
+    address: "349 Walsh Rd, Atherton, CA 94027",
+    street: "349 Walsh Rd",
+    city: "Atherton",
+    state: "CA",
+    zip: "94027",
+    status: "for sale",
+    zpid: "15598337",
+    mls_id: "ML82027150",
+    photo_count: 3,
+  });
+  assert.deepEqual(
+    describeZillowListing(
+      {
+        url: "https://www.zillow.com/homes/31-Rittenhouse-Ave_rb/",
+        property: { hdpUrl: "/homedetails/31-Rittenhouse-Ave-Atherton-CA-94027/15580183_zpid/" },
+      },
+      "https://www.zillow.com/x/",
+    ).url,
+    "https://www.zillow.com/homedetails/31-Rittenhouse-Ave-Atherton-CA-94027/15580183_zpid/",
+  );
+  assert.deepEqual(describeZillowListing({}, "https://www.zillow.com/homedetails/77_zpid/"), {
+    url: "https://www.zillow.com/homedetails/77_zpid/",
+    title: "",
+    address: "",
+    street: "",
+    city: "",
+    state: "",
+    zip: "",
+    status: "",
+    zpid: "77",
+    mls_id: "",
+    photo_count: null,
+  });
+});
+
+test("normalizeZillowPhoto orders both ladders widest first and keeps the key", () => {
+  const photo = normalizeZillowPhoto(
+    rawOriginal(KEY_1, { caption: "Modern architectural masterpiece", subjectType: "EXTERIOR" }),
+    0,
+    rawCropped(KEY_1),
+  );
+  assert.equal(photo.index, 1);
+  assert.equal(photo.photo_key, KEY_1);
+  assert.equal(photo.caption, "Modern architectural masterpiece");
+  assert.equal(photo.subject_type, "EXTERIOR");
+  assert.deepEqual(
+    photo.original.map((source) => source.width),
+    [1536, 1344, 1024, 800],
+  );
+  assert.equal(photo.original[0].url, `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`);
+  assert.deepEqual(
+    photo.cropped.map((source) => source.width),
+    [1536, 1344, 1152, 960, 768, 576, 384, 192],
+  );
+});
+
+test("normalizeZillowPhoto tolerates sparse candidates", () => {
+  const photo = normalizeZillowPhoto(
+    { mixedSources: { jpeg: [{ url: `${CDN}/${KEY_2}-o_a.jpg`, width: 1024 }, { url: "x" }] } },
+    4,
+  );
+  assert.equal(photo.index, 5);
+  assert.equal(photo.photo_key, KEY_2);
+  assert.equal(photo.caption, "");
+  assert.equal(photo.subject_type, "");
+  assert.deepEqual(photo.original, [{ url: `${CDN}/${KEY_2}-o_a.jpg`, width: 1024 }]);
+  assert.deepEqual(photo.cropped, []);
+  const croppedOnly = normalizeZillowPhoto(null, 0, rawCropped(KEY_3, { caption: "Kitchen" }));
+  assert.equal(croppedOnly.photo_key, KEY_3);
+  assert.equal(croppedOnly.caption, "Kitchen");
+  assert.deepEqual(croppedOnly.original, []);
+  assert.equal(croppedOnly.cropped.length, 8);
+});
+
+test("collectZillowPhotos uses the page state gallery in display order", () => {
+  const { photos, source } = collectZillowPhotos(hydratedPageData());
+  assert.equal(source, "state");
+  assert.deepEqual(
+    photos.map((photo) => [photo.index, photo.photo_key, photo.caption, photo.subject_type]),
+    [
+      [1, KEY_1, "Modern architectural masterpiece", "EXTERIOR"],
+      [2, KEY_2, "Glass entrance with wooden door", ""],
+      [3, KEY_3, "", ""],
+    ],
+  );
+  assert.equal(photos[2].cropped[0].url, `${CDN}/${KEY_3}-cc_ft_1536.jpg`);
+});
+
+test("collectZillowPhotos drops entries without any URL and renumbers the rest", () => {
+  const pageData = hydratedPageData();
+  pageData.property.responsivePhotosOriginalRatio.splice(1, 0, { caption: "broken", key: "nope" });
+  pageData.property.responsivePhotos.splice(1, 0, {});
+  const { photos } = collectZillowPhotos(pageData);
+  assert.deepEqual(
+    photos.map((photo) => [photo.index, photo.photo_key]),
+    [
+      [1, KEY_1],
+      [2, KEY_2],
+      [3, KEY_3],
+    ],
+  );
+});
+
+test("collectZillowPhotos falls back to the cropped ladder when the original-ratio list is absent", () => {
+  const pageData = hydratedPageData();
+  pageData.property.responsivePhotosOriginalRatio = null;
+  const { photos, source } = collectZillowPhotos(pageData);
+  assert.equal(source, "state");
+  assert.deepEqual(
+    photos.map((photo) => [
+      photo.index,
+      photo.photo_key,
+      photo.original.length,
+      photo.cropped.length,
+    ]),
+    [
+      [1, KEY_1, 0, 8],
+      [2, KEY_2, 0, 8],
+      [3, KEY_3, 0, 8],
+    ],
+  );
+});
+
+test("collectZillowPhotos falls back to HTML CDN URLs, one photo per key in order of appearance", () => {
+  const { photos, source } = collectZillowPhotos({
+    hydrated: false,
+    property: null,
+    html_photo_urls: [
+      `${CDN}/${KEY_1}-cc_ft_384.jpg`,
+      `${CDN}/${KEY_1}-p_d.jpg`,
+      `${CDN}/${KEY_2}-cc_ft_768.jpg`,
+      `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`,
+      `${CDN}/${KEY_1}-cc_ft_384.jpg`,
+      `${CDN}/${KEY_2}-o_a.jpg`,
+      "https://photos.zillowstatic.com/fp/logo.svg",
+      "not-a-url",
+    ],
+  });
+  assert.equal(source, "html");
+  assert.deepEqual(
+    photos.map((photo) => [photo.index, photo.photo_key, photo.caption]),
+    [
+      [1, KEY_1, ""],
+      [2, KEY_2, ""],
+    ],
+  );
+  assert.deepEqual(photos[0].original, [
+    { url: `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`, width: 1536 },
+    { url: `${CDN}/${KEY_1}-p_d.jpg`, width: 400 },
+  ]);
+  assert.deepEqual(photos[0].cropped, [{ url: `${CDN}/${KEY_1}-cc_ft_384.jpg`, width: 384 }]);
+  assert.deepEqual(photos[1].original, [{ url: `${CDN}/${KEY_2}-o_a.jpg`, width: 1024 }]);
+});
+
+test("collectZillowPhotos reports none when nothing is readable", () => {
+  assert.deepEqual(collectZillowPhotos({ hydrated: true, property: { responsivePhotos: [] } }), {
+    photos: [],
+    source: "none",
+  });
+  assert.deepEqual(collectZillowPhotos({ hydrated: true, property: null, html_photo_urls: [] }), {
+    photos: [],
+    source: "none",
+  });
+  assert.deepEqual(collectZillowPhotos(null), { photos: [], source: "none" });
+});
+
+test("selectZillowPhotoUrl maps each size to its width bucket and falls back sensibly", () => {
+  const photo = normalizeZillowPhoto(rawOriginal(KEY_1), 0, rawCropped(KEY_1));
+  assert.deepEqual(selectZillowPhotoUrl(photo, "full"), {
+    url: `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`,
+    width: 1536,
+  });
+  assert.deepEqual(selectZillowPhotoUrl(photo, "large"), {
+    url: `${CDN}/${KEY_1}-uncropped_scaled_within_1344_1008.jpg`,
+    width: 1344,
+  });
+  assert.deepEqual(selectZillowPhotoUrl(photo, "medium"), {
+    url: `${CDN}/${KEY_1}-o_a.jpg`,
+    width: 1024,
+  });
+  assert.deepEqual(selectZillowPhotoUrl(photo, "small"), {
+    url: `${CDN}/${KEY_1}-d_d.jpg`,
+    width: 800,
+  });
+  assert.deepEqual(selectZillowPhotoUrl(photo, "thumb"), {
+    url: `${CDN}/${KEY_1}-cc_ft_384.jpg`,
+    width: 384,
+  });
+
+  // Only a 1024 bucket published: small takes the narrowest bucket above its target.
+  const mediumOnly = normalizeZillowPhoto(
+    { mixedSources: { jpeg: [{ url: `${CDN}/${KEY_1}-o_a.jpg`, width: 1024 }] } },
+    0,
+  );
+  assert.deepEqual(selectZillowPhotoUrl(mediumOnly, "full"), {
+    url: `${CDN}/${KEY_1}-o_a.jpg`,
+    width: 1024,
+  });
+  assert.deepEqual(selectZillowPhotoUrl(mediumOnly, "small"), {
+    url: `${CDN}/${KEY_1}-o_a.jpg`,
+    width: 1024,
+  });
+  // No cropped ladder: thumb falls back to the original-ratio ladder.
+  assert.deepEqual(selectZillowPhotoUrl(mediumOnly, "thumb"), {
+    url: `${CDN}/${KEY_1}-o_a.jpg`,
+    width: 1024,
+  });
+  // No original-ratio ladder: full falls back to the widest crop.
+  const croppedOnly = normalizeZillowPhoto(null, 0, rawCropped(KEY_1));
+  assert.deepEqual(selectZillowPhotoUrl(croppedOnly, "full"), {
+    url: `${CDN}/${KEY_1}-cc_ft_1536.jpg`,
+    width: 1536,
+  });
+  assert.deepEqual(selectZillowPhotoUrl({ original: [], cropped: [] }, "full"), {
+    url: "",
+    width: 0,
+  });
+  assert.deepEqual(ZILLOW_PHOTO_SIZES, ["full", "large", "medium", "small", "thumb"]);
+});
+
+test("buildZillowPhotoFilename pads by gallery size and marks non-full variants", () => {
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`,
+      key: KEY_1,
+      index: 1,
+      total: 34,
+      size: "full",
+    }),
+    `01-${KEY_1}.jpg`,
+  );
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: `${CDN}/${KEY_1}-o_a.jpg`,
+      key: KEY_1,
+      index: 34,
+      total: 34,
+      size: "full",
+    }),
+    `34-${KEY_1}.jpg`,
+  );
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: `${CDN}/${KEY_1}-o_a.jpg`,
+      key: KEY_1,
+      index: 7,
+      total: 120,
+      size: "full",
+    }),
+    `007-${KEY_1}.jpg`,
+  );
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: `${CDN}/${KEY_1}-uncropped_scaled_within_1344_1008.webp`,
+      key: KEY_1,
+      index: 1,
+      total: 3,
+      size: "large",
+    }),
+    `01-large-${KEY_1}.webp`,
+  );
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: "https://photos.zillowstatic.com/fp/we%20ird%20name.PNG",
+      key: "",
+      index: 1,
+      total: 1,
+      size: "full",
+    }),
+    "01-we-ird-name.png",
+  );
+  assert.equal(
+    buildZillowPhotoFilename({
+      url: "https://photos.zillowstatic.com/",
+      key: "",
+      index: 2,
+      total: 2,
+      size: "full",
+    }),
+    "02-photo.jpg",
+  );
+});
+
+test("planZillowDownloads applies the limit and names files consistently", () => {
+  const { photos } = collectZillowPhotos(hydratedPageData());
+  const plan = planZillowDownloads(photos, { size: "full", limit: 2 });
+  assert.deepEqual(
+    plan.map((item) => [item.index, item.file_name, item.width, item.url]),
+    [
+      [1, `01-${KEY_1}.jpg`, 1536, `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`],
+      [2, `02-${KEY_2}.jpg`, 1536, `${CDN}/${KEY_2}-uncropped_scaled_within_1536_1152.jpg`],
+    ],
+  );
+  assert.equal(plan[0].caption, "Modern architectural masterpiece");
+  assert.equal(plan[0].subject_type, "EXTERIOR");
+  const all = planZillowDownloads(photos, { size: "medium" });
+  assert.equal(all.length, 3);
+  assert.equal(all[2].file_name, `03-medium-${KEY_3}.jpg`);
+  assert.equal(all[2].url, `${CDN}/${KEY_3}-o_a.jpg`);
+  const thumbs = planZillowDownloads(photos, { size: "thumb", limit: 1 });
+  assert.equal(thumbs[0].file_name, `01-thumb-${KEY_1}.jpg`);
+  assert.equal(thumbs[0].width, 384);
+  const unplannable = planZillowDownloads([{ ...photos[0], original: [], cropped: [] }], {
+    size: "full",
+  });
+  assert.deepEqual([unplannable[0].url, unplannable[0].file_name], ["", ""]);
+});
+
+test("formatBytes renders human-friendly sizes", () => {
+  assert.equal(formatBytes(0), "0 B");
+  assert.equal(formatBytes(512), "512 B");
+  assert.equal(formatBytes(85171), "83.2 KB");
+  assert.equal(formatBytes(1048576), "1.0 MB");
+  assert.equal(formatBytes(157286400), "150 MB");
+  assert.equal(formatBytes(-1), "");
+  assert.equal(formatBytes("nope"), "");
+});
+
+test("summarizeZillowDownload reports success and failure rows", () => {
+  const { photos } = collectZillowPhotos(hydratedPageData());
+  const listing = describeZillowListing(hydratedPageData());
+  const [item] = planZillowDownloads(photos, { size: "full" });
+  assert.deepEqual(
+    summarizeZillowDownload(
+      item,
+      { success: true, size: 85171 },
+      { listing, file: `/tmp/out/01-${KEY_1}.jpg` },
+    ),
+    {
+      index: 1,
+      status: "success",
+      size: "83.2 KB",
+      bytes: 85171,
+      file: `/tmp/out/01-${KEY_1}.jpg`,
+      error: "",
+      photo_key: KEY_1,
+      caption: "Modern architectural masterpiece",
+      subject_type: "EXTERIOR",
+      width: 1536,
+      url: `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`,
+      address: "349 Walsh Rd, Atherton, CA 94027",
+      zpid: "15598337",
+      listing_url:
+        "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+    },
+  );
+  const failed = summarizeZillowDownload(
+    item,
+    { success: false, size: 0, error: "HTTP 404" },
+    { listing, file: `/tmp/out/01-${KEY_1}.jpg` },
+  );
+  assert.equal(failed.status, "failed");
+  assert.equal(failed.size, "");
+  assert.equal(failed.bytes, 0);
+  assert.equal(failed.file, "");
+  assert.equal(failed.error, "HTTP 404");
+  assert.equal(summarizeZillowDownload(item, undefined).error, "unknown error");
+});
+
+test("normalizePhotoRow flattens a photo for the photos command", () => {
+  const { photos } = collectZillowPhotos(hydratedPageData());
+  const listing = describeZillowListing(hydratedPageData());
+  assert.deepEqual(normalizePhotoRow(photos[0], listing, "large"), {
+    index: 1,
+    photo_key: KEY_1,
+    caption: "Modern architectural masterpiece",
+    subject_type: "EXTERIOR",
+    width: 1344,
+    url: `${CDN}/${KEY_1}-uncropped_scaled_within_1344_1008.jpg`,
+    thumbnail_url: `${CDN}/${KEY_1}-cc_ft_384.jpg`,
+    full_url: `${CDN}/${KEY_1}-uncropped_scaled_within_1536_1152.jpg`,
+    address: "349 Walsh Rd, Atherton, CA 94027",
+    zpid: "15598337",
+    listing_url: "https://www.zillow.com/homedetails/349-Walsh-Rd-Atherton-CA-94027/15598337_zpid/",
+  });
+});
+
+test("integerInRange validates command limits", () => {
+  assert.equal(integerInRange("5", "limit", 0, 1000), 5);
+  assert.equal(integerInRange(0, "limit", 0, 1000), 0);
+  assert.throws(() => integerInRange("1.5", "limit", 0, 1000), /limit must be an integer/);
+  assert.throws(() => integerInRange(-1, "limit", 0, 1000), /between 0 and 1000/);
+  assert.throws(() => integerInRange("abc", "limit", 0, 1000), /limit must be an integer/);
+});


### PR DESCRIPTION
## What this PR does

The Gemini adapter could ask questions and generate images, but the web app's video composer had no command, and nothing could hand it a photo to animate. Turning a listing's stills into short cinematic clips therefore meant driving the page by hand every time.

`opencli gemini video PROMPT [--image A.jpg,B.jpg] [--ratio 16:9|9:16] [--output DIR] [--name FILE] [--timeout S] [--sd]` opens `gemini.google.com/videos` in the signed-in session, picks the aspect ratio, attaches the images, submits the prompt, polls the newest model turn until a player renders, and saves the MP4.

## Design & Invariants

- The composer, not a menu click, carries the mode: `/videos` pre-selects Gemini's Videos tool, and the command fails when that chip is absent rather than guessing at the tools menu.
- Gemini builds its file input on demand and only a trusted pointer click opens it. The command intercepts the file chooser over CDP (`Page.setInterceptFileChooserDialog` + `DOM.setFileInputFiles`), so image upload requires the direct `--cdp-endpoint` backend and says so when run through the Browser Bridge.
- A message sent while an attachment tile still shows its progress spinner is silently dropped, so the command waits for every tile to finish uploading, then verifies the submission cleared the editor and opened a conversation URL. A dropped prompt fails in seconds instead of after the whole generation timeout.
- The clip host (`contribution-rt.usercontent.google.com`) redirects anonymous requests to sign-in. The download forwards only the browser cookies whose domain covers that host and refuses any non-video response.
- Gemini locks the video composer without a message once the daily allowance is spent (Google AI Pro: 3 videos a day). That locked state is a typed error, as are Gemini's refusals with their wording.
- Page readers are self-contained functions; all shaping and classification lives in pure helpers with unit tests.

## Test plan

- [x] `npm test` in `opencli-plugins/gemini` (15 tests)
- [x] `biome check opencli-plugins/gemini` from the repo root, clean
- [x] Live over CDP: two 10 s clips from listing photos (upload, generation, download to a named file, `duration` reported)
- [x] Live: refusal surfaced as a typed error; spent allowance reported as the composer-locked error
- [ ] Browser Bridge path (only the "needs --cdp-endpoint" error is reachable there)

## Not in this PR

- Reusing an existing conversation or downloading a clip by conversation URL; every run starts a new video chat.
- The Gemini Flow / labs surface, which has its own credit model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)