### PR TITLE
feat(people): make All the placed roster and cut the page's descriptions

### DIFF
--- a/packages/ui/src/filter-chip-group.tsx
+++ b/packages/ui/src/filter-chip-group.tsx
@@ -14,6 +14,14 @@ export type FilterChipOption<T extends string = string> = {
    * the `--primary` fill.
    */
   count?: number;
+  /**
+   * Pushes this chip, and any after it, to the far end of the rail. For an
+   * option the rest are not peers of — a queue waiting on a decision beside a
+   * set of settled categories — so the gap carries that. Once the row is wide
+   * enough to scroll there is no slack left to push into, and the chip sits
+   * against its neighbor like any other.
+   */
+  alignEnd?: boolean;
   disabled?: boolean;
 };
 
@@ -85,6 +93,7 @@ export function FilterChipGroup<T extends string = string>({
             // every chip after it sideways.
             className={cn(
               "shrink-0 rounded-full border px-3 py-1 text-badge transition-colors outline-none focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50",
+              option.alignEnd && "ml-auto",
               checked
                 ? "border-transparent bg-primary text-primary-foreground"
                 : "border-border-strong bg-surface text-foreground hover:bg-surface-muted",

--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -1,6 +1,5 @@
 {
   "page": {
-    "subtitle": "Who has something new, most recent first. Search reaches everyone Rome knows.",
     "loading": "Loading…",
     "emptyTitle": "Nothing new yet",
     "emptyHint": "Anyone who messages you shows up here, ready to place.",
@@ -27,12 +26,6 @@
     "acquaintance": "Acquaintance",
     "other": "Other",
     "stranger": "Stranger"
-  },
-  "levelHints": {
-    "innerCircle": "Rome speaks freely, relays promptly",
-    "acquaintance": "Rome answers, but checks before acting",
-    "other": "Known, kept at arm's length",
-    "stranger": "Rome does not engage — reversible any time"
   },
   "channels": {
     "telegram": "Telegram",
@@ -107,10 +100,6 @@
     "label": "View",
     "latest": "Latest",
     "directory": "Directory"
-  },
-  "stream": {
-    "hint": "one row per person · newest first",
-    "searchHint": "searching everyone Rome knows, quiet contacts included"
   },
   "detail": {
     "back": "People",

--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -4,6 +4,7 @@
     "emptyTitle": "Nothing new yet",
     "emptyHint": "Anyone who messages you shows up here, ready to place.",
     "emptyForSearch": "Nobody matches your search",
+    "emptyDirectory": "Nobody here yet",
     "loadMore": "Show more"
   },
   "header": {

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -1,6 +1,5 @@
 {
   "page": {
-    "subtitle": "有新动态的人，最新的排在前面。搜索可覆盖 Rome 认识的所有人。",
     "loading": "加载中…",
     "emptyTitle": "暂无新动态",
     "emptyHint": "任何给你发消息的人都会出现在这里，等待你安置。",
@@ -27,12 +26,6 @@
     "acquaintance": "熟人",
     "other": "其他",
     "stranger": "陌生人"
-  },
-  "levelHints": {
-    "innerCircle": "Rome 畅所欲言，及时转达",
-    "acquaintance": "Rome 会回应，但行动前会先确认",
-    "other": "认识，但保持距离",
-    "stranger": "Rome 不予理会 — 随时可以撤回"
   },
   "channels": {
     "telegram": "Telegram",
@@ -107,10 +100,6 @@
     "label": "视图",
     "latest": "最新",
     "directory": "名录"
-  },
-  "stream": {
-    "hint": "每人一行 · 最新在前",
-    "searchHint": "正在搜索 Rome 认识的所有人，包括从未联系过的联系人"
   },
   "detail": {
     "back": "人物",

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -4,6 +4,7 @@
     "emptyTitle": "暂无新动态",
     "emptyHint": "任何给你发消息的人都会出现在这里，等待你安置。",
     "emptyForSearch": "没有符合搜索条件的人",
+    "emptyDirectory": "这里还没有人",
     "loadMore": "显示更多"
   },
   "header": {

--- a/packages/web/src/pages/PeoplePage.test.tsx
+++ b/packages/web/src/pages/PeoplePage.test.tsx
@@ -703,6 +703,20 @@ describe("PeoplePage directory", () => {
     expect(calls.some((c) => c.url.includes("cursor="))).toBe(true);
   });
 
+  it("says the roster is empty rather than blaming a search nobody ran", async () => {
+    const user = userEvent.setup();
+    // A fresh instance: the guardian exists, and nobody has been placed. All
+    // holds the guardian back, so the directory is legitimately empty with an
+    // empty search box.
+    mockApi({ people: [GUARDIAN], accounts: [] });
+    renderPage();
+
+    await showDirectory(user);
+
+    expect(await screen.findByText("Nobody here yet")).toBeTruthy();
+    expect(screen.queryByText("Nobody matches your search")).toBeNull();
+  });
+
   it("reaches a contact no page has loaded through the search box", async () => {
     const user = userEvent.setup();
     const { calls } = mockApi({ people: [FRIEND], accounts: [SILENT_CONTACT] });

--- a/packages/web/src/pages/PeoplePage.test.tsx
+++ b/packages/web/src/pages/PeoplePage.test.tsx
@@ -614,14 +614,16 @@ describe("PeoplePage directory", () => {
     await screen.findByText("Wei Chen");
     await showDirectory(user);
 
-    // Everyone is in a group, the quiet person and the address-book contact
-    // included — a contacts list answers "who does Rome know", not "who said
-    // something".
+    // All is the placed roster, the quiet person included — a contacts list
+    // answers "who does Rome know", not "who said something". The guardian and
+    // the accounts nobody has placed answer other questions, so neither pads it.
     expect(await screen.findByText("Nadia Petrova")).toBeTruthy();
-    expect(screen.getByText("Zhangfan Dong")).toBeTruthy();
-    expect(screen.getByText("Jonas Tan")).toBeTruthy();
+    expect(screen.queryByText("Zhangfan Dong")).toBeNull();
+    expect(screen.queryByText("Jonas Tan")).toBeNull();
+
+    await user.click(chip(/^Unknown/));
     // The heading's number is the directory's own, not the rows on screen.
-    const unknown = screen.getByRole("heading", { name: "Unknown" }).parentElement!;
+    const unknown = (await screen.findByRole("heading", { name: "Unknown" })).parentElement!;
     expect(within(unknown).getByText("2")).toBeTruthy();
   });
 
@@ -652,6 +654,7 @@ describe("PeoplePage directory", () => {
 
     await screen.findByText("Wei Chen");
     await showDirectory(user);
+    await user.click(chip(/^Unknown/));
 
     // The decision is available wherever the account is, but the roster is for
     // reading: the row wears one quiet control, and the stream's three verbs
@@ -687,6 +690,7 @@ describe("PeoplePage directory", () => {
     renderPage();
 
     await showDirectory(user);
+    await user.click(chip(/^Unknown/));
     // By name, so Priya comes first however recently Rachel said something.
     expect(await screen.findByText("Priya Nair")).toBeTruthy();
     expect(screen.queryByText("Rachel Lim")).toBeNull();

--- a/packages/web/src/pages/PeoplePage.tsx
+++ b/packages/web/src/pages/PeoplePage.tsx
@@ -70,15 +70,6 @@ import { usePeopleRoster } from "./people/use-roster";
  *  account read is narrowed by those instead. */
 const PLACED_FILTERS = new Set<PeopleFilter>(["inner-circle", "acquaintance", "other"]);
 
-/** The one-line reading of what each bond level means for Rome's behavior,
- *  sitting beside its group heading. */
-const LEVEL_HINT_KEY: Partial<Record<RowLevel, string>> = {
-  "inner-circle": "levelHints.innerCircle",
-  acquaintance: "levelHints.acquaintance",
-  other: "levelHints.other",
-  stranger: "levelHints.stranger",
-};
-
 /**
  * `/people` is the root the two views share and renders neither: it forwards to
  * the stream, carrying whatever chip and term the link arrived with, so an
@@ -206,7 +197,6 @@ export default function PeoplePage({ view }: { view: PeopleView }) {
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div className="min-w-0">
             <h1 className="text-title text-foreground">{tCommon("nav.people")}</h1>
-            <p className="mt-1 text-aux text-muted-foreground">{t("page.subtitle")}</p>
           </div>
           {/* Both of this page's one-of-N controls are the kit's radiogroups
               rather than buttons wearing `role="radio"`: Radix supplies the
@@ -241,8 +231,12 @@ export default function PeoplePage({ view }: { view: PeopleView }) {
               value: option,
               label: option === "all" ? t("filters.all") : t(levelLabelKey(option)),
               // Unknown is the page's one number that asks for a decision, so
-              // it carries a count; the other chips are plain labels.
+              // it carries a count; the other chips are plain labels. It sits
+              // at the far end for the same reason: the chips before it are
+              // bonds the guardian has given, and this is what is still
+              // waiting on them.
               count: option === "unknown" && counts.unknown > 0 ? counts.unknown : undefined,
+              alignEnd: option === "unknown",
             }))}
           />
         </div>
@@ -347,16 +341,10 @@ function LatestView({
     );
   }
 
+  // No heading: the stream is one ungrouped list, and the segmented control
+  // above it already says which view is on screen.
   return (
     <section>
-      <div className="flex items-baseline gap-2 border-b border-border pb-1">
-        <h2 className="text-section uppercase tracking-wide text-muted-foreground">
-          {t("views.latest")}
-        </h2>
-        <span className="ml-auto text-badge text-subtle-foreground">
-          {searching ? t("stream.searchHint") : t("stream.hint")}
-        </span>
-      </div>
       <div className="flex flex-col">
         {rows.map((row) =>
           row.kind === "account" ? (
@@ -404,11 +392,6 @@ function DirectoryView({
             <span className="font-mono text-badge tabular-nums text-subtle-foreground">
               {counts[group.level]}
             </span>
-            {LEVEL_HINT_KEY[group.level] && (
-              <span className="ml-auto text-badge text-subtle-foreground">
-                {t(LEVEL_HINT_KEY[group.level]!)}
-              </span>
-            )}
           </div>
           <div className="flex flex-col">
             {group.rows.map((row) =>

--- a/packages/web/src/pages/PeoplePage.tsx
+++ b/packages/web/src/pages/PeoplePage.tsx
@@ -291,6 +291,7 @@ export default function PeoplePage({ view }: { view: PeopleView }) {
           <DirectoryView
             groups={groups}
             counts={counts}
+            searching={settled !== ""}
             onOpen={openRow}
             renderUnplaced={(row) => unplaced(row, "directory")}
           />
@@ -361,19 +362,26 @@ function LatestView({
 function DirectoryView({
   groups,
   counts,
+  searching,
   onOpen,
   renderUnplaced,
 }: {
   groups: { level: RowLevel; rows: PeopleRow[] }[];
   counts: LevelCounts;
+  searching: boolean;
   onOpen: (row: PeopleRow) => void;
   renderUnplaced: (row: PeopleRow) => React.ReactNode;
 }) {
   const { t } = useTranslation("people");
+  // An empty roster is not a failed search. A chip whose level nobody sits at
+  // empties this view with the box untouched, and All does it on an instance
+  // where nobody has been placed yet.
   if (groups.length === 0) {
     return (
       <div className="rounded-12 border border-dashed border-border-strong bg-surface/50 py-10 text-center">
-        <p className="text-ui text-muted-foreground">{t("page.emptyForSearch")}</p>
+        <p className="text-ui text-muted-foreground">
+          {searching ? t("page.emptyForSearch") : t("page.emptyDirectory")}
+        </p>
       </div>
     );
   }

--- a/packages/web/src/pages/people/people-model.test.ts
+++ b/packages/web/src/pages/people/people-model.test.ts
@@ -211,33 +211,36 @@ describe("directoryGroups", () => {
       group.rows.map((row) => row.displayName),
     ]);
 
-  it("groups everyone in ladder order, and orders each group by name", () => {
-    // A contacts list: every account Rome holds is in here, and the order
-    // within a group is the name, not what anyone last said.
+  it("groups the placed people in ladder order, and orders each group by name", () => {
+    // "All" is the roster the guardian has placed, in ladder order, and the
+    // order within a group is the name, not what anyone last said.
     expect(groupsOf({ filter: "all", search: "" })).toEqual([
-      ["unknown", ["Abby Nunes", "Jonas Tan", "Jules"]],
-      ["guardian", ["Mock Guardian"]],
       ["inner-circle", ["Ray Oster"]],
       ["other", ["Sam Okafor"]],
     ]);
   });
 
-  it("holds both unplaced ends back from All, and enters each on purpose", () => {
-    // "All" means the placed people plus the accounts nobody has placed;
-    // dismissal is entered deliberately.
-    expect(groupsOf({ filter: "all", search: "" }).map(([level]) => level)).not.toContain(
-      "stranger",
-    );
-    // The guardian rides along, as in every view — see below.
-    expect(groupsOf({ filter: "stranger", search: "" })).toEqual([
-      ["guardian", ["Mock Guardian"]],
-      ["stranger", ["Prize"]],
+  it("holds every position but the placed ones back from All, and enters each on purpose", () => {
+    // A queue, a dismissal and the reader's own row each answer a different
+    // question than "who does Rome know", so none of the three pads All.
+    expect(groupsOf({ filter: "all", search: "" }).map(([level]) => level)).toEqual([
+      "inner-circle",
+      "other",
     ]);
+    expect(groupsOf({ filter: "unknown", search: "" })).toEqual([
+      ["unknown", ["Abby Nunes", "Jonas Tan", "Jules"]],
+    ]);
+    expect(groupsOf({ filter: "stranger", search: "" })).toEqual([["stranger", ["Prize"]]]);
   });
 
-  it("keeps the guardian in their own people list, whatever the chip says", () => {
-    const groups = groupsOf({ filter: "inner-circle", search: "" });
-    expect(groups.map(([level]) => level)).toContain("guardian");
+  it("leaves the guardian to a search rather than a chip", () => {
+    // No chip selects the guardian, and no chip carries them along either.
+    expect(groupsOf({ filter: "inner-circle", search: "" }).map(([level]) => level)).not.toContain(
+      "guardian",
+    );
+    expect(groupsOf({ filter: "all", search: "guardian" })).toEqual([
+      ["guardian", ["Mock Guardian"]],
+    ]);
   });
 
   it("reaches the address book through a search, whatever chip is lit", () => {

--- a/packages/web/src/pages/people/people-model.test.ts
+++ b/packages/web/src/pages/people/people-model.test.ts
@@ -238,9 +238,9 @@ describe("directoryGroups", () => {
     expect(groupsOf({ filter: "inner-circle", search: "" }).map(([level]) => level)).not.toContain(
       "guardian",
     );
-    expect(groupsOf({ filter: "all", search: "guardian" })).toEqual([
-      ["guardian", ["Mock Guardian"]],
-    ]);
+    // By name: "guardian" would also match the level, and the level is not
+    // what a search reads.
+    expect(groupsOf({ filter: "all", search: "mock" })).toEqual([["guardian", ["Mock Guardian"]]]);
   });
 
   it("reaches the address book through a search, whatever chip is lit", () => {

--- a/packages/web/src/pages/people/people-model.ts
+++ b/packages/web/src/pages/people/people-model.ts
@@ -1,5 +1,6 @@
 import {
   accountRef,
+  ASSIGNABLE_BOND_LEVELS,
   BOND_LADDER,
   compareAccountCursors,
   compareStreamCursors,
@@ -41,18 +42,22 @@ export type PeopleFilter = "all" | RowLevel;
 /**
  * The chips, in rail order.
  *
- * Guardian has none: it is the guardian's own row, which the directory always
- * shows and the stream never does. "All" holds back Stranger, so the dismissed
- * end of the ladder is entered on purpose rather than sitting in the default
- * view.
+ * Guardian has none: it is the guardian's own row, which neither view shows
+ * under a chip — a search is the way to it. "All" holds back both unplaced
+ * ends of the ladder too, so a queue and a dismissal are each entered on
+ * purpose rather than sitting in the default view.
+ *
+ * Unknown comes last and the rail pushes it to the far end, because it is not
+ * a peer of the chips before it: those name a bond the guardian has already
+ * given, and Unknown is the queue of accounts still waiting for one.
  */
 export const FILTER_ORDER: PeopleFilter[] = [
   "all",
-  "unknown",
   "inner-circle",
   "acquaintance",
   "other",
   "stranger",
+  "unknown",
 ];
 
 /**
@@ -327,13 +332,17 @@ export interface PeopleGroup {
  * The directory's groups, in ladder order, after the chip and the search box
  * have each had their say.
  *
- * Every contact Rome holds is in here: a contacts app hides nobody, and a
- * roster that held the address book back would answer "no such contact" for
- * someone the mirror has.
+ * "All" is the people the guardian has placed, and only those: the three
+ * assignable levels. The ladder's other positions each answer a different
+ * question — Unknown is the accounts still waiting on a decision, Stranger is
+ * what was decided against, Guardian is the reader themselves — so each is
+ * entered on purpose rather than padding the list somebody scrolls to look a
+ * contact up in.
  *
- * Guardian survives every filter: a roster that hid it would read as "you are
- * not in your own people list". Empty groups are dropped rather than rendered
- * as headings with nothing under them.
+ * A search still reaches every one of them, held-back positions included: a
+ * roster that filtered the address book would answer "no such contact" for
+ * someone the mirror has. Empty groups are dropped rather than rendered as
+ * headings with nothing under them.
  */
 export function directoryGroups(
   rows: readonly PeopleRow[],
@@ -347,8 +356,10 @@ export function directoryGroups(
     rows: matching.filter((row) => row.level === level).sort(compareRowsByName),
   })).filter((group) => {
     if (group.rows.length === 0) return false;
-    if (searching || group.level === "guardian") return true;
-    return options.filter === "all" ? group.level !== "stranger" : group.level === options.filter;
+    if (searching) return true;
+    return options.filter === "all"
+      ? (ASSIGNABLE_BOND_LEVELS as readonly RowLevel[]).includes(group.level)
+      : group.level === options.filter;
   });
 }
 

--- a/packages/web/src/pages/people/people-model.ts
+++ b/packages/web/src/pages/people/people-model.ts
@@ -280,9 +280,11 @@ export function compareRowsByName(a: PeopleRow, b: PeopleRow): number {
   );
 }
 
-/** Whether a row belongs to a chip's view. "all" is the placed levels: the two
- *  unplaced ends of the ladder are both entered on purpose, so neither an
- *  account waiting on a decision nor one already dismissed is the default. */
+/** Whether a row belongs to a chip's view, in the stream. "all" holds back the
+ *  two unplaced ends of the ladder, so neither an account waiting on a decision
+ *  nor one already dismissed is the default. It says nothing about the
+ *  guardian, whose row the stream drops through `isRowFixed` whatever the chip
+ *  says — `directoryGroups` states the directory's narrower rule itself. */
 export function rowMatchesFilter(row: PeopleRow, filter: PeopleFilter): boolean {
   return filter === "all"
     ? row.level !== "unknown" && row.level !== "stranger"


### PR DESCRIPTION
## What this PR does

The People page spent its top three lines describing itself. A subtitle under the title said "Who has something new, most recent first. Search reaches everyone Rome knows." A `LATEST` heading sat over the one list on screen, next to a hint reading "one row per person · newest first". None of the three told the reader anything the segmented control and the rows did not.

The directory's All had a second problem. It mixed three questions into one list: the people the guardian placed, the accounts still waiting on a decision, and the guardian's own row. Scrolling for a contact meant scrolling past a triage queue.

All is now the placed roster — Inner circle, Acquaintance, Other. Unknown moves to the far end of the chip rail, held out of All along with Stranger and Guardian.

The four bond-level hints beside the directory headings go as well. Bond level is a key that Inbox policies are written against, and only `guardian` sits on `trustedBondLevels` or `replyToBondLevels` by default (`packages/core/src/core/policy-engine.ts:16`, `rome_apps/inbox/src/actions/message-handler/index.ts:70`). "Rome speaks freely, relays promptly" therefore described intent, not behavior, and so would any plainer rewrite of it.

## Design & Invariants

**A chip's position on the rail says what kind of question it answers.** The rail's left group is the bond a guardian has already given. Unknown is a queue waiting on one, so it sits at the far end with a gap between. `alignEnd` on `FilterChipOption` is how a caller says that — the chip stays inside the same radiogroup, so Radix's roving focus still reaches it, and the flag has no effect once the rail is wide enough to scroll.

**All is the placed roster, and nothing else.** `directoryGroups` renders exactly `ASSIGNABLE_BOND_LEVELS` under All. Every other ladder position is reachable only through its own chip. A regression is any position appearing under All again: it puts a decision queue back inside a contacts list.

**A search still reaches every position.** Unknown, Stranger and Guardian are held out of All, not out of the directory. Someone typing a name wants that person wherever they sit, so no group is filtered while the box has a term in it. Guardian has no chip, so search is now the only way to that row.

The alternative considered for the Unknown chip was a second radiogroup on the right. It was rejected: two radiogroups over one filter tell assistive tech there are two independent choices, and arrow keys would stop at the boundary.

## Test plan

- [x] `pnpm typecheck` — clean across all 29 workspace packages.
- [x] `pnpm --filter rome-web test` — 1318 tests pass. Six encoded the old All and were rewritten: three `directoryGroups` cases in `people-model.test.ts` now pin "All is the placed roster", "each held-back position is entered on purpose", and "the guardian is reached by search, not by a chip"; three `PeoplePage.test.tsx` directory cases light the Unknown chip before reading unlinked accounts.
- [x] `pnpm --filter @rome-os/ui test` — 528 tests pass.
- [x] `biome check` on the touched files — clean.
- [x] Exercised in the browser against the mock dashboard (`pnpm start:web:mock`): `/people/latest` renders rows with no heading, `/people/directory` shows the three placed groups under All, and the Unknown chip reaches the 11 unplaced accounts.
- [ ] Not run: `pnpm dev:all`. This PR touches no backend path and adds no read.

## Not in this PR

- **Per-level copy on the directory headings.** Nothing true and specific can be written until a bond level carries behavior of its own. A tooltip reading the live `trustedBondLevels` / `replyToBondLevels` would be true today and stay true, and needs one settings read on the People page.
- **A way to the guardian row without searching.** A Guardian chip or a pinned row would restore it. Neither is obviously right, and All reads better without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)