### PR TITLE
feat(skills): add a babysit-pr skill

### DIFF
--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: babysit-pr
+description: Watch a PR for review feedback and answer each new round with the respond-to-review skill, on a self-paced timer, until the PR is approved or a round raises no new points. Use when the user says "babysit this PR".
+argument-hint: [pr]
+disable-model-invocation: true
+---
+
+# Babysit a PR
+
+Watch $ARGUMENTS — the PR for the current branch when the argument is empty — and run [respond-to-review](../respond-to-review/SKILL.md) on every new round of review feedback, until the PR is approved or a round raises no new points.
+
+The environment decides the mechanism: a watcher that wakes the session when a review lands, or a poll every five minutes. Each tick, read the reviews and comments posted since the last tick and run respond-to-review on the new findings, then end the turn with the next tick scheduled. Once the PR is approved or a round raises no new points, schedule nothing and report the outcome.


### PR DESCRIPTION
## What this PR does

Answering review feedback on an open PR takes a person to notice each round and to run `/respond-to-review` on it. Nothing watches the PR between rounds, so a finding sits until someone looks.

`/babysit-pr` watches the PR and answers each new round on its own. It stops when the PR is approved or a round raises no new points.

## Design & Invariants

The skill drives its own timer rather than wrapping `/loop`. Each tick ends by scheduling the next one, with the same `/babysit-pr` prompt, so the user types one command and every tick reloads the same instructions. Wrapping `/loop` would stack a second loop on top of each tick.

The skill names no tool for watching the PR or for scheduling a tick. It offers the two shapes a platform can supply — a watcher that wakes the session on a new review, or a five-minute poll — and leaves the agent to pick what its environment has, so the skill reads the same under an agent system with different plumbing. The interval is fixed rather than judged per tick, because an agent has nothing to estimate a reviewer's pace from.

Triage stays with [`respond-to-review`](../.claude/skills/respond-to-review/SKILL.md). This skill decides only when to look and when to stop.

## Test plan

- [x] `vale .claude/skills/babysit-pr/SKILL.md` — clean.
- [x] `scripts/check-pr-title.sh "feat(skills): add a babysit-pr skill"` — OK.
- [ ] Run `/babysit-pr` against a live PR and confirm it answers a new round and stops on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
