### PR TITLE
feat(people): send a message to a person

### DIFF
--- a/docs/concepts/people.md
+++ b/docs/concepts/people.md
@@ -1,4 +1,4 @@
-# People: Guardian, Visitor, Persons, Accounts, Addresses & Links
+# People: Guardian, Visitor, Persons, Accounts, Addresses, Links & Outbox
 
 ## Guardian
 
@@ -97,6 +97,23 @@ A link is the recorded fact that an [account](#account) belongs to a [person](#p
 
 - **[Bond level](#bond-levels)** — a bond level grades trust in a person. A link attributes an account to a person.
 - **Connection** — a connection joins the Rome instance to a service. A link joins an account to a person.
+
+## Outbox
+
+The outbox holds messages Rome has been asked to send and has not yet seen arrive. A message leaves it by appearing on the recipient's [timeline](#account). Nothing marks one delivered.
+
+**Contracts:**
+
+- A send names the [account](#account) it is for. Rome never chooses one on the guardian's behalf, on any evidence: a timeline entry names its channel and not its address, so no rule can tell two accounts on one channel apart, and reaching for a second channel when the first is down delivers somewhere nobody picked. A surface may preselect an account, and must show which one it picked.
+- A channel can be sent to only if it says so. `talk.feature("directMessaging")` answering null is the whole declaration, so a channel Rome mirrors but cannot write to needs no flag of its own.
+- An outbox row is exactly a send whose message is not on the timeline yet. It is derived from that comparison rather than cleared by anything, so no delivery callback can be missed and the two reads cannot disagree.
+- A message is recognized as arrived by the id the channel gave back, never by its text or its timing. A channel offering direct messaging must return one.
+- A failed send stays until the guardian retries it or discards it. A retry reuses the row, so it never reads as a second message they did not write.
+
+**Not to be confused with:**
+
+- **Timeline** — a timeline entry is a message that happened. An outbox row is one that has not, and may never.
+- **[Link](#link)** — a link says who an account belongs to. An outbox row is addressed to the account itself, so a merge moving the link leaves it true.
 
 ## Bond levels
 

--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -11,6 +11,8 @@
 //   DELETE /api/people/:id/accounts/:channel/:channelUserId -> PersonResource
 //   GET    /api/people/:id/outbox   -> OutboxPage
 //   POST   /api/people/:id/messages -> OutboxMessage (202) | SendRefusal (409)
+//   POST   /api/people/:id/outbox/:messageId/retry -> OutboxMessage (202)
+//   DELETE /api/people/:id/outbox/:messageId       -> 204
 //
 // The rest are request types that lead, with the backend following (issues
 // #64, #65):

--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -9,6 +9,8 @@
 //   POST   /api/people              -> PersonResource (201) | LinkConflict (409)
 //   POST   /api/people/:id/accounts -> PersonResource | LinkConflict (409)
 //   DELETE /api/people/:id/accounts/:channel/:channelUserId -> PersonResource
+//   GET    /api/people/:id/outbox   -> OutboxPage
+//   POST   /api/people/:id/messages -> OutboxMessage (202) | SendRefusal (409)
 //
 // The rest are request types that lead, with the backend following (issues
 // #64, #65):
@@ -820,6 +822,67 @@ export interface LinkedAccount {
   channel: string;
   channelUserId: string;
   displayName: string;
+  /** Whether Rome can send here, and when it cannot, which of the reasons it
+   *  is. See {@link AccountSendState}. */
+  send: AccountSendState;
+  /**
+   * When this account itself was last active, in epoch seconds, or null when
+   * nothing has ever passed on it.
+   *
+   * Per account rather than per person, and that is the point: the person's
+   * own {@link PersonResource.latest} names a channel and not an address, so it
+   * cannot say which of two accounts on one channel was the recent one. This
+   * can, which is what lets a composer open on the account the guardian last
+   * heard from without inventing the answer.
+   */
+  latestAt: number | null;
+}
+
+/**
+ * Whether Rome can send a message to an account, and why not when it cannot.
+ *
+ * Four states rather than a boolean, because the three failures are different
+ * things to a reader and to a retry: one is fixed by connecting a channel, one
+ * is a permanent fact about the channel, and one clears on its own once a
+ * direct conversation exists.
+ *
+ * - `yes` — the channel is connected and can address this account directly.
+ * - `not-connected` — no live connection for the channel. The guardian fixes
+ *   this in Settings.
+ * - `unsupported` — the connection is live but does not do direct messaging.
+ *   LinkedIn mirrors an inbox it cannot write to; a channel Rome has not
+ *   taught to send reads the same way. Why is a fact about the channel rather
+ *   than about this account, so the copy is keyed on the channel name and no
+ *   reason string crosses the wire — the dashboard localizes it, the same way
+ *   it already localizes every channel's own label.
+ * - `no-conversation` — the channel sends, but has no thread that reaches this
+ *   account yet, and could not open one. Per account, and recoverable.
+ */
+export type AccountSendState = "yes" | "not-connected" | "unsupported" | "no-conversation";
+
+export function canSend(account: Pick<LinkedAccount, "send">): boolean {
+  return account.send === "yes";
+}
+
+/**
+ * The account a composer opens on: the sendable one that was active most
+ * recently, ties broken by address so the answer is the same on every reload.
+ *
+ * A default, not an inference. Rome never picks a recipient on the guardian's
+ * behalf — {@link SendMessageRequest} names the account and has no form that
+ * omits it. This only decides which of the offered accounts is filled in
+ * first, and the surface showing it is expected to show it.
+ *
+ * Null when the person holds no account Rome can send to, which a caller must
+ * render as the reason rather than as an empty composer.
+ */
+export function defaultSendAccount(accounts: readonly LinkedAccount[]): LinkedAccount | null {
+  const sendable = accounts.filter(canSend);
+  if (sendable.length === 0) return null;
+  return [...sendable].sort(
+    (a, b) =>
+      (b.latestAt ?? 0) - (a.latestAt ?? 0) || compareCodePoints(a.channelUserId, b.channelUserId),
+  )[0]!;
 }
 
 /**
@@ -1211,4 +1274,115 @@ export function whatsAppDisplayName(contact: {
     contact.chatName ||
     formatWhatsAppPhone(contact.phoneNumber || contact.jid)
   );
+}
+
+// ---------------------------------------------------------------------------
+// Sending, and the outbox a send lives in until it lands
+// ---------------------------------------------------------------------------
+
+/**
+ * `POST /api/people/:id/messages` — say something to one of a person's
+ * accounts.
+ *
+ * The account is named, always. There is no shape of this request that omits
+ * it and no rule anywhere that fills it in, because every rule that could is a
+ * rule that decides who receives a message on evidence too thin to carry it:
+ * a timeline entry names its channel and not its address, so "reply where they
+ * last wrote" cannot separate two numbers on one channel, and "use another
+ * channel when this one is down" silently sends somewhere nobody chose.
+ * {@link defaultSendAccount} exists for surfaces that want a preselected
+ * account, and it is a default on screen rather than a decision off it.
+ */
+export interface SendMessageRequest {
+  channel: string;
+  channelUserId: string;
+  text: string;
+}
+
+export function parseSendMessageRequest(
+  body: unknown,
+): { request: SendMessageRequest } | { error: string } {
+  if (typeof body !== "object" || body === null) return { error: "body must be an object" };
+  const raw = body as Record<string, unknown>;
+  const channel = typeof raw.channel === "string" ? raw.channel.trim() : "";
+  const channelUserId = typeof raw.channelUserId === "string" ? raw.channelUserId.trim() : "";
+  const text = typeof raw.text === "string" ? raw.text.trim() : "";
+  if (!channel) return { error: "channel is required" };
+  if (!isChannelIdentifier(channel)) return { error: "channel must not contain ':'" };
+  if (!channelUserId) return { error: "channelUserId is required" };
+  if (!text) return { error: "text is required" };
+  if (text.length > SEND_MESSAGE_MAX_LENGTH) {
+    return { error: `text must be at most ${SEND_MESSAGE_MAX_LENGTH} characters` };
+  }
+  return { request: { channel, channelUserId, text } };
+}
+
+/** Long enough for anything a person types, short enough that no adapter has to
+ *  defend itself against a megabyte. Channels with tighter limits of their own
+ *  still chunk or refuse downstream. */
+export const SEND_MESSAGE_MAX_LENGTH = 8000;
+
+/**
+ * Where a send is between the guardian pressing Send and the message appearing
+ * on the timeline.
+ *
+ * - `sending` — handed to the channel, no answer yet.
+ * - `unconfirmed` — the channel accepted it and named it, but it has not
+ *   surfaced in the store the timeline reads. Normally under a second; a state
+ *   at all because "we sent it and cannot see it" is a thing that happens and
+ *   is worth saying rather than papering over.
+ * - `failed` — the channel refused. The only state a guardian can act on, and
+ *   the only one that persists without something else having gone wrong.
+ */
+export type OutboxState = "sending" | "unconfirmed" | "failed";
+
+/**
+ * One message Rome is still trying to deliver.
+ *
+ * Deliberately not a {@link TimelineEntry} with a status on it. A timeline
+ * entry is a message that happened; these have not, and some never will. Two
+ * nouns keep the timeline's contract — its `ref` uniqueness and the ordering
+ * its cursor is written against — free of rows that may yet be withdrawn, and
+ * keep each account owned by exactly one store.
+ *
+ * `ref` matches the timeline entry this message will become, so a reader can
+ * tell that a row has landed without being told twice.
+ */
+export interface OutboxMessage {
+  id: string;
+  channel: string;
+  channelUserId: string;
+  text: string;
+  /** Epoch seconds of the attempt, which is also the entry's timestamp once it
+   *  lands. */
+  timestamp: number;
+  state: OutboxState;
+  /** The timeline `ref` this will carry once it surfaces. Null while the
+   *  channel has not named the message yet. */
+  ref: string | null;
+  /** Why the channel refused, for a `failed` row. Provider text, shown as
+   *  detail beneath copy the dashboard owns. */
+  error: string | null;
+}
+
+/** `GET /api/people/:id/outbox` — every send of this person's that has not
+ *  reached their timeline. Unpaged: an outbox with enough rows to page is an
+ *  incident, not a listing. */
+export interface OutboxPage {
+  messages: OutboxMessage[];
+}
+
+/**
+ * A send the server would not attempt, and which of the reasons it was.
+ *
+ * Carries the same {@link AccountSendState} the person read carries, so the
+ * refusal renders as the copy the composer would already have shown had the
+ * read been fresh. A client that raced a disconnect therefore says the same
+ * thing either way instead of surfacing a bare 409.
+ *
+ * `error` is a fallback line, not the copy: the dashboard keys off `send`.
+ */
+export interface SendRefusal {
+  error: string;
+  send: Exclude<AccountSendState, "yes">;
 }

--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -1347,8 +1347,13 @@ export type OutboxState = "sending" | "unconfirmed" | "failed";
  * its cursor is written against — free of rows that may yet be withdrawn, and
  * keep each account owned by exactly one store.
  *
- * `ref` matches the timeline entry this message will become, so a reader can
- * tell that a row has landed without being told twice.
+ * `ref` is the entry this message would become at the address it was sent to.
+ * It is a hint and not a key: a channel that folds several addresses onto one
+ * account may deliver under another of them, and then the landed entry carries
+ * that address instead. Recognizing an arrival is the server's job, which is
+ * why it enumerates every folded address and why a client must not dedupe the
+ * timeline against this value — the row is gone from the outbox by the time
+ * there is anything to dedupe against.
  */
 export interface OutboxMessage {
   id: string;
@@ -1359,8 +1364,8 @@ export interface OutboxMessage {
    *  lands. */
   timestamp: number;
   state: OutboxState;
-  /** The timeline `ref` this will carry once it surfaces. Null while the
-   *  channel has not named the message yet. */
+  /** The entry this would become at the address it was sent to, or null while
+   *  the channel has not named the message yet. A hint — see above. */
   ref: string | null;
   /** Why the channel refused, for a `failed` row. Provider text, shown as
    *  detail beneath copy the dashboard owns. */

--- a/packages/app-runtime-sdk/src/index.ts
+++ b/packages/app-runtime-sdk/src/index.ts
@@ -1465,6 +1465,44 @@ export interface TalkDirectory {
   }): Promise<{ conversations: ConversationDescriptor[]; nextCursor?: string }>;
 }
 
+/**
+ * Reaching one account directly, rather than replying inside a conversation
+ * that already exists.
+ *
+ * A channel that offers this can be written to from a surface that knows only
+ * who it wants to talk to — the People page, which holds addresses and no
+ * thread ids. A channel that does not offer it can still be replied to, and
+ * still delivers inbound: `feature("directMessaging")` answering null is the
+ * whole declaration, which is why LinkedIn's read-only inbox needs no flag of
+ * its own and no exception anywhere else.
+ *
+ * Presence is the capability; the method is how the address becomes a thread.
+ * The two are separate answers because they fail differently — a channel that
+ * does not do direct messaging at all is a different thing from one that does
+ * but has no thread with this person yet.
+ */
+export interface TalkDirectMessaging {
+  /**
+   * The conversation that reaches `channelUserId` directly, or null when the
+   * channel cannot produce one.
+   *
+   * On channels where a direct chat is addressed by the contact — WhatsApp,
+   * Telegram — this is the address itself and costs nothing. On channels that
+   * key a thread separately, it opens or looks up that thread, which is a
+   * provider call: callers pricing a listing should treat it as one.
+   */
+  conversationFor(channelUserId: string): Promise<ConversationId | null>;
+}
+
+/**
+ * A talker offering {@link TalkDirectMessaging} must return a `messageId` from
+ * `send`. Rome recognizes a sent message when it comes back — from the
+ * provider's own mirror, or from Rome's transcript of the exchange — and the
+ * provider's id is the only thing both spellings of that entry share. A send
+ * accepted anonymously cannot be followed, and is reported as delivered the
+ * moment the channel takes it.
+ */
+
 export interface ConversationInteraction {
   id: string;
   conversationId: ConversationId;
@@ -1491,6 +1529,7 @@ export interface TalkFeatureMap {
   inboundMedia: TalkInboundMedia;
   activity: TalkActivity;
   directory: TalkDirectory;
+  directMessaging: TalkDirectMessaging;
   interactions: TalkInteractions;
 }
 

--- a/packages/core/drizzle/system/0062_gorgeous_star_brand.sql
+++ b/packages/core/drizzle/system/0062_gorgeous_star_brand.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `outbound_messages` (
+	`id` text PRIMARY KEY NOT NULL,
+	`channel` text NOT NULL,
+	`channel_user_id` text NOT NULL,
+	`conversation_id` text NOT NULL,
+	`text` text NOT NULL,
+	`state` text NOT NULL,
+	`provider_message_id` text,
+	`error` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_outbound_account` ON `outbound_messages` (`channel`,`channel_user_id`);

--- a/packages/core/drizzle/system/meta/0062_snapshot.json
+++ b/packages/core/drizzle/system/meta/0062_snapshot.json
@@ -1,0 +1,3178 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8d301aa9-bb54-46c4-8e3a-24b1512b6976",
+  "prevId": "c4381e36-83b2-43e7-8bab-c5475b54e30a",
+  "tables": {
+    "action_executions": {
+      "name": "action_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initiator": {
+          "name": "initiator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_keys": {
+      "name": "app_keys",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "approvals": {
+      "name": "approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_state": {
+          "name": "execution_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_error": {
+          "name": "execution_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_mappings": {
+      "name": "channel_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_channel_mappings_identity": {
+          "name": "idx_channel_mappings_identity",
+          "columns": [
+            "channel",
+            "channel_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_mappings_person_id_persons_id_fk": {
+          "name": "channel_mappings_person_id_persons_id_fk",
+          "tableFrom": "channel_mappings",
+          "tableTo": "persons",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connection_grants": {
+      "name": "connection_grants",
+      "columns": {
+        "custody": {
+          "name": "custody",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential": {
+          "name": "credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conferred_at": {
+          "name": "conferred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_at": {
+          "name": "degraded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_reason": {
+          "name": "degraded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connection_grants_custody_name_pk": {
+          "columns": [
+            "custody",
+            "name"
+          ],
+          "name": "connection_grants_custody_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connections": {
+      "name": "connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connections_service_unique": {
+          "name": "connections_service_unique",
+          "columns": [
+            "service"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tzid": {
+          "name": "tzid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_time": {
+          "name": "local_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rrule": {
+          "name": "rrule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "execution_journal": {
+      "name": "execution_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_hash": {
+          "name": "args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expected_action_name": {
+          "name": "expected_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expected_args_hash": {
+          "name": "expected_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_action_name": {
+          "name": "actual_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_args_hash": {
+          "name": "actual_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ej_root_execution_id": {
+          "name": "idx_ej_root_execution_id",
+          "columns": [
+            "root_execution_id"
+          ],
+          "isUnique": false
+        },
+        "idx_ej_created_at": {
+          "name": "idx_ej_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardian_auth": {
+      "name": "guardian_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guardian_auth_user_id_unique": {
+          "name": "guardian_auth_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_messages": {
+      "name": "linkedin_messages",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_profile_url": {
+          "name": "sender_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_headline": {
+          "name": "sender_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_is_self": {
+          "name": "sender_is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_messages_thread_sent": {
+          "name": "idx_linkedin_messages_thread_sent",
+          "columns": [
+            "thread_id",
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_messages_thread_id_message_id_pk": {
+          "columns": [
+            "thread_id",
+            "message_id"
+          ],
+          "name": "linkedin_messages_thread_id_message_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_participants": {
+      "name": "linkedin_participants",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_self": {
+          "name": "is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_thread_participants": {
+      "name": "linkedin_thread_participants",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_thread_participants_participant": {
+          "name": "idx_linkedin_thread_participants_participant",
+          "columns": [
+            "participant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_thread_participants_thread_id_participant_id_pk": {
+          "columns": [
+            "thread_id",
+            "participant_id"
+          ],
+          "name": "linkedin_thread_participants_thread_id_participant_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_threads": {
+      "name": "linkedin_threads",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_url": {
+          "name": "thread_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_name": {
+          "name": "person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_name": {
+          "name": "conversation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread": {
+          "name": "unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "counterparty_type": {
+          "name": "counterparty_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "participants_last_read_at": {
+          "name": "participants_last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_pending_attempts": {
+      "name": "oauth_pending_attempts",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_origin": {
+          "name": "callback_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_pending_attempts_expires_at": {
+          "name": "idx_oauth_pending_attempts_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "outbound_messages": {
+      "name": "outbound_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_outbound_account": {
+          "name": "idx_outbound_account",
+          "columns": [
+            "channel",
+            "channel_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persons": {
+      "name": "persons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bond_level": {
+          "name": "bond_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_path": {
+          "name": "profile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_value": {
+          "name": "scope_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sync_links": {
+      "name": "project_sync_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_type": {
+          "name": "project_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_extra": {
+          "name": "project_link_extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sync_links_project_path_unique": {
+          "name": "project_sync_links_project_path_unique",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_accounts": {
+      "name": "provider_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "provider_accounts_provider_unique": {
+          "name": "provider_accounts_provider_unique",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_messages": {
+      "name": "rome_agent_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_state": {
+          "name": "input_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_platform_message_id": {
+          "name": "reply_to_platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_injected_turn_id": {
+          "name": "context_injected_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_messages_session_id": {
+          "name": "idx_rome_agent_messages_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_turn_id": {
+          "name": "idx_rome_agent_messages_turn_id",
+          "columns": [
+            "turn_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_role_created_at": {
+          "name": "idx_rome_agent_messages_role_created_at",
+          "columns": [
+            "role",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_platform_message": {
+          "name": "idx_rome_agent_messages_platform_message",
+          "columns": [
+            "session_id",
+            "platform_message_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_agent_messages\".\"platform_message_id\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_trace_blocks": {
+      "name": "rome_agent_trace_blocks",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_trace_blocks_session_id": {
+          "name": "idx_rome_agent_trace_blocks_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_trace_blocks_terminal_message": {
+          "name": "idx_rome_agent_trace_blocks_terminal_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') IN ('result', 'error')"
+        },
+        "idx_rome_agent_trace_blocks_turn_end_message": {
+          "name": "idx_rome_agent_trace_blocks_turn_end_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') = 'turn_end'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rome_agent_trace_blocks_message_id_seq_pk": {
+          "columns": [
+            "message_id",
+            "seq"
+          ],
+          "name": "rome_agent_trace_blocks_message_id_seq_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_sessions": {
+      "name": "rome_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "large_model_selection": {
+          "name": "large_model_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webchat'"
+        },
+        "source_channel": {
+          "name": "source_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_name": {
+          "name": "source_thread_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_type": {
+          "name": "source_thread_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_settings": {
+          "name": "channel_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_turn_id": {
+          "name": "parent_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handoff_spec": {
+          "name": "handoff_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_activity_at": {
+          "name": "last_seen_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_sessions_project_path": {
+          "name": "idx_rome_sessions_project_path",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_sidebar_activity": {
+          "name": "idx_rome_sessions_sidebar_activity",
+          "columns": [
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_project_activity": {
+          "name": "idx_rome_sessions_project_activity",
+          "columns": [
+            "project_path",
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_channel": {
+          "name": "idx_rome_sessions_source_channel",
+          "columns": [
+            "source_channel"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_thread": {
+          "name": "idx_rome_sessions_source_thread",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_channel_address": {
+          "name": "idx_rome_sessions_channel_address",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_sessions\".\"type\" = 'channel' AND \"rome_sessions\".\"source_channel\" IS NOT NULL AND \"rome_sessions\".\"source_thread_id\" IS NOT NULL"
+        },
+        "idx_rome_sessions_parent_session": {
+          "name": "idx_rome_sessions_parent_session",
+          "columns": [
+            "parent_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routine_runs": {
+      "name": "routine_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_routine_runs_routine_id": {
+          "name": "idx_routine_runs_routine_id",
+          "columns": [
+            "routine_id"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_fired_at": {
+          "name": "idx_routine_runs_fired_at",
+          "columns": [
+            "fired_at"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_status": {
+          "name": "idx_routine_runs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "routine_runs_routine_id_routines_id_fk": {
+          "name": "routine_runs_routine_id_routines_id_fk",
+          "tableFrom": "routine_runs",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routines": {
+      "name": "routines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed_by": {
+          "name": "managed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "routines_key_unique": {
+          "name": "routines_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sentinel_log": {
+      "name": "sentinel_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_turn_checkpoints": {
+      "name": "session_turn_checkpoints",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_turn_checkpoints_session_id_sessions_id_fk": {
+          "name": "session_turn_checkpoints_session_id_sessions_id_fk",
+          "tableFrom": "session_turn_checkpoints",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_turn_checkpoints_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "session_turn_checkpoints_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_thread_key": {
+          "name": "channel_thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shared_chats": {
+      "name": "shared_chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_shared_chats_session_id": {
+          "name": "idx_shared_chats_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_chats": {
+      "name": "wa_chats",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_contacts": {
+      "name": "wa_contacts",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify": {
+          "name": "notify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "img_url": {
+          "name": "img_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_messages": {
+      "name": "wa_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_jid": {
+          "name": "chat_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_jid": {
+          "name": "sender_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_me": {
+          "name": "from_me",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_media": {
+          "name": "has_media",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "push_name": {
+          "name": "push_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reacts_to_id": {
+          "name": "reacts_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_chat_ts": {
+          "name": "idx_wa_messages_chat_ts",
+          "columns": [
+            "chat_jid",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wa_messages_chat_jid_id_pk": {
+          "columns": [
+            "chat_jid",
+            "id"
+          ],
+          "name": "wa_messages_chat_jid_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_projects": {
+      "name": "webchat_projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webchat_projects_path_unique": {
+          "name": "webchat_projects_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_turn_feedback": {
+      "name": "webchat_turn_feedback",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webchat_turn_feedback_session_id": {
+          "name": "idx_webchat_turn_feedback_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webchat_turn_feedback_session_id_rome_sessions_id_fk": {
+          "name": "webchat_turn_feedback_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_turn_feedback",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webchat_turn_feedback_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "webchat_turn_feedback_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_workspace_layouts": {
+      "name": "webchat_workspace_layouts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webchat_workspace_layouts_session_id_rome_sessions_id_fk": {
+          "name": "webchat_workspace_layouts_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_workspace_layouts",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_invocations": {
+      "name": "webhook_invocations",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_url": {
+          "name": "callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_status": {
+          "name": "callback_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_attempted_at": {
+          "name": "callback_attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_delivered_at": {
+          "name": "callback_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_response_status": {
+          "name": "callback_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_error": {
+          "name": "callback_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webhook_invocations_created_at": {
+          "name": "idx_webhook_invocations_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_webhook_invocations_action_name": {
+          "name": "idx_webhook_invocations_action_name",
+          "columns": [
+            "action_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/system/meta/_journal.json
+++ b/packages/core/drizzle/system/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1787898378247,
       "tag": "0061_nervous_human_fly",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "6",
+      "when": 1788402301789,
+      "tag": "0062_gorgeous_star_brand",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/api/deps.ts
+++ b/packages/core/src/api/deps.ts
@@ -1,6 +1,7 @@
 import type { ActionEngine } from "../actions/engine.js";
 import type { ActionLoader } from "../actions/loader.js";
 import type { DrizzleDb } from "../db/index.js";
+import type { OutboxRepository } from "../db/repositories/outbox.js";
 import type { PersonMappingRepository } from "../db/repositories/person-mapping.js";
 import type { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
 import type { Channels } from "../channels/channel.js";
@@ -83,6 +84,10 @@ export interface ApiDeps {
    *  person or account serializer puts on the wire. */
   accountNames: AccountNames;
   webchatRepo: WebChatRepository;
+  /** Messages Rome is still trying to deliver — the People surface's
+   *  outbox. Separate from every message store on purpose: a row here is a
+   *  send that has not happened yet. */
+  outboxRepo: OutboxRepository;
   webhookInvocationsRepo: WebhookInvocationsRepository;
   approvalsRepo: ApprovalsRepository;
   approvalHandler: ApprovalHandler;

--- a/packages/core/src/api/routes/people-send.test.ts
+++ b/packages/core/src/api/routes/people-send.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach } from "@rstest/core";
+import { Hono } from "hono";
+import type {
+  LinkedAccount,
+  OutboxMessage,
+  OutboxPage,
+  PersonResource,
+  SendRefusal,
+  TimelinePage,
+} from "@rome/api-types/people";
+import { peopleRoutes } from "./people.js";
+import { createTestDb, buildTestDeps, type TestDb, type TestDeps } from "../../test/helpers.js";
+import { seedBaseline } from "../../test/seeds.js";
+
+// Sending to a person, and the outbox a send lives in until it arrives.
+//
+// What these pin is the pair of rules the surface rests on: a send names the
+// account it is for and Rome never chooses one, and a row leaves the outbox by
+// being observed on the timeline rather than by anything remembering to clear
+// it.
+
+const TG = "tg-send-target";
+const OTHER_TG = "tg-someone-else";
+
+describe("People send API", () => {
+  let testDb: TestDb;
+  let deps: TestDeps;
+  let app: Hono;
+  let personId: string;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    await seedBaseline(testDb.db);
+    deps = await buildTestDeps(testDb.db);
+    app = new Hono().route("/", peopleRoutes(deps));
+
+    personId = await deps.personMappingRepo.create({
+      displayName: "Send Target",
+      bondLevel: "acquaintance",
+      approved: true,
+      channelMappings: [{ channel: "telegram", channelUserId: TG }],
+    });
+  });
+
+  const send = (body: unknown, id = personId) =>
+    app.request(`/people/${id}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+  const outbox = async (id = personId): Promise<OutboxMessage[]> => {
+    const res = await app.request(`/people/${id}/outbox`);
+    return ((await res.json()) as OutboxPage).messages;
+  };
+
+  const timeline = async (id = personId): Promise<TimelinePage> => {
+    const res = await app.request(`/people/${id}/messages`);
+    return (await res.json()) as TimelinePage;
+  };
+
+  const accountOf = async (channel: string): Promise<LinkedAccount> => {
+    const res = await app.request(`/people/${personId}`);
+    const person = (await res.json()) as PersonResource;
+    return person.accounts.find((account) => account.channel === channel)!;
+  };
+
+  it("sends to the account the request names, and answers the row it became", async () => {
+    const res = await send({ channel: "telegram", channelUserId: TG, text: "on my way" });
+
+    // 202: the channel took it. Whether it arrived is a different question and
+    // the outbox is where it is asked.
+    expect(res.status).toBe(202);
+    const message = (await res.json()) as OutboxMessage;
+    expect(message).toMatchObject({
+      channel: "telegram",
+      channelUserId: TG,
+      text: "on my way",
+      state: "unconfirmed",
+    });
+
+    expect(deps.channelPortMap.get("telegram")?.sentMessages).toEqual([
+      { channelUserId: TG, threadId: TG, message: { text: "on my way" } },
+    ]);
+  });
+
+  it("refuses an account the person does not hold", async () => {
+    const res = await send({ channel: "telegram", channelUserId: OTHER_TG, text: "hello" });
+
+    // Not a 404 and not a silent redirect to an account they do hold: the
+    // guardian addressed someone, and delivering to anyone else is worse than
+    // refusing.
+    expect(res.status).toBe(400);
+    expect(deps.channelPortMap.get("telegram")?.sentMessages).toEqual([]);
+  });
+
+  it("refuses a channel that does not do direct messaging, naming the state", async () => {
+    // A talker with no `directMessaging` feature is exactly LinkedIn: it
+    // mirrors an inbox it cannot write to, and says so rather than throwing
+    // when someone tries.
+    const readOnly = { ...deps, talkRouter: { ...deps.talkRouter, feature: () => null } };
+    const readOnlyApp = new Hono().route("/", peopleRoutes(readOnly));
+
+    const res = await readOnlyApp.request(`/people/${personId}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "telegram", channelUserId: TG, text: "hello" }),
+    });
+
+    expect(res.status).toBe(409);
+    // The same state the person read carries, so a client that raced a
+    // disconnect renders the reason it would already have shown.
+    expect((await res.json()) as SendRefusal).toMatchObject({ send: "unsupported" });
+  });
+
+  it("refuses a body naming no account or no text", async () => {
+    expect((await send({ channel: "telegram", text: "hi" })).status).toBe(400);
+    expect((await send({ channel: "telegram", channelUserId: TG, text: "  " })).status).toBe(400);
+  });
+
+  it("clears the outbox row once the message is on the timeline", async () => {
+    await send({ channel: "telegram", channelUserId: TG, text: "landed" });
+
+    // Telegram keeps no mirror of its own, so Rome's transcript of the send is
+    // what the timeline reads — and the row is on it immediately.
+    const entries = (await timeline()).entries;
+    expect(entries.map((entry) => entry.body)).toContain("landed");
+    expect(entries[0]?.direction).toBe("outbound");
+
+    // Nothing was told the send had arrived. The read noticed.
+    expect(await outbox()).toEqual([]);
+  });
+
+  it("keeps a refused send in the outbox, and retries it under its own id", async () => {
+    const adapter = deps.channelPortMap.get("telegram")!;
+    adapter.sendMessage = async () => {
+      throw new Error("provider rejected");
+    };
+
+    await send({ channel: "telegram", channelUserId: TG, text: "will fail" });
+
+    // Durable, unlike the first design where a failed send existed only in
+    // whatever the client held in memory.
+    const [failed] = await outbox();
+    expect(failed).toMatchObject({
+      state: "failed",
+      error: "provider rejected",
+      text: "will fail",
+    });
+    expect((await timeline()).entries.map((entry) => entry.body)).not.toContain("will fail");
+
+    // The retry succeeds and reuses the row, so the conversation does not grow
+    // a second message the guardian never wrote.
+    adapter.sendMessage = async (channelUserId, threadId, message) => {
+      adapter.sentMessages.push({ channelUserId, threadId, message });
+    };
+    const retried = await app.request(`/people/${personId}/outbox/${failed!.id}/retry`, {
+      method: "POST",
+    });
+    expect(retried.status).toBe(202);
+    expect(((await retried.json()) as OutboxMessage).id).toBe(failed!.id);
+    expect(await outbox()).toEqual([]);
+    expect((await timeline()).entries.map((entry) => entry.body)).toContain("will fail");
+  });
+
+  it("discards a failed send when the guardian gives up on it", async () => {
+    deps.channelPortMap.get("telegram")!.sendMessage = async () => {
+      throw new Error("nope");
+    };
+    await send({ channel: "telegram", channelUserId: TG, text: "abandon me" });
+    const [failed] = await outbox();
+
+    const res = await app.request(`/people/${personId}/outbox/${failed!.id}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+    expect(await outbox()).toEqual([]);
+  });
+
+  it("says on the person read whether each account can be written to", async () => {
+    const account = await accountOf("telegram");
+    expect(account.send).toBe("yes");
+    // Nothing has happened on it yet, which is a different answer from zero.
+    expect(account.latestAt).toBeNull();
+
+    await send({ channel: "telegram", channelUserId: TG, text: "now there is history" });
+    expect((await accountOf("telegram")).latestAt).toBeGreaterThan(0);
+  });
+
+  it("reports a channel with no connection as not-connected", async () => {
+    await app.request(`/people/${personId}/accounts`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "signal", channelUserId: "sig-1" }),
+    });
+    const account = await accountOf("signal");
+    expect(account.send).toBe("not-connected");
+  });
+});

--- a/packages/core/src/api/routes/people-send.test.ts
+++ b/packages/core/src/api/routes/people-send.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "@rstest/core";
 import { Hono } from "hono";
+import { sql } from "drizzle-orm";
 import type {
   LinkedAccount,
   OutboxMessage,
@@ -195,5 +196,167 @@ describe("People send API", () => {
     });
     const account = await accountOf("signal");
     expect(account.send).toBe("not-connected");
+  });
+});
+
+// Regressions found in review of #208. Each one is a way the outbox could
+// disagree with what actually happened to a message.
+describe("People send API — delivery bookkeeping", () => {
+  let testDb: TestDb;
+  let deps: TestDeps;
+  let app: Hono;
+  let personId: string;
+
+  // A WhatsApp contact reachable two ways. WhatsApp addresses one person by
+  // phone JID and by privacy LID, holds a chat under each, and folds both onto
+  // one account — so a message sent to one can be echoed back under the other.
+  const PN = "15550007777@s.whatsapp.net";
+  const LID = "77770000@lid";
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    await seedBaseline(testDb.db);
+    deps = await buildTestDeps(testDb.db, { channels: ["whatsapp", "telegram"] });
+    app = new Hono().route("/", peopleRoutes(deps));
+
+    await deps.whatsAppStoreRepo.upsertContacts([
+      { jid: PN, phoneNumber: "15550007777", name: "Folded Contact" },
+      { jid: LID, phoneNumber: "15550007777", name: "Folded Contact" },
+    ]);
+
+    // Linked by the LID, which is the half of the fold a send would address.
+    personId = await deps.personMappingRepo.create({
+      displayName: "Folded Contact",
+      bondLevel: "acquaintance",
+      approved: true,
+      channelMappings: [{ channel: "whatsapp", channelUserId: LID }],
+    });
+  });
+
+  const outbox = async (): Promise<OutboxMessage[]> => {
+    const res = await app.request(`/people/${personId}/outbox`);
+    return ((await res.json()) as OutboxPage).messages;
+  };
+
+  it("clears a row whose echo lands under the account's other address", async () => {
+    const res = await app.request(`/people/${personId}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "whatsapp", channelUserId: LID, text: "sent to the lid" }),
+    });
+    expect(res.status).toBe(202);
+    const sent = (await res.json()) as OutboxMessage;
+    const providerId = sent.ref!.split(":").pop()!;
+
+    // WhatsApp echoes Rome's own message back, and the chat it hangs off is the
+    // phone JID rather than the LID the send named. Predicting only the address
+    // sent to would leave this row waiting on a ref that never appears.
+    await deps.whatsAppStoreRepo.upsertMessages([
+      {
+        id: providerId,
+        chatJid: PN,
+        senderJid: PN,
+        fromMe: true,
+        timestamp: new Date(),
+        type: "text",
+        text: "sent to the lid",
+        hasMedia: false,
+      },
+    ]);
+
+    expect(await outbox()).toEqual([]);
+  });
+
+  it("keeps a delivered send delivered when Rome's own record of it fails", async () => {
+    // The provider accepted the message: it is out on a network Rome does not
+    // own. A local write failing afterwards cannot take it back, and reporting
+    // the send as failed invites a retry that delivers a second real message.
+    deps.webchatRepo.recordOutboundConversationMessage = async () => {
+      throw new Error("disk is full");
+    };
+
+    const res = await app.request(`/people/${personId}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "whatsapp", channelUserId: LID, text: "went out anyway" }),
+    });
+
+    expect(res.status).toBe(202);
+    expect((await res.json()) as OutboxMessage).toMatchObject({ state: "unconfirmed" });
+    expect((await outbox())[0]).toMatchObject({ state: "unconfirmed" });
+  });
+
+  it("recovers a send whose process died before the channel answered", async () => {
+    const row = await deps.outboxRepo.open({
+      channel: "whatsapp",
+      channelUserId: LID,
+      conversationId: LID,
+      text: "stranded",
+    });
+    // Older than the window a send is given to answer in.
+    testDb.db.run(
+      sql`UPDATE outbound_messages SET updated_at = ${Math.floor(Date.now() / 1000) - 3600} WHERE id = ${row.id}`,
+    );
+
+    // Not cleared — the message may well have gone out — but no longer stuck:
+    // it says what happened and can be tried again.
+    const [recovered] = await outbox();
+    expect(recovered).toMatchObject({ id: row.id, state: "failed" });
+    expect(recovered!.error).toMatch(/may or may not have been sent/);
+
+    const retried = await app.request(`/people/${personId}/outbox/${row.id}/retry`, {
+      method: "POST",
+    });
+    expect(retried.status).toBe(202);
+  });
+
+  it("will not retry or discard a row belonging to somebody else", async () => {
+    const otherId = await deps.personMappingRepo.create({
+      displayName: "Somebody Else",
+      bondLevel: "other",
+      approved: true,
+      channelMappings: [{ channel: "telegram", channelUserId: "tg-elsewhere" }],
+    });
+    deps.channelPortMap.get("telegram")!.sendMessage = async () => {
+      throw new Error("nope");
+    };
+    await app.request(`/people/${otherId}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        channel: "telegram",
+        channelUserId: "tg-elsewhere",
+        text: "theirs",
+      }),
+    });
+    const res = await app.request(`/people/${otherId}/outbox`);
+    const [theirs] = ((await res.json()) as OutboxPage).messages;
+
+    // A message id is not a capability. The person in the path owns the outbox
+    // the request is addressing.
+    expect(
+      (await app.request(`/people/${personId}/outbox/${theirs!.id}/retry`, { method: "POST" }))
+        .status,
+    ).toBe(404);
+    expect(
+      (await app.request(`/people/${personId}/outbox/${theirs!.id}`, { method: "DELETE" })).status,
+    ).toBe(404);
+
+    const still = await app.request(`/people/${otherId}/outbox`);
+    expect(((await still.json()) as OutboxPage).messages).toHaveLength(1);
+  });
+
+  it("will not discard a send that is still in flight", async () => {
+    const row = await deps.outboxRepo.open({
+      channel: "whatsapp",
+      channelUserId: LID,
+      conversationId: LID,
+      text: "still going",
+    });
+    // Dropping this row would leave the guardian with no account of a message
+    // that may yet arrive.
+    const res = await app.request(`/people/${personId}/outbox/${row.id}`, { method: "DELETE" });
+    expect(res.status).toBe(404);
+    expect(await outbox()).toHaveLength(1);
   });
 });

--- a/packages/core/src/api/routes/people-send.test.ts
+++ b/packages/core/src/api/routes/people-send.test.ts
@@ -346,18 +346,105 @@ describe("People send API — delivery bookkeeping", () => {
     expect(((await still.json()) as OutboxPage).messages).toHaveLength(1);
   });
 
-  it("will not discard a send that is still in flight", async () => {
+  it("will not discard a send while the channel has not answered", async () => {
     const row = await deps.outboxRepo.open({
       channel: "whatsapp",
       channelUserId: LID,
       conversationId: LID,
       text: "still going",
     });
-    // Dropping this row would leave the guardian with no account of a message
-    // that may yet arrive.
+    // The one state where Rome does not yet know what happened. Dropping the
+    // row here would lose the only record of a call that is still outstanding.
     const res = await app.request(`/people/${personId}/outbox/${row.id}`, { method: "DELETE" });
     expect(res.status).toBe(404);
     expect(await outbox()).toHaveLength(1);
+  });
+
+  it("dismisses a delivered send Rome never managed to record", async () => {
+    // Telegram keeps no mirror, so Rome's own transcript is how a sent message
+    // reaches the timeline. If that write fails the message is delivered and
+    // will never appear, and the row would otherwise be a phantom the guardian
+    // can neither retry nor dismiss.
+    deps.webchatRepo.recordOutboundConversationMessage = async () => {
+      throw new Error("disk is full");
+    };
+    const tgPersonId = await deps.personMappingRepo.create({
+      displayName: "Unmirrored",
+      bondLevel: "other",
+      approved: true,
+      channelMappings: [{ channel: "telegram", channelUserId: "tg-unmirrored" }],
+    });
+    await app.request(`/people/${tgPersonId}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        channel: "telegram",
+        channelUserId: "tg-unmirrored",
+        text: "delivered but unseen",
+      }),
+    });
+
+    const listing = await app.request(`/people/${tgPersonId}/outbox`);
+    const [stuck] = ((await listing.json()) as OutboxPage).messages;
+    expect(stuck).toMatchObject({ state: "unconfirmed" });
+
+    // Fresh, it is an ordinary row that usually clears itself, and dismissing
+    // it would race the clearing.
+    expect(
+      (await app.request(`/people/${tgPersonId}/outbox/${stuck!.id}`, { method: "DELETE" })).status,
+    ).toBe(404);
+
+    // Past the window a message lands in, it is a phantom and the guardian gets
+    // a way out.
+    testDb.db.run(
+      sql`UPDATE outbound_messages SET updated_at = ${Math.floor(Date.now() / 1000) - 3600} WHERE id = ${stuck!.id}`,
+    );
+    const res = await app.request(`/people/${tgPersonId}/outbox/${stuck!.id}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+    const after = await app.request(`/people/${tgPersonId}/outbox`);
+    expect(((await after.json()) as OutboxPage).messages).toEqual([]);
+  });
+
+  it("never leaves a delivered message with no record when discard races retry", async () => {
+    const adapter = deps.channelPortMap.get("whatsapp")!;
+    adapter.sendMessage = async () => {
+      throw new Error("nope");
+    };
+    await app.request(`/people/${personId}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "whatsapp", channelUserId: LID, text: "contested" }),
+    });
+    const [failed] = await outbox();
+
+    adapter.sentMessages.length = 0;
+    adapter.sendMessage = async (channelUserId, threadId, message) => {
+      adapter.sentMessages.push({ channelUserId, threadId, message });
+    };
+
+    // Whichever wins is fine. What must never happen is the discard passing a
+    // `failed` check, the retry claiming the row in between, and the delete
+    // then removing a row whose message is already on its way.
+    await Promise.all([
+      app.request(`/people/${personId}/outbox/${failed!.id}/retry`, { method: "POST" }),
+      app.request(`/people/${personId}/outbox/${failed!.id}`, { method: "DELETE" }),
+    ]);
+
+    expect(adapter.sentMessages.length).toBeLessThanOrEqual(1);
+    if (adapter.sentMessages.length === 1) {
+      // Somewhere, not necessarily the outbox: a message that reached the
+      // timeline has left the outbox legitimately, and that is the row doing
+      // its job rather than being lost. What must never happen is a delivered
+      // message the guardian can find no trace of.
+      const res = await app.request(`/people/${personId}/messages`);
+      const onTimeline = ((await res.json()) as { entries: { body: string | null }[] }).entries;
+      const stillQueued = await outbox();
+      expect(
+        onTimeline.some((entry) => entry.body === "contested") || stillQueued.length === 1,
+      ).toBe(true);
+    }
   });
 
   it("sends once when a failed row is retried twice at the same moment", async () => {

--- a/packages/core/src/api/routes/people-send.test.ts
+++ b/packages/core/src/api/routes/people-send.test.ts
@@ -359,4 +359,62 @@ describe("People send API — delivery bookkeeping", () => {
     expect(res.status).toBe(404);
     expect(await outbox()).toHaveLength(1);
   });
+
+  it("sends once when a failed row is retried twice at the same moment", async () => {
+    const adapter = deps.channelPortMap.get("whatsapp")!;
+    adapter.sendMessage = async () => {
+      throw new Error("nope");
+    };
+    await app.request(`/people/${personId}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "whatsapp", channelUserId: LID, text: "retry me once" }),
+    });
+    const [failed] = await outbox();
+
+    adapter.sendMessage = async (channelUserId, threadId, message) => {
+      adapter.sentMessages.push({ channelUserId, threadId, message });
+    };
+
+    // A double-clicked Retry. Reading the state and then writing would let both
+    // requests past, and the guardian's one message would arrive twice.
+    const both = await Promise.all([
+      app.request(`/people/${personId}/outbox/${failed!.id}/retry`, { method: "POST" }),
+      app.request(`/people/${personId}/outbox/${failed!.id}/retry`, { method: "POST" }),
+    ]);
+
+    expect(both.map((r) => r.status).sort()).toEqual([202, 404]);
+    expect(adapter.sentMessages).toHaveLength(1);
+  });
+
+  it("answers no-conversation when the channel throws looking for a thread", async () => {
+    // What a thread-keyed channel does when it cannot open a DM. The person
+    // read already calls this account `no-conversation`; the send path has to
+    // agree rather than answering with a stack trace.
+    const throwing = {
+      ...deps,
+      talkRouter: {
+        ...deps.talkRouter,
+        feature: (_connectionId: string, name: string) =>
+          name === "directMessaging"
+            ? {
+                conversationFor: async () => {
+                  throw new Error("provider is down");
+                },
+              }
+            : null,
+      },
+    } as unknown as TestDeps;
+
+    const res = await new Hono()
+      .route("/", peopleRoutes(throwing))
+      .request(`/people/${personId}/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ channel: "whatsapp", channelUserId: LID, text: "no thread" }),
+      });
+
+    expect(res.status).toBe(409);
+    expect((await res.json()) as SendRefusal).toMatchObject({ send: "no-conversation" });
+  });
 });

--- a/packages/core/src/api/routes/people.test.ts
+++ b/packages/core/src/api/routes/people.test.ts
@@ -4,6 +4,7 @@ import { sql } from "drizzle-orm";
 import {
   latestDynamic,
   type PeopleList,
+  type LinkedAccount,
   type PersonResource,
   type TimelinePage,
 } from "@rome/api-types/people";
@@ -25,6 +26,18 @@ const GROUP_THREAD = "tg-group-timeline";
 
 const at = (iso: string) => new Date(iso);
 const textContent = (text: string) => JSON.stringify([{ type: "text", content: text }]);
+
+/** An account's naming, and only that. The assertions that use it are about
+ *  which name a channel puts on an account; whether Rome can send there and
+ *  when it was last active are separate answers on the same row, and a test
+ *  about naming should not restate them. */
+function naming(accounts: readonly LinkedAccount[]) {
+  return accounts.map(({ channel, channelUserId, displayName }) => ({
+    channel,
+    channelUserId,
+    displayName,
+  }));
+}
 
 describe("People timeline API", () => {
   let testDb: TestDb;
@@ -593,7 +606,7 @@ describe("People API", () => {
     expect(ids).not.toContain(STRANGER_PERSON_ID);
 
     const alice = people.find((person) => person.id === baseline.persons.innerCircleId);
-    expect(alice?.accounts).toEqual([
+    expect(naming(alice?.accounts ?? [])).toEqual([
       // Telegram mirrors no address book, so the name is the one the sender put
       // on their own messages — the directory seam's second fallback.
       { channel: "telegram", channelUserId: "tg-alice", displayName: "Alice Inner" },
@@ -602,7 +615,7 @@ describe("People API", () => {
     const carol = people.find((person) => person.id === baseline.persons.otherId);
     // Nothing has ever named this account, so it is rendered as its identifier
     // rather than as an empty string.
-    expect(carol?.accounts).toEqual([
+    expect(naming(carol?.accounts ?? [])).toEqual([
       { channel: "whatsapp", channelUserId: "wa-carol", displayName: "wa-carol" },
     ]);
   });
@@ -611,7 +624,7 @@ describe("People API", () => {
     const nadia = await fetchPerson(nadiaId);
     // One account, two mappings: a client addresses the link it stored, and
     // both carry the mirror's name for the account rather than the raw jid.
-    expect(nadia.accounts).toEqual([
+    expect(naming(nadia.accounts)).toEqual([
       { channel: "whatsapp", channelUserId: NADIA_JID, displayName: "Nadia Cross" },
       { channel: "whatsapp", channelUserId: NADIA_LID, displayName: "Nadia Cross" },
     ]);
@@ -796,7 +809,7 @@ describe("People create API", () => {
     const person = (await res.json()) as PersonResource;
     expect(person.id).toBe("bob-reyes");
     expect(person.bondLevel).toBe("inner-circle");
-    expect(person.accounts).toEqual([
+    expect(naming(person.accounts)).toEqual([
       { channel: "whatsapp", channelUserId: BOB_JID, displayName: "Bob Reyes" },
       // No mirror answers for telegram, so the address is the only name there
       // is — the person's own name never stands in for it.

--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -20,7 +20,7 @@ import {
 } from "@rome/api-types/people";
 import { createPerson } from "../../people/create.js";
 import { mergePeople } from "../../people/merge.js";
-import { readOutbox, retrySend, sendToAccount } from "../../people/outbox.js";
+import { discardSend, readOutbox, retrySend, sendToAccount } from "../../people/outbox.js";
 import { findPerson, readPeople, readPerson } from "../../people/resource.js";
 import { updatePerson } from "../../people/update.js";
 import { readPersonTimeline } from "../../people/timeline.js";
@@ -201,24 +201,36 @@ export function peopleRoutes(deps: ApiDeps): Hono {
     } satisfies OutboxPage);
   });
 
-  /** Try a failed send again. Under its own id, so a retry never reads as a
-   *  second message the guardian did not write. */
+  /**
+   * Try a failed send again. Under its own id, so a retry never reads as a
+   * second message the guardian did not write.
+   *
+   * Both outbox mutations are scoped to the person in the path. A message id
+   * is not a capability, and the person named is the one whose outbox this is
+   * — a row of somebody else's reached through this address is a 404, not a
+   * shortcut.
+   */
   app.post("/people/:id/outbox/:messageId/retry", async (c) => {
     const person = await findPerson(deps, c.req.param("id"));
     if (!person) return c.json({ error: "Unknown person" }, 404);
 
-    const message = await retrySend(deps, c.req.param("messageId"));
-    return message ? c.json(message, 202) : c.json({ error: "Unknown message" }, 404);
+    const message = await retrySend(deps, person.channelMappings, c.req.param("messageId"));
+    return message
+      ? c.json(message, 202)
+      : c.json({ error: "No failed message of theirs with that id" }, 404);
   });
 
   /** Give up on a failed send. The only way a row leaves the outbox without
-   *  having been delivered. */
+   *  having been delivered — a send still in flight may yet arrive, and
+   *  dropping its record would leave the guardian with no account of it. */
   app.delete("/people/:id/outbox/:messageId", async (c) => {
     const person = await findPerson(deps, c.req.param("id"));
     if (!person) return c.json({ error: "Unknown person" }, 404);
 
-    await deps.outboxRepo.remove(c.req.param("messageId"));
-    return c.body(null, 204);
+    const discarded = await discardSend(deps, person.channelMappings, c.req.param("messageId"));
+    return discarded
+      ? c.body(null, 204)
+      : c.json({ error: "No failed message of theirs with that id" }, 404);
   });
 
   app.get("/people/:id/messages", async (c) => {

--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -7,15 +7,20 @@ import {
   parseLinkAccountRequest,
   parseMergeRequest,
   parsePersonFilterLevel,
+  parseSendMessageRequest,
   parseTimelineCursor,
   parseUpdatePersonRequest,
   personMatchesLevel,
   personMatchesQuery,
   timelinePageLimit,
+  type AccountSendState,
+  type OutboxPage,
   type PeopleList,
+  type SendRefusal,
 } from "@rome/api-types/people";
 import { createPerson } from "../../people/create.js";
 import { mergePeople } from "../../people/merge.js";
+import { readOutbox, retrySend, sendToAccount } from "../../people/outbox.js";
 import { findPerson, readPeople, readPerson } from "../../people/resource.js";
 import { updatePerson } from "../../people/update.js";
 import { readPersonTimeline } from "../../people/timeline.js";
@@ -147,6 +152,75 @@ export function peopleRoutes(deps: ApiDeps): Hono {
     return respondWithPerson(deps, c, person.id);
   });
 
+  /**
+   * Say something to one of this person's accounts.
+   *
+   * 202 rather than 200: the channel taking a message is not the message
+   * arriving, and the body says which of those has happened. A refusal answers
+   * the same `send` state the person read carries, so a client that raced a
+   * disconnect renders the reason it would already have shown.
+   */
+  app.post("/people/:id/messages", async (c) => {
+    const person = await findPerson(deps, c.req.param("id"));
+    if (!person) return c.json({ error: "Unknown person" }, 404);
+
+    const parsed = parseSendMessageRequest(await c.req.json().catch(() => null));
+    if ("error" in parsed) return c.json({ error: parsed.error }, 400);
+
+    // The account has to be one of theirs. A client that names another
+    // person's address is not making a request this person's page can answer,
+    // and sending anyway would deliver a message the guardian addressed to
+    // someone else.
+    const held = person.channelMappings.some(
+      (mapping) =>
+        mapping.channel === parsed.request.channel &&
+        mapping.channelUserId === parsed.request.channelUserId,
+    );
+    if (!held) {
+      return c.json({ error: "That account is not linked to this person" }, 400);
+    }
+
+    const result = await sendToAccount(deps, parsed.request, parsed.request.text);
+    return result.ok
+      ? c.json(result.message, 202)
+      : c.json(
+          { error: refusalMessage(result.send), send: result.send } satisfies SendRefusal,
+          409,
+        );
+  });
+
+  /** Every send of this person's still in flight. Unpaged — an outbox long
+   *  enough to page is an incident rather than a listing. */
+  app.get("/people/:id/outbox", async (c) => {
+    const person = await findPerson(deps, c.req.param("id"));
+    if (!person) return c.json({ error: "Unknown person" }, 404);
+
+    const [accounts] = await timelineAccounts(deps, [person.channelMappings]);
+    return c.json({
+      messages: await readOutbox(deps, personMessageStores(deps), accounts),
+    } satisfies OutboxPage);
+  });
+
+  /** Try a failed send again. Under its own id, so a retry never reads as a
+   *  second message the guardian did not write. */
+  app.post("/people/:id/outbox/:messageId/retry", async (c) => {
+    const person = await findPerson(deps, c.req.param("id"));
+    if (!person) return c.json({ error: "Unknown person" }, 404);
+
+    const message = await retrySend(deps, c.req.param("messageId"));
+    return message ? c.json(message, 202) : c.json({ error: "Unknown message" }, 404);
+  });
+
+  /** Give up on a failed send. The only way a row leaves the outbox without
+   *  having been delivered. */
+  app.delete("/people/:id/outbox/:messageId", async (c) => {
+    const person = await findPerson(deps, c.req.param("id"));
+    if (!person) return c.json({ error: "Unknown person" }, 404);
+
+    await deps.outboxRepo.remove(c.req.param("messageId"));
+    return c.body(null, 204);
+  });
+
   app.get("/people/:id/messages", async (c) => {
     const person = await findPerson(deps, c.req.param("id"));
     if (!person) return c.json({ error: "Unknown person" }, 404);
@@ -182,4 +256,23 @@ export function peopleRoutes(deps: ApiDeps): Hono {
 async function respondWithPerson(deps: ApiDeps, c: Context, id: string) {
   const person = await readPerson(deps, id);
   return person ? c.json(person) : c.json({ error: "Unknown person" }, 404);
+}
+
+/**
+ * The line a refusal carries when a client has nothing better.
+ *
+ * A fallback, not the copy: the dashboard renders `send` through its own
+ * locale files, because why a channel cannot be written to is a fact about the
+ * channel and every surface that states it has to state it in the reader's
+ * language.
+ */
+function refusalMessage(send: Exclude<AccountSendState, "yes">): string {
+  switch (send) {
+    case "not-connected":
+      return "That channel is not connected";
+    case "unsupported":
+      return "Rome cannot send on that channel";
+    case "no-conversation":
+      return "Rome has no conversation open with that account";
+  }
 }

--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -220,9 +220,9 @@ export function peopleRoutes(deps: ApiDeps): Hono {
       : c.json({ error: "No failed message of theirs with that id" }, 404);
   });
 
-  /** Give up on a failed send. The only way a row leaves the outbox without
-   *  having been delivered — a send still in flight may yet arrive, and
-   *  dropping its record would leave the guardian with no account of it. */
+  /** Give up on a send. The only way a row leaves the outbox without having
+   *  been observed on the timeline. Refused only while the provider call is
+   *  outstanding, since until it answers nobody knows what happened. */
   app.delete("/people/:id/outbox/:messageId", async (c) => {
     const person = await findPerson(deps, c.req.param("id"));
     if (!person) return c.json({ error: "Unknown person" }, 404);
@@ -230,7 +230,7 @@ export function peopleRoutes(deps: ApiDeps): Hono {
     const discarded = await discardSend(deps, person.channelMappings, c.req.param("messageId"));
     return discarded
       ? c.body(null, 204)
-      : c.json({ error: "No failed message of theirs with that id" }, 404);
+      : c.json({ error: "No dismissable message of theirs with that id" }, 404);
   });
 
   app.get("/people/:id/messages", async (c) => {

--- a/packages/core/src/connections/integrations/talk-features.ts
+++ b/packages/core/src/connections/integrations/talk-features.ts
@@ -5,6 +5,7 @@ import type {
   MessageReceipt,
   NormalizedMessage,
   TalkActivity,
+  TalkDirectMessaging,
   TalkHistory,
   TalkInboundMedia,
 } from "@rome-os/app-runtime";
@@ -106,6 +107,25 @@ export function inboundMediaFeature(adapter: {
 }): TalkInboundMedia {
   return {
     materialize: (message) => adapter.saveIncomingAttachments(normalizedFromInbound(message)),
+  };
+}
+
+/**
+ * Direct messaging for a channel whose direct chat is addressed by the contact
+ * themselves — WhatsApp, Telegram — where the account's own address already
+ * names the conversation.
+ *
+ * Costs nothing and cannot fail, so a caller may ask it per account across a
+ * whole listing. A channel that keys threads separately writes its own
+ * implementation instead, opening or looking up the thread; that one is a
+ * provider call and should be priced as one.
+ */
+export function addressIsConversationFeature(): TalkDirectMessaging {
+  return {
+    async conversationFor(channelUserId: string) {
+      const trimmed = channelUserId.trim();
+      return trimmed === "" ? null : (trimmed as ConversationId);
+    },
   };
 }
 

--- a/packages/core/src/connections/integrations/telegram.ts
+++ b/packages/core/src/connections/integrations/telegram.ts
@@ -23,7 +23,12 @@ import { tokenPaste } from "../schemes.js";
 import { SetupAbortError } from "../setup/session.js";
 import type { SetupFn, SetupView } from "../setup/types.js";
 import type { ConnectionDescriptor, ProfileDisplay, ProfileRecord, Talker } from "../types.js";
-import { inboundMediaFeature, toInboundMessage, toMessageReceipt } from "./talk-features.js";
+import {
+  addressIsConversationFeature,
+  inboundMediaFeature,
+  toInboundMessage,
+  toMessageReceipt,
+} from "./talk-features.js";
 
 /**
  * True iff `err` is a Telegram "credential refused" — a grammy `GrammyError`
@@ -458,6 +463,9 @@ export function makeTelegramDescriptor(deps: TelegramDescriptorDeps = {}): Conne
             feature<K extends TalkFeatureName>(name: K): TalkFeatureMap[K] | null {
               const features: Partial<TalkFeatureMap> = {
                 inboundMedia: inboundMediaFeature(adapter),
+                // A Telegram private chat carries the user's own id as its chat
+                // id, so the address is already the conversation.
+                directMessaging: addressIsConversationFeature(),
               };
               return (features[name] as TalkFeatureMap[K] | undefined) ?? null;
             },

--- a/packages/core/src/connections/integrations/whatsapp.ts
+++ b/packages/core/src/connections/integrations/whatsapp.ts
@@ -47,6 +47,7 @@ import {
   type WhatsAppAuthMaterial,
 } from "./whatsapp-auth-state.js";
 import {
+  addressIsConversationFeature,
   historyFeature,
   inboundMediaFeature,
   toInboundMessage,
@@ -344,6 +345,9 @@ export function createWhatsAppDescriptor(deps: WhatsAppDescriptorDeps): Connecti
               const features: Partial<TalkFeatureMap> = {
                 inboundMedia: inboundMediaFeature(adapter),
                 history: historyFeature(adapter),
+                // A WhatsApp direct chat is addressed by the contact's own JID,
+                // so the address is already the conversation.
+                directMessaging: addressIsConversationFeature(),
               };
               return (features[name] as TalkFeatureMap[K] | undefined) ?? null;
             },

--- a/packages/core/src/db/repositories/outbox.ts
+++ b/packages/core/src/db/repositories/outbox.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, lt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 import { outboundMessages } from "../schema.js";
 import type { DrizzleDb } from "../index.js";
@@ -100,14 +100,40 @@ export class OutboxRepository {
     return row === null ? null : { ...row, updatedAt };
   }
 
-  /** Give up on a send Rome is not going to make. Refuses any other state: a
-   *  row still in flight is a message that may yet arrive, and dropping its
-   *  record would leave the guardian with no account of it. */
-  async discard(id: string): Promise<boolean> {
-    const row = await this.find(id);
-    if (row === null || row.state !== "failed") return false;
-    await this.db.delete(outboundMessages).where(eq(outboundMessages.id, id));
-    return true;
+  /**
+   * Give up on a send, and answer whether there was one to give up on.
+   *
+   * A row is dismissable once nothing is going to happen to it on its own. A
+   * `failed` one is finished. An `unconfirmed` one that has outlived the window
+   * a message lands in was delivered and will never be seen — on a channel with
+   * no mirror, one whose transcript write failed has no other way out, and
+   * leaving it would be a phantom the guardian can neither retry nor dismiss.
+   *
+   * Everything else is refused. A send whose provider call is still outstanding
+   * has no known outcome, and one that has just been accepted is about to clear
+   * itself; dismissing either loses the record of a message already on its way.
+   *
+   * Both conditions ride in the WHERE clause rather than a read before it. A
+   * discard racing a retry could otherwise pass its check, have the retry claim
+   * and deliver the row in between, and delete it a moment later — a message
+   * sent with no record of it, which is the thing this table exists to prevent.
+   */
+  async discard(id: string, settledBefore: Date): Promise<boolean> {
+    const deleted = await this.db
+      .delete(outboundMessages)
+      .where(
+        and(
+          eq(outboundMessages.id, id),
+          or(
+            eq(outboundMessages.state, "failed"),
+            and(
+              eq(outboundMessages.state, "unconfirmed"),
+              lt(outboundMessages.updatedAt, settledBefore),
+            ),
+          ),
+        ),
+      );
+    return deleted.changes > 0;
   }
 
   /** A send whose process died before the channel answered, marked so it can

--- a/packages/core/src/db/repositories/outbox.ts
+++ b/packages/core/src/db/repositories/outbox.ts
@@ -1,0 +1,123 @@
+import { and, eq, inArray } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+import { outboundMessages } from "../schema.js";
+import type { DrizzleDb } from "../index.js";
+
+/**
+ * The outbox: messages Rome has been asked to send and has not yet seen land.
+ *
+ * Rows are addressed by account, not by person. A send names an account and a
+ * merge moves a link, so a row keyed by the person it was addressed to would
+ * point at the wrong one afterwards; keyed by the address it stays true.
+ *
+ * Nothing here decides when a row is done. That is a question about the
+ * timeline — has this message shown up in the store the timeline reads — and it
+ * is answered where both are in hand (`src/people/outbox.ts`).
+ */
+
+export interface OutboxRow {
+  id: string;
+  channel: string;
+  channelUserId: string;
+  conversationId: string;
+  text: string;
+  state: "sending" | "unconfirmed" | "failed";
+  providerMessageId: string | null;
+  error: string | null;
+  createdAt: Date;
+}
+
+export interface OutboxAccount {
+  channel: string;
+  channelUserId: string;
+}
+
+export class OutboxRepository {
+  constructor(private readonly db: DrizzleDb) {}
+
+  /** Record the attempt before it is made, so a process that dies mid-send
+   *  leaves evidence rather than silence. */
+  async open(input: {
+    channel: string;
+    channelUserId: string;
+    conversationId: string;
+    text: string;
+  }): Promise<OutboxRow> {
+    const now = new Date();
+    const row = {
+      id: uuid(),
+      ...input,
+      state: "sending" as const,
+      providerMessageId: null,
+      error: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.db.insert(outboundMessages).values(row);
+    return row;
+  }
+
+  /** The channel took it and named it. Not "delivered" — that is decided by
+   *  the message appearing on the timeline, not by this answer. */
+  async accepted(id: string, providerMessageId: string | null): Promise<void> {
+    await this.db
+      .update(outboundMessages)
+      .set({ state: "unconfirmed", providerMessageId, error: null, updatedAt: new Date() })
+      .where(eq(outboundMessages.id, id));
+  }
+
+  async refused(id: string, error: string): Promise<void> {
+    await this.db
+      .update(outboundMessages)
+      .set({ state: "failed", error, updatedAt: new Date() })
+      .where(eq(outboundMessages.id, id));
+  }
+
+  /** Put a failed row back in flight, under its own id, so a retry does not
+   *  read as a second message the guardian never wrote. */
+  async reopen(id: string): Promise<OutboxRow | null> {
+    const row = await this.find(id);
+    if (row === null || row.state !== "failed") return null;
+    await this.db
+      .update(outboundMessages)
+      .set({ state: "sending", error: null, providerMessageId: null, updatedAt: new Date() })
+      .where(eq(outboundMessages.id, id));
+    return { ...row, state: "sending", error: null, providerMessageId: null };
+  }
+
+  async find(id: string): Promise<OutboxRow | null> {
+    const [row] = await this.db
+      .select()
+      .from(outboundMessages)
+      .where(eq(outboundMessages.id, id))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.db.delete(outboundMessages).where(eq(outboundMessages.id, id));
+  }
+
+  /** Every open row for a set of accounts, oldest first — the order they were
+   *  written in, which is the order they were meant to arrive in. */
+  async forAccounts(accounts: readonly OutboxAccount[]): Promise<OutboxRow[]> {
+    if (accounts.length === 0) return [];
+    const channels = [...new Set(accounts.map((a) => a.channel))];
+    const addresses = [...new Set(accounts.map((a) => a.channelUserId))];
+    // Narrowed by the index and then filtered exactly: the two `IN`s together
+    // admit pairs nobody asked for when a person holds several accounts.
+    const rows = await this.db
+      .select()
+      .from(outboundMessages)
+      .where(
+        and(
+          inArray(outboundMessages.channel, channels),
+          inArray(outboundMessages.channelUserId, addresses),
+        ),
+      );
+    const wanted = new Set(accounts.map((a) => `${a.channel}\n${a.channelUserId}`));
+    return rows
+      .filter((row) => wanted.has(`${row.channel}\n${row.channelUserId}`))
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+}

--- a/packages/core/src/db/repositories/outbox.ts
+++ b/packages/core/src/db/repositories/outbox.ts
@@ -77,17 +77,27 @@ export class OutboxRepository {
       .where(eq(outboundMessages.id, id));
   }
 
-  /** Put a failed row back in flight, under its own id, so a retry does not
-   *  read as a second message the guardian never wrote. */
+  /**
+   * Put a failed row back in flight, under its own id, so a retry does not read
+   * as a second message the guardian never wrote.
+   *
+   * The claim is the update itself, not a check before it. Reading the state
+   * and then writing lets two retries of one row both pass the read and both
+   * reach the provider — a double-clicked button delivering the message twice,
+   * which is the harm this whole surface is arranged to avoid. Guarding on
+   * `failed` and answering off the affected count makes exactly one of them
+   * win, and the loser sees a row that is no longer theirs to send.
+   */
   async reopen(id: string): Promise<OutboxRow | null> {
-    const row = await this.find(id);
-    if (row === null || row.state !== "failed") return null;
     const updatedAt = new Date();
-    await this.db
+    const claimed = await this.db
       .update(outboundMessages)
       .set({ state: "sending", error: null, providerMessageId: null, updatedAt })
-      .where(eq(outboundMessages.id, id));
-    return { ...row, state: "sending", error: null, providerMessageId: null, updatedAt };
+      .where(and(eq(outboundMessages.id, id), eq(outboundMessages.state, "failed")));
+    if (claimed.changes === 0) return null;
+
+    const row = await this.find(id);
+    return row === null ? null : { ...row, updatedAt };
   }
 
   /** Give up on a send Rome is not going to make. Refuses any other state: a

--- a/packages/core/src/db/repositories/outbox.ts
+++ b/packages/core/src/db/repositories/outbox.ts
@@ -25,6 +25,10 @@ export interface OutboxRow {
   providerMessageId: string | null;
   error: string | null;
   createdAt: Date;
+  /** When the row last changed state. A retry moves this and not `createdAt`,
+   *  so "how long has this been in flight" is asked of the attempt rather than
+   *  of the first one. */
+  updatedAt: Date;
 }
 
 export interface OutboxAccount {
@@ -78,11 +82,32 @@ export class OutboxRepository {
   async reopen(id: string): Promise<OutboxRow | null> {
     const row = await this.find(id);
     if (row === null || row.state !== "failed") return null;
+    const updatedAt = new Date();
     await this.db
       .update(outboundMessages)
-      .set({ state: "sending", error: null, providerMessageId: null, updatedAt: new Date() })
+      .set({ state: "sending", error: null, providerMessageId: null, updatedAt })
       .where(eq(outboundMessages.id, id));
-    return { ...row, state: "sending", error: null, providerMessageId: null };
+    return { ...row, state: "sending", error: null, providerMessageId: null, updatedAt };
+  }
+
+  /** Give up on a send Rome is not going to make. Refuses any other state: a
+   *  row still in flight is a message that may yet arrive, and dropping its
+   *  record would leave the guardian with no account of it. */
+  async discard(id: string): Promise<boolean> {
+    const row = await this.find(id);
+    if (row === null || row.state !== "failed") return false;
+    await this.db.delete(outboundMessages).where(eq(outboundMessages.id, id));
+    return true;
+  }
+
+  /** A send whose process died before the channel answered, marked so it can
+   *  be seen and retried. Rome cannot know whether it went out, and the error
+   *  says exactly that rather than guessing either way. */
+  async stranded(id: string, error: string): Promise<void> {
+    await this.db
+      .update(outboundMessages)
+      .set({ state: "failed", error, updatedAt: new Date() })
+      .where(and(eq(outboundMessages.id, id), eq(outboundMessages.state, "sending")));
   }
 
   async find(id: string): Promise<OutboxRow | null> {

--- a/packages/core/src/db/repositories/webchat.ts
+++ b/packages/core/src/db/repositories/webchat.ts
@@ -222,7 +222,14 @@ export function channelConversationId(channel: string, threadId: string): string
   return `channel:${channel}:${threadId}`;
 }
 
-function conversationPlatformMessageId(sessionId: string, platformMessageId: string): string {
+/** The row id a recorded outbound message takes when the provider named it.
+ *  Derived rather than random so a caller that knows the provider's id can
+ *  predict the timeline `ref` the message will carry — which is how the
+ *  outbox knows a send has landed (`src/people/outbox.ts`). */
+export function conversationPlatformMessageId(
+  sessionId: string,
+  platformMessageId: string,
+): string {
   const digest = createHash("sha256")
     .update(sessionId)
     .update("\0")

--- a/packages/core/src/db/schema/system.ts
+++ b/packages/core/src/db/schema/system.ts
@@ -143,6 +143,48 @@ export const waContacts = sqliteTable("wa_contacts", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });
 
+/**
+ * Messages Rome is still trying to deliver — the
+ * [outbox](docs/concepts/people.md).
+ *
+ * Not a message store, and deliberately not part of the timeline. A row here
+ * is a send that has not happened yet and may never; a timeline entry is one
+ * that did. Keeping them apart is what lets `TimelineEntry`'s `ref` stay unique
+ * and its ordering stay total — a cursor cannot be written across rows that may
+ * still be withdrawn — and what keeps each account owned by exactly one message
+ * store rather than two that disagree.
+ *
+ * A row leaves by being delivered: once `provider_message_id` names a message
+ * the channel's own store holds, the entry is on the timeline and the row is
+ * redundant. Nothing has to remember to clear it, because the read derives
+ * that (`src/people/outbox.ts`).
+ *
+ * Addressed by the account rather than by the person, because that is what a
+ * send names. A merge moves the link, and this row keeps pointing at the
+ * address it was sent to, which stays true whoever ends up holding it.
+ */
+export const outboundMessages = sqliteTable(
+  "outbound_messages",
+  {
+    id: text("id").primaryKey(),
+    channel: text("channel").notNull(),
+    channelUserId: text("channel_user_id").notNull(),
+    /** The conversation the channel resolved the address to, kept so a retry
+     *  does not have to ask again. */
+    conversationId: text("conversation_id").notNull(),
+    text: text("text").notNull(),
+    state: text("state", { enum: ["sending", "unconfirmed", "failed"] }).notNull(),
+    /** The channel's own id for the message, once it has taken it. Null while
+     *  sending and after a failure. Half of the ref the delivered entry
+     *  carries, which is how the read knows the row has landed. */
+    providerMessageId: text("provider_message_id"),
+    error: text("error"),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+  },
+  (table) => [index("idx_outbound_account").on(table.channel, table.channelUserId)],
+);
+
 export const waChats = sqliteTable("wa_chats", {
   jid: text("jid").primaryKey(),
   name: text("name"),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ import { runMigrations } from "./db/migrate.js";
 import { SessionsRepository } from "./db/repositories/sessions.js";
 import { PersonMappingRepository } from "./db/repositories/person-mapping.js";
 import { LinkedInStoreRepository } from "./db/repositories/linkedin-store.js";
+import { OutboxRepository } from "./db/repositories/outbox.js";
 import { WhatsAppStoreRepository } from "./db/repositories/whatsapp-store.js";
 import { LinkedInAccounts } from "./channels/linkedin-accounts.js";
 import { WhatsAppAccounts } from "./channels/whatsapp-accounts.js";
@@ -235,6 +236,7 @@ async function main() {
   const sessionsRepo = new SessionsRepository(db);
   const personMappingRepo = new PersonMappingRepository(db);
   const whatsAppStoreRepo = new WhatsAppStoreRepository(db);
+  const outboxRepo = new OutboxRepository(db);
   const whatsAppAccounts = new WhatsAppAccounts(whatsAppStoreRepo);
   const linkedInStoreRepo = new LinkedInStoreRepository(db);
   const linkedInAccounts = new LinkedInAccounts(linkedInStoreRepo);
@@ -1225,6 +1227,7 @@ async function main() {
       actionEngine,
       actionLoader,
       personMappingRepo,
+      outboxRepo,
       whatsAppStoreRepo,
       channels,
       accountNames,

--- a/packages/core/src/people/activity.ts
+++ b/packages/core/src/people/activity.ts
@@ -15,13 +15,35 @@ import {
   type TimelineEntry,
 } from "@rome/api-types/people";
 import type { MessageAccount, Messages } from "../channels/messages.js";
-import { assignAccounts } from "./timeline.js";
+import { assignAccountHeads } from "./timeline.js";
 
 /** A person's history at a glance. `latest` is null exactly when
  *  `messageCount` is zero — a person nobody has ever written to. */
 export interface PersonActivity {
   latest: AccountDynamic | null;
   messageCount: number;
+}
+
+/**
+ * A read of the same stores, answered at both grains it is asked at.
+ *
+ * The per-account heads are not a second read: deciding which store owns an
+ * account already requires that store's `latest` for it, so the entry is in
+ * hand either way and dropping it would only mean fetching it again. The
+ * person-level answer is a fold of the same pass.
+ *
+ * Both grains exist because they answer different questions. A person's
+ * `latest` says what they last did anywhere, which is what a row previews; an
+ * account's says when that address was last active, which is the only thing
+ * that can tell two accounts on one channel apart.
+ */
+export interface PeopleActivity {
+  /** One per group of accounts, in the order the groups were given. */
+  perPerson: PersonActivity[];
+  /** Each account's own newest entry, keyed by the account object passed in —
+   *  the idiom `assignAccountHeads` uses, so a caller reads its answer back off
+   *  the values it gave. Absent for an account no store holds. */
+  perAccount: Map<MessageAccount, TimelineEntry>;
 }
 
 /**
@@ -35,9 +57,19 @@ export async function readPeopleActivity(
   stores: readonly Messages[],
   accountsByPerson: readonly (readonly MessageAccount[])[],
 ): Promise<PersonActivity[]> {
+  return (await readActivity(stores, accountsByPerson)).perPerson;
+}
+
+export async function readActivity(
+  stores: readonly Messages[],
+  accountsByPerson: readonly (readonly MessageAccount[])[],
+): Promise<PeopleActivity> {
+  const owned = await assignAccountHeads(stores, accountsByPerson.flat());
   const owner = new Map<MessageAccount, Messages>();
-  for (const [store, held] of await assignAccounts(stores, accountsByPerson.flat())) {
-    for (const account of held) owner.set(account, store);
+  const perAccount = new Map<MessageAccount, TimelineEntry>();
+  for (const [account, { store, head }] of owned) {
+    owner.set(account, store);
+    perAccount.set(account, head);
   }
 
   // One summary per person per store, over every account of theirs that store
@@ -73,12 +105,15 @@ export async function readPeopleActivity(
     if (head) person.heads.push(head);
   });
 
-  return activity.map((person) => ({
-    // Through `latestDynamic`, over the stores' heads in the timeline's own
-    // order, so a person whose two accounts last spoke in the same second
-    // previews the entry their merged timeline opens on rather than whichever
-    // store the fold reached first.
-    latest: latestDynamic(person.heads.sort(compareTimelineEntries)),
-    messageCount: person.messageCount,
-  }));
+  return {
+    perPerson: activity.map((person) => ({
+      // Through `latestDynamic`, over the stores' heads in the timeline's own
+      // order, so a person whose two accounts last spoke in the same second
+      // previews the entry their merged timeline opens on rather than whichever
+      // store the fold reached first.
+      latest: latestDynamic(person.heads.sort(compareTimelineEntries)),
+      messageCount: person.messageCount,
+    })),
+    perAccount,
+  };
 }

--- a/packages/core/src/people/outbox.ts
+++ b/packages/core/src/people/outbox.ts
@@ -181,7 +181,9 @@ export async function discardSend(
   id: string,
 ): Promise<boolean> {
   if (!(await heldBy(deps, accounts, id))) return false;
-  return await deps.outboxRepo.discard(id);
+  // The same window a send is given to arrive in. Inside it an unconfirmed row
+  // is ordinary and usually clears itself; past it, it is stuck.
+  return await deps.outboxRepo.discard(id, new Date(Date.now() - STRANDED_AFTER_MS));
 }
 
 /** Whether a row is addressed to one of these accounts. */

--- a/packages/core/src/people/outbox.ts
+++ b/packages/core/src/people/outbox.ts
@@ -1,0 +1,219 @@
+// The outbox: what Rome has been asked to send and has not yet seen arrive.
+//
+// The timeline is what happened; this is what is still being attempted. Two
+// nouns rather than a delivery status on a timeline entry, because a timeline
+// entry's `ref` has to stay unique and its ordering total — a cursor is written
+// against them — and neither survives rows that may still be withdrawn.
+//
+// Nothing clears a row. A row is gone once its message is on the timeline, and
+// this read is what notices. That is why there is no delivery callback to
+// forget to call and no state the two reads can disagree about: an outbox row
+// is exactly a send whose entry is not there yet.
+
+import type { OutboxMessage, OutboxState } from "@rome/api-types/people";
+import type { MessageAccount, Messages } from "../channels/messages.js";
+import { channelConversationId } from "../db/repositories/webchat.js";
+import { conversationPlatformMessageId } from "../db/repositories/webchat.js";
+import type { OutboxRepository, OutboxRow } from "../db/repositories/outbox.js";
+import {
+  resolveSendTarget,
+  sendToTarget,
+  type RefusedState,
+  type SendDeps,
+  type SendTarget,
+} from "./send.js";
+import { readPersonTimeline } from "./timeline.js";
+
+/** How far back the landing check looks. A message lands within a second of
+ *  being accepted, so anything this deep is already an incident; the window is
+ *  wide enough that a burst of sends cannot push an entry past it. */
+const LANDING_WINDOW = 100;
+
+/** What Rome writes into its own transcript when it sends. `senderId` is the
+ *  mark every outbound path stamps, and `messages-agent.ts` reads it back to
+ *  put the line on Rome's side of the conversation. */
+const ROME_SENDER = { senderId: "rome", senderName: "Rome" } as const;
+
+/** The slice of the conversation repository this needs: a channel thread's
+ *  session, and Rome's own record of what it said there. Named as `ApiDeps`
+ *  names it so no adapter sits between the two. */
+export interface Conversations {
+  ensureChannelConversation(input: {
+    channel: string;
+    threadId: string;
+    agentName?: string;
+  }): Promise<{ id: string }>;
+  recordOutboundConversationMessage(input: {
+    sessionId: string;
+    content: string;
+    platformMessageId?: string;
+    senderId?: string;
+    senderName?: string;
+    knownToProvider: boolean;
+  }): Promise<void>;
+}
+
+export interface OutboxDeps extends SendDeps {
+  outboxRepo: OutboxRepository;
+  webchatRepo: Conversations;
+}
+
+export type SendResult = { ok: true; message: OutboxMessage } | { ok: false; send: RefusedState };
+
+/**
+ * Send to one account, and answer with the outbox row it became.
+ *
+ * The row is written before the channel is called, so a process that dies
+ * mid-send leaves a `sending` row rather than nothing at all. It is never
+ * written as delivered: the channel accepting a message is not the same fact
+ * as the message being on the timeline, and only the read below can see the
+ * second one.
+ */
+export async function sendToAccount(
+  deps: OutboxDeps,
+  account: { channel: string; channelUserId: string },
+  text: string,
+): Promise<SendResult> {
+  const resolution = await resolveSendTarget(deps, account);
+  if (!resolution.ok) return { ok: false, send: resolution.send };
+
+  const row = await deps.outboxRepo.open({
+    channel: account.channel,
+    channelUserId: account.channelUserId,
+    conversationId: resolution.target.conversationId,
+    text,
+  });
+
+  return { ok: true, message: await attempt(deps, row, resolution.target) };
+}
+
+/** Send a `sending` row and record whichever way it went. Shared by the first
+ *  attempt and by a retry, so the two cannot drift. */
+async function attempt(
+  deps: OutboxDeps,
+  row: OutboxRow,
+  target: SendTarget,
+): Promise<OutboxMessage> {
+  try {
+    const receipt = await sendToTarget(deps, target, row.text);
+    await deps.outboxRepo.accepted(row.id, receipt.messageId);
+    // Rome's own transcript of what it said, the same record every other
+    // outbound path writes. On a channel with no mirror of its own this IS the
+    // timeline entry; on one with a mirror it sits behind the provider's copy,
+    // which is the store precedence in timeline-sources.ts and not a special
+    // case here.
+    await record(deps, row, receipt.messageId);
+    return wire({ ...row, state: "unconfirmed", providerMessageId: receipt.messageId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await deps.outboxRepo.refused(row.id, message);
+    return wire({ ...row, state: "failed", error: message });
+  }
+}
+
+/** Retry a failed send, under its own id so it does not read as a second
+ *  message the guardian never wrote. */
+export async function retrySend(deps: OutboxDeps, id: string): Promise<OutboxMessage | null> {
+  const row = await deps.outboxRepo.reopen(id);
+  if (row === null) return null;
+  const resolution = await resolveSendTarget(deps, row);
+  if (!resolution.ok) {
+    const error = `cannot send on ${row.channel}: ${resolution.send}`;
+    await deps.outboxRepo.refused(row.id, error);
+    return wire({ ...row, state: "failed", error });
+  }
+  return attempt(deps, row, resolution.target);
+}
+
+async function record(deps: OutboxDeps, row: OutboxRow, messageId: string | null): Promise<void> {
+  const conversation = await deps.webchatRepo.ensureChannelConversation({
+    channel: row.channel,
+    threadId: row.conversationId,
+  });
+  await deps.webchatRepo.recordOutboundConversationMessage({
+    sessionId: conversation.id,
+    content: JSON.stringify([{ type: "text", content: row.text }]),
+    ...(messageId ? { platformMessageId: messageId } : {}),
+    ...ROME_SENDER,
+    // False: this line was not produced by an agent turn. It decides the role
+    // the row is stored under, which `agentMessageOutbound` then reads back
+    // together with the sender to put it on Rome's side.
+    knownToProvider: false,
+  });
+}
+
+/**
+ * Every send for these accounts that has not arrived, clearing the ones that
+ * have.
+ *
+ * The check is exact rather than approximate: a delivered message's `ref` is
+ * predictable from the id the channel gave back, in both of the two forms a
+ * store can produce. Matching on anything looser — the text, a timestamp
+ * window — would clear a row on a message the guardian sent from their phone.
+ */
+export async function readOutbox(
+  deps: OutboxDeps,
+  stores: readonly Messages[],
+  accounts: readonly MessageAccount[],
+): Promise<OutboxMessage[]> {
+  const rows = await deps.outboxRepo.forAccounts(
+    accounts.flatMap((account) =>
+      account.addresses.map((channelUserId) => ({ channel: account.channel, channelUserId })),
+    ),
+  );
+  if (rows.length === 0) return [];
+
+  const awaiting = rows.filter((row) => row.state === "unconfirmed");
+  if (awaiting.length === 0) return rows.map(wire);
+
+  const { entries } = await readPersonTimeline(stores, accounts, { limit: LANDING_WINDOW });
+  const arrived = new Set(entries.map((entry) => entry.ref));
+
+  // A row the channel accepted but never named cannot be recognized when it
+  // arrives, so waiting on it is waiting forever. Clearing it is the lesser
+  // wrong, and the requirement that makes it unreachable is stated on
+  // `TalkDirectMessaging`.
+  const landed = awaiting.filter(
+    (row) => row.providerMessageId === null || refsFor(row).some((ref) => arrived.has(ref)),
+  );
+  await Promise.all(landed.map((row) => deps.outboxRepo.remove(row.id)));
+
+  const cleared = new Set(landed.map((row) => row.id));
+  return rows.filter((row) => !cleared.has(row.id)).map(wire);
+}
+
+/**
+ * The two `ref`s a delivered message can carry, because two stores can hold it.
+ *
+ * A channel mirror keys its rows by the provider's own id under the
+ * conversation (`wa_messages` is `chat_jid || ':' || id`). Rome's transcript
+ * keys its own row by a digest of the session and that same provider id, which
+ * is why `conversationPlatformMessageId` is derived and not random. Whichever
+ * store ends up owning the account, one of these is the entry.
+ *
+ * Both need the provider's id, so a channel offering `directMessaging` has to
+ * return one from `send` — see the note there. A send that is accepted without
+ * one cannot be tracked, and the row is cleared rather than left waiting on an
+ * answer that will never come.
+ */
+function refsFor(row: OutboxRow): string[] {
+  if (row.providerMessageId === null) return [];
+  const sessionId = channelConversationId(row.channel, row.conversationId);
+  return [
+    `${row.conversationId}:${row.providerMessageId}`,
+    `agent:${conversationPlatformMessageId(sessionId, row.providerMessageId)}`,
+  ];
+}
+
+function wire(row: OutboxRow): OutboxMessage {
+  return {
+    id: row.id,
+    channel: row.channel,
+    channelUserId: row.channelUserId,
+    text: row.text,
+    timestamp: Math.floor(row.createdAt.getTime() / 1000),
+    state: row.state as OutboxState,
+    ref: refsFor(row)[0] ?? null,
+    error: row.error,
+  };
+}

--- a/packages/core/src/people/outbox.ts
+++ b/packages/core/src/people/outbox.ts
@@ -11,10 +11,11 @@
 // is exactly a send whose entry is not there yet.
 
 import type { OutboxMessage, OutboxState } from "@rome/api-types/people";
+import { createLogger } from "../logger.js";
 import type { MessageAccount, Messages } from "../channels/messages.js";
 import { channelConversationId } from "../db/repositories/webchat.js";
 import { conversationPlatformMessageId } from "../db/repositories/webchat.js";
-import type { OutboxRepository, OutboxRow } from "../db/repositories/outbox.js";
+import type { OutboxAccount, OutboxRepository, OutboxRow } from "../db/repositories/outbox.js";
 import {
   resolveSendTarget,
   sendToTarget,
@@ -29,10 +30,21 @@ import { readPersonTimeline } from "./timeline.js";
  *  wide enough that a burst of sends cannot push an entry past it. */
 const LANDING_WINDOW = 100;
 
+/** How long a send may sit `sending` before it is treated as abandoned. A send
+ *  is one provider call inside one request, so minutes here is generous — long
+ *  enough that a slow channel is never called dead, short enough that a crash
+ *  does not leave a row spinning until someone looks. */
+const STRANDED_AFTER_MS = 5 * 60_000;
+
+const STRANDED_ERROR =
+  "Rome stopped before the channel answered; this may or may not have been sent";
+
 /** What Rome writes into its own transcript when it sends. `senderId` is the
  *  mark every outbound path stamps, and `messages-agent.ts` reads it back to
  *  put the line on Rome's side of the conversation. */
 const ROME_SENDER = { senderId: "rome", senderName: "Rome" } as const;
+
+const log = createLogger("people-outbox");
 
 /** The slice of the conversation repository this needs: a channel thread's
  *  session, and Rome's own record of what it said there. Named as `ApiDeps`
@@ -87,33 +99,69 @@ export async function sendToAccount(
   return { ok: true, message: await attempt(deps, row, resolution.target) };
 }
 
-/** Send a `sending` row and record whichever way it went. Shared by the first
- *  attempt and by a retry, so the two cannot drift. */
+/**
+ * Send a `sending` row and record whichever way it went. Shared by the first
+ * attempt and by a retry, so the two cannot drift.
+ *
+ * Only the provider call decides whether this failed. Once it returns, the
+ * message is out on a network Rome does not own and no local mishap can take
+ * it back — so the acceptance is written first and alone, and everything after
+ * it is bookkeeping that may fail without changing what happened. Wrapping the
+ * two together reported a delivered message as refused, which invites a retry
+ * and a second real message to someone who already got the first.
+ */
 async function attempt(
   deps: OutboxDeps,
   row: OutboxRow,
   target: SendTarget,
 ): Promise<OutboxMessage> {
+  let receipt: Awaited<ReturnType<typeof sendToTarget>>;
   try {
-    const receipt = await sendToTarget(deps, target, row.text);
-    await deps.outboxRepo.accepted(row.id, receipt.messageId);
-    // Rome's own transcript of what it said, the same record every other
-    // outbound path writes. On a channel with no mirror of its own this IS the
-    // timeline entry; on one with a mirror it sits behind the provider's copy,
-    // which is the store precedence in timeline-sources.ts and not a special
-    // case here.
-    await record(deps, row, receipt.messageId);
-    return wire({ ...row, state: "unconfirmed", providerMessageId: receipt.messageId });
+    receipt = await sendToTarget(deps, target, row.text);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     await deps.outboxRepo.refused(row.id, message);
     return wire({ ...row, state: "failed", error: message });
   }
+
+  await deps.outboxRepo.accepted(row.id, receipt.messageId);
+
+  // Rome's own transcript of what it said, the same record every other outbound
+  // path writes. On a channel with no mirror of its own this IS the timeline
+  // entry; on one with a mirror it sits behind the provider's copy, which is
+  // the store precedence in timeline-sources.ts and not a special case here.
+  //
+  // A failure here leaves the row `unconfirmed`, which is the truth: the
+  // message was sent and Rome cannot yet see it. On a mirrored channel the
+  // provider's own copy still lands and clears the row; on an unmirrored one
+  // the row stays, visibly, which is the outbox doing its job.
+  try {
+    await record(deps, row, receipt.messageId);
+  } catch (error) {
+    log.warn("outbound message delivered but recording failed", {
+      outboxId: row.id,
+      channel: row.channel,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return wire({ ...row, state: "unconfirmed", providerMessageId: receipt.messageId });
 }
 
-/** Retry a failed send, under its own id so it does not read as a second
- *  message the guardian never wrote. */
-export async function retrySend(deps: OutboxDeps, id: string): Promise<OutboxMessage | null> {
+/**
+ * Retry a failed send, under its own id so it does not read as a second
+ * message the guardian never wrote.
+ *
+ * Scoped to the accounts given. A message id is not a capability: the route
+ * that reaches this names a person, and a row belonging to someone else is not
+ * that person's to move, however plausible the id looks.
+ */
+export async function retrySend(
+  deps: OutboxDeps,
+  accounts: readonly OutboxAccount[],
+  id: string,
+): Promise<OutboxMessage | null> {
+  if (!(await heldBy(deps, accounts, id))) return null;
   const row = await deps.outboxRepo.reopen(id);
   if (row === null) return null;
   const resolution = await resolveSendTarget(deps, row);
@@ -123,6 +171,32 @@ export async function retrySend(deps: OutboxDeps, id: string): Promise<OutboxMes
     return wire({ ...row, state: "failed", error });
   }
   return attempt(deps, row, resolution.target);
+}
+
+/** Give up on a failed send of this person's. Answers whether there was one to
+ *  give up on, so the route can tell a wrong id from a done job. */
+export async function discardSend(
+  deps: OutboxDeps,
+  accounts: readonly OutboxAccount[],
+  id: string,
+): Promise<boolean> {
+  if (!(await heldBy(deps, accounts, id))) return false;
+  return await deps.outboxRepo.discard(id);
+}
+
+/** Whether a row is addressed to one of these accounts. */
+async function heldBy(
+  deps: OutboxDeps,
+  accounts: readonly OutboxAccount[],
+  id: string,
+): Promise<boolean> {
+  const row = await deps.outboxRepo.find(id);
+  return (
+    row !== null &&
+    accounts.some(
+      (account) => account.channel === row.channel && account.channelUserId === row.channelUserId,
+    )
+  );
 }
 
 async function record(deps: OutboxDeps, row: OutboxRow, messageId: string | null): Promise<void> {
@@ -163,6 +237,19 @@ export async function readOutbox(
   );
   if (rows.length === 0) return [];
 
+  // A row still `sending` long after its attempt began is one whose process
+  // died between the insert and the channel's answer. Nothing will ever move
+  // it, so the read that notices says so: it becomes a failed row the guardian
+  // can see and retry, carrying the only honest error there is. It is not
+  // cleared — the message may well have gone out.
+  const stale = Date.now() - STRANDED_AFTER_MS;
+  const stranded = rows.filter((row) => row.state === "sending" && row.updatedAt.getTime() < stale);
+  for (const row of stranded) {
+    await deps.outboxRepo.stranded(row.id, STRANDED_ERROR);
+    row.state = "failed";
+    row.error = STRANDED_ERROR;
+  }
+
   const awaiting = rows.filter((row) => row.state === "unconfirmed");
   if (awaiting.length === 0) return rows.map(wire);
 
@@ -174,7 +261,9 @@ export async function readOutbox(
   // wrong, and the requirement that makes it unreachable is stated on
   // `TalkDirectMessaging`.
   const landed = awaiting.filter(
-    (row) => row.providerMessageId === null || refsFor(row).some((ref) => arrived.has(ref)),
+    (row) =>
+      row.providerMessageId === null ||
+      refsFor(row, addressesOf(accounts, row)).some((ref) => arrived.has(ref)),
   );
   await Promise.all(landed.map((row) => deps.outboxRepo.remove(row.id)));
 
@@ -183,26 +272,44 @@ export async function readOutbox(
 }
 
 /**
- * The two `ref`s a delivered message can carry, because two stores can hold it.
+ * Every `ref` a delivered message could carry, because two stores can hold it
+ * and one of them keys by an address the send did not necessarily name.
  *
- * A channel mirror keys its rows by the provider's own id under the
- * conversation (`wa_messages` is `chat_jid || ':' || id`). Rome's transcript
- * keys its own row by a digest of the session and that same provider id, which
- * is why `conversationPlatformMessageId` is derived and not random. Whichever
- * store ends up owning the account, one of these is the entry.
+ * A channel mirror keys its rows by the provider's id under the conversation
+ * (`wa_messages` is `chat_jid || ':' || id`). Rome's transcript keys its own
+ * row by a digest of the session and that same provider id, which is why
+ * `conversationPlatformMessageId` is derived and not random.
  *
- * Both need the provider's id, so a channel offering `directMessaging` has to
- * return one from `send` — see the note there. A send that is accepted without
+ * The mirror form is generated over every address of the account, not only the
+ * one the send was addressed to. A channel folds several addresses onto one
+ * account — WhatsApp reaches a contact as both a phone JID and an `@lid`, and
+ * holds a chat under each — so a message sent to one can be echoed back under
+ * the other. Predicting only the address we sent to left the row waiting on a
+ * ref that would never appear, which is a send accepted and then stuck.
+ *
+ * All of them need the provider's id, so a channel offering `directMessaging`
+ * has to return one from `send` — see the note there. A send accepted without
  * one cannot be tracked, and the row is cleared rather than left waiting on an
  * answer that will never come.
  */
-function refsFor(row: OutboxRow): string[] {
-  if (row.providerMessageId === null) return [];
+function refsFor(row: OutboxRow, addresses: readonly string[]): string[] {
+  const messageId = row.providerMessageId;
+  if (messageId === null) return [];
   const sessionId = channelConversationId(row.channel, row.conversationId);
   return [
-    `${row.conversationId}:${row.providerMessageId}`,
-    `agent:${conversationPlatformMessageId(sessionId, row.providerMessageId)}`,
+    ...new Set(addresses.map((address) => `${address}:${messageId}`)),
+    `agent:${conversationPlatformMessageId(sessionId, messageId)}`,
   ];
+}
+
+/** Every address the channel folds onto this row's account, the row's own
+ *  included. Falls back to that one alone for a channel that folds nothing. */
+function addressesOf(accounts: readonly MessageAccount[], row: OutboxRow): readonly string[] {
+  const account = accounts.find(
+    (candidate) =>
+      candidate.channel === row.channel && candidate.addresses.includes(row.channelUserId),
+  );
+  return account?.addresses ?? [row.channelUserId];
 }
 
 function wire(row: OutboxRow): OutboxMessage {
@@ -213,7 +320,7 @@ function wire(row: OutboxRow): OutboxMessage {
     text: row.text,
     timestamp: Math.floor(row.createdAt.getTime() / 1000),
     state: row.state as OutboxState,
-    ref: refsFor(row)[0] ?? null,
+    ref: row.providerMessageId ? `${row.conversationId}:${row.providerMessageId}` : null,
     error: row.error,
   };
 }

--- a/packages/core/src/people/resource.ts
+++ b/packages/core/src/people/resource.ts
@@ -9,16 +9,18 @@
 // account is linked to, not someone the guardian knows. It is excluded here,
 // once, so no route can serve it by forgetting to.
 
-import type { PersonResource } from "@rome/api-types/people";
+import type { AccountSendState, PersonResource, TimelineEntry } from "@rome/api-types/people";
 import { STRANGER_PERSON_ID } from "../constants.js";
 import type { AccountNames } from "../channels/account-names.js";
 import type { Channels } from "../channels/channel.js";
+import type { MessageAccount } from "../channels/messages.js";
 import type { DrizzleDb } from "../db/index.js";
 import type { PersonMappingRepository } from "../db/repositories/person-mapping.js";
-import { readPeopleActivity } from "./activity.js";
+import { readActivity } from "./activity.js";
+import { readSendStates, type SendDeps } from "./send.js";
 import { personMessageStores, timelineAccounts } from "./timeline-sources.js";
 
-export interface PeopleReadDeps {
+export interface PeopleReadDeps extends SendDeps {
   db: DrizzleDb;
   personMappingRepo: Pick<PersonMappingRepository, "findAllWithMappings" | "findById">;
   channels: Channels;
@@ -71,25 +73,55 @@ async function serialize(
   // Independent of each other, and both reach the same channel mirrors: read
   // together, a mirror that folds its whole address book per call serves both
   // from one read of it instead of two.
-  const [accountsByPerson, names] = await Promise.all([
+  const [accountsByPerson, names, sendStates] = await Promise.all([
     timelineAccounts(
       deps,
       persons.map((person) => person.channelMappings),
     ),
     deps.accountNames.displayNames(refs),
+    // Whether each mapping can be written to, asked of the live connections
+    // rather than stored: a channel that went down between two reads has to
+    // change this answer, and nothing writes a row when it does.
+    readSendStates(deps, refs),
   ]);
-  const activity = await readPeopleActivity(personMessageStores(deps), accountsByPerson);
+  const activity = await readActivity(personMessageStores(deps), accountsByPerson);
 
   let next = 0;
   return persons.map((person, i) => ({
     id: person.id,
     displayName: person.displayName,
     bondLevel: person.bondLevel,
-    accounts: person.channelMappings.map((mapping) => ({
-      channel: mapping.channel,
-      channelUserId: mapping.channelUserId,
-      displayName: names[next++],
-    })),
-    ...activity[i],
+    accounts: person.channelMappings.map((mapping) => {
+      const index = next++;
+      return {
+        channel: mapping.channel,
+        channelUserId: mapping.channelUserId,
+        displayName: names[index],
+        send: sendStates[index] ?? ("not-connected" as AccountSendState),
+        latestAt: latestAtOf(activity.perAccount, accountsByPerson[i], mapping),
+      };
+    }),
+    ...activity.perPerson[i],
   }));
+}
+
+/**
+ * When the account behind one mapping was last active.
+ *
+ * The activity read is keyed by folded account and this is asked per mapping,
+ * and the two are not the same count: a channel that folds a phone JID and its
+ * `@lid` form onto one account answers one head for the two links naming it.
+ * So the mapping is matched by the address the fold put on its account, which
+ * is the same rule `timelineAccounts` grouped by.
+ */
+function latestAtOf(
+  heads: Map<MessageAccount, TimelineEntry>,
+  accounts: readonly MessageAccount[] | undefined,
+  mapping: { channel: string; channelUserId: string },
+): number | null {
+  const account = accounts?.find(
+    (candidate) =>
+      candidate.channel === mapping.channel && candidate.addresses.includes(mapping.channelUserId),
+  );
+  return (account && heads.get(account)?.timestamp) ?? null;
 }

--- a/packages/core/src/people/send.ts
+++ b/packages/core/src/people/send.ts
@@ -70,7 +70,12 @@ export async function resolveSendTarget(deps: SendDeps, account: SendAccount): P
   const direct = deps.talkRouter.feature(connectionId, "directMessaging");
   if (!direct) return { ok: false, send: "unsupported" };
 
-  const conversationId = await direct.conversationFor(account.channelUserId);
+  // A channel that throws asking for a thread is a channel that could not
+  // produce one, which is the same answer as null and the same answer the
+  // person read already gives for this account. Letting it escape would make
+  // the send path report a 500 where the read reported `no-conversation`, so
+  // the two would disagree about one condition.
+  const conversationId = await direct.conversationFor(account.channelUserId).catch(() => null);
   if (conversationId === null) return { ok: false, send: "no-conversation" };
 
   return { ok: true, target: { connectionId, conversationId } };

--- a/packages/core/src/people/send.ts
+++ b/packages/core/src/people/send.ts
@@ -1,0 +1,132 @@
+// Sending to a person: which of their accounts a message may go to, and
+// everything that has to be true before one is handed to a channel.
+//
+// Vocabulary: docs/concepts/people.md. The wire shapes are the People
+// contract's (`@rome/api-types/people`).
+//
+// A send names its account. There is no entry point here that takes a person
+// and picks for them, because every rule that could pick decides who receives
+// a message on evidence too thin to carry it — a timeline entry names its
+// channel and not its address, so "reply where they last wrote" cannot
+// separate two numbers on one channel, and reaching for another channel when
+// one is down sends somewhere nobody chose. `defaultSendAccount` in the
+// contract offers surfaces a preselected account; it is a default rendered on
+// screen, not a decision taken off it.
+//
+// Whether a channel can be sent to at all is the channel's own declaration:
+// `talk.feature("directMessaging")`. A talker that does not offer it cannot be
+// written to from here, which is how LinkedIn's mirrored inbox stays readable
+// without a read-only flag threaded through anything.
+
+import type { ConversationId, TalkRouter } from "@rome-os/app-runtime";
+import type { AccountSendState } from "@rome/api-types/people";
+
+export interface SendAccount {
+  channel: string;
+  channelUserId: string;
+}
+
+export interface SendDeps {
+  talkRouter: Pick<TalkRouter, "list" | "feature" | "send">;
+}
+
+/** A resolved target: the connection to send on, and the conversation on it
+ *  that reaches this account. */
+export interface SendTarget {
+  connectionId: string;
+  conversationId: ConversationId;
+}
+
+export type Resolution = { ok: true; target: SendTarget } | { ok: false; send: RefusedState };
+
+export type RefusedState = Exclude<AccountSendState, "yes">;
+
+/**
+ * The connection that answers for a channel, or null when none does.
+ *
+ * A lookup rather than a choice: `connections.service` carries a unique index
+ * (`connections_service_unique`), so a service has at most one connection and
+ * "which one is this account on" is a question that cannot arise.
+ */
+async function connectionFor(deps: SendDeps, channel: string): Promise<string | null> {
+  const connections = await deps.talkRouter.list();
+  return connections.find((connection) => connection.service === channel)?.connectionId ?? null;
+}
+
+/**
+ * Everything true before a body may be handed to a talker, or which of the
+ * three ways it is not.
+ *
+ * The two cheap answers come first and cost no provider call: whether the
+ * channel is connected, and whether its talker does direct messaging at all.
+ * Only the third — does a thread reaching this account exist — can be
+ * expensive, and on the channels where the address is already the conversation
+ * it is not.
+ */
+export async function resolveSendTarget(deps: SendDeps, account: SendAccount): Promise<Resolution> {
+  const connectionId = await connectionFor(deps, account.channel);
+  if (connectionId === null) return { ok: false, send: "not-connected" };
+
+  const direct = deps.talkRouter.feature(connectionId, "directMessaging");
+  if (!direct) return { ok: false, send: "unsupported" };
+
+  const conversationId = await direct.conversationFor(account.channelUserId);
+  if (conversationId === null) return { ok: false, send: "no-conversation" };
+
+  return { ok: true, target: { connectionId, conversationId } };
+}
+
+/**
+ * Whether Rome can send to each of the given accounts, positionally.
+ *
+ * Over every account at once because it is read for a whole listing: the
+ * connection list is read once for all of them rather than once per row, and
+ * `feature` is a synchronous registry lookup. Only `conversationFor` can reach
+ * a provider, and it is asked once per account — cheap on the channels in
+ * play, and the reason a channel that keys threads separately has to be
+ * priced before it is added to a listing read.
+ */
+export async function readSendStates(
+  deps: SendDeps,
+  accounts: readonly SendAccount[],
+): Promise<AccountSendState[]> {
+  if (accounts.length === 0) return [];
+
+  const connections = await deps.talkRouter.list();
+  const byService = new Map(connections.map((c) => [c.service, c.connectionId]));
+
+  return await Promise.all(
+    accounts.map(async (account): Promise<AccountSendState> => {
+      const connectionId = byService.get(account.channel);
+      if (connectionId === undefined) return "not-connected";
+      const direct = deps.talkRouter.feature(connectionId, "directMessaging");
+      if (!direct) return "unsupported";
+      // A provider that throws here is a channel that cannot answer, which is
+      // the same fact as one that answers null. A listing must not fail
+      // because one account of one person could not be priced.
+      const conversationId = await direct.conversationFor(account.channelUserId).catch(() => null);
+      return conversationId === null ? "no-conversation" : "yes";
+    }),
+  );
+}
+
+/** What a channel said when it took the message: its own id for it, so the
+ *  entry this becomes on the timeline can be recognized when it lands. */
+export interface SendReceipt {
+  messageId: string | null;
+}
+
+/**
+ * Hand the text to the channel.
+ *
+ * Throws whatever the talker throws — the caller records the failure, because
+ * only it knows which outbox row is waiting on the answer.
+ */
+export async function sendToTarget(
+  deps: SendDeps,
+  target: SendTarget,
+  text: string,
+): Promise<SendReceipt> {
+  const receipt = await deps.talkRouter.send(target.connectionId, target.conversationId, { text });
+  return { messageId: receipt.messageId ?? null };
+}

--- a/packages/core/src/test/helpers.ts
+++ b/packages/core/src/test/helpers.ts
@@ -43,6 +43,7 @@ import { SystemUpgradeService } from "../system-upgrade/service.js";
 import type { ProviderAdapter } from "../channels/adapter.js";
 import type {
   ConversationId,
+  TalkFeatureMap,
   ConversationSettingsControl,
   InboundMessage,
   TalkRouter,
@@ -50,6 +51,7 @@ import type {
 import { SessionsRepository } from "../db/repositories/sessions.js";
 import { PersonMappingRepository } from "../db/repositories/person-mapping.js";
 import { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
+import { OutboxRepository } from "../db/repositories/outbox.js";
 import { WhatsAppStoreRepository } from "../db/repositories/whatsapp-store.js";
 import { LinkedInAccounts } from "../channels/linkedin-accounts.js";
 import { WhatsAppAccounts } from "../channels/whatsapp-accounts.js";
@@ -217,6 +219,7 @@ export function createMockTalkRouter(adapters: Map<string, MockProviderAdapter>)
   const byConnection = new Map<string, { service: string; adapter: MockProviderAdapter }>(
     [...adapters].map(([service, adapter]) => [`test:${service}`, { service, adapter }] as const),
   );
+  let sent = 0;
   return {
     list: async () =>
       [...byConnection].map(([connectionId, value]) => ({
@@ -249,9 +252,22 @@ export function createMockTalkRouter(adapters: Map<string, MockProviderAdapter>)
       const target = byConnection.get(connectionId);
       if (!target) throw new Error(`Unknown test connection ${connectionId}`);
       await target.adapter.sendMessage(conversationId, conversationId, message);
-      return { conversationId };
+      // A message id, the way every real talker answers with one. The outbox
+      // recognizes a delivered message by it, so a router that named nothing
+      // would make every send untrackable in tests and only in tests.
+      return { conversationId, messageId: `sent-${++sent}` };
     },
-    feature: () => null,
+    // Every test channel addresses a direct chat by the contact, like the two
+    // channels that ship with sending. A test needing a channel that cannot be
+    // written to overrides `feature` to answer null.
+    feature: (_connectionId, name) =>
+      name === "directMessaging"
+        ? ({
+            async conversationFor(channelUserId: string) {
+              return channelUserId as ConversationId;
+            },
+          } as TalkFeatureMap[typeof name])
+        : null,
   };
 }
 
@@ -409,6 +425,7 @@ export async function buildTestDeps(
   const sessionsRepo = new SessionsRepository(db);
   const personMappingRepo = new PersonMappingRepository(db);
   const whatsAppStoreRepo = new WhatsAppStoreRepository(db);
+  const outboxRepo = new OutboxRepository(db);
   const whatsAppAccounts = new WhatsAppAccounts(whatsAppStoreRepo);
   const linkedInStoreRepo = new LinkedInStoreRepository(db);
   const linkedInAccounts = new LinkedInAccounts(linkedInStoreRepo);
@@ -574,6 +591,7 @@ export async function buildTestDeps(
     db,
     sessionsRepo,
     personMappingRepo,
+    outboxRepo,
     whatsAppStoreRepo,
     whatsAppAccounts,
     linkedInStoreRepo,

--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -24,6 +24,7 @@ import {
   type DirectoryAccount,
   type LinkAccountRequest,
   type LinkConflict,
+  type AccountSendState,
   type AccountState,
   type PeopleList,
   type PersonResource,
@@ -59,6 +60,19 @@ import {
  * `accountPresentation`, and no /api/people route addresses the sentinel.
  */
 
+/**
+ * Whether Rome can send on a channel, as the real read answers it.
+ *
+ * Production asks the live connection — `talk.feature("directMessaging")`
+ * answering null is a channel that cannot be written to. Mock mode holds no
+ * connections, so the two channels of the first cut answer yes and every other
+ * answers unsupported, which is what a dashboard built against this has to
+ * render anyway.
+ */
+function sendState(channel: string): AccountSendState {
+  return channel === "whatsapp" || channel === "telegram" ? "yes" : "unsupported";
+}
+
 type PersonFixture = (typeof persons)[number];
 
 function personResource(person: PersonFixture): PersonResource {
@@ -71,6 +85,11 @@ function personResource(person: PersonFixture): PersonResource {
       channel: a.channel,
       channelUserId: a.channelUserId,
       displayName: nameForAccount(a.channel, a.channelUserId),
+      send: sendState(a.channel),
+      // The account's own head, not the person's: the person's newest entry
+      // names a channel and not an address, so it cannot say which of two
+      // accounts on one channel was the recent one.
+      latestAt: accountTimeline(a)[0]?.timestamp ?? null,
     })),
     // Timeline entries, not records: the contract pins a person's count to the
     // history GET /api/people/:id/messages pages.

--- a/packages/web/src/pages/PeoplePage.tsx
+++ b/packages/web/src/pages/PeoplePage.tsx
@@ -159,14 +159,7 @@ export default function PeoplePage({ view }: { view: PeopleView }) {
     () =>
       rows
         .filter((row) => row.kind === "person" && row.level !== "guardian")
-        .map((row) => ({
-          id: row.id,
-          displayName: row.displayName,
-          bondLevel: row.level,
-          accounts: row.accounts,
-          messageCount: row.messageCount,
-          latest: row.latest,
-        })),
+        .map((row) => ({ id: row.id, displayName: row.displayName, bondLevel: row.level })),
     [rows],
   );
 

--- a/packages/web/src/pages/people/people-api.test.ts
+++ b/packages/web/src/pages/people/people-api.test.ts
@@ -105,8 +105,15 @@ test("proposed /people contract walkthrough", async () => {
     r.body.accounts.find((a: { channelUserId: string }) => a.channelUserId === DEV_JID),
   ).toMatchObject({ state: "linked", personId: devikaId });
   r = await call("GET", `/api/people/${devikaId}`);
+  // Exactly one account, and it is the one just linked. Whether Rome can send
+  // there and when it was last active are answers on the same row that this
+  // walkthrough is not about.
   expect(r.body.accounts).toEqual([
-    { channel: "whatsapp", channelUserId: DEV_JID, displayName: expect.any(String) },
+    expect.objectContaining({
+      channel: "whatsapp",
+      channelUserId: DEV_JID,
+      displayName: expect.any(String),
+    }),
   ]);
 
   // Link a second account — an unseen LinkedIn account; linking does not

--- a/packages/web/src/pages/people/people-model.ts
+++ b/packages/web/src/pages/people/people-model.ts
@@ -124,6 +124,20 @@ export const GROUP_ORDER: RowLevel[] = [...BOND_LADDER];
  * `channel:channelUserId` ref otherwise — never mixed, so nothing has to guess
  * which read a row came from.
  */
+/**
+ * A person a link can land on, as the picker needs them.
+ *
+ * Not a `PersonResource`: the picker names an option and ranks it by bond, and
+ * knows nothing about how the person is reachable. Rebuilding the full resource
+ * from a listing row meant inventing the fields the row does not carry, which
+ * is how a picker ends up asserting a person cannot be written to.
+ */
+export interface LinkTarget {
+  id: string;
+  displayName: string;
+  bondLevel: string;
+}
+
 export interface PeopleRow {
   kind: "person" | "account";
   id: string;

--- a/packages/web/src/pages/people/triage.tsx
+++ b/packages/web/src/pages/people/triage.tsx
@@ -32,7 +32,7 @@ import { DirectoryRow, UnknownRow } from "./rows";
 import { levelLabelKey } from "./rows";
 import { TransferConfirm } from "./transfer";
 import { usePeopleWrites } from "./use-writes";
-import type { PeopleRow, PeopleView } from "./people-model";
+import type { LinkTarget, PeopleRow, PeopleView } from "./people-model";
 
 // Placing an account that nobody has decided about, and taking one back.
 //
@@ -187,7 +187,7 @@ function LinkForm({
   onSubmit,
   onCancel,
 }: {
-  people: PersonResource[];
+  people: LinkTarget[];
   error: string | null;
   onSubmit: (personId: string) => Promise<void>;
   onCancel: () => void;
@@ -284,7 +284,7 @@ export function UnknownEntry({
 }: {
   row: PeopleRow;
   /** The people a link can land on — the listing's own rows. */
-  people: PersonResource[];
+  people: LinkTarget[];
   /** Which view this row is in — see {@link entryRow}. */
   variant: PeopleView;
 }) {


### PR DESCRIPTION
## What this PR does

The People surface could read a person's whole history and place them on the bond ladder, and could not answer them. `/api/people` held eight routes, all reads or curation. The one send path that existed — `POST /api/whatsapp/contacts/:jid/send` — was WhatsApp-shaped and reached from nothing in the dashboard.

This adds the backend for sending: `POST /api/people/:id/messages`, an outbox behind it, and the two facts the dashboard needs on each account to render a composer without guessing.

Nothing renders it yet. The UI is the next PR.

## Design & Invariants

Vocabulary lands in [`docs/concepts/people.md#outbox`](docs/concepts/people.md).

**A send names its account.** `resolveSendTarget` has no signature that omits it. Every rule that could infer one decides who receives a message on evidence too thin to carry it: a `TimelineEntry` names its channel and not its address, so "reply where they last wrote" cannot separate two accounts on one channel, and falling through to another channel when the first is down delivers somewhere nobody picked. `defaultSendAccount` gives surfaces a preselect — a default rendered on screen, not a decision taken off it, which is why `LinkedAccount` now carries each account's own `latestAt`.

**Sending is declared, not discovered.** `TalkDirectMessaging` joins `TalkFeatureMap`, and `feature("directMessaging")` answering null is the entire read-only declaration. LinkedIn implements no such feature and its mirrored inbox stays readable with no flag threaded through anything; the alternative was a `sends` boolean on the talker, which would have been a second mechanism beside the one the map already is. The same feature turns an address into a conversation — the step nothing above the adapter could take, and the reason Discord is out of this cut rather than broken in it.

**Channel to connection is a lookup, not a choice.** `connections.service` carries a unique index, so a service has at most one connection and "which one is this account on" cannot arise.

**The timeline is what happened; the outbox is what Rome is still trying.** Two nouns rather than a delivery status on one. `TimelineEntry` and the cursor written against it stay free of rows that may yet be withdrawn, and each account still belongs to exactly one message store — the `assignAccounts` rule is untouched. The rejected alternative was writing sends into the channel's own mirror, which would have made Rome a writer to a table that is otherwise a faithful copy of the provider.

**An outbox row is exactly a send whose message is not on the timeline yet.** It is derived from that comparison, not cleared by anything, so no delivery callback can be missed and the two reads cannot disagree about what is in flight. Recognition is exact: a delivered message's `ref` is predictable in both forms a store can produce — `<conversation>:<providerId>` for a channel mirror, `agent:<digest>` for Rome's own transcript. Matching on text or timing instead would clear a row on a message the guardian sent from their phone. This is why `conversationPlatformMessageId` is a digest rather than random, and why a talker offering direct messaging must return a message id.

**A regression is:** any path that picks a recipient without being told one, a send that is accepted and then invisible, a failed send that does not survive a reload, or two timeline entries sharing a `ref`.

`latestAt` costs no extra read — deciding which store owns an account already fetches that store's `latest` for it, so `readPeopleActivity` was discarding the per-account head. It now answers both grains from one pass.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm --filter @rome/core test:unit` — 4327 pass, 9 new in `people-send.test.ts`
- [x] The clearing rule proves itself: "clears the outbox row once the message is on the timeline" sends, finds the message on the timeline, then finds the outbox empty, with nothing having been told the send arrived
- [x] Refusals covered per state — an account the person does not hold (400), a channel with no `directMessaging` (409 naming `unsupported`), a channel with no connection (`not-connected` on the person read)
- [x] Failure and recovery — a refused send stays in the outbox with its error, retries under its own id, and discards on request
- [x] `pnpm lint:prose`
- [x] Review findings pinned by their own tests — each fix reverted independently fails exactly the test that covers it and nothing else
- [ ] Exercised against a live WhatsApp or Telegram connection. The `@lid`/phone-JID fold is now covered by a fixture, which is not the same as a real DM to an `@lid`-addressed contact

## Review follow-ups

Four findings from review, all fixed in `74302b7` with tests:

- A send the channel accepted and Rome then failed to record was reported as refused, inviting a retry that delivers a second real message. Delivery and bookkeeping are separate now.
- Arrival was predicted only at the address the send named, so a WhatsApp echo landing under the account's other folded address left the row stuck. The prediction covers every address of the account.
- The two outbox mutations took a message id and nothing else. Both are scoped to the person in the path, and discard refuses a row still in flight.
- A send whose process died before the channel answered sat in `sending` forever. It ages out to `failed` and becomes retryable.

Two more from the re-review, fixed in `339b128`:

- `reopen` read the row, checked it was failed, then wrote — so two retries of one row both passed the read and both reached the provider. The update carries the state predicate now and the caller answers off the affected count.
- A channel that threw looking for a thread escaped the send path as a 500 while the person read called the same account `no-conversation`. Two answers to one condition; the send path agrees now.

And three from the third round, fixed in `667e4be`:

- Separating delivery from bookkeeping left an unmirrored-channel row nothing could move: the transcript write is how the message lands there, so a failed write meant a phantom the guardian could neither retry nor dismiss. Discard takes a row once nothing will happen to it on its own.
- `discard` did its own check-then-delete, the shape `reopen` and `stranded` avoid. The condition rides in the WHERE clause now.
- `OutboxMessage.ref` promised the entry the message would become, which cannot hold for an account whose channel folds addresses. The claim was corrected; the value cannot be.

Declined and split out: [#211](https://github.com/rome-os/rome/issues/211), making the initial send idempotent. Both cheap server-side fixes are wrong — content matching or blocking a conversation on a provider round-trip — and the right one is a client-supplied idempotency key, which is a contract addition rather than a bug fix.

## Not in this PR

- The dashboard. `PersonDetailPage` still renders a read-only timeline.
- Discord, which needs `conversationFor` to open a DM channel before an address resolves.
- LinkedIn, which needs sending to exist at all.
- Attachments — `SendMessageRequest` carries text.
- Any bond-level gate on sending. Bond levels govern what Rome does on its own; a guardian pressing Send is acting themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


