### PR TITLE
feat: promote a completed side chat to an ordinary chat

### DIFF
--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -3521,6 +3521,160 @@ describe("Webchat API", () => {
       expect(res.status).toBe(409);
       expect(runForked).not.toHaveBeenCalled();
     });
+
+    it("promotes a completed branch to an ordinary chat", async () => {
+      // The mocked runner below skips the real AgentRunner.runForked, which is
+      // what creates the fork's Rome session row; seed it so promotion has a
+      // row to flip.
+      await deps.webchatRepo.ensureRomeSession({
+        id: "branch-fork-session",
+        type: "fork",
+        name: "branch: Branch Routes",
+        agentName: null,
+        trigger: { triggerKind: "fork", triggerName: "branch" },
+        parentSessionId: SESSION_ID,
+        parentTurnId: TURN_ID,
+      });
+      deps.agentRunner = {
+        run: deps.agentRunner.run.bind(deps.agentRunner),
+        async *runForked(params) {
+          yield {
+            type: "turn_start",
+            turnId: "branch-fork-turn",
+            sessionId: "branch-fork-session",
+            userPrompt: params.prompt,
+          };
+          yield { type: "result", content: "Here is the side-chat answer." };
+          yield {
+            type: "turn_end",
+            turnId: "branch-fork-turn",
+            status: "completed",
+            durationMs: 1,
+          };
+        },
+      };
+      rs.spyOn(deps.agentSessionManager, "acquire").mockResolvedValue({
+        sessionId: "live-source-session",
+      } as AgentSession);
+      rs.spyOn(deps.sessionManager, "getTurnCheckpoint").mockResolvedValue({
+        sessionId: "live-source-session",
+        turnId: TURN_ID,
+        provider: "openai",
+        providerThreadId: "source-provider-thread",
+        checkpointId: "provider-turn-t2",
+      });
+      rs.spyOn(deps.actionEngine, "run").mockResolvedValue({
+        status: "place_widget",
+        placement: { appId: "sessions", route: "branch-fork-session" },
+      });
+      // The drain promotes only when the resumable row exists — the row
+      // persistForkThread writes on completion. The mocked runner skips the
+      // real persistForkThread, so its outcome is represented here.
+      const findRow = rs.spyOn(deps.sessionManager, "findReusableSession").mockResolvedValue({
+        id: "branch-fork-session",
+        provider: "anthropic",
+        providerThreadId: "fork-provider-thread",
+        model: "claude",
+        createdAt: new Date(),
+        lastActiveAt: new Date(),
+      });
+      const app = createWebchatRuntime(deps).routes;
+
+      const res = await app.request(`/chat/sessions/${SESSION_ID}/turns/${TURN_ID}/forks`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: "What about the other approach?" }),
+      });
+      expect(res.status).toBe(201);
+
+      // The drain runs in the background; wait for the flip to land.
+      await rs.waitFor(async () => {
+        const session = await deps.webchatRepo.getSession("branch-fork-session");
+        expect(session?.type).toBe("webchat");
+      });
+      const promoted = await deps.webchatRepo.getSession("branch-fork-session");
+      // Provenance survives promotion.
+      expect(promoted?.parentSessionId).toBe(SESSION_ID);
+      // The unread clock is armed like any ordinary chat's.
+      expect(promoted?.lastSeenActivityAt).not.toBeNull();
+      // The raw `branch: …` name never reaches the sidebar: the retitle runs
+      // at promotion. The harness stubs the title generator with the
+      // deterministic fallback, so this settles quickly.
+      await rs.waitFor(async () => {
+        const session = await deps.webchatRepo.getSession("branch-fork-session");
+        expect(session?.name).not.toMatch(/^branch:/);
+      });
+      expect(findRow).toHaveBeenCalled();
+      // The sidebar list now contains it with no query change.
+      const listed = (await (await app.request("/chat/sessions")).json()) as Array<{ id: string }>;
+      expect(listed.map((s) => s.id)).toContain("branch-fork-session");
+    });
+
+    it("does not promote a branch whose thread was never persisted", async () => {
+      await deps.webchatRepo.ensureRomeSession({
+        id: "branch-fork-session",
+        type: "fork",
+        name: "branch: Branch Routes",
+        agentName: null,
+        trigger: { triggerKind: "fork", triggerName: "branch" },
+        parentSessionId: SESSION_ID,
+        parentTurnId: TURN_ID,
+      });
+      deps.agentRunner = {
+        run: deps.agentRunner.run.bind(deps.agentRunner),
+        async *runForked(params) {
+          yield {
+            type: "turn_start",
+            turnId: "branch-fork-turn",
+            sessionId: "branch-fork-session",
+            userPrompt: params.prompt,
+          };
+          yield { type: "result", content: "Here is the side-chat answer." };
+          yield {
+            type: "turn_end",
+            turnId: "branch-fork-turn",
+            status: "completed",
+            durationMs: 1,
+          };
+        },
+      };
+      rs.spyOn(deps.agentSessionManager, "acquire").mockResolvedValue({
+        sessionId: "live-source-session",
+      } as AgentSession);
+      rs.spyOn(deps.sessionManager, "getTurnCheckpoint").mockResolvedValue({
+        sessionId: "live-source-session",
+        turnId: TURN_ID,
+        provider: "openai",
+        providerThreadId: "source-provider-thread",
+        checkpointId: "provider-turn-t2",
+      });
+      rs.spyOn(deps.actionEngine, "run").mockResolvedValue({
+        status: "place_widget",
+        placement: { appId: "sessions", route: "branch-fork-session" },
+      });
+      const findRow = rs
+        .spyOn(deps.sessionManager, "findReusableSession")
+        .mockResolvedValue(undefined);
+      const app = createWebchatRuntime(deps).routes;
+
+      const res = await app.request(`/chat/sessions/${SESSION_ID}/turns/${TURN_ID}/forks`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: "What about the other approach?" }),
+      });
+      expect(res.status).toBe(201);
+
+      // "Still a fork" is true from t=0, so waiting on the type alone would
+      // pass vacuously. Wait for the drain to actually reach its decision
+      // point, then assert it declined.
+      await rs.waitFor(() => expect(findRow).toHaveBeenCalled());
+      const session = await deps.webchatRepo.getSession("branch-fork-session");
+      // Promoting without the row would open a fresh provider thread on the
+      // next message and silently lose the branched context.
+      expect(session?.type).toBe("fork");
+      const listed = (await (await app.request("/chat/sessions")).json()) as Array<{ id: string }>;
+      expect(listed.map((s) => s.id)).not.toContain("branch-fork-session");
+    });
   });
 
   describe("continuable side chats", () => {

--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -3519,6 +3519,9 @@ describe("Webchat API", () => {
       });
 
       expect(res.status).toBe(409);
+      // The distinct code lets the client say "this answer has no branch
+      // point" instead of implying a transient failure.
+      await expect(res.json()).resolves.toMatchObject({ code: "turn_not_branchable" });
       expect(runForked).not.toHaveBeenCalled();
     });
 

--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -3597,13 +3597,10 @@ describe("Webchat API", () => {
       expect(promoted?.parentSessionId).toBe(SESSION_ID);
       // The unread clock is armed like any ordinary chat's.
       expect(promoted?.lastSeenActivityAt).not.toBeNull();
-      // The raw `branch: …` name never reaches the sidebar: the retitle runs
-      // at promotion. The harness stubs the title generator with the
-      // deterministic fallback, so this settles quickly.
-      await rs.waitFor(async () => {
-        const session = await deps.webchatRepo.getSession("branch-fork-session");
-        expect(session?.name).not.toMatch(/^branch:/);
-      });
+      // The raw `branch: …` name never reaches the sidebar: the fallback
+      // retitle lands BEFORE the type flips, so the instant an observer sees
+      // "webchat" the name is already clean — no waitFor needed here.
+      expect(promoted?.name).not.toMatch(/^branch:/);
       expect(findRow).toHaveBeenCalled();
       // The sidebar list now contains it with no query change.
       const listed = (await (await app.request("/chat/sessions")).json()) as Array<{ id: string }>;

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -1172,7 +1172,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
      * fork behind turn feedback is a background errand and stays one-shot.
      */
     continuable: boolean;
-  }): Promise<ForkSessionPlacement | null> => {
+  }): Promise<ForkSessionPlacement | "no_turn_checkpoint" | null> => {
     if (!deps.agentRunner.runForked) {
       log.warn("turn fork unavailable: runner cannot fork", {
         sessionId: input.session.id,
@@ -1254,7 +1254,10 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
           turnId: input.turnId,
           label: input.label,
         });
-        return null;
+        // Distinguishable so the branch route can tell the user this turn has
+        // no branch point (a promoted side chat's own first answer is the
+        // common case) rather than implying a transient failure.
+        return "no_turn_checkpoint";
       }
       sourceCheckpoint = {
         providerId: storedCheckpoint.provider,
@@ -1414,7 +1417,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     turnId: string;
     rating: "positive" | "negative";
     comment: string;
-  }): Promise<ForkSessionPlacement | null> => {
+  }): Promise<ForkSessionPlacement | "no_turn_checkpoint" | null> => {
     // The fork inherits the source transcript at its current head, which may
     // have moved past the rated turn (feedback stays available on older
     // turns). Reconstruct the rated exchange from the persisted transcript
@@ -2476,6 +2479,11 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       initiator: "system:turn-branch",
       continuable: true,
     });
+    if (placement === "no_turn_checkpoint") {
+      // Not transient: this turn persisted no provider checkpoint to fork
+      // from. A follow-up answer in the same conversation is branchable.
+      return c.json({ error: "This answer has no branch point", code: "turn_not_branchable" }, 409);
+    }
     if (!placement) {
       return c.json({ error: "Couldn't start side chat from this conversation" }, 409);
     }
@@ -2591,10 +2599,13 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
           comment,
         })
       : null;
+    // The learning fork is best-effort; a turn with no branch point (e.g. a
+    // promoted side chat's first answer) just skips it.
+    const processingPlacement = typeof processing === "object" ? processing : null;
 
     return c.json({
       feedback: formatFeedback(stored),
-      ...(processing ? { processing } : {}),
+      ...(processingPlacement ? { processing: processingPlacement } : {}),
     });
   });
 

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -2601,7 +2601,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       : null;
     // The learning fork is best-effort; a turn with no branch point (e.g. a
     // promoted side chat's first answer) just skips it.
-    const processingPlacement = typeof processing === "object" ? processing : null;
+    const processingPlacement = typeof processing === "string" ? null : processing;
 
     return c.json({
       feedback: formatFeedback(stored),

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -1317,8 +1317,33 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     const forkSessionId = first.value.sessionId;
     const forkTurnId = first.value.turnId;
     void (async () => {
-      while (!(await iterator.next()).done) {
-        // AgentRunner persists every fork message; this caller only has to drain.
+      let finalStatus: string | undefined;
+      let next = await iterator.next();
+      while (!next.done) {
+        // AgentRunner persists every fork message; this caller only watches
+        // for the terminal turn_end.
+        if (next.value.type === "turn_end") finalStatus = next.value.status;
+        next = await iterator.next();
+      }
+      // A branch that completed on its own provider thread stops being
+      // special. The resumable row is the source of truth: persistForkThread
+      // already declined errored turns and borrowed threads, and promoting
+      // without it would hand the next message a fresh provider thread and
+      // silently drop the branched context.
+      if (input.continuable && finalStatus === "completed") {
+        const row = await deps.sessionManager.findReusableSession(
+          buildWebchatChannelThreadKey(forkSessionId, null),
+          agentName,
+        );
+        if (row?.providerThreadId) {
+          const current = await deps.webchatRepo.getSession(forkSessionId);
+          await deps.webchatRepo.promoteForkToChat(forkSessionId);
+          // An ordinary chat is titled from its first user message; the
+          // branch's is the prompt typed into the branch popover.
+          if (current) {
+            void generateAndPersistConversationTitle(forkSessionId, current.name, input.prompt);
+          }
+        }
       }
     })().catch((err) => {
       log.warn("turn fork failed", {

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -1337,11 +1337,25 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
         );
         if (row?.providerThreadId) {
           const current = await deps.webchatRepo.getSession(forkSessionId);
+          // Retitle BEFORE the flip: the sidebar refetches the moment any
+          // observer sees type "webchat", and nothing re-notifies it when a
+          // late title lands — so the raw `branch: …` name must already be
+          // gone when the type changes. The deterministic fallback (the
+          // branch prompt, truncated) is written synchronously; the generated
+          // title replaces it afterwards unless the guardian renamed the chat
+          // meanwhile. An ordinary chat is titled from its first user
+          // message; the branch's is the prompt typed into the popover.
+          const fallbackTitle = fallbackConversationTitle(input.prompt);
+          if (current && fallbackTitle) {
+            await deps.webchatRepo.updateSessionNameIfCurrent(
+              forkSessionId,
+              current.name,
+              fallbackTitle,
+            );
+          }
           await deps.webchatRepo.promoteForkToChat(forkSessionId);
-          // An ordinary chat is titled from its first user message; the
-          // branch's is the prompt typed into the branch popover.
-          if (current) {
-            void generateAndPersistConversationTitle(forkSessionId, current.name, input.prompt);
+          if (current && fallbackTitle) {
+            void generateAndPersistConversationTitle(forkSessionId, fallbackTitle, input.prompt);
           }
         }
       }

--- a/packages/core/src/db/repositories/webchat.ts
+++ b/packages/core/src/db/repositories/webchat.ts
@@ -1419,6 +1419,23 @@ export class WebChatRepository {
     return rows[0] ?? null;
   }
 
+  /**
+   * A branch whose first answer completed on its own provider thread stops
+   * being special: it becomes an ordinary chat, listed and managed like any
+   * other. Provenance columns are left in place — only the type and the
+   * unread clock change. Guarded on the current type so a double call, or a
+   * call racing a delete, is a no-op.
+   */
+  async promoteForkToChat(id: string): Promise<void> {
+    await this.db
+      .update(romeSessions)
+      .set({
+        type: "webchat",
+        lastSeenActivityAt: sql`${romeSessions.activityAt}`,
+      })
+      .where(and(eq(romeSessions.id, id), eq(romeSessions.type, "fork")));
+  }
+
   async updateSessionName(id: string, name: string) {
     const rows = await this.db
       .update(romeSessions)

--- a/packages/web/src/components/chat/TurnBranchButton.test.tsx
+++ b/packages/web/src/components/chat/TurnBranchButton.test.tsx
@@ -69,4 +69,33 @@ describe("TurnBranchButton", () => {
       }),
     );
   });
+
+  it("explains a turn with no branch point instead of the generic failure", async () => {
+    rs.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json(
+        { error: "This answer has no branch point", code: "turn_not_branchable" },
+        { status: 409 },
+      ),
+    );
+    render(<TurnBranchButton sessionId="chat-session" turnId="turn-3" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "message.branch.open" }));
+    fireEvent.click(screen.getByRole("button", { name: "message.branch.suggestions.mermaid" }));
+
+    expect(await screen.findByText("message.branch.notBranchable")).toBeTruthy();
+    expect(autoPlaceApp).not.toHaveBeenCalled();
+  });
+
+  it("shows the generic failure on other errors", async () => {
+    rs.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ error: "Couldn't start side chat from this conversation" }, { status: 409 }),
+    );
+    render(<TurnBranchButton sessionId="chat-session" turnId="turn-4" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "message.branch.open" }));
+    fireEvent.click(screen.getByRole("button", { name: "message.branch.suggestions.mermaid" }));
+
+    expect(await screen.findByText("message.branch.submitFailed")).toBeTruthy();
+    expect(autoPlaceApp).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/src/components/chat/TurnBranchButton.tsx
+++ b/packages/web/src/components/chat/TurnBranchButton.tsx
@@ -28,7 +28,7 @@ export function TurnBranchButton({ sessionId, turnId }: { sessionId: string; tur
   const [open, setOpen] = useState(false);
   const [prompt, setPrompt] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<false | "generic" | "notBranchable">(false);
 
   const submit = useCallback(
     async (rawPrompt: string) => {
@@ -43,7 +43,15 @@ export function TurnBranchButton({ sessionId, turnId }: { sessionId: string; tur
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ prompt: nextPrompt }),
         });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        if (!res.ok) {
+          // A turn with no branch point (a side chat's own first answer is
+          // the common case) is a permanent property of that turn, not a
+          // transient failure — tell the user what to do instead of
+          // suggesting a retry.
+          const body = (await res.json().catch(() => null)) as { code?: string } | null;
+          setError(body?.code === "turn_not_branchable" ? "notBranchable" : "generic");
+          return;
+        }
         const body = (await res.json()) as {
           placement: { appId: string; route: string };
         };
@@ -51,7 +59,7 @@ export function TurnBranchButton({ sessionId, turnId }: { sessionId: string; tur
         setPrompt("");
         setOpen(false);
       } catch {
-        setError(true);
+        setError("generic");
       } finally {
         setSubmitting(false);
       }
@@ -122,7 +130,11 @@ export function TurnBranchButton({ sessionId, turnId }: { sessionId: string; tur
           <div className="flex items-center justify-between gap-2">
             {error ? (
               <span aria-live="polite" className="text-aux text-destructive">
-                {t("message.branch.submitFailed")}
+                {t(
+                  error === "notBranchable"
+                    ? "message.branch.notBranchable"
+                    : "message.branch.submitFailed",
+                )}
               </span>
             ) : (
               <span />

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -87,7 +87,8 @@
       "promptPlaceholder": "Ask a question about this response…",
       "submit": "Start side chat",
       "submitting": "Starting…",
-      "submitFailed": "Couldn't start the side chat"
+      "submitFailed": "Couldn't start the side chat",
+      "notBranchable": "This answer can't be branched. Send a follow-up and branch from the new answer."
     }
   },
   "blocks": {

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -87,7 +87,8 @@
       "promptPlaceholder": "针对这条回复提问…",
       "submit": "发起侧边对话",
       "submitting": "正在创建…",
-      "submitFailed": "无法创建侧边对话"
+      "submitFailed": "无法创建侧边对话",
+      "notBranchable": "无法从这条回复创建侧边对话。发送一条追问，再从新的回复创建即可。"
     }
   },
   "blocks": {

--- a/packages/web/src/lib/session-events.ts
+++ b/packages/web/src/lib/session-events.ts
@@ -21,7 +21,13 @@ export function emitSessionsChanged(): void {
   // window. Without this hop, a branch promoted while its widget is open
   // never appears in the sidebar until an unrelated refresh.
   if (window.parent !== window) {
-    window.parent.dispatchEvent(new CustomEvent(CHAT_SESSIONS_CHANGED_EVENT));
+    try {
+      window.parent.dispatchEvent(new CustomEvent(CHAT_SESSIONS_CHANGED_EVENT));
+    } catch {
+      // A cross-origin parent (no supported embedding today) refuses the
+      // dispatch; the same-window event above has already served this frame,
+      // and a caller's mutation must not fail over a notification.
+    }
   }
 }
 

--- a/packages/web/src/lib/session-events.ts
+++ b/packages/web/src/lib/session-events.ts
@@ -16,6 +16,13 @@ export const CHAT_SESSIONS_CHANGED_EVENT = "rome:chat-sessions-changed";
 export function emitSessionsChanged(): void {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new CustomEvent(CHAT_SESSIONS_CHANGED_EVENT));
+  // The Sessions view also runs inside a same-origin app iframe (AppWidget
+  // renders /full/apps/sessions/<id>), and the sidebar listens on the top
+  // window. Without this hop, a branch promoted while its widget is open
+  // never appears in the sidebar until an unrelated refresh.
+  if (window.parent !== window) {
+    window.parent.dispatchEvent(new CustomEvent(CHAT_SESSIONS_CHANGED_EVENT));
+  }
 }
 
 /**

--- a/packages/web/src/pages/SessionsPage.test.tsx
+++ b/packages/web/src/pages/SessionsPage.test.tsx
@@ -3,6 +3,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-libra
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, rs } from "@rstest/core";
 import * as chatApiModule from "@/lib/chat-api" with { rstest: "importActual" };
+import * as sessionEventsModule from "@/lib/session-events" with { rstest: "importActual" };
 import {
   getRomeSession,
   getSession,
@@ -67,6 +68,12 @@ rs.mock("@/lib/chat-api", () => {
     postSessionTurn: rs.fn(),
   };
 });
+
+const emitSessionsChanged = rs.hoisted(() => rs.fn());
+rs.mock("@/lib/session-events", () => ({
+  ...sessionEventsModule,
+  emitSessionsChanged,
+}));
 
 const FORK_SESSION = {
   id: "feedback-fork-session",
@@ -333,6 +340,29 @@ describe("SessionsPage live fork details", () => {
     finish();
 
     expect(await screen.findByTestId("side-chat-composer")).toBeTruthy();
+    // A branch that did not promote signals nothing.
+    expect(emitSessionsChanged).not.toHaveBeenCalled();
+  });
+
+  it("retires the widget composer and signals the sidebar when the branch promotes", async () => {
+    // Continuable at mount, so the composer is genuinely present…
+    rs.mocked(getSession).mockResolvedValue({ id: "feedback-fork-session" } as never);
+    // …and promoted by the time the completion refetch asks again.
+    rs.mocked(getRomeSession)
+      .mockResolvedValueOnce(FORK_SESSION)
+      .mockResolvedValue({ ...FORK_SESSION, type: "webchat" } as never);
+    const finish = mockFinishableTurnStream();
+
+    renderDetail();
+    expect(await screen.findByTestId("side-chat-composer")).toBeTruthy();
+    await waitFor(() => expect(openTurnStream).toHaveBeenCalled());
+    finish();
+
+    // An ordinary chat is not served by this read-only frame: the composer
+    // retires, and the sidebar is told to pick the new chat up. Both land
+    // behind two awaits, so both assertions must wait.
+    await waitFor(() => expect(emitSessionsChanged).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByTestId("side-chat-composer")).toBeNull());
   });
 
   it("sends a follow-up, refreshes the transcript, and re-attaches the live turn", async () => {

--- a/packages/web/src/pages/SessionsPage.test.tsx
+++ b/packages/web/src/pages/SessionsPage.test.tsx
@@ -365,6 +365,24 @@ describe("SessionsPage live fork details", () => {
     expect(screen.getByTestId("side-chat-composer")).toBeTruthy();
   });
 
+  it("retries the refetch once when the promotion lands late", async () => {
+    rs.mocked(getSession).mockResolvedValue({ id: "feedback-fork-session" } as never);
+    // The completion refetch loses the race (still "fork"); the single
+    // delayed retry sees the promotion and still signals the sidebar.
+    rs.mocked(getRomeSession)
+      .mockResolvedValueOnce(FORK_SESSION)
+      .mockResolvedValueOnce(FORK_SESSION)
+      .mockResolvedValue({ ...FORK_SESSION, type: "webchat" } as never);
+    const finish = mockFinishableTurnStream();
+
+    renderDetail();
+    expect(await screen.findByTestId("side-chat-composer")).toBeTruthy();
+    await waitFor(() => expect(openTurnStream).toHaveBeenCalled());
+    finish();
+
+    await waitFor(() => expect(emitSessionsChanged).toHaveBeenCalled(), { timeout: 4000 });
+  });
+
   it("sends a follow-up, refreshes the transcript, and re-attaches the live turn", async () => {
     rs.mocked(getSession).mockResolvedValue({ id: "feedback-fork-session" } as never);
     rs.mocked(listSessionTurns).mockResolvedValue([]);

--- a/packages/web/src/pages/SessionsPage.test.tsx
+++ b/packages/web/src/pages/SessionsPage.test.tsx
@@ -358,11 +358,11 @@ describe("SessionsPage live fork details", () => {
     await waitFor(() => expect(openTurnStream).toHaveBeenCalled());
     finish();
 
-    // An ordinary chat is not served by this read-only frame: the composer
-    // retires, and the sidebar is told to pick the new chat up. Both land
-    // behind two awaits, so both assertions must wait.
+    // The sidebar is told to pick the new chat up, and the widget keeps its
+    // composer: a promoted branch is an ordinary chat, and ordinary chats can
+    // be continued right here — no forced hop to the full chat view.
     await waitFor(() => expect(emitSessionsChanged).toHaveBeenCalled());
-    await waitFor(() => expect(screen.queryByTestId("side-chat-composer")).toBeNull());
+    expect(screen.getByTestId("side-chat-composer")).toBeTruthy();
   });
 
   it("sends a follow-up, refreshes the transcript, and re-attaches the live turn", async () => {

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -1275,11 +1275,11 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
     let cancelled = false;
     // Both completion sites below share this: promotion happens server-side
     // at the same completion, so refetch rather than trusting mount-time
-    // state. A promoted session comes back "webchat", which retires this
-    // read-only frame's composer (the probe returns early for non-forks),
-    // surfaces "Open chat", fixes the badge, and is the sidebar's cue to
-    // pick the new chat up. A transient refetch failure keeps the current
-    // state rather than replacing a just-finished answer with an error card.
+    // state. A promoted session comes back "webchat", which keeps the
+    // composer (an ordinary chat is continuable right here), surfaces
+    // "Open chat", fixes the badge, and is the sidebar's cue to pick the
+    // new chat up. A transient refetch failure keeps the current state
+    // rather than replacing a just-finished answer with an error card.
     // The server's promotion usually wins the race against this refetch (a
     // few local writes vs a network round trip); when it loses, one delayed
     // retry keeps the sidebar from missing the promotion until an unrelated

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -51,6 +51,7 @@ import {
   postSessionTurn,
   type ListRomeSessionsOptions,
 } from "@/lib/chat-api";
+import { emitSessionsChanged } from "@/lib/session-events";
 import { parseSSEEvents } from "@/lib/chat-sse";
 import { artifactLocalName } from "@/lib/artifact-name";
 import type {
@@ -1287,7 +1288,30 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
           // answer can finish between the mount probe (which 404s while it is
           // still running) and this lookup, and a failed listSessionTurns lands
           // here as well. Without it the composer would never appear.
-          void probeContinuable(session?.type);
+          if (session?.type !== "fork") {
+            void probeContinuable(session?.type);
+          } else {
+            // Promotion happens server-side at this same completion. Refetch
+            // rather than trusting mount-time state: a promoted session comes
+            // back "webchat", which retires this read-only frame's composer
+            // (the probe returns early for non-forks), surfaces "Open chat",
+            // fixes the badge, and is the sidebar's cue to pick the new chat
+            // up. A branch that did not promote behaves the same, at the cost
+            // of one extra GET per completion on fork views, and a transient
+            // refetch failure keeps the current state rather than replacing a
+            // just-finished answer with an error card.
+            let refreshed: RomeSessionDetail | null = null;
+            try {
+              refreshed = await getRomeSession(sessionId);
+            } catch {
+              // Transient — the next completion or navigation reconciles.
+            }
+            if (!cancelled) {
+              if (refreshed) setSession(refreshed);
+              void probeContinuable(refreshed?.type ?? session?.type);
+              if (refreshed?.type === "webchat") emitSessionsChanged();
+            }
+          }
         }
         return;
       }
@@ -1364,7 +1388,30 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
         setSending(false);
         // The branch's own first answer only writes its resumable row on
         // completion, and this view opened while that turn was still running.
-        void probeContinuable(session?.type);
+        if (session?.type !== "fork") {
+          void probeContinuable(session?.type);
+        } else {
+          // Promotion happens server-side at this same completion. Refetch
+          // rather than trusting mount-time state: a promoted session comes
+          // back "webchat", which retires this read-only frame's composer
+          // (the probe returns early for non-forks), surfaces "Open chat",
+          // fixes the badge, and is the sidebar's cue to pick the new chat
+          // up. A branch that did not promote behaves the same, at the cost
+          // of one extra GET per completion on fork views, and a transient
+          // refetch failure keeps the current state rather than replacing a
+          // just-finished answer with an error card.
+          let refreshed: RomeSessionDetail | null = null;
+          try {
+            refreshed = await getRomeSession(sessionId);
+          } catch {
+            // Transient — the next completion or navigation reconciles.
+          }
+          if (!cancelled) {
+            if (refreshed) setSession(refreshed);
+            void probeContinuable(refreshed?.type ?? session?.type);
+            if (refreshed?.type === "webchat") emitSessionsChanged();
+          }
+        }
       }
     })().catch((err) => {
       if (!cancelled && (err as { name?: string }).name !== "AbortError") {

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -1273,6 +1273,34 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
     }
     const controller = new AbortController();
     let cancelled = false;
+    // Both completion sites below share this: promotion happens server-side
+    // at the same completion, so refetch rather than trusting mount-time
+    // state. A promoted session comes back "webchat", which retires this
+    // read-only frame's composer (the probe returns early for non-forks),
+    // surfaces "Open chat", fixes the badge, and is the sidebar's cue to
+    // pick the new chat up. A transient refetch failure keeps the current
+    // state rather than replacing a just-finished answer with an error card.
+    // The server's promotion usually wins the race against this refetch (a
+    // few local writes vs a network round trip); when it loses, one delayed
+    // retry keeps the sidebar from missing the promotion until an unrelated
+    // refresh.
+    const reconcileFork = async (attempt = 0): Promise<void> => {
+      let refreshed: RomeSessionDetail | null = null;
+      try {
+        refreshed = await getRomeSession(sessionId);
+      } catch {
+        // Transient — the retry, next completion, or navigation reconciles.
+      }
+      if (cancelled) return;
+      if (refreshed) setSession(refreshed);
+      void probeContinuable(refreshed?.type ?? session?.type);
+      if (refreshed?.type === "webchat") {
+        emitSessionsChanged();
+      } else if (attempt === 0) {
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        if (!cancelled) await reconcileFork(1);
+      }
+    };
     void (async () => {
       const turns = await listSessionTurns(sessionId);
       // A turn is reported `queued` until it becomes the session's current
@@ -1295,26 +1323,7 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
           if (session?.type !== "fork") {
             void probeContinuable(session?.type);
           } else {
-            // Promotion happens server-side at this same completion. Refetch
-            // rather than trusting mount-time state: a promoted session comes
-            // back "webchat", which retires this read-only frame's composer
-            // (the probe returns early for non-forks), surfaces "Open chat",
-            // fixes the badge, and is the sidebar's cue to pick the new chat
-            // up. A branch that did not promote behaves the same, at the cost
-            // of one extra GET per completion on fork views, and a transient
-            // refetch failure keeps the current state rather than replacing a
-            // just-finished answer with an error card.
-            let refreshed: RomeSessionDetail | null = null;
-            try {
-              refreshed = await getRomeSession(sessionId);
-            } catch {
-              // Transient — the next completion or navigation reconciles.
-            }
-            if (!cancelled) {
-              if (refreshed) setSession(refreshed);
-              void probeContinuable(refreshed?.type ?? session?.type);
-              if (refreshed?.type === "webchat") emitSessionsChanged();
-            }
+            await reconcileFork();
           }
         }
         return;
@@ -1395,26 +1404,7 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
         if (session?.type !== "fork") {
           void probeContinuable(session?.type);
         } else {
-          // Promotion happens server-side at this same completion. Refetch
-          // rather than trusting mount-time state: a promoted session comes
-          // back "webchat", which retires this read-only frame's composer
-          // (the probe returns early for non-forks), surfaces "Open chat",
-          // fixes the badge, and is the sidebar's cue to pick the new chat
-          // up. A branch that did not promote behaves the same, at the cost
-          // of one extra GET per completion on fork views, and a transient
-          // refetch failure keeps the current state rather than replacing a
-          // just-finished answer with an error card.
-          let refreshed: RomeSessionDetail | null = null;
-          try {
-            refreshed = await getRomeSession(sessionId);
-          } catch {
-            // Transient — the next completion or navigation reconciles.
-          }
-          if (!cancelled) {
-            if (refreshed) setSession(refreshed);
-            void probeContinuable(refreshed?.type ?? session?.type);
-            if (refreshed?.type === "webchat") emitSessionsChanged();
-          }
+          await reconcileFork();
         }
       }
     })().catch((err) => {

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -1163,7 +1163,11 @@ function SessionDetailPage({ sessionId }: { sessionId: string }) {
 
   const probeContinuable = useCallback(
     async (sessionType: string | undefined) => {
-      if (sessionType !== "fork") {
+      // A fork may be continuable once its first answer persists a thread; an
+      // ordinary chat always is (the send routes accept it), which keeps the
+      // composer alive in the branch widget after promotion instead of
+      // forcing a hop to the full chat view. Everything else stays read-only.
+      if (sessionType !== "fork" && sessionType !== "webchat") {
         setContinuable(false);
         return;
       }


### PR DESCRIPTION
## What this PR does

A side chat was a special session type most of the product refused: absent from the sidebar, unmanageable, stripped of interactive cards and async work. Now, when its first answer completes on its own provider thread, the session is promoted to an ordinary chat — listed in the sidebar under a title from the branch question, with every ordinary-chat capability and no branch labelling.

## Design & Invariants

- **Promotion is one write in one place.** The fork drain flips `rome_sessions.type` to `"webchat"` and arms the unread clock. Every existing type-keyed gate then grants ordinary-chat behavior with no per-surface changes.
- **Promotion is conditional on the resumable row, never on turn status alone.** `persistForkThread` already declines errored turns and borrowed provider threads; promoting without its row would hand the next message a fresh provider thread and silently drop the branched context.
- **The name is clean before it is visible.** The deterministic fallback title (the branch prompt) lands synchronously before the type flips — nothing re-notifies the sidebar about a late title. The generated title still replaces it unless the guardian renamed the chat meanwhile.
- **Visibility and capability arrive in one write**, so the sidebar can never list a chat that `/chat/<id>` refuses. The branch widget is a same-origin iframe; `emitSessionsChanged` now also dispatches on `window.parent` (guarded against a cross-origin parent) so the sidebar hears a promotion while the widget is open; if the widget's refetch outruns the server's promotion, one delayed retry closes the gap.
- **The widget keeps its composer after promotion.** The send routes already accept ordinary chats, so the conversation continues in the widget; the Sessions detail view offers the same composer for any ordinary chat it shows.
- **A turn with no branch point answers 409 with `code: "turn_not_branchable"`** and the popover explains what to do, instead of implying a transient failure.
- Provenance (`parentSessionId`, `parentTurnId`, trigger) survives; the explorer's lineage panel keeps working. A `feedback:` fork never promotes because it is never continuable. A promoted chat cannot store a model selection (it always has ≥2 messages), so its channel-thread key cannot drift.
- Known cosmetic seam: one stale unread dot if the trace recorder bumps `activityAt` just after promotion arms the clock — self-clearing on first open.

## Test plan

- `webchat.test.ts`: a completed branch with a persisted thread is promoted (type, provenance, unread clock, synchronous retitle, sidebar listing); one without stays an unlisted fork; the checkpoint-missing 409 carries its code.
- `SessionsPage.test.tsx`: promotion keeps the widget composer and signals the sidebar; a late promotion is caught by the single retry; a non-promoting branch signals nothing.
- `TurnBranchButton.test.tsx`: `turn_not_branchable` shows the explanatory message; other errors keep the generic one.
- Browser (the `window.parent` hop is untestable in jsdom): branch → completion with the widget open → sidebar row appears without reload, cleanly titled; follow-ups stream in the widget; rename/pin/archive/delete work; parent untouched; feedback forks appear nowhere.

## Not in this PR

- Provenance UI — the data is kept; deliberately no UI per product decision.
- Backfilling branches created before this change (explorer-only, as today).
- Branching from a branch's first answer: persisting the fork's first-turn checkpoint needs provider-level work on both providers; the 409 now explains itself.
- The first-turn approval delivery seam documented in PR #169.
- Removing the now-legacy fork-era gates; they still serve legacy branches and the pre-promotion window.

