### PR TITLE
feat(core): create a side chat as an ordinary chat at birth

### DIFF
--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -2934,6 +2934,18 @@ describe("Webchat API", () => {
       // Seed the rated exchange plus a later turn: the fork inherits the
       // source transcript at its head, so the prompt must quote the rated
       // turn's exchange verbatim rather than pointing at "the latest turn".
+      // The mocked runner skips createForkTraceRecorder, which is what writes
+      // the fork's Rome session row; seed it so the type assertion below has a
+      // row to read.
+      await deps.webchatRepo.ensureRomeSession({
+        id: "feedback-fork-session",
+        type: "fork",
+        name: "feedback: Branch Routes",
+        agentName: null,
+        trigger: { triggerKind: "fork", triggerName: "feedback" },
+        parentSessionId: SESSION_ID,
+        parentTurnId: TURN_ID,
+      });
       await deps.webchatRepo.addMessage(
         "fb-rated-user",
         SESSION_ID,
@@ -3019,6 +3031,10 @@ describe("Webchat API", () => {
         },
         processing: { appId: "sessions", route: "feedback-fork-session" },
       });
+      // Promotion keys off `continuable`, and the feedback fork is one-shot:
+      // it stays a fork and never reaches the sidebar.
+      const feedbackFork = await deps.webchatRepo.getSession("feedback-fork-session");
+      expect(feedbackFork?.type).toBe("fork");
       expect(forkParams).toMatchObject({
         agentName: "main",
         sourceSessionId: "live-source-session",
@@ -3525,7 +3541,7 @@ describe("Webchat API", () => {
       expect(runForked).not.toHaveBeenCalled();
     });
 
-    it("promotes a completed branch to an ordinary chat", async () => {
+    it("creates the branch as an ordinary chat at 201", async () => {
       // The mocked runner below skips the real AgentRunner.runForked, which is
       // what creates the fork's Rome session row; seed it so promotion has a
       // row to flip.
@@ -3570,17 +3586,6 @@ describe("Webchat API", () => {
         status: "place_widget",
         placement: { appId: "sessions", route: "branch-fork-session" },
       });
-      // The drain promotes only when the resumable row exists — the row
-      // persistForkThread writes on completion. The mocked runner skips the
-      // real persistForkThread, so its outcome is represented here.
-      const findRow = rs.spyOn(deps.sessionManager, "findReusableSession").mockResolvedValue({
-        id: "branch-fork-session",
-        provider: "anthropic",
-        providerThreadId: "fork-provider-thread",
-        model: "claude",
-        createdAt: new Date(),
-        lastActiveAt: new Date(),
-      });
       const app = createWebchatRuntime(deps).routes;
 
       const res = await app.request(`/chat/sessions/${SESSION_ID}/turns/${TURN_ID}/forks`, {
@@ -3590,27 +3595,24 @@ describe("Webchat API", () => {
       });
       expect(res.status).toBe(201);
 
-      // The drain runs in the background; wait for the flip to land.
-      await rs.waitFor(async () => {
-        const session = await deps.webchatRepo.getSession("branch-fork-session");
-        expect(session?.type).toBe("webchat");
-      });
+      // Promotion happens before the 201 leaves the server — no waiting, no
+      // drain involvement, and no resumable-row consultation.
       const promoted = await deps.webchatRepo.getSession("branch-fork-session");
+      expect(promoted?.type).toBe("webchat");
       // Provenance survives promotion.
       expect(promoted?.parentSessionId).toBe(SESSION_ID);
       // The unread clock is armed like any ordinary chat's.
       expect(promoted?.lastSeenActivityAt).not.toBeNull();
-      // The raw `branch: …` name never reaches the sidebar: the fallback
-      // retitle lands BEFORE the type flips, so the instant an observer sees
-      // "webchat" the name is already clean — no waitFor needed here.
-      expect(promoted?.name).not.toMatch(/^branch:/);
-      expect(findRow).toHaveBeenCalled();
-      // The sidebar list now contains it with no query change.
+      // The raw `branch: …` name never exists once the type is visible: the
+      // fallback retitle (the branch prompt, normalized — trailing punctuation
+      // stripped) lands before the flip.
+      expect(promoted?.name).toBe("What about the other approach");
+      // The sidebar list contains it immediately, with no query change.
       const listed = (await (await app.request("/chat/sessions")).json()) as Array<{ id: string }>;
       expect(listed.map((s) => s.id)).toContain("branch-fork-session");
     });
 
-    it("does not promote a branch whose thread was never persisted", async () => {
+    it("refuses a follow-up until the branch thread exists", async () => {
       await deps.webchatRepo.ensureRomeSession({
         id: "branch-fork-session",
         type: "fork",
@@ -3664,22 +3666,66 @@ describe("Webchat API", () => {
       });
       expect(res.status).toBe(201);
 
-      // "Still a fork" is true from t=0, so waiting on the type alone would
-      // pass vacuously. Wait for the drain to actually reach its decision
-      // point, then assert it declined.
-      await rs.waitFor(() => expect(findRow).toHaveBeenCalled());
-      const session = await deps.webchatRepo.getSession("branch-fork-session");
-      // Promoting without the row would open a fresh provider thread on the
-      // next message and silently lose the branched context.
-      expect(session?.type).toBe("fork");
-      const listed = (await (await app.request("/chat/sessions")).json()) as Array<{ id: string }>;
-      expect(listed.map((s) => s.id)).not.toContain("branch-fork-session");
+      // Visibility now precedes thread persistence, so the send guard is what
+      // keeps "visible" from outrunning "continuable": a follow-up before
+      // persistForkThread's row exists would acquire a fresh provider thread
+      // and silently lose the branched context.
+      const refused = await app.request(`/chat/sessions/branch-fork-session/turns`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "And the failure case?" }),
+      });
+      expect(refused.status).toBe(409);
+      await expect(refused.json()).resolves.toMatchObject({ code: "branch_thread_missing" });
+      expect(findRow).toHaveBeenCalled();
+
+      // Once the thread lands, the same send is accepted.
+      findRow.mockResolvedValue({
+        id: "branch-fork-session",
+        provider: "anthropic",
+        providerThreadId: "fork-provider-thread",
+        model: "claude",
+        createdAt: new Date(),
+        lastActiveAt: new Date(),
+      });
+      deps.agentSessionManager = {
+        acquire: rs.fn(async () => {
+          return {
+            key: { agentName: "main", channelThreadKey: "webchat:branch-fork-session" },
+            sessionId: "fork-agent-session",
+            status: "idle",
+            sendTurn() {
+              return {
+                turnId: "follow-up-turn",
+                events: (async function* () {
+                  yield { type: "result", content: "It fails closed." };
+                })(),
+                turnContext: otelContext.active(),
+              };
+            },
+            subscribe: () => () => undefined,
+            onStatusChange: () => () => undefined,
+            interrupt: async () => undefined,
+            close: async () => undefined,
+          } satisfies AgentSession;
+        }),
+        peek: () => undefined,
+        shutdown: async () => undefined,
+      };
+      const accepted = await app.request(`/chat/sessions/branch-fork-session/turns`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "And the failure case?" }),
+      });
+      expect(accepted.status).toBe(200);
     });
   });
 
   describe("continuable side chats", () => {
     const FORK_ID = "branch-session-continuable";
     const LEGACY_FORK_ID = "branch-session-legacy";
+    // A branch as it ships now: born type "webchat" with lineage intact.
+    const PROMOTED_ID = "branch-session-promoted";
 
     const withThread = (id: string) => ({
       id,
@@ -3702,6 +3748,15 @@ describe("Webchat API", () => {
           parentTurnId: "parent-turn",
         });
       }
+      await deps.webchatRepo.ensureRomeSession({
+        id: PROMOTED_ID,
+        type: "webchat",
+        name: "What about the other approach?",
+        agentName: null,
+        trigger: { triggerKind: "fork", triggerName: "branch" },
+        parentSessionId: "parent-chat",
+        parentTurnId: "parent-turn",
+      });
     });
 
     it("serves a fork that has a resumable thread and refuses one that does not", async () => {
@@ -3715,8 +3770,9 @@ describe("Webchat API", () => {
     });
 
     it("leaves every other fork-facing route closed", async () => {
-      // The feature needs two routes. Widening the shared lookup would also
-      // hand a branch nested forks and turn feedback, which nothing designed.
+      // Legacy fork-typed rows keep the narrow surface. A branch that ships
+      // today is born type "webchat" and deliberately gets every ordinary
+      // route — this fixture covers the pre-promotion shape that remains.
       rs.spyOn(deps.sessionManager, "findReusableSession").mockResolvedValue(withThread(FORK_ID));
       const app = createWebchatRuntime(deps).routes;
 
@@ -3736,8 +3792,10 @@ describe("Webchat API", () => {
       );
     });
 
-    it("resumes the fork's own thread for a follow-up turn, with no interactive surface", async () => {
-      rs.spyOn(deps.sessionManager, "findReusableSession").mockResolvedValue(withThread(FORK_ID));
+    it("resumes the branch's own thread for a follow-up turn, with no interactive surface", async () => {
+      rs.spyOn(deps.sessionManager, "findReusableSession").mockResolvedValue(
+        withThread(PROMOTED_ID),
+      );
       let acquiredKey: unknown;
       let acquiredInit: AgentSessionInit | undefined;
       deps.agentSessionManager = {
@@ -3745,7 +3803,7 @@ describe("Webchat API", () => {
           acquiredKey = key;
           acquiredInit = init;
           return {
-            key: { agentName: "main", channelThreadKey: `webchat:${FORK_ID}` },
+            key: { agentName: "main", channelThreadKey: `webchat:${PROMOTED_ID}` },
             sessionId: "fork-agent-session",
             status: "idle",
             sendTurn() {
@@ -3768,33 +3826,42 @@ describe("Webchat API", () => {
       };
       const app = createWebchatRuntime(deps).routes;
 
-      const res = await app.request(`/chat/sessions/${FORK_ID}/turns`, {
+      const res = await app.request(`/chat/sessions/${PROMOTED_ID}/turns`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text: "And what about the failure case?" }),
       });
 
       expect(res.status).toBe(200);
-      // Runs under the fork's own key, so it resumes the branch instead of
+      // Runs under the branch's own key, so it resumes the branch instead of
       // leasing or extending the parent chat.
-      expect(acquiredKey).toEqual({ agentName: "main", channelThreadKey: `webchat:${FORK_ID}` });
-      expect(acquiredInit?.romeSessionId).toBe(FORK_ID);
+      expect(acquiredKey).toEqual({
+        agentName: "main",
+        channelThreadKey: `webchat:${PROMOTED_ID}`,
+      });
+      expect(acquiredInit?.romeSessionId).toBe(PROMOTED_ID);
       // The Sessions detail view renders this read-only, so the session must
-      // not open believing it can mount a card nobody can answer.
+      // not open believing it can mount a card nobody can answer. The guard
+      // keys on lineage, not type — a born-webchat branch must stay detached.
       expect(acquiredInit?.interactiveSurfaceDetached).toBe(true);
     });
 
     it("resumes a branch under its persisted key even when a selection is sent", async () => {
       // `persistForkThread` stored the row without a model-selection suffix. If
       // a follow-up ever recomputed a suffixed key, `acquire` would open a
-      // fresh provider thread and lose the branch history with no error.
-      rs.spyOn(deps.sessionManager, "findReusableSession").mockResolvedValue(withThread(FORK_ID));
+      // fresh provider thread and lose the branch history with no error. The
+      // selector setting must be ON or the selection is discarded before the
+      // pin and this proves nothing.
+      await deps.settingsRepo.set("enableModelSelector", true);
+      rs.spyOn(deps.sessionManager, "findReusableSession").mockResolvedValue(
+        withThread(PROMOTED_ID),
+      );
       let acquiredKey: unknown;
       deps.agentSessionManager = {
         acquire: rs.fn(async (key) => {
           acquiredKey = key;
           return {
-            key: { agentName: "main", channelThreadKey: `webchat:${FORK_ID}` },
+            key: { agentName: "main", channelThreadKey: `webchat:${PROMOTED_ID}` },
             sessionId: "fork-agent-session",
             status: "idle",
             sendTurn() {
@@ -3817,13 +3884,16 @@ describe("Webchat API", () => {
       };
       const app = createWebchatRuntime(deps).routes;
 
-      await app.request(`/chat/sessions/${FORK_ID}/turns`, {
+      await app.request(`/chat/sessions/${PROMOTED_ID}/turns`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text: "and then?", largeModelSelection: "claude-opus" }),
       });
 
-      expect(acquiredKey).toEqual({ agentName: "main", channelThreadKey: `webchat:${FORK_ID}` });
+      expect(acquiredKey).toEqual({
+        agentName: "main",
+        channelThreadKey: `webchat:${PROMOTED_ID}`,
+      });
     });
 
     it("leaves an ordinary chat's interactive surface attached", async () => {

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -1319,48 +1319,30 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
 
     const forkSessionId = first.value.sessionId;
     const forkTurnId = first.value.turnId;
-    void (async () => {
-      let finalStatus: string | undefined;
-      let next = await iterator.next();
-      while (!next.done) {
-        // AgentRunner persists every fork message; this caller only watches
-        // for the terminal turn_end.
-        if (next.value.type === "turn_end") finalStatus = next.value.status;
-        next = await iterator.next();
-      }
-      // A branch that completed on its own provider thread stops being
-      // special. The resumable row is the source of truth: persistForkThread
-      // already declined errored turns and borrowed threads, and promoting
-      // without it would hand the next message a fresh provider thread and
-      // silently drop the branched context.
-      if (input.continuable && finalStatus === "completed") {
-        const row = await deps.sessionManager.findReusableSession(
-          buildWebchatChannelThreadKey(forkSessionId, null),
-          agentName,
+    if (input.continuable) {
+      // Born an ordinary chat: createForkTraceRecorder wrote the row when
+      // turn_start arrived, and the chat surface can already list and stream
+      // this turn. Retitle before anyone can see it (the deterministic
+      // fallback is the branch prompt; the generated title follows
+      // asynchronously and respects a manual rename), then flip the type so
+      // every type-keyed gate grants ordinary-chat behavior from the 201 on.
+      // The send guard in handleChatSend keeps "visible" from outrunning
+      // "continuable" until persistForkThread lands the provider thread.
+      const fallbackTitle = fallbackConversationTitle(input.prompt);
+      const current = await deps.webchatRepo.getSession(forkSessionId);
+      if (current && fallbackTitle) {
+        await deps.webchatRepo.updateSessionNameIfCurrent(
+          forkSessionId,
+          current.name,
+          fallbackTitle,
         );
-        if (row?.providerThreadId) {
-          const current = await deps.webchatRepo.getSession(forkSessionId);
-          // Retitle BEFORE the flip: the sidebar refetches the moment any
-          // observer sees type "webchat", and nothing re-notifies it when a
-          // late title lands — so the raw `branch: …` name must already be
-          // gone when the type changes. The deterministic fallback (the
-          // branch prompt, truncated) is written synchronously; the generated
-          // title replaces it afterwards unless the guardian renamed the chat
-          // meanwhile. An ordinary chat is titled from its first user
-          // message; the branch's is the prompt typed into the popover.
-          const fallbackTitle = fallbackConversationTitle(input.prompt);
-          if (current && fallbackTitle) {
-            await deps.webchatRepo.updateSessionNameIfCurrent(
-              forkSessionId,
-              current.name,
-              fallbackTitle,
-            );
-          }
-          await deps.webchatRepo.promoteForkToChat(forkSessionId);
-          if (current && fallbackTitle) {
-            void generateAndPersistConversationTitle(forkSessionId, fallbackTitle, input.prompt);
-          }
-        }
+        void generateAndPersistConversationTitle(forkSessionId, fallbackTitle, input.prompt);
+      }
+      await deps.webchatRepo.promoteForkToChat(forkSessionId);
+    }
+    void (async () => {
+      while (!(await iterator.next()).done) {
+        // AgentRunner persists every fork message; this caller only has to drain.
       }
     })().catch((err) => {
       log.warn("turn fork failed", {
@@ -2900,6 +2882,27 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       return c.json({ error: "This chat is archived and read-only" }, 409);
     }
 
+    // A branch is visible in the sidebar from its 201, but its provider thread
+    // only exists once persistForkThread lands at first-answer completion.
+    // Sending before then (or after a failed first answer) would acquire a
+    // fresh thread and silently drop the branched context — refuse instead.
+    if (session.parentSessionId !== null) {
+      const branchThread = await deps.sessionManager.findReusableSession(
+        buildWebchatChannelThreadKey(session.id, null),
+        session.agentName ?? "main",
+      );
+      if (!branchThread?.providerThreadId) {
+        return c.json(
+          {
+            error:
+              "This side chat's thread isn't ready — its first answer is still running or did not complete.",
+            code: "branch_thread_missing",
+          },
+          409,
+        );
+      }
+    }
+
     // The session's open interactions gate resolution: a resolution turn is
     // honored only when it cites the toolUseId of a card still awaiting a
     // result. Several inline components can be open at once, so this is a set
@@ -3030,7 +3033,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     // the selection to null so the two derivations cannot drift: a suffix here
     // would open a fresh provider thread and silently lose the branch history.
     const modelSelection =
-      session.type === "fork"
+      session.parentSessionId !== null
         ? null
         : await resolveSessionModelSelectionForTurn(
             {
@@ -3123,7 +3126,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
           // session would advertise a live surface (its key starts with
           // "webchat:") and could park a turn on a card nobody can answer —
           // dead-ending the conversation this is meant to keep alive.
-          interactiveSurfaceDetached: session.type === "fork",
+          interactiveSurfaceDetached: session.parentSessionId !== null,
         },
       );
     } catch (err) {

--- a/packages/web/src/components/chat/TurnBranchButton.test.tsx
+++ b/packages/web/src/components/chat/TurnBranchButton.test.tsx
@@ -11,6 +11,11 @@ rs.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
+const emitSessionsChanged = rs.hoisted(() => rs.fn());
+rs.mock("@/lib/session-events", () => ({
+  emitSessionsChanged,
+}));
+
 afterEach(() => {
   cleanup();
   autoPlaceApp.mockClear();
@@ -35,6 +40,8 @@ describe("TurnBranchButton", () => {
     await waitFor(() => {
       expect(autoPlaceApp).toHaveBeenCalledWith("sessions", "branch-session");
     });
+    // The sidebar learns about the born-webchat branch at creation.
+    expect(emitSessionsChanged).toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/chat/sessions/chat-session/turns/turn-1/forks",
       expect.objectContaining({
@@ -84,6 +91,7 @@ describe("TurnBranchButton", () => {
 
     expect(await screen.findByText("message.branch.notBranchable")).toBeTruthy();
     expect(autoPlaceApp).not.toHaveBeenCalled();
+    expect(emitSessionsChanged).not.toHaveBeenCalled();
   });
 
   it("shows the generic failure on other errors", async () => {

--- a/packages/web/src/components/chat/TurnBranchButton.tsx
+++ b/packages/web/src/components/chat/TurnBranchButton.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
 import { autoPlaceApp } from "@/pages/free/use-free-cells";
+import { emitSessionsChanged } from "@/lib/session-events";
 
 const SUGGESTION_KEYS = [
   "message.branch.suggestions.mermaid",
@@ -56,6 +57,9 @@ export function TurnBranchButton({ sessionId, turnId }: { sessionId: string; tur
           placement: { appId: string; route: string };
         };
         autoPlaceApp(body.placement.appId, body.placement.route);
+        // The branch is an ordinary chat from its 201 — tell the sidebar now;
+        // nothing else announces the row at creation.
+        emitSessionsChanged();
         setPrompt("");
         setOpen(false);
       } catch {


### PR DESCRIPTION
## What this PR does

A branch became an ordinary chat only when its first answer completed; until then it was invisible and untouchable. Now it is an ordinary chat from the moment it is created: promoted to `type: "webchat"` — retitled from the branch prompt — before the 201 leaves the server, so the sidebar lists it immediately and every type-keyed gate grants ordinary-chat behavior from the start. This is the ground the next PR stands on, which replaces the branch widget with a real chat card; the current widget keeps working unchanged in the meantime.

## Design & Invariants

- **Promotion moves from the drain to creation.** `createForkTraceRecorder` writes the session row and registers the turn stream before `turn_start` is yielded, so at the 201 the row exists and the chat surface can already list and stream the turn. The drain returns to plain draining.
- **"Visible" can no longer outrun "continuable" — a send guard replaces the completion-time coupling.** A follow-up to a session with `parentSessionId` is refused with `409 branch_thread_missing` until `persistForkThread` lands the branch's provider thread. This covers both the first-answer window and a failed first answer; without it, an early send would acquire a fresh provider thread and silently drop the branched context.
- **The two guards that keyed on the fork type now key on lineage.** The model-selection pin and the detached interactive surface use `parentSessionId !== null` — `createSession` never writes that column, so no ordinary chat is affected, and born-webchat branches stay covered.
- **The name is clean before the type is visible**: the deterministic fallback (the branch prompt) lands before the flip; the generated title follows asynchronously and respects a manual rename.
- **A feedback fork never promotes** (`continuable: false`) and stays invisible.
- Born-webchat deliberately opens the `isStoredWebchatSession`-gated routes (`/messages`, `/events`, delete, feedback, nested forks) to branches — `/messages` and `/events` are exactly what the next PR's chat card needs.
- Interim behaviors, by design: the sidebar unread dot lingers until the chat is opened (the widget never marks read; the next PR's card does), and a branch whose first answer fails stays in the sidebar with sends refused by the guard — delete it from the sidebar.

## Test plan

- `webchat.test.ts`: promotion is observable at the 201 (type, provenance, unread clock, normalized fallback title, sidebar listing) with no drain involvement; the send guard refuses before the thread exists and accepts after; a promoted-branch fixture re-points the persisted-key and detached-surface regression tests (model selector enabled so the pin is actually exercised); the feedback fork stays a fork.
- Full suites green (core 4465, web 1323, both typechecks); the only failures observed were known load-flaky watcher/timer tests, each passing in isolation and also failing on a clean baseline.
- Browser: branch → sidebar row appears at creation, cleanly titled; widget streams and continues as before; sending into the branch while its first answer runs → the guard's 409 message, and no second provider thread exists.

## Not in this PR

- The chat card beside the parent, the sessions-widget composer removal, and the additive `{sessionId, placement}` response — the follow-up PR.
- Persisting the fork's first-turn checkpoint (branch-from-first-answer still 409s with its explanatory message).
- The crash window between `turn_start` and the 201 (leaves an invisible fork row — same blast radius as today).

