### PR TITLE
feat(people): compose a message from the person page

### DIFF
--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -167,6 +167,13 @@ const strangerRow = () => persons.find((p) => p.id === STRANGER_PERSON_ID);
 
 const notFound = (what: string) => HttpResponse.json({ error: `Unknown ${what}` }, { status: 404 });
 
+/** What both outbox mutations answer for a row that is not this person's failed
+ *  row. One reply for "no such row", "not yours" and "already claimed": the
+ *  caller re-reads the outbox either way, and telling them apart would be
+ *  telling a caller about somebody else's rows. */
+const notTheirs = () =>
+  HttpResponse.json({ error: "No failed message of theirs with that id" }, { status: 404 });
+
 const linkConflict = (ref: AccountRef, owner: { id: string; displayName: string }) =>
   ({
     error: "account is already linked to another person",
@@ -247,13 +254,6 @@ const ACCEPTED_AFTER_MS = 700;
 const LANDS_AFTER_MS = 1_400;
 
 /**
- * Whether this attempt is refused.
- *
- * Text-triggered, because nothing else in mock mode can fail: there is no
- * provider to be down. Only the first attempt, so Retry has something to
- * succeed at — the gesture is the point of the state.
- */
-/**
  * The fallback line on a refusal, in the route's own words.
  *
  * A fallback and not the copy: the dashboard keys off `send` and owns every
@@ -271,8 +271,46 @@ function refusalMessage(send: Exclude<AccountSendState, "yes">): string {
   }
 }
 
-function refuses(row: OutboxRow): boolean {
-  return row.attempts === 1 && row.text.toLowerCase().startsWith("fail");
+/**
+ * The server's own line for a send whose process died before the channel
+ * answered. Not a provider message, and deliberately equivocal — Rome does not
+ * know whether it went out. Kept identical to `people/outbox.ts`'s, so the
+ * dashboard is exercised against the text production actually sends.
+ */
+const STRANDED_ERROR =
+  "Rome stopped before the channel answered; this may or may not have been sent";
+
+/**
+ * Why this attempt stops, or null when it goes through.
+ *
+ * Text-triggered, because nothing else in mock mode can go wrong: there is no
+ * provider to be down and no process to die. `fail` stops only the first
+ * attempt, so Retry has something to succeed at — the gesture is the point of
+ * the state. `stranded` keeps answering the same way, because it stands in for
+ * a row nothing will ever move.
+ */
+function stops(row: OutboxRow): string | null {
+  const text = row.text.toLowerCase();
+  if (text.startsWith("stranded")) return STRANDED_ERROR;
+  if (text.startsWith("fail") && row.attempts === 1) return "the channel rejected this message";
+  return null;
+}
+
+/**
+ * This person's failed row with that id, or null.
+ *
+ * Both outbox mutations resolve their row through this, because both are scoped
+ * the same way: a message id is not a capability, the person in the path is
+ * whose outbox it is, and neither verb may touch a row still in flight — a send
+ * that may yet arrive is not one to retry or to drop the record of.
+ */
+function failedRowOf(person: PersonFixture, messageId: string): OutboxRow | null {
+  const row = outbox.find((candidate) => candidate.id === messageId);
+  if (!row || row.state !== "failed") return null;
+  const held = person.channelMappings.some(
+    (m) => m.channel === row.channel && m.channelUserId === row.channelUserId,
+  );
+  return held ? row : null;
 }
 
 function openRow(account: AccountRef, text: string): OutboxRow {
@@ -317,9 +355,10 @@ function readOutbox(person: PersonFixture): OutboxMessage[] {
   for (const row of outbox.filter(held)) {
     const elapsed = now - row.attemptedAt;
     if (row.state === "sending" && elapsed >= ACCEPTED_AFTER_MS) {
-      if (refuses(row)) {
+      const stopped = stops(row);
+      if (stopped !== null) {
         row.state = "failed";
-        row.error = "the channel rejected this message";
+        row.error = stopped;
       } else {
         row.state = "unconfirmed";
         // The id the channel gives back, and the `ref` the entry will carry
@@ -562,8 +601,11 @@ export const peopleHandlers = [
   http.post("/api/people/:id/outbox/:messageId/retry", ({ params }) => {
     const person = findVisiblePerson(String(params.id));
     if (!person) return notFound("person");
-    const row = outbox.find((candidate) => candidate.id === String(params.messageId));
-    if (!row) return notFound("message");
+    // The row is claimed by the state it is in: a second retry of one already
+    // reopened finds nothing, which is what stops a double-clicked Retry
+    // delivering the guardian's message twice.
+    const row = failedRowOf(person, String(params.messageId));
+    if (!row) return notTheirs();
     row.state = "sending";
     row.error = null;
     row.ref = null;
@@ -577,8 +619,9 @@ export const peopleHandlers = [
   http.delete("/api/people/:id/outbox/:messageId", ({ params }) => {
     const person = findVisiblePerson(String(params.id));
     if (!person) return notFound("person");
-    const at = outbox.findIndex((candidate) => candidate.id === String(params.messageId));
-    if (at !== -1) outbox.splice(at, 1);
+    const row = failedRowOf(person, String(params.messageId));
+    if (!row) return notTheirs();
+    outbox.splice(outbox.indexOf(row), 1);
     return new HttpResponse(null, { status: 204 });
   }),
 

--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -12,6 +12,7 @@ import {
   parseStreamCursor,
   parseMergeRequest,
   parsePersonFilterLevel,
+  parseSendMessageRequest,
   parseTimelineCursor,
   parseUpdatePersonRequest,
   personMatchesLevel,
@@ -26,12 +27,16 @@ import {
   type LinkConflict,
   type AccountSendState,
   type AccountState,
+  type OutboxMessage,
+  type OutboxPage,
   type PeopleList,
   type PersonResource,
+  type SendRefusal,
   type StreamAccount,
   type TimelineEntry,
   type TimelinePage,
 } from "@rome/api-types/people";
+import { talkConnections } from "./connections-store";
 import {
   accountTimeline,
   nameForAccount,
@@ -39,6 +44,7 @@ import {
   ownerOf,
   personTimeline,
   persons,
+  recordDelivered,
   sentinelSenders,
   whatsappContacts,
   type AccountRef,
@@ -63,13 +69,20 @@ import {
 /**
  * Whether Rome can send on a channel, as the real read answers it.
  *
- * Production asks the live connection — `talk.feature("directMessaging")`
- * answering null is a channel that cannot be written to. Mock mode holds no
- * connections, so the two channels of the first cut answer yes and every other
- * answers unsupported, which is what a dashboard built against this has to
- * render anyway.
+ * Production asks the live connection in two steps, and this asks the same two
+ * against the fixture ledger. No connection for the channel is `not-connected`
+ * — the ledger is `./connections-store.ts`, so revoking a grant on the
+ * Connections page relocks talk and this read notices, the way the real one
+ * does. A connection whose talker does not do direct messaging is
+ * `unsupported`, which in the first cut is every channel but the two.
+ *
+ * `no-conversation` is unreachable here, as it is on those two channels in
+ * production: their address already names the conversation. A channel that
+ * keys threads separately would answer it, and the dashboard renders it —
+ * `../../src/pages/people/send-copy.ts` carries the copy for all three.
  */
 function sendState(channel: string): AccountSendState {
+  if (talkConnections(channel).length === 0) return "not-connected";
   return channel === "whatsapp" || channel === "telegram" ? "yes" : "unsupported";
 }
 
@@ -201,6 +214,135 @@ const refFromParams = (params: Record<string, unknown>): AccountRef => ({
   channel: String(params.channel),
   channelUserId: decodeURIComponent(String(params.channelUserId)),
 });
+
+// ---------------------------------------------------------------------------
+// The outbox
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends Rome has been asked to make and has not seen arrive.
+ *
+ * Nothing here clears a row. A row is gone once its message is on the timeline,
+ * and {@link readOutbox} is what notices — the same derivation the route runs,
+ * so a dashboard built against this cannot come to depend on a delivery
+ * callback production does not send.
+ *
+ * A real channel answers on its own schedule; this one answers on the clock,
+ * because a mock with no provider behind it has nothing else to wait for. The
+ * two waits are what make `sending` and `unconfirmed` visible states rather
+ * than a flicker nobody can look at.
+ */
+interface OutboxRow extends OutboxMessage {
+  /** When the current attempt started, in ms. A retry resets it, so the row
+   *  walks the same two stages again. */
+  attemptedAt: number;
+  attempts: number;
+}
+
+const outbox: OutboxRow[] = [];
+
+/** How long the channel takes to accept a message, and how long after that it
+ *  surfaces in the store the timeline reads. */
+const ACCEPTED_AFTER_MS = 700;
+const LANDS_AFTER_MS = 1_400;
+
+/**
+ * Whether this attempt is refused.
+ *
+ * Text-triggered, because nothing else in mock mode can fail: there is no
+ * provider to be down. Only the first attempt, so Retry has something to
+ * succeed at — the gesture is the point of the state.
+ */
+/**
+ * The fallback line on a refusal, in the route's own words.
+ *
+ * A fallback and not the copy: the dashboard keys off `send` and owns every
+ * sentence a reader sees, which is what lets the refusal localize. Kept
+ * identical to the route's so nothing can come to depend on the difference.
+ */
+function refusalMessage(send: Exclude<AccountSendState, "yes">): string {
+  switch (send) {
+    case "not-connected":
+      return "That channel is not connected";
+    case "unsupported":
+      return "Rome cannot send on that channel";
+    case "no-conversation":
+      return "Rome has no conversation open with that account";
+  }
+}
+
+function refuses(row: OutboxRow): boolean {
+  return row.attempts === 1 && row.text.toLowerCase().startsWith("fail");
+}
+
+function openRow(account: AccountRef, text: string): OutboxRow {
+  const row: OutboxRow = {
+    id: crypto.randomUUID(),
+    channel: account.channel,
+    channelUserId: account.channelUserId,
+    text,
+    timestamp: Math.floor(Date.now() / 1000),
+    state: "sending",
+    ref: null,
+    error: null,
+    attemptedAt: Date.now(),
+    attempts: 1,
+  };
+  outbox.push(row);
+  return row;
+}
+
+/** The wire shape: the row minus the bookkeeping that drives the mock's clock,
+ *  which is not on the contract. */
+function outboxMessage(row: OutboxRow): OutboxMessage {
+  const { attemptedAt: _at, attempts: _n, ...message } = row;
+  return message;
+}
+
+/**
+ * This person's outbox, after moving every row as far as its clock allows.
+ *
+ * Two steps, in the order the real one takes them. First each attempt resolves:
+ * accepted and named, or refused. Then a message that has surfaced clears its
+ * row — by looking its `ref` up on the timeline, never by a flag, because that
+ * comparison is what the contract says an outbox row *is*.
+ */
+function readOutbox(person: PersonFixture): OutboxMessage[] {
+  const now = Date.now();
+  const held = (row: OutboxRow) =>
+    person.channelMappings.some(
+      (m) => m.channel === row.channel && m.channelUserId === row.channelUserId,
+    );
+
+  for (const row of outbox.filter(held)) {
+    const elapsed = now - row.attemptedAt;
+    if (row.state === "sending" && elapsed >= ACCEPTED_AFTER_MS) {
+      if (refuses(row)) {
+        row.state = "failed";
+        row.error = "the channel rejected this message";
+      } else {
+        row.state = "unconfirmed";
+        // The id the channel gives back, and the `ref` the entry will carry
+        // when it lands. A row the channel never named could not be recognized
+        // on arrival, which is why the contract requires one.
+        row.ref = `${row.channelUserId}:${row.id}`;
+      }
+    }
+    if (row.state === "unconfirmed" && elapsed >= LANDS_AFTER_MS && row.ref !== null) {
+      recordDelivered(row, { timestamp: row.timestamp, body: row.text, ref: row.ref });
+    }
+  }
+
+  const arrived = new Set((personTimeline(person.id) ?? []).map((entry) => entry.ref));
+  for (let i = outbox.length - 1; i >= 0; i -= 1) {
+    const row = outbox[i]!;
+    if (held(row) && row.state === "unconfirmed" && row.ref !== null && arrived.has(row.ref)) {
+      outbox.splice(i, 1);
+    }
+  }
+
+  return outbox.filter(held).map(outboxMessage);
+}
 
 export const peopleHandlers = [
   // Curated people only — the sentinel's holdings surface on /api/accounts as
@@ -363,6 +505,81 @@ export const peopleHandlers = [
       entries: page,
       nextCursor: remaining.length > page.length && oldest ? timelineCursor(oldest) : null,
     } satisfies TimelinePage);
+  }),
+
+  /**
+   * Say something to one of this person's accounts.
+   *
+   * 202 rather than 200, and an outbox row rather than a timeline entry: the
+   * channel taking a message is not the message arriving, and the body says
+   * which of those has happened.
+   */
+  http.post("/api/people/:id/messages", async ({ params, request }) => {
+    const person = findVisiblePerson(String(params.id));
+    if (!person) return notFound("person");
+
+    const parsed = parseSendMessageRequest(await request.json().catch(() => null));
+    if ("error" in parsed) return HttpResponse.json({ error: parsed.error }, { status: 400 });
+
+    // The account has to be one of theirs. A request naming somebody else's
+    // address is not one this person's page can answer, and sending anyway
+    // would deliver a message the guardian addressed to someone else.
+    const held = person.channelMappings.some(
+      (m) =>
+        m.channel === parsed.request.channel && m.channelUserId === parsed.request.channelUserId,
+    );
+    if (!held) {
+      return HttpResponse.json(
+        { error: "That account is not linked to this person" },
+        { status: 400 },
+      );
+    }
+
+    // The same state the person read answered with, so a client that raced a
+    // disconnect renders the reason it would already have shown.
+    const send = sendState(parsed.request.channel);
+    if (send !== "yes") {
+      return HttpResponse.json({ error: refusalMessage(send), send } satisfies SendRefusal, {
+        status: 409,
+      });
+    }
+
+    return HttpResponse.json(outboxMessage(openRow(parsed.request, parsed.request.text)), {
+      status: 202,
+    });
+  }),
+
+  /** Every send of this person's still in flight. Unpaged — an outbox long
+   *  enough to page is an incident rather than a listing. */
+  http.get("/api/people/:id/outbox", ({ params }) => {
+    const person = findVisiblePerson(String(params.id));
+    if (!person) return notFound("person");
+    return HttpResponse.json({ messages: readOutbox(person) } satisfies OutboxPage);
+  }),
+
+  /** Try a failed send again. Under its own id, so a retry never reads as a
+   *  second message the guardian did not write. */
+  http.post("/api/people/:id/outbox/:messageId/retry", ({ params }) => {
+    const person = findVisiblePerson(String(params.id));
+    if (!person) return notFound("person");
+    const row = outbox.find((candidate) => candidate.id === String(params.messageId));
+    if (!row) return notFound("message");
+    row.state = "sending";
+    row.error = null;
+    row.ref = null;
+    row.attempts += 1;
+    row.attemptedAt = Date.now();
+    return HttpResponse.json(outboxMessage(row), { status: 202 });
+  }),
+
+  /** Give up on a failed send. The only way a row leaves the outbox without
+   *  having been delivered. */
+  http.delete("/api/people/:id/outbox/:messageId", ({ params }) => {
+    const person = findVisiblePerson(String(params.id));
+    if (!person) return notFound("person");
+    const at = outbox.findIndex((candidate) => candidate.id === String(params.messageId));
+    if (at !== -1) outbox.splice(at, 1);
+    return new HttpResponse(null, { status: 204 });
   }),
 
   http.get("/api/people/:id", ({ params }) => {

--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -253,6 +253,11 @@ const outbox: OutboxRow[] = [];
 const ACCEPTED_AFTER_MS = 700;
 const LANDS_AFTER_MS = 1_400;
 
+/** How long a row may sit unconfirmed before it counts as stuck. The route's
+ *  five minutes; a mock row lands in under two seconds, so anything still here
+ *  after this has been deliberately wedged. */
+const STRANDED_AFTER_MS = 5 * 60_000;
+
 /**
  * The fallback line on a refusal, in the route's own words.
  *
@@ -297,20 +302,50 @@ function stops(row: OutboxRow): string | null {
 }
 
 /**
- * This person's failed row with that id, or null.
+ * A send the channel took and whose message never reaches the timeline.
+ *
+ * The phantom Discard exists for: on a channel with no mirror of its own,
+ * Rome's transcript write is how a sent message lands, so a write that failed
+ * leaves a row nothing will ever move. Text-triggered, because a mock has no
+ * transcript to fail. Its row is backdated past the landing window on the way
+ * to `unconfirmed`, since nobody is going to sit here for five minutes to watch
+ * a button appear.
+ */
+function wedges(row: OutboxRow): boolean {
+  return row.text.toLowerCase().startsWith("wedged");
+}
+
+/**
+ * This person's row with that id, or null.
  *
  * Both outbox mutations resolve their row through this, because both are scoped
- * the same way: a message id is not a capability, the person in the path is
- * whose outbox it is, and neither verb may touch a row still in flight — a send
- * that may yet arrive is not one to retry or to drop the record of.
+ * the same way: a message id is not a capability, and the person in the path is
+ * whose outbox it is. Which states each verb then accepts is its own question,
+ * and the two answers differ.
  */
-function failedRowOf(person: PersonFixture, messageId: string): OutboxRow | null {
+function rowOf(person: PersonFixture, messageId: string): OutboxRow | null {
   const row = outbox.find((candidate) => candidate.id === messageId);
-  if (!row || row.state !== "failed") return null;
+  if (!row) return null;
   const held = person.channelMappings.some(
     (m) => m.channel === row.channel && m.channelUserId === row.channelUserId,
   );
   return held ? row : null;
+}
+
+/**
+ * Whether a row can be given up on: the route's rule, kept here so the mock and
+ * production never disagree about whether a button works.
+ *
+ * A row is dismissable once nothing is going to happen to it on its own. A
+ * `failed` one is finished. An `unconfirmed` one inside the landing window is
+ * ordinary and about to clear itself, so dropping it would race the clearing;
+ * past the window it was delivered and will never be seen, and on a channel
+ * with no mirror of its own that is the only way out it has. A `sending` one
+ * has not been answered yet.
+ */
+function isDismissableRow(row: OutboxRow, now: number): boolean {
+  if (row.state === "failed") return true;
+  return row.state === "unconfirmed" && now - row.attemptedAt >= STRANDED_AFTER_MS;
 }
 
 function openRow(account: AccountRef, text: string): OutboxRow {
@@ -361,13 +396,28 @@ function readOutbox(person: PersonFixture): OutboxMessage[] {
         row.error = stopped;
       } else {
         row.state = "unconfirmed";
-        // The id the channel gives back, and the `ref` the entry will carry
-        // when it lands. A row the channel never named could not be recognized
-        // on arrival, which is why the contract requires one.
+        // The id the channel gives back. A hint at the entry this would become
+        // at the address it was sent to, not a key: the server recognizes an
+        // arrival across every address the account folds, and this is the mock
+        // playing server rather than anything a client may rely on.
         row.ref = `${row.channelUserId}:${row.id}`;
+        if (wedges(row)) {
+          // Backdated on the wire as well as in the bookkeeping. The row stands
+          // in for one accepted five minutes ago, and a reader decides whether
+          // to offer Discard from `timestamp` — the only age the contract
+          // carries. A row old to the route and fresh to the client would be a
+          // button that looks wrong rather than a state worth looking at.
+          row.attemptedAt = now - STRANDED_AFTER_MS;
+          row.timestamp = Math.floor((now - STRANDED_AFTER_MS) / 1000);
+        }
       }
     }
-    if (row.state === "unconfirmed" && elapsed >= LANDS_AFTER_MS && row.ref !== null) {
+    if (
+      row.state === "unconfirmed" &&
+      elapsed >= LANDS_AFTER_MS &&
+      row.ref !== null &&
+      !wedges(row)
+    ) {
       recordDelivered(row, { timestamp: row.timestamp, body: row.text, ref: row.ref });
     }
   }
@@ -604,8 +654,11 @@ export const peopleHandlers = [
     // The row is claimed by the state it is in: a second retry of one already
     // reopened finds nothing, which is what stops a double-clicked Retry
     // delivering the guardian's message twice.
-    const row = failedRowOf(person, String(params.messageId));
-    if (!row) return notTheirs();
+    // Retry accepts a failed row and nothing else, and the state is what claims
+    // it: the second of two retries finds a row that is no longer theirs to
+    // send.
+    const row = rowOf(person, String(params.messageId));
+    if (!row || row.state !== "failed") return notTheirs();
     row.state = "sending";
     row.error = null;
     row.ref = null;
@@ -619,8 +672,8 @@ export const peopleHandlers = [
   http.delete("/api/people/:id/outbox/:messageId", ({ params }) => {
     const person = findVisiblePerson(String(params.id));
     if (!person) return notFound("person");
-    const row = failedRowOf(person, String(params.messageId));
-    if (!row) return notTheirs();
+    const row = rowOf(person, String(params.messageId));
+    if (!row || !isDismissableRow(row, Date.now())) return notTheirs();
     outbox.splice(outbox.indexOf(row), 1);
     return new HttpResponse(null, { status: 204 });
   }),

--- a/packages/web/mock/handlers/people.ts
+++ b/packages/web/mock/handlers/people.ts
@@ -681,11 +681,42 @@ export function accountTimeline(ref: AccountRef): TimelineEntry[] {
   return timelineForChannels([ref]);
 }
 
+/**
+ * What Rome has said through the send route and the channel has since surfaced.
+ *
+ * The mock's stand-in for the store a real channel's mirror would put a
+ * delivered message into. It is a store of its own rather than a flag on an
+ * outbox row for the reason the contract gives: an outbox row is exactly a send
+ * whose message is not on the timeline yet, so the outbox read has to be able
+ * to look the message up here and find it — the same comparison the route runs,
+ * rather than a delivery bit someone remembered to set.
+ */
+const deliveredEntries: (TimelineEntry & { channelUserId: string })[] = [];
+
+/** Put a sent message where the timeline will find it. The `ref` is the one the
+ *  outbox row is waiting on, which is what clears the row. */
+export function recordDelivered(
+  account: AccountRef,
+  entry: Omit<TimelineEntry, "source" | "direction">,
+): void {
+  deliveredEntries.push({
+    ...entry,
+    source: account.channel,
+    channelUserId: account.channelUserId,
+    direction: "outbound",
+  });
+}
+
 /** One channel set's dynamics, newest first. The row's `latest` is this
  *  sequence's head, so the two cannot disagree about what happened last. */
 function timelineForChannels(channels: AccountRef[]): TimelineEntry[] {
   const entries: TimelineEntry[] = [];
   for (const mapping of channels) {
+    for (const sent of deliveredEntries) {
+      if (sent.source !== mapping.channel || sent.channelUserId !== mapping.channelUserId) continue;
+      const { channelUserId: _address, ...entry } = sent;
+      entries.push(entry);
+    }
     if (mapping.channel === "whatsapp") {
       const jid = mapping.channelUserId;
       const mirrored = threads[jid] ?? [];

--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -129,12 +129,12 @@
     "retry": "Retry",
     "discard": "Discard this message",
     "outbox": {
-      "label": "Messages Rome is still sending"
+      "label": "Outbox"
     },
     "state": {
       "sending": "Sending",
       "unconfirmed": "Sent, not confirmed yet",
-      "failed": "The channel refused it"
+      "stopped": "Rome stopped trying to send this"
     },
     "refusal": {
       "notConnected": "{{channel}} isn't connected, so Rome can't send there. Connect it in Settings.",

--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -119,6 +119,32 @@
     "linkDescription": "The account you pick starts resolving to this person, and its history joins this timeline.",
     "noAccounts": "No accounts yet"
   },
+  "send": {
+    "segments": {
+      "label": "Account",
+      "all": "All",
+      "empty": "Nothing on this {{channel}} account yet."
+    },
+    "submit": "Send",
+    "retry": "Retry",
+    "discard": "Discard this message",
+    "outbox": {
+      "label": "Messages Rome is still sending"
+    },
+    "state": {
+      "sending": "Sending",
+      "unconfirmed": "Sent, not confirmed yet",
+      "failed": "The channel refused it"
+    },
+    "refusal": {
+      "notConnected": "{{channel}} isn't connected, so Rome can't send there. Connect it in Settings.",
+      "noConversation": "Rome has no {{channel}} conversation with them yet, so there is nowhere to send. It opens once either of you writes first.",
+      "unsupported": {
+        "linkedin": "Rome reads {{channel}} but cannot write to it. Reply from {{channel}} itself.",
+        "default": "Rome cannot send on {{channel}} yet."
+      }
+    }
+  },
   "timeline": {
     "today": "Today",
     "yesterday": "Yesterday"

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -129,12 +129,12 @@
     "retry": "重试",
     "discard": "放弃这条消息",
     "outbox": {
-      "label": "Rome 仍在发送的消息"
+      "label": "发件箱"
     },
     "state": {
       "sending": "发送中",
       "unconfirmed": "已发出，尚未确认",
-      "failed": "渠道拒绝了这条消息"
+      "stopped": "Rome 已停止尝试发送这条消息"
     },
     "refusal": {
       "notConnected": "{{channel}} 未连接，Rome 无法从这里发送。请在设置中连接。",

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -119,6 +119,32 @@
     "linkDescription": "你选择的账号将归属到此人名下，其历史记录也会并入这条时间线。",
     "noAccounts": "暂无账号"
   },
+  "send": {
+    "segments": {
+      "label": "账号",
+      "all": "全部",
+      "empty": "这个 {{channel}} 账号还没有往来。"
+    },
+    "submit": "发送",
+    "retry": "重试",
+    "discard": "放弃这条消息",
+    "outbox": {
+      "label": "Rome 仍在发送的消息"
+    },
+    "state": {
+      "sending": "发送中",
+      "unconfirmed": "已发出，尚未确认",
+      "failed": "渠道拒绝了这条消息"
+    },
+    "refusal": {
+      "notConnected": "{{channel}} 未连接，Rome 无法从这里发送。请在设置中连接。",
+      "noConversation": "Rome 与他们还没有 {{channel}} 会话，因此无处可发。任一方先开口后即可建立。",
+      "unsupported": {
+        "linkedin": "Rome 只能读取 {{channel}}，无法写入。请直接在 {{channel}} 上回复。",
+        "default": "Rome 还不支持在 {{channel}} 上发送。"
+      }
+    }
+  },
   "timeline": {
     "today": "今天",
     "yesterday": "昨天"

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -176,9 +176,13 @@ function mockApi(
      * persists and the only one a guardian can act on.
      */
     send?: "land" | "refuse" | "fail";
-    /** The 404 a retry earns when the row is no longer this reader's to send —
-     *  claimed by a concurrent retry, or already discarded. */
-    retry?: "refuse";
+    /**
+     * How the retry route answers. `"refuse"` is the 404 for a row no longer
+     * this reader's to send — claimed by a concurrent retry, or already
+     * discarded. `"fail"` is the request itself going wrong, which has changed
+     * nothing and is the guardian's to try again.
+     */
+    retry?: "refuse" | "fail";
     /** Rows already in the outbox when the page opens — how a send stranded by
      *  an earlier process reaches a reader. */
     outbox?: OutboxMessage[];
@@ -237,6 +241,7 @@ function mockApi(
       const row = outbox.find((candidate) => path.includes(candidate.id));
       // Only a failed row of theirs is retryable, and the state is what claims
       // it: the second of two retries finds a row no longer theirs to send.
+      if (options.retry === "fail") return json({ error: "retry store unavailable" }, 500);
       if (!row || row.state !== "failed" || options.retry === "refuse") {
         return json({ error: "No failed message of theirs with that id" }, 404);
       }
@@ -935,6 +940,108 @@ describe("PersonDetailPage, sending", () => {
       calls.filter((call) => call.method === "GET" && call.url.endsWith("/outbox")).length,
     ).toBeGreaterThan(1);
     expect(screen.queryByText(/No failed message/)).toBeNull();
+  });
+
+  it("retires a refusal when the target changes, so it never names the wrong channel", async () => {
+    const user = userEvent.setup();
+    mockApi({ send: "refuse" });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.type(screen.getByRole("textbox", { name: "Message text" }), "on my way");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    // The 409 renders as the line the composer would have shown had the read
+    // been fresh — WhatsApp's, because WhatsApp is the target.
+    const refusal = await screen.findByText(
+      "WhatsApp isn't connected, so Rome can't send there. Connect it in Settings.",
+    );
+    expect(refusal).toBeTruthy();
+
+    // Switching account retires it. A refusal names a channel, so one left
+    // standing here would be describing a channel that is no longer the one
+    // being written to.
+    await user.click(screen.getByRole("button", { name: /WhatsApp · / }));
+    await user.click(await screen.findByRole("menuitem", { name: /Telegram/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          "WhatsApp isn't connected, so Rome can't send there. Connect it in Settings.",
+        ),
+      ).toBeNull(),
+    );
+    expect(screen.getByText(/Telegram · 418820113/)).toBeTruthy();
+  });
+
+  it("says why a retry could not be made, and leaves the row actionable", async () => {
+    const user = userEvent.setup();
+    mockApi({ send: "fail", retry: "fail" });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.type(screen.getByRole("textbox", { name: "Message text" }), "are you there");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    const outbox = await screen.findByRole("list", { name: "Outbox" });
+    await user.click(within(outbox).getByRole("button", { name: "Retry" }));
+
+    // A gesture that never reached the server has changed nothing and is the
+    // guardian's to try again — and this row is the only place the attempt can
+    // be made, so it says what happened rather than going quiet.
+    expect(
+      await within(screen.getByRole("list", { name: "Outbox" })).findByRole("status"),
+    ).toBeTruthy();
+
+    // And it stays usable. An outbox with nothing in flight has stopped
+    // polling, so a row left disabled here is one nothing else recovers.
+    const rows = screen.getByRole("list", { name: "Outbox" });
+    expect(within(rows).getByRole("button", { name: "Retry" })).toHaveProperty("disabled", false);
+    expect(within(rows).getByRole("button", { name: "Discard this message" })).toHaveProperty(
+      "disabled",
+      false,
+    );
+  });
+
+  it("gives a stuck unconfirmed row a way out, and a fresh one none", async () => {
+    const WINDOW = 5 * 60;
+    // Against the real clock, not the fixture's noon anchor: staleness is what
+    // is under test, and the block that renders it reads `Date.now()`. Noon is
+    // in the future for any run that starts before it.
+    const REAL_NOW = Math.floor(Date.now() / 1000);
+    const stuck = {
+      id: "outbox-stuck",
+      channel: "whatsapp",
+      channelUserId: "6591881123@s.whatsapp.net",
+      text: "delivered but never seen",
+      timestamp: REAL_NOW - WINDOW - 10,
+      state: "unconfirmed" as const,
+      ref: "sent-stuck",
+      error: null,
+    };
+    mockApi({
+      outbox: [
+        stuck,
+        { ...stuck, id: "outbox-fresh", text: "just went out", timestamp: REAL_NOW - 5 },
+      ],
+    });
+    renderPage();
+
+    const outbox = await screen.findByRole("list", { name: "Outbox" });
+    const rows = within(outbox).getAllByRole("listitem");
+    const stuckRow = rows.find((row) => row.textContent?.includes("delivered but never seen"))!;
+    const freshRow = rows.find((row) => row.textContent?.includes("just went out"))!;
+
+    // Past the landing window nothing will move it on its own, so dismissing it
+    // is the only exit it has. Retry is not offered — a refusal is what can be
+    // tried again, and this was accepted.
+    expect(within(stuckRow).getByRole("button", { name: "Discard this message" })).toBeTruthy();
+    expect(within(stuckRow).queryByRole("button", { name: "Retry" })).toBeNull();
+
+    // Inside the window it is ordinary and about to clear itself, so there is
+    // nothing to offer — and the route would refuse it anyway.
+    expect(within(freshRow).queryByRole("button", { name: "Discard this message" })).toBeNull();
+    expect(within(freshRow).queryByRole("button", { name: "Retry" })).toBeNull();
   });
 
   it("replaces the composer with the reason when the account cannot be written to", async () => {

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -176,6 +176,12 @@ function mockApi(
      * persists and the only one a guardian can act on.
      */
     send?: "land" | "refuse" | "fail";
+    /** The 404 a retry earns when the row is no longer this reader's to send —
+     *  claimed by a concurrent retry, or already discarded. */
+    retry?: "refuse";
+    /** Rows already in the outbox when the page opens — how a send stranded by
+     *  an earlier process reaches a reader. */
+    outbox?: OutboxMessage[];
   } = {},
 ) {
   const calls: FetchCall[] = [];
@@ -183,7 +189,7 @@ function mockApi(
   // The server's two stores, kept as two: a row is on the timeline or in the
   // outbox, never both and never neither. Nothing here marks a row delivered —
   // it moves between the stores, and the reads report where it is.
-  const outbox: OutboxMessage[] = [];
+  const outbox: OutboxMessage[] = [...(options.outbox ?? [])];
   const delivered: TimelineEntry[] = [];
   /** The channel took it and its mirror now holds it — which is what puts it on
    *  the timeline, and therefore what takes it out of the outbox. */
@@ -229,7 +235,11 @@ function mockApi(
     }
     if (method === "POST" && path.endsWith("/retry")) {
       const row = outbox.find((candidate) => path.includes(candidate.id));
-      if (!row) return json({ error: "Unknown message" }, 404);
+      // Only a failed row of theirs is retryable, and the state is what claims
+      // it: the second of two retries finds a row no longer theirs to send.
+      if (!row || row.state !== "failed" || options.retry === "refuse") {
+        return json({ error: "No failed message of theirs with that id" }, 404);
+      }
       // A retry reuses the row, so it never reads as a second message the
       // guardian did not write.
       Object.assign(row, { state: "unconfirmed", error: null });
@@ -811,7 +821,7 @@ describe("PersonDetailPage, sending", () => {
     await waitFor(
       () => {
         expect(screen.getByText("on my way")).toBeTruthy();
-        expect(screen.queryByRole("list", { name: "Messages Rome is still sending" })).toBeNull();
+        expect(screen.queryByRole("list", { name: "Outbox" })).toBeNull();
       },
       { timeout: 4000 },
     );
@@ -851,7 +861,7 @@ describe("PersonDetailPage, sending", () => {
 
     // A failed row stays until the guardian acts on it — the one outbox state
     // that persists, and the only one they can do anything about.
-    const outbox = await screen.findByRole("list", { name: "Messages Rome is still sending" });
+    const outbox = await screen.findByRole("list", { name: "Outbox" });
     expect(within(outbox).getByText("are you there")).toBeTruthy();
     expect(within(outbox).getByText("the channel rejected this message")).toBeTruthy();
 
@@ -866,6 +876,65 @@ describe("PersonDetailPage, sending", () => {
     expect(
       calls.filter((call) => call.url.endsWith("/messages") && call.method === "POST"),
     ).toHaveLength(1);
+  });
+
+  it("renders a send Rome was stranded on in the server's own equivocal words", async () => {
+    // The one error text on this surface that is not a provider message. Rome
+    // does not know whether the message went out, and the row says exactly that
+    // rather than flattening it to "refused" — a guardian deciding whether to
+    // send it again is deciding on this sentence.
+    const stranded = "Rome stopped before the channel answered; this may or may not have been sent";
+    mockApi({
+      outbox: [
+        {
+          id: "outbox-stranded",
+          channel: "whatsapp",
+          channelUserId: "6591881123@s.whatsapp.net",
+          text: "are we still on for six",
+          timestamp: NOW - 400,
+          state: "failed",
+          ref: null,
+          error: stranded,
+        },
+      ],
+    });
+    renderPage();
+
+    const outbox = await screen.findByRole("list", { name: "Outbox" });
+    expect(within(outbox).getByText("are we still on for six")).toBeTruthy();
+    expect(within(outbox).getByText(stranded)).toBeTruthy();
+    // And it is actionable, which is why the read marks it rather than leaving
+    // it spinning where nothing can move it.
+    expect(within(outbox).getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(within(outbox).getByRole("button", { name: "Discard this message" })).toBeTruthy();
+  });
+
+  it("stays quiet when a retry loses a race, and leaves the row actionable", async () => {
+    const user = userEvent.setup();
+    const calls = mockApi({ send: "fail", retry: "refuse" });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.type(screen.getByRole("textbox", { name: "Message text" }), "are you there");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    const outbox = await screen.findByRole("list", { name: "Outbox" });
+    await user.click(within(outbox).getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(calls.some((call) => call.url.endsWith("/retry"))).toBe(true));
+
+    // The winner is sending the message correctly, so the loser has nothing to
+    // report. It re-reads the outbox instead, and hands the row's gestures back
+    // rather than leaving a row nobody can act on.
+    await waitFor(() => {
+      expect(
+        within(screen.getByRole("list", { name: "Outbox" })).getByRole("button", { name: "Retry" }),
+      ).toHaveProperty("disabled", false);
+    });
+    expect(
+      calls.filter((call) => call.method === "GET" && call.url.endsWith("/outbox")).length,
+    ).toBeGreaterThan(1);
+    expect(screen.queryByText(/No failed message/)).toBeNull();
   });
 
   it("replaces the composer with the reason when the account cannot be written to", async () => {

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -4,7 +4,7 @@ import { act, cleanup, render, screen, waitFor, within } from "@testing-library/
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { TimelineEntry } from "@rome/api-types/people";
+import type { OutboxMessage, TimelineEntry } from "@rome/api-types/people";
 import {
   countPeople,
   linkConflict,
@@ -47,12 +47,45 @@ const PERSON: PersonResource = {
   id: "wei-chen",
   displayName: "Wei Chen",
   bondLevel: "acquaintance",
+  // Both sendable, WhatsApp heard from more recently — so `defaultSendAccount`
+  // has a preference to express and the composer has one to render.
   accounts: [
-    { channel: "whatsapp", channelUserId: "6591881123@s.whatsapp.net", displayName: "Wei" },
-    { channel: "telegram", channelUserId: "418820113", displayName: "wei_c" },
+    {
+      channel: "whatsapp",
+      channelUserId: "6591881123@s.whatsapp.net",
+      displayName: "Wei",
+      send: "yes",
+      latestAt: NOW - 300,
+    },
+    {
+      channel: "telegram",
+      channelUserId: "418820113",
+      displayName: "wei_c",
+      send: "yes",
+      latestAt: NOW - 90_000,
+    },
   ],
   messageCount: 12,
   latest: { source: "whatsapp", timestamp: NOW - 300, preview: "the landlord replies fast" },
+};
+
+/** Reachable on one channel Rome mirrors and cannot write to — the composer's
+ *  place is taken by the reason instead. */
+const READ_ONLY_PERSON: PersonResource = {
+  id: "arvind",
+  displayName: "Arvind Srivastav",
+  bondLevel: "acquaintance",
+  accounts: [
+    {
+      channel: "linkedin",
+      channelUserId: "ACoAAB1",
+      displayName: "Arvind",
+      send: "unsupported",
+      latestAt: NOW - 4_000,
+    },
+  ],
+  messageCount: 1,
+  latest: null,
 };
 
 const ENTRIES: TimelineEntry[] = [
@@ -117,6 +150,7 @@ interface WriteBody {
   channelUserId?: string;
   transferFrom?: string;
   from?: string;
+  text?: string;
 }
 
 interface FetchCall {
@@ -134,10 +168,33 @@ function mockApi(
     people?: PersonResource[];
     accounts?: DirectoryAccount[];
     writes?: "fail";
+    /**
+     * How the channel answers a send. `"land"` accepts it and surfaces it on
+     * the timeline a read later, which is how a row leaves the outbox;
+     * `"refuse"` is the 409 a client that raced a disconnect earns; `"fail"` is
+     * the channel taking it and rejecting it, which is the one state that
+     * persists and the only one a guardian can act on.
+     */
+    send?: "land" | "refuse" | "fail";
   } = {},
 ) {
   const calls: FetchCall[] = [];
   const person = typeof options.person === "object" ? { ...options.person } : { ...PERSON };
+  // The server's two stores, kept as two: a row is on the timeline or in the
+  // outbox, never both and never neither. Nothing here marks a row delivered —
+  // it moves between the stores, and the reads report where it is.
+  const outbox: OutboxMessage[] = [];
+  const delivered: TimelineEntry[] = [];
+  /** The channel took it and its mirror now holds it — which is what puts it on
+   *  the timeline, and therefore what takes it out of the outbox. */
+  const accept = (row: OutboxMessage) =>
+    delivered.unshift({
+      source: row.channel,
+      timestamp: row.timestamp,
+      body: row.text,
+      direction: "outbound",
+      ref: row.ref!,
+    });
   rs.spyOn(globalThis, "fetch").mockImplementation((async (
     input: RequestInfo | URL,
     init?: RequestInit,
@@ -151,6 +208,39 @@ function mockApi(
     const path = new URL(url, "http://localhost").pathname;
     const json = (payload: unknown, status = 200) =>
       ({ ok: status < 400, status, json: async () => payload }) as Response;
+
+    if (method === "POST" && path.endsWith("/messages")) {
+      if (options.send === "refuse") {
+        return json({ error: "That channel is not connected", send: "not-connected" }, 409);
+      }
+      const row: OutboxMessage = {
+        id: `outbox-${outbox.length + 1}`,
+        channel: String(body?.channel),
+        channelUserId: String(body?.channelUserId),
+        text: String(body?.text),
+        timestamp: NOW,
+        state: options.send === "fail" ? "failed" : "unconfirmed",
+        ref: `sent-${outbox.length + 1}`,
+        error: options.send === "fail" ? "the channel rejected this message" : null,
+      };
+      outbox.push(row);
+      if (options.send === "land") accept(row);
+      return json(row, 202);
+    }
+    if (method === "POST" && path.endsWith("/retry")) {
+      const row = outbox.find((candidate) => path.includes(candidate.id));
+      if (!row) return json({ error: "Unknown message" }, 404);
+      // A retry reuses the row, so it never reads as a second message the
+      // guardian did not write.
+      Object.assign(row, { state: "unconfirmed", error: null });
+      if (options.send !== "fail") accept(row);
+      return json(row, 202);
+    }
+    if (method === "DELETE" && path.includes("/outbox/")) {
+      const at = outbox.findIndex((candidate) => path.endsWith(candidate.id));
+      if (at !== -1) outbox.splice(at, 1);
+      return { ok: true, status: 204, json: async () => null } as Response;
+    }
 
     if (method !== "GET") {
       if (options.writes === "fail") return json({ error: "write refused" }, 500);
@@ -180,12 +270,23 @@ function mockApi(
       return json({ error: "Unknown route" }, 404);
     }
 
+    if (path.endsWith("/outbox")) {
+      // The read that clears a row, and the comparison the route makes: a row
+      // is gone once its `ref` is on the timeline. Nothing marks one delivered,
+      // so there is no callback to miss and the two reads cannot disagree.
+      const arrived = new Set(delivered.map((entry) => entry.ref));
+      for (let i = outbox.length - 1; i >= 0; i -= 1) {
+        if (outbox[i]!.ref !== null && arrived.has(outbox[i]!.ref!)) outbox.splice(i, 1);
+      }
+      return json({ messages: [...outbox] });
+    }
+
     if (url.includes("/messages")) {
       if (options.entries === "fail") return json({ error: "timeline unavailable" }, 500);
       const cursor = new URL(url, "http://localhost").searchParams.get("cursor");
       if (cursor) return json({ entries: options.older ?? [], nextCursor: null });
       return json({
-        entries: options.entries ?? ENTRIES,
+        entries: [...delivered, ...(options.entries ?? ENTRIES)],
         nextCursor: options.nextCursor ?? null,
       });
     }
@@ -666,5 +767,120 @@ describe("PersonDetailPage back link consumes the dossier's history entry", () =
 
     expect(screen.queryByRole("heading", { name: "Wei Chen" })).toBeNull();
     expect(screen.getByTestId("address").textContent).toBe("/people/latest");
+  });
+});
+
+// The composer, the outbox and the switcher — the half of this page that writes.
+//
+// What is under test is the one rule the design turns on: Rome never picks a
+// recipient out of sight. So the target is on screen before Send is pressed, the
+// request carries the account that was on screen, and the view that already
+// names an account offers no second choice.
+describe("PersonDetailPage, sending", () => {
+  it("names the account it will send to before anything is typed", async () => {
+    mockApi();
+    renderPage();
+
+    // The sendable account heard from most recently, which is
+    // `defaultSendAccount`'s answer and WhatsApp's here. A default rendered, not
+    // a decision taken off screen.
+    expect(await screen.findByRole("button", { name: /WhatsApp · \+6591881123/ })).toBeTruthy();
+  });
+
+  it("sends from the merged view to the account it showed, and settles both reads", async () => {
+    const user = userEvent.setup();
+    const calls = mockApi({ send: "land" });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.type(screen.getByRole("textbox", { name: "Message text" }), "on my way");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    const sent = await waitFor(() =>
+      calls.find((call) => call.method === "POST" && call.url.endsWith("/messages")),
+    );
+    // The account is named, always — and it is the one the composer showed.
+    expect(sent?.body).toEqual({
+      channel: "whatsapp",
+      channelUserId: "6591881123@s.whatsapp.net",
+      text: "on my way",
+    });
+
+    // It lives in the outbox until the timeline has it, then leaves on its own.
+    // Nothing here marks it delivered: the reads are re-asked and they answer.
+    await waitFor(
+      () => {
+        expect(screen.getByText("on my way")).toBeTruthy();
+        expect(screen.queryByRole("list", { name: "Messages Rome is still sending" })).toBeNull();
+      },
+      { timeout: 4000 },
+    );
+  });
+
+  it("offers no picker inside an account view, because the view is the target", async () => {
+    const user = userEvent.setup();
+    const calls = mockApi({ send: "land" });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("radio", { name: "Telegram" }));
+
+    // The trigger that changes the target is gone; the target itself is still
+    // stated. Asking the guardian to choose again inside a view named after one
+    // account is asking twice.
+    expect(screen.queryByRole("button", { name: /WhatsApp · / })).toBeNull();
+    expect(screen.getByText(/Telegram · 418820113/)).toBeTruthy();
+
+    await user.type(screen.getByRole("textbox", { name: "Message text" }), "see you there");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    const sent = await waitFor(() =>
+      calls.find((call) => call.method === "POST" && call.url.endsWith("/messages")),
+    );
+    expect(sent?.body).toMatchObject({ channel: "telegram", channelUserId: "418820113" });
+  });
+
+  it("keeps a refused send with the channel's words, and retries it under its own id", async () => {
+    const user = userEvent.setup();
+    const calls = mockApi({ send: "fail" });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.type(screen.getByRole("textbox", { name: "Message text" }), "are you there");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    // A failed row stays until the guardian acts on it — the one outbox state
+    // that persists, and the only one they can do anything about.
+    const outbox = await screen.findByRole("list", { name: "Messages Rome is still sending" });
+    expect(within(outbox).getByText("are you there")).toBeTruthy();
+    expect(within(outbox).getByText("the channel rejected this message")).toBeTruthy();
+
+    await user.click(within(outbox).getByRole("button", { name: "Retry" }));
+
+    const retry = await waitFor(() =>
+      calls.find((call) => call.method === "POST" && call.url.endsWith("/retry")),
+    );
+    // The row's own id: a retry is the same message again, not a second one the
+    // guardian never wrote.
+    expect(retry?.url).toContain("/outbox/outbox-1/retry");
+    expect(
+      calls.filter((call) => call.url.endsWith("/messages") && call.method === "POST"),
+    ).toHaveLength(1);
+  });
+
+  it("replaces the composer with the reason when the account cannot be written to", async () => {
+    mockApi({ person: READ_ONLY_PERSON });
+    renderPage("arvind");
+
+    await screen.findByRole("heading", { name: "Arvind Srivastav" });
+    // The reason the server declared, in this locale's words — no sentence
+    // crossed the wire. LinkedIn's is its own: it is an inbox Rome mirrors and
+    // cannot write to, which is not the same as a channel it has yet to learn.
+    expect(
+      screen.getByText("Rome reads LinkedIn but cannot write to it. Reply from LinkedIn itself."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("textbox", { name: "Message text" })).toBeNull();
+    // And the history stays readable.
+    expect(await screen.findByText("the landlord replies fast")).toBeTruthy();
   });
 });

--- a/packages/web/src/pages/PersonDetailPage.tsx
+++ b/packages/web/src/pages/PersonDetailPage.tsx
@@ -1,36 +1,29 @@
-import { useMemo } from "react";
 import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft, CircleAlert } from "lucide-react";
-import { formatWhatsAppPhone, type TimelineEntry } from "@rome/api-types/people";
+import { formatWhatsAppPhone } from "@rome/api-types/people";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { PageShell, PageBody } from "@/shell/PageShell";
 import { Avatar } from "./people/avatar";
 import { ChannelPill } from "./people/channel-meta";
-import { clockTime, dayLabel, navigatorLocale, startOfDay } from "./people/format";
+import { PersonConversation } from "./people/conversation";
 import { PersonManagement } from "./people/manage";
 import { PEOPLE_VIEW_PATH, personPath } from "./people/people-model";
-import { usePerson, usePersonTimeline } from "./people/use-roster";
+import { usePerson } from "./people/use-roster";
 
 /**
  * One person's page: the dossier.
  *
- * Who they are on top — name, bond, the accounts that resolve to this person — then
- * the merged timeline of everything said on any of them, grouped by day.
- * Timeline entries are generic, so a channel Rome learns about later shows up
- * here without a change to this page.
- *
- * Two reads own it. `GET /api/people/:id` and `GET /api/people/:id/messages`:
- * one request for the person, one for the history across every account they
- * hold. Which stores that history is merged from is the server's business, and
- * a client that merged per-channel reads itself would have to re-derive the
- * ordering the cursor is written against — and would disagree with it at every
- * page boundary.
+ * Who they are on top — name, bond, the accounts that resolve to this person —
+ * and everything said to or by them below. This file owns the header and the
+ * one read behind it, `GET /api/people/:id`; the conversation under it is
+ * `people/conversation.tsx`, which owns the timeline, the outbox and the
+ * composer together because the three are one surface and settle as one.
  *
  * The management gestures the design puts on this card — the bond select, Link
  * account…, Merge into… — are `people/manage.tsx`, and each settles by
- * invalidating those reads.
+ * invalidating the reads it moved.
  */
 
 /**
@@ -64,10 +57,7 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
   const back = () => (origin ? navigate(-1) : navigate(PEOPLE_VIEW_PATH.latest, { replace: true }));
 
   const personQuery = usePerson(personId);
-  const timeline = usePersonTimeline(personId);
   const person = personQuery.data ?? null;
-
-  const days = useMemo(() => groupByDay(timeline.entries), [timeline.entries]);
 
   if (personQuery.isPending) {
     return (
@@ -158,81 +148,7 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
           />
         </div>
 
-        <section>
-          <h2 className="text-section uppercase tracking-wide text-muted-foreground">
-            {t("detail.timeline")}
-          </h2>
-          {timeline.isPending ? (
-            <p className="py-8 text-center text-aux text-muted-foreground">{t("page.loading")}</p>
-          ) : timeline.error ? (
-            // Same reason as the person read: "nothing has happened yet" is a
-            // claim about this person, and a failed fetch has not earned it.
-            <div className="py-4">
-              <Alert variant="destructive">
-                <CircleAlert aria-hidden="true" />
-                <AlertTitle>{t("errors.loadFailedTitle")}</AlertTitle>
-                <AlertDescription>{timeline.error.message}</AlertDescription>
-              </Alert>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="mt-2"
-                onClick={() => void timeline.refetch()}
-              >
-                {t("errors.retry")}
-              </Button>
-            </div>
-          ) : days.length === 0 ? (
-            <p className="py-8 text-center text-aux text-subtle-foreground">
-              {t("detail.timelineEmpty")}
-            </p>
-          ) : (
-            days.map((day) => (
-              <div key={day.dayStart}>
-                <h3 className="mt-5 mb-1 text-badge uppercase tracking-wide text-subtle-foreground">
-                  {dayLabel(t, day.dayStart, navigatorLocale())}
-                </h3>
-                {day.entries.map((entry) => (
-                  <div
-                    key={`${entry.source}:${entry.ref}`}
-                    className="grid grid-cols-[auto_1fr_auto] items-baseline gap-3 border-b border-border-subtle px-2 py-2"
-                  >
-                    <ChannelPill channel={entry.source} />
-                    <p className="min-w-0 text-ui text-foreground">
-                      {entry.direction === "outbound" && (
-                        <span className="text-subtle-foreground">
-                          {t("detail.outboundPrefix")}{" "}
-                        </span>
-                      )}
-                      <span
-                        className={entry.direction === "outbound" ? "text-muted-foreground" : ""}
-                      >
-                        {entry.body ?? t("row.noPreview")}
-                      </span>
-                    </p>
-                    <span className="font-mono text-badge tabular-nums text-subtle-foreground">
-                      {clockTime(entry.timestamp, navigatorLocale())}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            ))
-          )}
-          {timeline.hasNextPage && (
-            <div className="flex justify-center pt-3">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={timeline.isFetchingNextPage}
-                onClick={() => void timeline.fetchNextPage()}
-              >
-                {t("detail.loadOlder")}
-              </Button>
-            </div>
-          )}
-        </section>
+        <PersonConversation person={person} />
       </PageBody>
     </PageShell>
   );
@@ -259,22 +175,4 @@ function BackLink({ onClick }: { onClick: () => void }) {
       {t("detail.back")}
     </Button>
   );
-}
-
-interface TimelineDay {
-  dayStart: number;
-  entries: TimelineEntry[];
-}
-
-/** Entries arrive newest first and stay that way inside each day, so the page
- *  reads top-down as "most recent first" at both levels. */
-function groupByDay(entries: TimelineEntry[]): TimelineDay[] {
-  const days: TimelineDay[] = [];
-  for (const entry of entries) {
-    const dayStart = startOfDay(entry.timestamp);
-    const current = days.at(-1);
-    if (current && current.dayStart === dayStart) current.entries.push(entry);
-    else days.push({ dayStart, entries: [entry] });
-  }
-  return days;
 }

--- a/packages/web/src/pages/people/composer.tsx
+++ b/packages/web/src/pages/people/composer.tsx
@@ -50,8 +50,19 @@ export function Composer({
   const writes = usePeopleWrites();
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
-  const [refusal, setRefusal] = useState<{ send: RefusedSendState; channel: string } | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  // How the last send went, and which account it was addressed to.
+  //
+  // The account is carried so the line can be shown only while it is still
+  // about the target on screen. A refusal names a channel, so one left standing
+  // after the guardian switches accounts is not merely stale — it describes a
+  // channel that is no longer the one being written to, which is worse than
+  // showing nothing. Held together and compared at render rather than cleared
+  // by an effect, so there is no ordering in which the wrong pair can be shown.
+  const [attempt, setAttempt] = useState<{
+    account: { channel: string; channelUserId: string };
+    refusal: RefusedSendState | null;
+    message: string | null;
+  } | null>(null);
 
   // Nothing at all for a person Rome holds no address for. The dossier header
   // already says they have no accounts, and this slot is for a channel giving a
@@ -79,14 +90,22 @@ export function Composer({
 
   const options = person.accounts.filter(canSend);
   const text = draft.trim();
+  // Shown only while it still describes the account being written to. A switch
+  // of target retires it without anything having to remember to.
+  const failed =
+    attempt &&
+    attempt.account.channel === target.channel &&
+    attempt.account.channelUserId === target.channelUserId
+      ? attempt
+      : null;
 
   async function submit() {
     // `target` is narrowed above; the closure is re-created every render, so it
     // is the account rendered beside the box and not an earlier one.
     if (target === null || text === "" || sending) return;
+    const account = { channel: target.channel, channelUserId: target.channelUserId };
     setSending(true);
-    setRefusal(null);
-    setError(null);
+    setAttempt(null);
     const outcome = await writes.say(person.id, target, text);
     setSending(false);
     if (outcome.ok) {
@@ -97,8 +116,11 @@ export function Composer({
     // and is not now. It renders as the line the composer would have shown had
     // the read been fresh, which is what carrying the state rather than a
     // sentence buys.
-    if ("conflict" in outcome) setRefusal({ send: outcome.conflict.send, channel: target.channel });
-    else setError(outcome.message);
+    setAttempt(
+      "conflict" in outcome
+        ? { account, refusal: outcome.conflict.send, message: null }
+        : { account, refusal: null, message: outcome.message },
+    );
   }
 
   return (
@@ -134,12 +156,11 @@ export function Composer({
           {t("send.submit")}
         </Button>
       </div>
-      {refusal && (
+      {failed && (
         <p className="mt-2 text-aux text-destructive">
-          {refusalText(t, refusal.send, refusal.channel)}
+          {failed.refusal ? refusalText(t, failed.refusal, failed.account.channel) : failed.message}
         </p>
       )}
-      {error && <p className="mt-2 text-aux text-destructive">{error}</p>}
     </div>
   );
 }

--- a/packages/web/src/pages/people/composer.tsx
+++ b/packages/web/src/pages/people/composer.tsx
@@ -1,0 +1,199 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown, SendHorizontal } from "lucide-react";
+import { canSend, type LinkedAccount, type PersonResource } from "@rome/api-types/people";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { ChannelGlyph, channelLabel } from "./channel-meta";
+import { sendRefusalKey, type RefusedSendState } from "./send-copy";
+import { accountHandle } from "./send-model";
+import { usePeopleWrites } from "./use-writes";
+
+/**
+ * The composer: one message, to one account the guardian can see it is going
+ * to.
+ *
+ * The target is always on screen before Send is pressed. That is the contract's
+ * rule rather than a layout choice — a send names its account and nothing infers
+ * one, so a surface offering a preselected account has to show which one it
+ * picked. `defaultSendAccount` decides the preselection, and it is the
+ * contract's function rather than a rule restated here.
+ *
+ * The picker appears only in the merged view, and only when more than one
+ * account can be written to. Inside an account view the view is the target, so a
+ * second choice would be asking the guardian to say the same thing twice.
+ *
+ * An account that cannot be written to shows why instead of a text box. The
+ * reason is the state the server declared, rendered through `./send-copy.ts` —
+ * no sentence crosses the wire, so every locale reads the same way.
+ */
+export function Composer({
+  person,
+  target,
+  onChangeTarget,
+}: {
+  person: PersonResource;
+  /** The account this composer writes to, or null when the person holds none
+   *  at all. */
+  target: LinkedAccount | null;
+  /** Offered where there is something to pick: the merged view. Null inside an
+   *  account view, where the view already names the target. */
+  onChangeTarget: ((account: LinkedAccount) => void) | null;
+}) {
+  const { t } = useTranslation("people");
+  const writes = usePeopleWrites();
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [refusal, setRefusal] = useState<{ send: RefusedSendState; channel: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Nothing at all for a person Rome holds no address for. The dossier header
+  // already says they have no accounts, and this slot is for a channel giving a
+  // reason — an absent account is not a channel refusing.
+  if (target === null) {
+    if (person.accounts.length === 0) return null;
+    // Every reason, not a summary of them. Declaring sendability per account is
+    // what the person read went and fetched; spending it on one flat "cannot
+    // send" would waste the only thing it got.
+    const reasons = [
+      ...new Set(
+        person.accounts.flatMap((account) =>
+          account.send === "yes" ? [] : [refusalText(t, account.send, account.channel)],
+        ),
+      ),
+    ];
+    return <Note>{reasons.join(" ")}</Note>;
+  }
+
+  // An account view still opens on a target that cannot be written to: its
+  // history is readable, and the reason takes the text box's place.
+  if (target.send !== "yes") {
+    return <Note>{refusalText(t, target.send, target.channel)}</Note>;
+  }
+
+  const options = person.accounts.filter(canSend);
+  const text = draft.trim();
+
+  async function submit() {
+    // `target` is narrowed above; the closure is re-created every render, so it
+    // is the account rendered beside the box and not an earlier one.
+    if (target === null || text === "" || sending) return;
+    setSending(true);
+    setRefusal(null);
+    setError(null);
+    const outcome = await writes.say(person.id, target, text);
+    setSending(false);
+    if (outcome.ok) {
+      setDraft("");
+      return;
+    }
+    // A 409 raced a disconnect: the account was sendable when the page read it
+    // and is not now. It renders as the line the composer would have shown had
+    // the read been fresh, which is what carrying the state rather than a
+    // sentence buys.
+    if ("conflict" in outcome) setRefusal({ send: outcome.conflict.send, channel: target.channel });
+    else setError(outcome.message);
+  }
+
+  return (
+    <div className="mt-4 border-t border-border pt-3">
+      <div className="flex items-center gap-2">
+        {onChangeTarget && options.length > 1 ? (
+          <TargetMenu options={options} value={target} onChange={onChangeTarget} />
+        ) : (
+          <span className="flex shrink-0 items-center gap-1 rounded-8 bg-surface-muted px-2 py-1 text-badge text-muted-foreground">
+            <ChannelGlyph channel={target.channel} />
+            {channelLabel(t, target.channel)} · {accountHandle(target)}
+          </span>
+        )}
+        <Input
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              void submit();
+            }
+          }}
+          placeholder={t("detail.composerPlaceholder", { name: person.displayName })}
+          aria-label={t("detail.composerLabel")}
+        />
+        <Button
+          type="button"
+          size="sm"
+          disabled={text === "" || sending}
+          onClick={() => void submit()}
+        >
+          <SendHorizontal aria-hidden="true" />
+          {t("send.submit")}
+        </Button>
+      </div>
+      {refusal && (
+        <p className="mt-2 text-aux text-destructive">
+          {refusalText(t, refusal.send, refusal.channel)}
+        </p>
+      )}
+      {error && <p className="mt-2 text-aux text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+/** The reason, in this locale's words: the server names which refusal it is and
+ *  the dashboard owns every sentence. */
+function refusalText(
+  t: ReturnType<typeof useTranslation<"people">>["t"],
+  send: RefusedSendState,
+  channel: string,
+): string {
+  return t(sendRefusalKey(send, channel), { channel: channelLabel(t, channel) });
+}
+
+/** The target, visible at rest and one click from being changed. */
+function TargetMenu({
+  options,
+  value,
+  onChange,
+}: {
+  options: LinkedAccount[];
+  value: LinkedAccount;
+  onChange: (account: LinkedAccount) => void;
+}) {
+  const { t } = useTranslation("people");
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="outline" size="sm" className="shrink-0">
+          <ChannelGlyph channel={value.channel} />
+          {channelLabel(t, value.channel)} · {accountHandle(value)}
+          <ChevronDown aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {options.map((account) => (
+          <DropdownMenuItem
+            key={`${account.channel}:${account.channelUserId}`}
+            onSelect={() => onChange(account)}
+          >
+            <ChannelGlyph channel={account.channel} />
+            <span>{channelLabel(t, account.channel)}</span>
+            <span className="font-mono text-badge text-subtle-foreground">
+              {accountHandle(account)}
+            </span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function Note({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mt-4 border-t border-border pt-3 text-aux text-muted-foreground">{children}</p>
+  );
+}

--- a/packages/web/src/pages/people/conversation.tsx
+++ b/packages/web/src/pages/people/conversation.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { CircleAlert } from "lucide-react";
+import {
+  defaultSendAccount,
+  type LinkedAccount,
+  type PersonResource,
+  type TimelineEntry,
+} from "@rome/api-types/people";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { ChannelGlyph, ChannelPill, channelLabel } from "./channel-meta";
+import { Composer } from "./composer";
+import { clockTime, dayLabel, navigatorLocale, startOfDay } from "./format";
+import { Outbox } from "./outbox";
+import {
+  ALL_ACCOUNTS,
+  accountSegments,
+  segmentAccount,
+  segmentEntries,
+  segmentOutbox,
+} from "./send-model";
+import { usePersonOutbox, usePersonTimeline } from "./use-roster";
+
+/**
+ * A person's conversation: what has been said, what Rome is still trying to
+ * say, and the box for saying the next thing.
+ *
+ * Two views, both able to send. "All" is the merged timeline the dossier has
+ * always shown, with a composer whose target is named on screen and changed in
+ * one click. An account view scopes the same three blocks to one account, and
+ * its composer takes no picker at all — the view is the target, and asking the
+ * guardian to choose again inside it would be asking twice.
+ *
+ * The segments are per account rather than per channel ({@link accountSegments}
+ * for why), and the merged view's target is `defaultSendAccount`'s — the
+ * contract's, so no second rule here can decide who receives a message.
+ */
+export function PersonConversation({ person }: { person: PersonResource }) {
+  const { t } = useTranslation("people");
+  const timeline = usePersonTimeline(person.id);
+  const outbox = usePersonOutbox(person.id);
+
+  const segments = useMemo(() => accountSegments(person.accounts), [person.accounts]);
+  const [segment, setSegment] = useState<string>(ALL_ACCOUNTS);
+  // A segment survives a merge or an unlink that takes its account away, so the
+  // lookup answers null and the view falls back to the merged one rather than
+  // scoping to an account this person no longer holds.
+  const scoped = segmentAccount(segments, segment);
+
+  // Only in the merged view, and only until the guardian picks: an account view
+  // has no override to hold, and the default is the contract's answer to which
+  // account a composer opens on.
+  const [override, setOverride] = useState<LinkedAccount | null>(null);
+  const chosen =
+    override && person.accounts.some((a) => sameAccount(a, override)) ? override : null;
+  const target = scoped ?? chosen ?? defaultSendAccount(person.accounts);
+
+  const entries = segmentEntries(timeline.entries, scoped);
+  const days = useMemo(() => groupByDay(entries), [entries]);
+
+  return (
+    <section>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-section uppercase tracking-wide text-muted-foreground">
+          {t("detail.timeline")}
+        </h2>
+        {segments.length > 1 && (
+          <SegmentedControl
+            aria-label={t("send.segments.label")}
+            size="sm"
+            value={segment}
+            onValueChange={setSegment}
+            options={[
+              { value: ALL_ACCOUNTS, label: t("send.segments.all") },
+              // The channel's own name, and the handle instead where two
+              // segments would otherwise both say the same channel — see
+              // {@link accountSegments}. Not both: a segment carrying the
+              // handle as a second, hidden label would say the address twice
+              // to a screen reader for every person who has one account per
+              // channel, which is almost everyone.
+              ...segments.map((option) => ({
+                value: option.value,
+                label: option.handle ?? channelLabel(t, option.account.channel),
+                icon: <ChannelGlyph channel={option.account.channel} />,
+              })),
+            ]}
+          />
+        )}
+      </div>
+
+      <Outbox personId={person.id} messages={segmentOutbox(outbox.messages, scoped)} />
+
+      {timeline.isPending ? (
+        <p className="py-8 text-center text-aux text-muted-foreground">{t("page.loading")}</p>
+      ) : timeline.error ? (
+        // Same reason as the person read: "nothing has happened yet" is a
+        // claim about this person, and a failed fetch has not earned it.
+        <div className="py-4">
+          <Alert variant="destructive">
+            <CircleAlert aria-hidden="true" />
+            <AlertTitle>{t("errors.loadFailedTitle")}</AlertTitle>
+            <AlertDescription>{timeline.error.message}</AlertDescription>
+          </Alert>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="mt-2"
+            onClick={() => void timeline.refetch()}
+          >
+            {t("errors.retry")}
+          </Button>
+        </div>
+      ) : days.length === 0 ? (
+        // What an empty view means depends on how much it was looking at. "On
+        // any channel" is a false claim inside a view that has only ever looked
+        // at one.
+        <p className="py-8 text-center text-aux text-subtle-foreground">
+          {scoped
+            ? t("send.segments.empty", { channel: channelLabel(t, scoped.channel) })
+            : t("detail.timelineEmpty")}
+        </p>
+      ) : (
+        days.map((day) => (
+          <div key={day.dayStart}>
+            <h3 className="mt-5 mb-1 text-badge uppercase tracking-wide text-subtle-foreground">
+              {dayLabel(t, day.dayStart, navigatorLocale())}
+            </h3>
+            {day.entries.map((entry) => (
+              <div
+                key={`${entry.source}:${entry.ref}`}
+                className="grid grid-cols-[auto_1fr_auto] items-baseline gap-3 border-b border-border-subtle px-2 py-2"
+              >
+                {/* Off inside an account view, where every row would name the
+                    one channel the view is already named after. */}
+                {scoped ? <span /> : <ChannelPill channel={entry.source} />}
+                <p className="min-w-0 text-ui text-foreground">
+                  {entry.direction === "outbound" && (
+                    <span className="text-subtle-foreground">{t("detail.outboundPrefix")} </span>
+                  )}
+                  <span className={entry.direction === "outbound" ? "text-muted-foreground" : ""}>
+                    {entry.body ?? t("row.noPreview")}
+                  </span>
+                </p>
+                <span className="font-mono text-badge tabular-nums text-subtle-foreground">
+                  {clockTime(entry.timestamp, navigatorLocale())}
+                </span>
+              </div>
+            ))}
+          </div>
+        ))
+      )}
+
+      {timeline.hasNextPage && (
+        <div className="flex justify-center pt-3">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={timeline.isFetchingNextPage}
+            onClick={() => void timeline.fetchNextPage()}
+          >
+            {t("detail.loadOlder")}
+          </Button>
+        </div>
+      )}
+
+      <Composer person={person} target={target} onChangeTarget={scoped ? null : setOverride} />
+    </section>
+  );
+}
+
+function sameAccount(a: LinkedAccount, b: LinkedAccount): boolean {
+  return a.channel === b.channel && a.channelUserId === b.channelUserId;
+}
+
+interface TimelineDay {
+  dayStart: number;
+  entries: TimelineEntry[];
+}
+
+/** Entries arrive newest first and stay that way inside each day, so the page
+ *  reads top-down as "most recent first" at both levels. */
+function groupByDay(entries: readonly TimelineEntry[]): TimelineDay[] {
+  const days: TimelineDay[] = [];
+  for (const entry of entries) {
+    const dayStart = startOfDay(entry.timestamp);
+    const current = days.at(-1);
+    if (current && current.dayStart === dayStart) current.entries.push(entry);
+    else days.push({ dayStart, entries: [entry] });
+  }
+  return days;
+}

--- a/packages/web/src/pages/people/outbox.tsx
+++ b/packages/web/src/pages/people/outbox.tsx
@@ -63,29 +63,43 @@ export function Outbox({
 }
 
 /**
- * A refused send, with the two gestures that can end it.
+ * A send Rome has stopped trying to deliver, with the two gestures that can end
+ * it.
  *
- * `error` is the channel's own words and is shown as detail beneath copy the
- * dashboard owns — the contract says so, and a provider sentence is not a line
- * this page can localize or promise the shape of.
+ * `error` is what stopped it, shown as the row's detail. Usually the channel's
+ * own words, which this page can neither localize nor promise the shape of. One
+ * of them is not: a send whose process died before the channel answered carries
+ * the server's own equivocal line, because Rome genuinely does not know whether
+ * it went out. Both read as the reason this row is waiting, which is what the
+ * slot is for.
+ *
+ * Neither gesture reports its own refusal. A 404 here means the row is not what
+ * this page thought it was — already discarded, or claimed by a retry that won —
+ * and the outbox read that follows says which. Alarming the loser of a
+ * double-click would be reporting a failure for a message that is being sent.
  */
 function FailedRow({ personId, message }: { personId: string; message: OutboxMessage }) {
   const { t } = useTranslation("people");
   const writes = usePeopleWrites();
   const [busy, setBusy] = useState(false);
 
+  // Released once the read behind the gesture has settled. Not left set: a
+  // refused gesture leaves this row on screen, and a row whose only two
+  // gestures stay disabled is one the guardian can no longer act on at all.
   const act = (run: () => Promise<unknown>) => async () => {
     setBusy(true);
-    await run();
-    // No `setBusy(false)`: both gestures settle by invalidating the outbox, and
-    // this row is either gone or back in flight by the time that read lands.
+    try {
+      await run();
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (
     <span className="flex items-center gap-2">
       <span className="flex items-center gap-1 text-badge text-destructive">
         <CircleAlert className="size-3 shrink-0" aria-hidden="true" />
-        <span>{message.error ?? t("send.state.failed")}</span>
+        <span>{message.error ?? t("send.state.stopped")}</span>
       </span>
       <Button
         type="button"

--- a/packages/web/src/pages/people/outbox.tsx
+++ b/packages/web/src/pages/people/outbox.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { CircleAlert, Clock, RotateCcw, X } from "lucide-react";
+import type { OutboxMessage } from "@rome/api-types/people";
+import { Button } from "@/components/ui/button";
+import { ChannelPill } from "./channel-meta";
+import { usePeopleWrites } from "./use-writes";
+
+/**
+ * The outbox: what Rome has been asked to send and has not seen arrive.
+ *
+ * Its own block above the timeline rather than rows inside it, because it makes
+ * a different claim — "Rome is still trying" is not "this happened", and the
+ * contract keeps the two as two nouns so the timeline's ordering stays free of
+ * rows that may yet be withdrawn.
+ *
+ * It empties itself. A row is gone once its message is on the timeline, which
+ * the outbox read is what notices, so there is no "sent" state drawn here: a
+ * delivered message is a timeline row and this block is where it is not.
+ *
+ * `failed` is the one state a guardian can act on, and the only one that
+ * persists. Retry reuses the row — the contract's rule, so a second attempt
+ * never reads as a second message they did not write — and Discard is the only
+ * way a row leaves without having been delivered.
+ */
+export function Outbox({
+  personId,
+  messages,
+}: {
+  personId: string;
+  messages: readonly OutboxMessage[];
+}) {
+  const { t } = useTranslation("people");
+  if (messages.length === 0) return null;
+
+  return (
+    <ul aria-label={t("send.outbox.label")} className="mt-3 rounded-14 border border-border p-1">
+      {messages.map((message) => (
+        <li
+          key={message.id}
+          className="grid grid-cols-[auto_1fr_auto] items-center gap-3 px-2 py-2"
+        >
+          <ChannelPill channel={message.channel} />
+          <p
+            className={`min-w-0 text-ui ${
+              message.state === "failed" ? "text-foreground" : "text-muted-foreground"
+            }`}
+          >
+            {message.text}
+          </p>
+          {message.state === "failed" ? (
+            <FailedRow personId={personId} message={message} />
+          ) : (
+            <span className="flex items-center gap-1 text-badge text-subtle-foreground">
+              <Clock className="size-3" aria-hidden="true" />
+              {t(message.state === "sending" ? "send.state.sending" : "send.state.unconfirmed")}
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * A refused send, with the two gestures that can end it.
+ *
+ * `error` is the channel's own words and is shown as detail beneath copy the
+ * dashboard owns — the contract says so, and a provider sentence is not a line
+ * this page can localize or promise the shape of.
+ */
+function FailedRow({ personId, message }: { personId: string; message: OutboxMessage }) {
+  const { t } = useTranslation("people");
+  const writes = usePeopleWrites();
+  const [busy, setBusy] = useState(false);
+
+  const act = (run: () => Promise<unknown>) => async () => {
+    setBusy(true);
+    await run();
+    // No `setBusy(false)`: both gestures settle by invalidating the outbox, and
+    // this row is either gone or back in flight by the time that read lands.
+  };
+
+  return (
+    <span className="flex items-center gap-2">
+      <span className="flex items-center gap-1 text-badge text-destructive">
+        <CircleAlert className="size-3 shrink-0" aria-hidden="true" />
+        <span>{message.error ?? t("send.state.failed")}</span>
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        disabled={busy}
+        onClick={act(() => writes.retry(personId, message.id))}
+      >
+        <RotateCcw aria-hidden="true" />
+        {t("send.retry")}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-label={t("send.discard")}
+        disabled={busy}
+        onClick={act(() => writes.discard(personId, message.id))}
+      >
+        <X aria-hidden="true" />
+      </Button>
+    </span>
+  );
+}

--- a/packages/web/src/pages/people/outbox.tsx
+++ b/packages/web/src/pages/people/outbox.tsx
@@ -4,7 +4,9 @@ import { CircleAlert, Clock, RotateCcw, X } from "lucide-react";
 import type { OutboxMessage } from "@rome/api-types/people";
 import { Button } from "@/components/ui/button";
 import { ChannelPill } from "./channel-meta";
+import { isDismissable } from "./send-model";
 import { usePeopleWrites } from "./use-writes";
+import type { WriteOutcome } from "./writes";
 
 /**
  * The outbox: what Rome has been asked to send and has not seen arrive.
@@ -18,10 +20,11 @@ import { usePeopleWrites } from "./use-writes";
  * the outbox read is what notices, so there is no "sent" state drawn here: a
  * delivered message is a timeline row and this block is where it is not.
  *
- * `failed` is the one state a guardian can act on, and the only one that
- * persists. Retry reuses the row — the contract's rule, so a second attempt
- * never reads as a second message they did not write — and Discard is the only
- * way a row leaves without having been delivered.
+ * Nothing here reads `OutboxMessage.ref`. It names the entry the message would
+ * become at the address it was sent to, and a channel that folds several
+ * addresses onto one account can deliver under another of them — recognizing an
+ * arrival is the server's job, and by the time the timeline holds the entry this
+ * row is already gone.
  */
 export function Outbox({
   personId,
@@ -48,14 +51,7 @@ export function Outbox({
           >
             {message.text}
           </p>
-          {message.state === "failed" ? (
-            <FailedRow personId={personId} message={message} />
-          ) : (
-            <span className="flex items-center gap-1 text-badge text-subtle-foreground">
-              <Clock className="size-3" aria-hidden="true" />
-              {t(message.state === "sending" ? "send.state.sending" : "send.state.unconfirmed")}
-            </span>
-          )}
+          <OutboxRowActions personId={personId} message={message} />
         </li>
       ))}
     </ul>
@@ -63,64 +59,104 @@ export function Outbox({
 }
 
 /**
- * A send Rome has stopped trying to deliver, with the two gestures that can end
- * it.
+ * What a row says about itself, and what can be done about it.
  *
- * `error` is what stopped it, shown as the row's detail. Usually the channel's
- * own words, which this page can neither localize nor promise the shape of. One
- * of them is not: a send whose process died before the channel answered carries
- * the server's own equivocal line, because Rome genuinely does not know whether
- * it went out. Both read as the reason this row is waiting, which is what the
- * slot is for.
+ * The two gestures are offered by what the server will accept, which is not one
+ * set. Retry is for a `failed` row alone — the only state a refusal can be tried
+ * again from. Discard reaches further: a row Rome accepted and never saw arrive
+ * is stuck once the landing window has passed, and on a channel with no mirror
+ * of its own, dismissing it is the only way it ever leaves.
  *
- * Neither gesture reports its own refusal. A 404 here means the row is not what
- * this page thought it was — already discarded, or claimed by a retry that won —
- * and the outbox read that follows says which. Alarming the loser of a
+ * A 404 is not reported. It means the row is not what this page thought it was
+ * — already discarded, claimed by a retry that won, or not yet stale enough to
+ * dismiss — and the outbox read that follows says which. Alarming the loser of a
  * double-click would be reporting a failure for a message that is being sent.
+ *
+ * Anything else is. A gesture that never reached the server, or that the server
+ * failed on, has changed nothing and is the guardian's to try again — and this
+ * row is the one place the attempt can be made, so it has to say what happened
+ * and stay usable. Silence there would be a row that looks ignored.
  */
-function FailedRow({ personId, message }: { personId: string; message: OutboxMessage }) {
+function OutboxRowActions({ personId, message }: { personId: string; message: OutboxMessage }) {
   const { t } = useTranslation("people");
   const writes = usePeopleWrites();
   const [busy, setBusy] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
 
-  // Released once the read behind the gesture has settled. Not left set: a
-  // refused gesture leaves this row on screen, and a row whose only two
-  // gestures stay disabled is one the guardian can no longer act on at all.
-  const act = (run: () => Promise<unknown>) => async () => {
-    setBusy(true);
-    try {
-      await run();
-    } finally {
-      setBusy(false);
-    }
-  };
+  // `busy` is released in a `finally`, never on the way out of the happy path:
+  // a gesture that fails leaves this row on screen, and a row whose only
+  // gestures stay disabled is one the guardian can no longer act on at all —
+  // an outbox with nothing in flight has stopped polling, so nothing else
+  // would bring it back.
+  const act =
+    <T,>(run: () => Promise<WriteOutcome<T>>) =>
+    async () => {
+      setBusy(true);
+      setFailure(null);
+      try {
+        const outcome = await run();
+        // 404 is the quiet one: the row was not this reader's to act on, and the
+        // settle that already ran will say what it is now.
+        if (!outcome.ok && "message" in outcome && outcome.status !== 404) {
+          setFailure(outcome.message);
+        }
+      } finally {
+        setBusy(false);
+      }
+    };
+
+  const failed = message.state === "failed";
+  // The poll keeps this row re-rendering while anything is in flight, so one
+  // crossing the window grows its Discard within a tick of doing so.
+  const dismissable = isDismissable(message, Math.floor(Date.now() / 1000));
 
   return (
     <span className="flex items-center gap-2">
-      <span className="flex items-center gap-1 text-badge text-destructive">
-        <CircleAlert className="size-3 shrink-0" aria-hidden="true" />
-        <span>{message.error ?? t("send.state.stopped")}</span>
-      </span>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        disabled={busy}
-        onClick={act(() => writes.retry(personId, message.id))}
-      >
-        <RotateCcw aria-hidden="true" />
-        {t("send.retry")}
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        aria-label={t("send.discard")}
-        disabled={busy}
-        onClick={act(() => writes.discard(personId, message.id))}
-      >
-        <X aria-hidden="true" />
-      </Button>
+      {failed ? (
+        // `error` is what stopped it, shown as the row's detail. Usually the
+        // channel's own words, which this page can neither localize nor promise
+        // the shape of. One of them is not: a send whose process died before the
+        // channel answered carries the server's own equivocal line, because Rome
+        // genuinely does not know whether it went out.
+        <span className="flex items-center gap-1 text-badge text-destructive">
+          <CircleAlert className="size-3 shrink-0" aria-hidden="true" />
+          <span>{message.error ?? t("send.state.stopped")}</span>
+        </span>
+      ) : (
+        <span className="flex items-center gap-1 text-badge text-subtle-foreground">
+          <Clock className="size-3" aria-hidden="true" />
+          {t(message.state === "sending" ? "send.state.sending" : "send.state.unconfirmed")}
+        </span>
+      )}
+      {failed && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={busy}
+          onClick={act(() => writes.retry(personId, message.id))}
+        >
+          <RotateCcw aria-hidden="true" />
+          {t("send.retry")}
+        </Button>
+      )}
+      {dismissable && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={t("send.discard")}
+          disabled={busy}
+          onClick={act(() => writes.discard(personId, message.id))}
+        >
+          <X aria-hidden="true" />
+        </Button>
+      )}
+      {failure && (
+        <span role="status" className="text-badge text-destructive">
+          {failure}
+        </span>
+      )}
     </span>
   );
 }

--- a/packages/web/src/pages/people/send-copy.test.ts
+++ b/packages/web/src/pages/people/send-copy.test.ts
@@ -1,0 +1,64 @@
+import { beforeAll, describe, expect, it } from "@rstest/core";
+import type { TFunction } from "i18next";
+import i18n from "@/i18n";
+import { sendRefusalKey, type RefusedSendState } from "./send-copy";
+
+// The copy rule for a refused send. What is under test is that no reason string
+// crosses the wire and none has to: the server names which refusal it is, this
+// answers a key, and every locale carries that key.
+
+const REFUSALS: RefusedSendState[] = ["not-connected", "unsupported", "no-conversation"];
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+});
+
+describe("sendRefusalKey", () => {
+  it("answers a distinct key for each way a channel cannot be written to", () => {
+    const keys = REFUSALS.map((send) => sendRefusalKey(send, "telegram"));
+    expect(new Set(keys).size).toBe(REFUSALS.length);
+  });
+
+  it("keys unsupported on the channel, because it means a different thing per channel", () => {
+    // LinkedIn is an inbox Rome mirrors and cannot write to; a channel Rome has
+    // not taught to send is a gap that will close. Reading them the same way
+    // would tell a guardian to wait for something that is never coming.
+    expect(sendRefusalKey("unsupported", "linkedin")).not.toBe(
+      sendRefusalKey("unsupported", "discord"),
+    );
+  });
+
+  it("falls back for a channel with no line of its own, the way the glyph lookup does", () => {
+    // The branch every channel added after this was written lands in — including
+    // one a Rome App brings, which has no entry here to add.
+    expect(sendRefusalKey("unsupported", "discord")).toBe(
+      sendRefusalKey("unsupported", "some-app-channel"),
+    );
+  });
+
+  it("does not key the other two on the channel — neither is a fact about one", () => {
+    for (const send of ["not-connected", "no-conversation"] as const) {
+      expect(sendRefusalKey(send, "linkedin")).toBe(sendRefusalKey(send, "whatsapp"));
+    }
+  });
+});
+
+describe("the locales behind those keys", () => {
+  // Both, not just the one the tests run in: a key that only English carries is
+  // a reason that renders as its own key for every other reader.
+  for (const language of ["en", "zh-CN"]) {
+    it(`answers every key in ${language}, naming the channel`, async () => {
+      await i18n.changeLanguage(language);
+      const t = i18n.getFixedT(language, "people") as TFunction<"people">;
+      for (const send of REFUSALS) {
+        for (const channel of ["linkedin", "discord", "whatsapp"]) {
+          const key = sendRefusalKey(send, channel);
+          const line = t(key, { channel: "Discord" });
+          expect(line).not.toBe(key);
+          expect(line).not.toContain("{{channel}}");
+        }
+      }
+      await i18n.changeLanguage("en");
+    });
+  }
+});

--- a/packages/web/src/pages/people/send-copy.ts
+++ b/packages/web/src/pages/people/send-copy.ts
@@ -1,0 +1,45 @@
+import type { AccountSendState } from "@rome/api-types/people";
+
+/**
+ * Why Rome cannot send to an account, in the dashboard's words.
+ *
+ * The server declares which of the three refusals it is and never a sentence:
+ * `AccountSendState` crosses the wire, the copy does not, so every locale reads
+ * the same way and a `SendRefusal` racing a disconnect renders as the line the
+ * composer would already have shown. A pure key map, like
+ * `@/lib/connection-capability-copy` — the consumer owns the `t()` call.
+ *
+ * One of the three is not a fact about the account at all. "Unsupported" means
+ * a different thing per channel — LinkedIn is an inbox Rome mirrors and cannot
+ * write to, while a channel Rome has simply not taught to send is a gap that
+ * will close — so its copy is keyed on the channel name, the way
+ * `./channel-meta.tsx` already keys labels and glyphs. A channel with no entry
+ * falls back to the general line, which is the branch every channel added after
+ * this was written lands in.
+ */
+
+/** Every send state that is a refusal — the four minus the one that is not. */
+export type RefusedSendState = Exclude<AccountSendState, "yes">;
+
+/** Channels whose "unsupported" has a reason of its own to give. */
+const UNSUPPORTED_COPY: Record<string, string> = {
+  linkedin: "send.refusal.unsupported.linkedin",
+};
+
+/**
+ * The people-namespace key that says why this account cannot be written to.
+ *
+ * Every key it can answer interpolates `{{channel}}`, so a caller renders it as
+ * `t(key, { channel: channelLabel(t, channel) })` — the channel's own localized
+ * name rather than its wire slug.
+ */
+export function sendRefusalKey(send: RefusedSendState, channel: string): string {
+  switch (send) {
+    case "not-connected":
+      return "send.refusal.notConnected";
+    case "no-conversation":
+      return "send.refusal.noConversation";
+    case "unsupported":
+      return UNSUPPORTED_COPY[channel] ?? "send.refusal.unsupported.default";
+  }
+}

--- a/packages/web/src/pages/people/send-model.test.ts
+++ b/packages/web/src/pages/people/send-model.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "@rstest/core";
+import { defaultSendAccount, type LinkedAccount, type TimelineEntry } from "@rome/api-types/people";
+import {
+  ALL_ACCOUNTS,
+  accountHandle,
+  accountSegments,
+  segmentAccount,
+  segmentEntries,
+  segmentOutbox,
+} from "./send-model";
+
+// The shape of the person page's two views. What is under test is the one rule
+// the design turns on — a segment names an account, not a channel — and the two
+// narrowings that follow from it, each over the key its noun actually carries.
+
+function account(over: Partial<LinkedAccount> & Pick<LinkedAccount, "channel">): LinkedAccount {
+  return {
+    channelUserId: "u1",
+    displayName: "someone",
+    send: "yes",
+    latestAt: null,
+    ...over,
+  };
+}
+
+describe("accountSegments", () => {
+  it("labels a segment with its channel when the channel tells it apart", () => {
+    const segments = accountSegments([
+      account({ channel: "whatsapp", channelUserId: "6591881123@s.whatsapp.net" }),
+      account({ channel: "telegram", channelUserId: "418820113" }),
+    ]);
+
+    expect(segments.map((segment) => segment.handle)).toEqual([null, null]);
+    expect(segments.map((segment) => segment.value)).toEqual([
+      "whatsapp:6591881123@s.whatsapp.net",
+      "telegram:418820113",
+    ]);
+  });
+
+  it("labels with the handle where two segments would otherwise name one channel", () => {
+    // The whole reason a segment is an account and not a channel: two WhatsApp
+    // numbers would give two segments both saying "WhatsApp", and picking one
+    // would be picking blind.
+    const segments = accountSegments([
+      account({ channel: "whatsapp", channelUserId: "6591881123@s.whatsapp.net" }),
+      account({ channel: "whatsapp", channelUserId: "14155550100@s.whatsapp.net" }),
+      account({ channel: "telegram", channelUserId: "418820113" }),
+    ]);
+
+    expect(segments.map((segment) => segment.handle)).toEqual([
+      "+6591881123",
+      "+1 (415) 555-0100",
+      null,
+    ]);
+  });
+
+  it("never mints a value the merged segment could collide with", () => {
+    const segments = accountSegments([account({ channel: "telegram" })]);
+    expect(segments.every((segment) => segment.value !== ALL_ACCOUNTS)).toBe(true);
+  });
+});
+
+describe("accountHandle", () => {
+  it("renders a WhatsApp jid as the number a guardian would recognize", () => {
+    expect(accountHandle({ channel: "whatsapp", channelUserId: "6591881123@s.whatsapp.net" })).toBe(
+      "+6591881123",
+    );
+  });
+
+  it("leaves a channel with no phone shape its own identifier", () => {
+    expect(accountHandle({ channel: "telegram", channelUserId: "418820113" })).toBe("418820113");
+  });
+});
+
+describe("segmentAccount", () => {
+  const accounts = [account({ channel: "whatsapp" }), account({ channel: "telegram" })];
+  const segments = accountSegments(accounts);
+
+  it("answers null for the merged segment", () => {
+    expect(segmentAccount(segments, ALL_ACCOUNTS)).toBeNull();
+  });
+
+  it("answers null for an account the person no longer holds", () => {
+    // A merge or an unlink can take the segmented account away while the view
+    // sits open. Falling back to the merged view is the only honest answer —
+    // scoping to an account nobody holds would show an empty history under a
+    // heading naming somebody else's address.
+    expect(segmentAccount(segments, "discord:gone")).toBeNull();
+  });
+});
+
+describe("segmentEntries", () => {
+  const entries: TimelineEntry[] = [
+    { source: "whatsapp", timestamp: 20, body: "wa", direction: "inbound", ref: "a" },
+    { source: "telegram", timestamp: 10, body: "tg", direction: "inbound", ref: "b" },
+  ];
+
+  it("shows everything on the merged segment", () => {
+    expect(segmentEntries(entries, null)).toHaveLength(2);
+  });
+
+  it("narrows to the segment's channel, which is all an entry names", () => {
+    const scoped = segmentEntries(entries, account({ channel: "telegram" }));
+    expect(scoped.map((entry) => entry.body)).toEqual(["tg"]);
+  });
+});
+
+describe("segmentOutbox", () => {
+  const messages = [
+    {
+      id: "1",
+      channel: "whatsapp",
+      channelUserId: "a",
+      text: "one",
+      timestamp: 1,
+      state: "sending" as const,
+      ref: null,
+      error: null,
+    },
+    {
+      id: "2",
+      channel: "whatsapp",
+      channelUserId: "b",
+      text: "two",
+      timestamp: 2,
+      state: "sending" as const,
+      ref: null,
+      error: null,
+    },
+  ];
+
+  it("narrows by the account itself, which an outbox row does name", () => {
+    // Unlike a timeline entry. Two accounts on one channel therefore share a
+    // history under either segment and keep their outboxes apart, which is the
+    // half of the pair that can be told apart.
+    const scoped = segmentOutbox(messages, account({ channel: "whatsapp", channelUserId: "b" }));
+    expect(scoped.map((message) => message.text)).toEqual(["two"]);
+  });
+});
+
+describe("the account a composer opens on", () => {
+  it("is the contract's, and it is the sendable one heard from most recently", () => {
+    // Not restated here — `defaultSendAccount` is the contract's function, and a
+    // second rule in the dashboard would be a second answer to who receives a
+    // message. This pins that the page's inputs reach it in the shape it wants.
+    const accounts = [
+      account({ channel: "whatsapp", channelUserId: "old", latestAt: 100 }),
+      account({ channel: "telegram", channelUserId: "recent", latestAt: 900 }),
+      account({ channel: "linkedin", channelUserId: "newest", latestAt: 999, send: "unsupported" }),
+    ];
+    expect(defaultSendAccount(accounts)?.channelUserId).toBe("recent");
+  });
+
+  it("is null when nothing is sendable, which is a reason to render and not an empty box", () => {
+    expect(defaultSendAccount([account({ channel: "linkedin", send: "unsupported" })])).toBeNull();
+  });
+});

--- a/packages/web/src/pages/people/send-model.test.ts
+++ b/packages/web/src/pages/people/send-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@rstest/core";
 import { defaultSendAccount, type LinkedAccount, type TimelineEntry } from "@rome/api-types/people";
 import {
   ALL_ACCOUNTS,
+  isDismissable,
   accountHandle,
   accountSegments,
   segmentAccount,
@@ -153,5 +154,35 @@ describe("the account a composer opens on", () => {
 
   it("is null when nothing is sendable, which is a reason to render and not an empty box", () => {
     expect(defaultSendAccount([account({ channel: "linkedin", send: "unsupported" })])).toBeNull();
+  });
+});
+
+describe("isDismissable", () => {
+  const NOW = 1_800_000;
+  const WINDOW = 5 * 60;
+  const row = (state: "sending" | "unconfirmed" | "failed", age: number) => ({
+    state,
+    timestamp: NOW - age,
+  });
+
+  it("offers the gesture on a failed row, which is finished", () => {
+    expect(isDismissable(row("failed", 0), NOW)).toBe(true);
+  });
+
+  it("withholds it from a sending row, which has not been answered", () => {
+    expect(isDismissable(row("sending", WINDOW * 10), NOW)).toBe(false);
+  });
+
+  it("withholds it from a fresh unconfirmed row, which is about to clear itself", () => {
+    // Offering to drop one inside the window would race the clearing, and the
+    // route refuses it for the same reason.
+    expect(isDismissable(row("unconfirmed", WINDOW - 1), NOW)).toBe(false);
+  });
+
+  it("offers it once an unconfirmed row has outlived the landing window", () => {
+    // The phantom this exists for: delivered, never seen, and on a channel with
+    // no mirror of its own this is the only way the row ever leaves.
+    expect(isDismissable(row("unconfirmed", WINDOW), NOW)).toBe(true);
+    expect(isDismissable(row("unconfirmed", WINDOW * 3), NOW)).toBe(true);
   });
 });

--- a/packages/web/src/pages/people/send-model.ts
+++ b/packages/web/src/pages/people/send-model.ts
@@ -1,0 +1,106 @@
+import {
+  accountRef,
+  formatWhatsAppPhone,
+  type LinkedAccount,
+  type OutboxMessage,
+  type TimelineEntry,
+} from "@rome/api-types/people";
+
+// The shape of the person page's two views, with no React in it: which segments
+// the switcher offers, and what each one scopes.
+//
+// The segments are per account, not per channel. For almost everyone the two
+// are the same thing and a segment reads as a channel; for a person holding two
+// numbers on one channel it is the difference between a composer that knows
+// where it is going and one that does not — and that person is exactly who the
+// contract refuses to guess for.
+//
+// Which account a send names is `defaultSendAccount` in the contract, not here.
+// A second answer to "who receives this" is the one thing this surface must not
+// have.
+
+/** The merged segment's value. Not an account ref, which always carries a colon
+ *  ({@link accountRef}), so no account can collide with it. */
+export const ALL_ACCOUNTS = "all";
+
+/** One segment of the switcher: an account, and how to tell it from its
+ *  neighbours. */
+export interface AccountSegment {
+  /** {@link accountRef} of the account — the segment's value and its key. */
+  value: string;
+  account: LinkedAccount;
+  /**
+   * The handle to label this segment with, or null to label it with the
+   * channel's own name.
+   *
+   * Set only where the channel name would not tell two segments apart: a person
+   * holding two WhatsApp numbers would otherwise get two segments both saying
+   * "WhatsApp", and picking one would be picking blind.
+   */
+  handle: string | null;
+}
+
+/**
+ * The identifier a guardian recognizes an account by.
+ *
+ * A WhatsApp jid renders as the phone number it carries; every other channel
+ * shows the address it minted, which is what its own UI shows. The same rule
+ * `rowHandle` applies on the listing — a reader should recognize the same
+ * account by the same string on both surfaces.
+ */
+export function accountHandle(account: { channel: string; channelUserId: string }): string {
+  return account.channel === "whatsapp"
+    ? (formatWhatsAppPhone(account.channelUserId) ?? account.channelUserId)
+    : account.channelUserId;
+}
+
+/** One segment per account, in the order the person read listed them. */
+export function accountSegments(accounts: readonly LinkedAccount[]): AccountSegment[] {
+  return accounts.map((account) => {
+    const sameChannel = accounts.filter((other) => other.channel === account.channel);
+    return {
+      value: accountRef(account),
+      account,
+      handle: sameChannel.length > 1 ? accountHandle(account) : null,
+    };
+  });
+}
+
+/** The account a segment names, or null on the merged segment. */
+export function segmentAccount(
+  segments: readonly AccountSegment[],
+  value: string,
+): LinkedAccount | null {
+  return segments.find((segment) => segment.value === value)?.account ?? null;
+}
+
+/**
+ * The timeline a segment shows: everything on the merged segment, and one
+ * channel's entries inside an account segment.
+ *
+ * By channel, because that is all an entry names. A person with two numbers on
+ * one channel sees both accounts' history under either of their segments, which
+ * is the honest answer — the contract is explicit that a timeline entry carries
+ * no address to narrow by, and inventing one here is the guess the composer
+ * refuses to make.
+ */
+export function segmentEntries(
+  entries: readonly TimelineEntry[],
+  account: LinkedAccount | null,
+): TimelineEntry[] {
+  return account ? entries.filter((entry) => entry.source === account.channel) : [...entries];
+}
+
+/** The outbox rows a segment shows. Narrowed by the account itself, which an
+ *  outbox row does name. */
+export function segmentOutbox(
+  messages: readonly OutboxMessage[],
+  account: LinkedAccount | null,
+): OutboxMessage[] {
+  return account
+    ? messages.filter(
+        (message) =>
+          message.channel === account.channel && message.channelUserId === account.channelUserId,
+      )
+    : [...messages];
+}

--- a/packages/web/src/pages/people/send-model.ts
+++ b/packages/web/src/pages/people/send-model.ts
@@ -104,3 +104,35 @@ export function segmentOutbox(
       )
     : [...messages];
 }
+
+/**
+ * How long a send is given to arrive before a reader may offer to dismiss it.
+ *
+ * The server's own landing window, mirrored here to decide whether to *offer*
+ * the gesture — never whether it is allowed. The route holds the rule and
+ * answers 404 for a row that is not dismissable yet, so a copy that drifts
+ * shows the button a moment early or late rather than deciding anything. Which
+ * is also why this measures `timestamp` rather than reconstructing the
+ * `updatedAt` the server compares: that column is not on the wire, and a client
+ * that needed it would be deciding.
+ */
+const SETTLES_WITHIN_SECONDS = 5 * 60;
+
+/**
+ * Whether a reader may offer to give up on this row.
+ *
+ * A row is dismissable once nothing is going to happen to it on its own. A
+ * `failed` one is finished. An `unconfirmed` one still inside the window is
+ * ordinary and about to clear itself, so offering to drop it would race the
+ * clearing; past the window it was delivered and will never be seen, and on a
+ * channel with no mirror of its own that is the only way out it has. A
+ * `sending` one is never offered — it has not been answered yet.
+ */
+export function isDismissable(
+  message: Pick<OutboxMessage, "state" | "timestamp">,
+  nowSeconds: number,
+): boolean {
+  if (message.state === "failed") return true;
+  if (message.state !== "unconfirmed") return false;
+  return nowSeconds - message.timestamp >= SETTLES_WITHIN_SECONDS;
+}

--- a/packages/web/src/pages/people/use-roster.ts
+++ b/packages/web/src/pages/people/use-roster.ts
@@ -1,10 +1,16 @@
-import { useEffect, useState } from "react";
-import { keepPreviousData, useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import type {
   AccountDirectory,
   AccountState,
   AccountStream,
+  OutboxPage,
   PeopleList,
   PersonResource,
   TimelinePage,
@@ -45,8 +51,15 @@ import { peopleRows, type PeopleRow, type PeopleView } from "./people-model";
 export const PEOPLE_KEY = "people";
 export const ACCOUNTS_KEY = "accounts";
 export const TIMELINE_KEY = "person-timeline";
+export const OUTBOX_KEY = "person-outbox";
 
 const ROSTER_POLL_MS = 30_000;
+
+// How often the outbox is re-read while Rome is still trying to deliver
+// something. Only while: a row that has failed is waiting on the guardian, not
+// on the server, and an outbox with nothing in flight is a read that would
+// answer the same thing forever.
+const OUTBOX_POLL_MS = 1_000;
 
 // How long the search box settles before its term reaches the wire. Long enough
 // that a typed word is one request rather than one per letter, short enough
@@ -286,4 +299,58 @@ export function usePersonTimeline(id: string | undefined) {
     },
   });
   return { ...query, entries: query.data?.pages.flatMap((page) => page.entries) ?? [] };
+}
+
+/**
+ * One person's outbox: every send of theirs that has not reached their
+ * timeline.
+ *
+ * A row leaves this read by arriving, and the read is what notices — the server
+ * derives the listing by comparing its sends against the timeline, so there is
+ * no delivery to track here and nothing for a client to mark. That is why this
+ * polls rather than settling once: the send returns before the message lands,
+ * and the landing is a later answer to the same question.
+ *
+ * Only while something is in flight. A `failed` row waits on the guardian, and
+ * an outbox with nothing being attempted would answer the same thing forever.
+ *
+ * The timeline is invalidated when a row disappears, because that is the same
+ * event: a send Rome has stopped waiting on is a message the timeline now
+ * holds, and the person's own `latest` and count moved with it.
+ */
+export function usePersonOutbox(id: string | undefined) {
+  const { t } = useTranslation("people");
+  const queryClient = useQueryClient();
+  const query = useQuery<OutboxPage>({
+    queryKey: [OUTBOX_KEY, id],
+    enabled: id != null,
+    refetchInterval: ({ state }) =>
+      (state.data?.messages ?? []).some((message) => message.state !== "failed")
+        ? OUTBOX_POLL_MS
+        : false,
+    queryFn: ({ signal }) =>
+      fetchJson<OutboxPage>(`/api/people/${encodeURIComponent(id!)}/outbox`, {
+        signal,
+        fallback: t("errors.loadFailedFallback"),
+      }),
+  });
+
+  // Which rows this reader last saw Rome still trying to deliver. A discard
+  // takes a row out too, and settles the reads itself; this only has to catch
+  // the rows that left because they arrived.
+  const inFlight = useRef<string[]>([]);
+  const messages = query.data?.messages;
+  useEffect(() => {
+    if (messages === undefined) return;
+    const present = new Set(messages.map((message) => message.id));
+    const landed = inFlight.current.some((messageId) => !present.has(messageId));
+    inFlight.current = messages
+      .filter((message) => message.state !== "failed")
+      .map((message) => message.id);
+    if (!landed) return;
+    void queryClient.invalidateQueries({ queryKey: [TIMELINE_KEY, id] });
+    void queryClient.invalidateQueries({ queryKey: [PEOPLE_KEY] });
+  }, [messages, queryClient, id]);
+
+  return { ...query, messages: messages ?? [] };
 }

--- a/packages/web/src/pages/people/use-writes.ts
+++ b/packages/web/src/pages/people/use-writes.ts
@@ -74,9 +74,16 @@ export interface PeopleWrites {
     account: AccountRef,
     text: string,
   ): Promise<WriteOutcome<OutboxMessage, SendRefusal>>;
-  /** Try a failed send again, under its own outbox id. */
+  /**
+   * Try a failed send again, under its own outbox id.
+   *
+   * Refuses with a 404 for a row that is not this person's failed row — one
+   * already discarded, or one a concurrent retry has claimed. Both re-read the
+   * outbox, so a caller has nothing to report and nothing to undo.
+   */
   retry(personId: string, messageId: string): Promise<WriteOutcome<OutboxMessage>>;
-  /** Give up on a failed send. */
+  /** Give up on a failed send. Refuses the same way {@link retry} does, and a
+   *  send still in flight is not discardable — it may yet arrive. */
   discard(personId: string, messageId: string): Promise<WriteOutcome<void>>;
 }
 
@@ -110,6 +117,23 @@ export function usePeopleWrites(): PeopleWrites {
       return outcome;
     };
 
+    // The two outbox gestures settle whichever way they went.
+    //
+    // Every other verb here refuses by naming something the caller must then do
+    // — the person who holds an account, the channel that cannot be written to
+    // — so its refusal is worth surfacing and there is nothing to re-read. A
+    // refused outbox gesture says only that the row is not what this page
+    // thought it was: somebody else's, already discarded, or claimed by a retry
+    // that won. Every one of those is answered by reading the outbox again, and
+    // none of them is the guardian's to fix. Settling anyway is what keeps a
+    // double-clicked Retry quiet — the loser re-reads and finds the row the
+    // winner is already sending.
+    const resettling = async <T, C>(write: () => Promise<WriteOutcome<T, C>>) => {
+      const outcome = await write();
+      await settle();
+      return outcome;
+    };
+
     // Callers hand over whatever row they are holding — a directory account, a
     // person's linked account — so the pair is projected here rather than
     // spread, and a request never carries a field the verb has no place for.
@@ -131,8 +155,8 @@ export function usePeopleWrites(): PeopleWrites {
       setBond: (personId, bondLevel) => settling(() => updatePerson(personId, { bondLevel }, t)),
       say: (personId, account, text) =>
         settling(() => sendMessage(personId, { ...ref(account), text }, t)),
-      retry: (personId, messageId) => settling(() => retrySend(personId, messageId, t)),
-      discard: (personId, messageId) => settling(() => discardSend(personId, messageId, t)),
+      retry: (personId, messageId) => resettling(() => retrySend(personId, messageId, t)),
+      discard: (personId, messageId) => resettling(() => discardSend(personId, messageId, t)),
     };
   }, [settle, t]);
 }

--- a/packages/web/src/pages/people/use-writes.ts
+++ b/packages/web/src/pages/people/use-writes.ts
@@ -1,14 +1,23 @@
 import { useCallback, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import type { AssignableBondLevel, DirectoryAccount, PersonResource } from "@rome/api-types/people";
-import { ACCOUNTS_KEY, PEOPLE_KEY, TIMELINE_KEY } from "./use-roster";
+import type {
+  AssignableBondLevel,
+  DirectoryAccount,
+  OutboxMessage,
+  PersonResource,
+  SendRefusal,
+} from "@rome/api-types/people";
+import { ACCOUNTS_KEY, OUTBOX_KEY, PEOPLE_KEY, TIMELINE_KEY } from "./use-roster";
 import {
   createPerson,
+  discardSend,
   dismissAccount,
   linkAccount,
   mergePeople,
   restoreAccount,
+  retrySend,
+  sendMessage,
   updatePerson,
   type AccountRef,
   type WriteOutcome,
@@ -51,6 +60,24 @@ export interface PeopleWrites {
   /** `into` absorbs `from`, and `from` is gone. */
   merge(into: string, from: string): Promise<WriteOutcome<PersonResource>>;
   setBond(personId: string, bondLevel: AssignableBondLevel): Promise<WriteOutcome<PersonResource>>;
+  /**
+   * Say something to one of a person's accounts. The account is named, always —
+   * the caller shows which one it picked and the request carries it.
+   *
+   * Answers the outbox row the send became, not a delivered message. A 409
+   * carries which of the ways the channel could not be written to, so a send
+   * that raced a disconnect renders the reason the composer would already have
+   * shown.
+   */
+  say(
+    personId: string,
+    account: AccountRef,
+    text: string,
+  ): Promise<WriteOutcome<OutboxMessage, SendRefusal>>;
+  /** Try a failed send again, under its own outbox id. */
+  retry(personId: string, messageId: string): Promise<WriteOutcome<OutboxMessage>>;
+  /** Give up on a failed send. */
+  discard(personId: string, messageId: string): Promise<WriteOutcome<void>>;
 }
 
 export function usePeopleWrites(): PeopleWrites {
@@ -59,12 +86,17 @@ export function usePeopleWrites(): PeopleWrites {
 
   // By prefix, so one call covers the roster's people query, the dossier's
   // single-person read, the composer's shared mention cache and every cached
-  // chip, term and page of the directory. The three roots are the whole of what
+  // chip, term and page of the directory. The four roots are the whole of what
   // a people write can have changed.
+  //
+  // A send settles the same way, and settles both the outbox and the timeline:
+  // a row is on exactly one of the two and the server decides which, so a
+  // client that refreshed only the outbox would leave the message it just sent
+  // showing as in flight until something else happened on the page.
   const settle = useCallback(
     () =>
       Promise.all(
-        [PEOPLE_KEY, ACCOUNTS_KEY, TIMELINE_KEY].map((key) =>
+        [PEOPLE_KEY, ACCOUNTS_KEY, TIMELINE_KEY, OUTBOX_KEY].map((key) =>
           queryClient.invalidateQueries({ queryKey: [key] }),
         ),
       ),
@@ -72,7 +104,7 @@ export function usePeopleWrites(): PeopleWrites {
   );
 
   return useMemo(() => {
-    const settling = async <T>(write: () => Promise<WriteOutcome<T>>) => {
+    const settling = async <T, C>(write: () => Promise<WriteOutcome<T, C>>) => {
       const outcome = await write();
       if (outcome.ok) await settle();
       return outcome;
@@ -97,6 +129,10 @@ export function usePeopleWrites(): PeopleWrites {
       restore: (account) => settling(() => restoreAccount(ref(account), t)),
       merge: (into, from) => settling(() => mergePeople(into, from, t)),
       setBond: (personId, bondLevel) => settling(() => updatePerson(personId, { bondLevel }, t)),
+      say: (personId, account, text) =>
+        settling(() => sendMessage(personId, { ...ref(account), text }, t)),
+      retry: (personId, messageId) => settling(() => retrySend(personId, messageId, t)),
+      discard: (personId, messageId) => settling(() => discardSend(personId, messageId, t)),
     };
   }, [settle, t]);
 }

--- a/packages/web/src/pages/people/writes-against-mock.test.ts
+++ b/packages/web/src/pages/people/writes-against-mock.test.ts
@@ -232,6 +232,26 @@ describe("Sending, against the contract's own handlers", () => {
     await outboxUntil(RAY, (page) => !holds(page, sent.value.id));
   });
 
+  it("lets a delivered-but-unseen send be discarded once it is past the window", async () => {
+    // The phantom the rule exists for: the channel took it, the message never
+    // reached the timeline, and nothing will ever move the row. On a channel
+    // with no mirror of its own this is the only way out it has.
+    const sent = await sendMessage(RAY, { ...RAY_TELEGRAM, text: "wedged forever" }, t);
+    expect(sent.ok).toBe(true);
+    if (!sent.ok) return;
+
+    const stuck = await outboxUntil(RAY, (page) =>
+      page.messages.some((m) => m.id === sent.value.id && m.state === "unconfirmed"),
+    );
+    expect(stuck.messages.find((m) => m.id === sent.value.id)?.error).toBeNull();
+
+    // Not retryable — a refusal is what can be tried again, and this was
+    // accepted — but dismissable, because it has outlived the landing window.
+    expect(await retrySend(RAY, sent.value.id, t)).toMatchObject({ ok: false });
+    expect(await discardSend(RAY, sent.value.id, t)).toMatchObject({ ok: true });
+    expect(holds(await readOutbox(RAY), sent.value.id)).toBe(false);
+  });
+
   it("refuses an outbox row of somebody else's, reached through this person", async () => {
     const sent = await sendMessage(RAY, { ...RAY_TELEGRAM, text: "fail for the scope check" }, t);
     expect(sent.ok).toBe(true);

--- a/packages/web/src/pages/people/writes-against-mock.test.ts
+++ b/packages/web/src/pages/people/writes-against-mock.test.ts
@@ -202,6 +202,52 @@ describe("Sending, against the contract's own handlers", () => {
     expect(refused.conflict.send).toBe("unsupported");
   });
 
+  it("lets one of two retries of a row win, so a double click sends once", async () => {
+    const sent = await sendMessage(RAY, { ...RAY_TELEGRAM, text: "fail then retry twice" }, t);
+    expect(sent.ok).toBe(true);
+    if (!sent.ok) return;
+    await outboxUntil(RAY, (page) =>
+      page.messages.some((m) => m.id === sent.value.id && m.state === "failed"),
+    );
+
+    // Both reach the route; the state is what claims the row, so the second
+    // finds a row that is no longer theirs to send. Sending the guardian's
+    // message twice is the exact harm the outbox is arranged around.
+    const [first, second] = await Promise.all([
+      retrySend(RAY, sent.value.id, t),
+      retrySend(RAY, sent.value.id, t),
+    ]);
+    expect([first!.ok, second!.ok].filter(Boolean)).toHaveLength(1);
+  });
+
+  it("refuses a retry of a row still in flight, and a discard of one too", async () => {
+    const sent = await sendMessage(RAY, { ...RAY_TELEGRAM, text: "still going" }, t);
+    expect(sent.ok).toBe(true);
+    if (!sent.ok) return;
+
+    // A send that may yet arrive is not the guardian's to retry or to drop the
+    // record of — losing it would leave them with no account of the message.
+    expect(await retrySend(RAY, sent.value.id, t)).toMatchObject({ ok: false });
+    expect(await discardSend(RAY, sent.value.id, t)).toMatchObject({ ok: false });
+    await outboxUntil(RAY, (page) => !holds(page, sent.value.id));
+  });
+
+  it("refuses an outbox row of somebody else's, reached through this person", async () => {
+    const sent = await sendMessage(RAY, { ...RAY_TELEGRAM, text: "fail for the scope check" }, t);
+    expect(sent.ok).toBe(true);
+    if (!sent.ok) return;
+    await outboxUntil(RAY, (page) =>
+      page.messages.some((m) => m.id === sent.value.id && m.state === "failed"),
+    );
+
+    // A message id is not a capability. The person in the path is whose outbox
+    // it is, and Ray's row is not reachable through Sam's.
+    expect(await retrySend("sam-okafor", sent.value.id, t)).toMatchObject({ ok: false });
+    expect(await discardSend("sam-okafor", sent.value.id, t)).toMatchObject({ ok: false });
+    expect(holds(await readOutbox(RAY), sent.value.id)).toBe(true);
+    await discardSend(RAY, sent.value.id, t);
+  });
+
   it("refuses an account the person does not hold, before anything is sent", async () => {
     // Not a refusal about a channel — a request this person's page cannot
     // answer, and sending anyway would deliver a message addressed to someone

--- a/packages/web/src/pages/people/writes-against-mock.test.ts
+++ b/packages/web/src/pages/people/writes-against-mock.test.ts
@@ -5,12 +5,17 @@ import type { TFunction } from "i18next";
 import i18n from "@/i18n";
 import { channelMirrorHandlers } from "../../../mock/handlers/people";
 import { peopleHandlers } from "../../../mock/handlers/people-api";
+import type { OutboxPage } from "@rome/api-types/people";
+import { fetchJson } from "@/lib/fetch-json";
 import {
   createPerson,
+  discardSend,
   dismissAccount,
   linkAccount,
   mergePeople,
   restoreAccount,
+  retrySend,
+  sendMessage,
   unlinkAccount,
   updatePerson,
 } from "./writes";
@@ -98,5 +103,112 @@ describe("People writes, against the contract's own handlers", () => {
 
     const merged = await mergePeople(survivor.value.id, duplicate.value.id, t);
     expect(merged).toMatchObject({ ok: true, value: { id: survivor.value.id } });
+  });
+});
+
+// The send verbs, against the same handlers.
+//
+// The outbox is the one read on this surface that clears itself, and it clears
+// by comparing its rows against the timeline rather than by being told. A client
+// asserting that against a stub of its own would only be asserting its own
+// reading of the rule; this asserts it against something that implements it.
+
+const RAY = "ray-oster";
+/** Ray's Telegram account, which the fixture ledger can be written to. */
+const RAY_TELEGRAM = { channel: "telegram", channelUserId: "418820113" };
+/** Arvind's LinkedIn account: a live connection whose talker does no direct
+ *  messaging, which is the `unsupported` refusal. */
+const ARVIND = { channel: "linkedin", channelUserId: "ACoAAArvind01" };
+
+const readOutbox = (personId: string) =>
+  fetchJson<OutboxPage>(`/api/people/${personId}/outbox`, { fallback: "outbox unavailable" });
+
+/** Read the outbox until it answers what the caller is waiting for — the same
+ *  poll a reader of the page makes, and the read that clears a landed row. */
+async function outboxUntil(
+  personId: string,
+  done: (page: OutboxPage) => boolean,
+): Promise<OutboxPage> {
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    const page = await readOutbox(personId);
+    if (done(page)) return page;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("the outbox never reached the state under test");
+}
+
+const holds = (page: OutboxPage, id: string) => page.messages.some((m) => m.id === id);
+
+describe("Sending, against the contract's own handlers", () => {
+  it("holds a send in the outbox, and lets it go once it is on the timeline", async () => {
+    const sent = await sendMessage(RAY, { ...RAY_TELEGRAM, text: "on my way" }, t);
+    expect(sent.ok).toBe(true);
+    if (!sent.ok) return;
+    // Never delivered on the way out: the channel taking a message is not the
+    // message arriving, and the body says which of the two has happened.
+    expect(sent.value.state).toBe("sending");
+
+    const inFlight = await outboxUntil(RAY, (page) => holds(page, sent.value.id));
+    expect(inFlight.messages.find((m) => m.id === sent.value.id)?.text).toBe("on my way");
+
+    // And it leaves on its own. Nothing cleared it — the read compared the two
+    // stores and found the message in the other one.
+    await outboxUntil(RAY, (page) => !holds(page, sent.value.id));
+
+    const timeline = await fetchJson<{ entries: { body: string | null }[] }>(
+      `/api/people/${RAY}/messages`,
+      { fallback: "timeline unavailable" },
+    );
+    expect(timeline.entries.some((entry) => entry.body === "on my way")).toBe(true);
+  });
+
+  it("keeps a refused send, and clears it on a retry that reuses the row", async () => {
+    const sent = await sendMessage(RAY, { ...RAY_TELEGRAM, text: "fail this one" }, t);
+    expect(sent.ok).toBe(true);
+    if (!sent.ok) return;
+
+    const failed = await outboxUntil(RAY, (page) =>
+      page.messages.some((m) => m.id === sent.value.id && m.state === "failed"),
+    );
+    // The channel's own words, shown as detail under copy the dashboard owns.
+    expect(failed.messages.find((m) => m.id === sent.value.id)?.error).toBeTruthy();
+
+    const retried = await retrySend(RAY, sent.value.id, t);
+    expect(retried).toMatchObject({ ok: true, value: { id: sent.value.id } });
+
+    // The same row throughout, so a retry never reads as a second message the
+    // guardian did not write.
+    await outboxUntil(RAY, (page) => !holds(page, sent.value.id));
+  });
+
+  it("discards a refused send — the one way a row leaves undelivered", async () => {
+    const sent = await sendMessage(RAY, { ...RAY_TELEGRAM, text: "fail and forget" }, t);
+    expect(sent.ok).toBe(true);
+    if (!sent.ok) return;
+
+    await outboxUntil(RAY, (page) =>
+      page.messages.some((m) => m.id === sent.value.id && m.state === "failed"),
+    );
+    expect(await discardSend(RAY, sent.value.id, t)).toMatchObject({ ok: true });
+    expect(holds(await readOutbox(RAY), sent.value.id)).toBe(false);
+  });
+
+  it("refuses a channel that cannot be written to, naming which refusal it is", async () => {
+    const refused = await sendMessage("arvind-srivastav", { ...ARVIND, text: "hello" }, t);
+    expect(refused.ok).toBe(false);
+    if (refused.ok || !("conflict" in refused)) throw new Error("expected a refusal");
+    // The state, not a sentence. That is what lets the dashboard localize the
+    // reason, and say the same thing whether it read it or raced it.
+    expect(refused.conflict.send).toBe("unsupported");
+  });
+
+  it("refuses an account the person does not hold, before anything is sent", async () => {
+    // Not a refusal about a channel — a request this person's page cannot
+    // answer, and sending anyway would deliver a message addressed to someone
+    // else.
+    const refused = await sendMessage(RAY, { ...ARVIND, text: "hello" }, t);
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect("conflict" in refused).toBe(false);
   });
 });

--- a/packages/web/src/pages/people/writes.test.ts
+++ b/packages/web/src/pages/people/writes.test.ts
@@ -203,7 +203,10 @@ describe("people writes — what an answer becomes", () => {
 
     const result = await createPerson({ displayName: " " }, t);
 
-    expect(result).toEqual({ ok: false, message: "displayName is required" });
+    // The status rides along beside the message: most callers render the line
+    // and ignore it, and the outbox gestures read it to tell a row that is not
+    // theirs to act on from a write that actually failed.
+    expect(result).toEqual({ ok: false, message: "displayName is required", status: 400 });
   });
 
   it("never puts a server fault on screen in its own words", async () => {
@@ -213,7 +216,7 @@ describe("people writes — what an answer becomes", () => {
 
     // A 5xx body carries the same shape as a 4xx one and not the same meaning:
     // the API error handler serializes an unhandled exception into it.
-    expect(result).toEqual({ ok: false, message: t("errors.requestFailed") });
+    expect(result).toEqual({ ok: false, message: t("errors.requestFailed"), status: 500 });
   });
 
   it("says the server was unreachable rather than throwing at a click handler", async () => {

--- a/packages/web/src/pages/people/writes.ts
+++ b/packages/web/src/pages/people/writes.ts
@@ -45,7 +45,20 @@ export interface AccountRef {
 export type WriteOutcome<T, C = LinkConflict> =
   | { ok: true; value: T }
   | { ok: false; conflict: C }
-  | { ok: false; message: string };
+  | {
+      ok: false;
+      message: string;
+      /**
+       * What the server answered, absent when nothing was reached.
+       *
+       * Beside the message rather than instead of it: every caller has a line
+       * to render and most have nothing to say about the code. It is here for
+       * the ones that do — a 404 on an outbox gesture means the row is not
+       * this reader's to act on, which is a different thing from a write that
+       * failed, and only the status tells the two apart.
+       */
+      status?: number;
+    };
 
 function isLinkConflict(payload: unknown): payload is LinkConflict {
   if (typeof payload !== "object" || payload === null) return false;
@@ -109,11 +122,13 @@ async function send<T, C = LinkConflict>(
     const conflict = readConflict(payload);
     if (conflict !== null) return { ok: false, conflict };
   }
-  if (response.status >= 500) return { ok: false, message: t("errors.requestFailed") };
+  const status = response.status;
+  if (status >= 500) return { ok: false, message: t("errors.requestFailed"), status };
   const error = (payload as { error?: unknown } | null)?.error;
   return {
     ok: false,
     message: typeof error === "string" && error !== "" ? error : t("errors.requestFailed"),
+    status,
   };
 }
 

--- a/packages/web/src/pages/people/writes.ts
+++ b/packages/web/src/pages/people/writes.ts
@@ -4,7 +4,10 @@ import type {
   DirectoryAccount,
   LinkAccountRequest,
   LinkConflict,
+  OutboxMessage,
   PersonResource,
+  SendMessageRequest,
+  SendRefusal,
   UpdatePersonRequest,
 } from "@rome/api-types/people";
 
@@ -30,18 +33,32 @@ export interface AccountRef {
  * What a write answers.
  *
  * A conflict is its own outcome rather than an error string: the caller has to
- * name the person who holds the account and offer an explicit transfer, and a
- * sentence it would have to parse is not a person's id.
+ * act on what the refusal named — the person who holds the account, or which of
+ * the ways a channel cannot be written to — and a sentence it would have to
+ * parse is neither a person's id nor a send state.
+ *
+ * `C` is which 409 this verb can earn. It defaults to {@link LinkConflict},
+ * which is every verb that moves a link; a send earns a {@link SendRefusal}
+ * instead, and typing the pair together would leave each caller narrowing away
+ * a refusal its route cannot answer with.
  */
-export type WriteOutcome<T> =
+export type WriteOutcome<T, C = LinkConflict> =
   | { ok: true; value: T }
-  | { ok: false; conflict: LinkConflict }
+  | { ok: false; conflict: C }
   | { ok: false; message: string };
 
 function isLinkConflict(payload: unknown): payload is LinkConflict {
   if (typeof payload !== "object" || payload === null) return false;
   const body = payload as Record<string, unknown>;
   return typeof body.channel === "string" && typeof body.channelUserId === "string";
+}
+
+/** A 409 from the send route: which of the three ways the channel could not be
+ *  written to. `error` is a fallback line; the dashboard renders `send`. */
+function isSendRefusal(payload: unknown): payload is SendRefusal {
+  if (typeof payload !== "object" || payload === null) return false;
+  const send = (payload as Record<string, unknown>).send;
+  return send === "not-connected" || send === "unsupported" || send === "no-conversation";
 }
 
 /**
@@ -67,11 +84,15 @@ function accountPath(account: AccountRef): string {
  * error handler serializes an unhandled exception as `{ error: err.message }`,
  * so trusting it would put a raw SQLite or repository message on screen.
  */
-async function send<T>(
+async function send<T, C = LinkConflict>(
   url: string,
   init: { method: string; json?: unknown },
   t: TFunction<"people">,
-): Promise<WriteOutcome<T>> {
+  /** Read a 409 body as this verb's conflict, or null when it is not one.
+   *  Defaults to the link conflict every account-moving verb answers with. */
+  readConflict: (payload: unknown) => C | null = (payload) =>
+    isLinkConflict(payload) ? (payload as C) : null,
+): Promise<WriteOutcome<T, C>> {
   const response = await fetch(url, {
     method: init.method,
     credentials: "include",
@@ -84,7 +105,10 @@ async function send<T>(
   if (!response) return { ok: false, message: t("errors.network") };
   const payload: unknown = await response.json().catch(() => null);
   if (response.ok) return { ok: true, value: payload as T };
-  if (response.status === 409 && isLinkConflict(payload)) return { ok: false, conflict: payload };
+  if (response.status === 409) {
+    const conflict = readConflict(payload);
+    if (conflict !== null) return { ok: false, conflict };
+  }
   if (response.status >= 500) return { ok: false, message: t("errors.requestFailed") };
   const error = (payload as { error?: unknown } | null)?.error;
   return {
@@ -179,4 +203,53 @@ export function updatePerson(
   t: TFunction<"people">,
 ): Promise<WriteOutcome<PersonResource>> {
   return send(`/api/people/${encodeURIComponent(personId)}`, { method: "PATCH", json: update }, t);
+}
+
+/**
+ * `POST /api/people/:id/messages`. The account is in the body, always — the
+ * contract has no shape of this request that omits it.
+ *
+ * Answers the outbox row the send became, never a delivered message: the
+ * channel taking a message is not the message arriving, and only a later read
+ * of the outbox can see the second one.
+ */
+export function sendMessage(
+  personId: string,
+  request: SendMessageRequest,
+  t: TFunction<"people">,
+): Promise<WriteOutcome<OutboxMessage, SendRefusal>> {
+  return send(
+    `/api/people/${encodeURIComponent(personId)}/messages`,
+    { method: "POST", json: request },
+    t,
+    (payload) => (isSendRefusal(payload) ? payload : null),
+  );
+}
+
+/** `POST /api/people/:id/outbox/:messageId/retry`. Under the failed row's own
+ *  id, so a retry never reads as a second message the guardian did not write. */
+export function retrySend(
+  personId: string,
+  messageId: string,
+  t: TFunction<"people">,
+): Promise<WriteOutcome<OutboxMessage>> {
+  return send(
+    `/api/people/${encodeURIComponent(personId)}/outbox/${encodeURIComponent(messageId)}/retry`,
+    { method: "POST" },
+    t,
+  );
+}
+
+/** `DELETE /api/people/:id/outbox/:messageId`. The only way a row leaves the
+ *  outbox without having been delivered. */
+export function discardSend(
+  personId: string,
+  messageId: string,
+  t: TFunction<"people">,
+): Promise<WriteOutcome<void>> {
+  return send(
+    `/api/people/${encodeURIComponent(personId)}/outbox/${encodeURIComponent(messageId)}`,
+    { method: "DELETE" },
+    t,
+  );
 }


### PR DESCRIPTION
#208 has merged, so this now sits directly on `main` and its diff is 18 files, all under `packages/web`.

## What this PR does

The person page could read everything anyone had ever said and answer none of it. #208 landed the send route, the outbox and the `LinkedAccount.send` / `.latestAt` fields; nothing on the dashboard reached any of them.

`/people/person/:personId` keeps its dossier header and grows a conversation under it: a segmented control offering "All" plus one segment per account, the outbox as its own block, the merged timeline, and a composer.

## Design & Invariants

**Nothing decides a recipient out of sight.** `defaultSendAccount` preselects; the composer renders what it picked before Send is live; the request carries the account either way. The dashboard restates none of that rule — it calls the contract's function. Rendering a composer whose target is not on screen is the regression this surface exists to prevent.

**The segments are per account, not per channel.** For almost everyone the two are the same thing and a segment reads as a channel. For a person holding two numbers on one channel it is the difference between a composer that knows where it is going and one that does not — and that person is exactly who the contract refuses to guess for. Those two segments are labelled by handle, since the channel name would name them both.

**Inside an account view there is no picker.** The view is the target. A second choice would ask the guardian to say the same thing twice.

**The two narrowings run over different keys, because the two nouns carry different keys.** A timeline entry names a channel and no address, so an account view shows both same-channel accounts' history; an outbox row names the account, so it narrows exactly. Narrowing the timeline by address would mean inventing the address the entry does not carry — the same guess the composer refuses.

**The outbox is its own block above the timeline, never rows inside it.** A timeline entry is a message that happened; an outbox row is one that has not and may never. It draws no "sent" state: a row leaves by its message reaching the timeline, so after a send the page invalidates the outbox, the timeline and the person read, then polls the outbox while anything is in flight and invalidates the timeline when a row disappears. Nothing is tracked client-side — the server compares its two stores and the page re-asks. Nothing reads `OutboxMessage.ref`; it is a hint about one address, and recognizing an arrival is the server's job.

**No reason string crosses the wire.** `AccountSendState` does. `send-copy.ts` is a pure key map in the shape of `lib/connection-capability-copy.ts`, and the consumer owns the `t()` call. `"unsupported"` is keyed on the channel because it means different things per channel: LinkedIn is an inbox Rome mirrors and cannot write to, while a channel Rome has not taught to send is a gap that will close. A 409 racing a disconnect renders the same line the composer would have shown.

**A refusal never outlives the target it names.** The outcome of a send is held together with the account it was addressed to and rendered only while the two still match. Derived rather than cleared by an effect, so there is no ordering in which a line describing one channel is shown against another.

**The two outbox gestures are offered by what the server will accept, which is not one set.** Retry is for a `failed` row alone. Discard reaches further: a row Rome accepted and never saw arrive is stuck once the landing window has passed, and on a channel with no mirror of its own dismissing it is the only way it ever leaves. The client decides only whether to *offer*; the route holds the rule and answers 404.

**A refused gesture is recoverable, and a quiet one is quiet on purpose.** `busy` resets in a `finally` — an outbox with nothing in flight has stopped polling, so a row left disabled is one nothing recovers. A genuine failure is reported on the row, since that row is the only place the attempt can be made. A 404 is not: it means the row was already claimed or discarded, and the winner is sending the message correctly.

Two supporting changes: `WriteOutcome<T, C>` takes the 409 it can earn (a send earns a `SendRefusal`, not a `LinkConflict`) and carries the status beside the message, which only the outbox reads. `mock/handlers/people-api.ts` serves all four routes with the route's own scoping and state predicates, clears a row by looking its `ref` up on the timeline rather than by a flag, and reproduces the stranded and delivered-but-unseen rows that are otherwise unreachable without a crash.

The rejected alternative was a per-channel tab. It loses the person holding two accounts on one channel, which is the only case where any of this is hard.

## Test plan

- [x] `pnpm --filter rome-web typecheck` — clean.
- [x] `pnpm --filter rome-web test` — 1357 pass, none broken.
- [x] `biome check` (nixpkgs binary, per CLAUDE.md) — clean.
- [x] `PersonDetailPage.test.tsx`: the default target rendered before anything is typed; a send from the merged view carrying the account it showed and settling both reads; a send from an account segment with no picker present; a refused send surviving with the channel's words and retrying under its own outbox id; an un-sendable account showing its reason with the history still readable; a stranded row in the server's own equivocal words; a stuck `unconfirmed` row offered Discard and a fresh one offered nothing; a retry that loses a race staying silent; a retry whose request fails saying why and leaving the row actionable; a refusal retired when the target changes.
- [x] `send-model.test.ts`, `send-copy.test.ts`: the segment labelling rule, the two narrowings, the dismissable predicate at each boundary, and every refusal key resolving in **both** `en` and `zh-CN` with `{{channel}}` interpolated.
- [x] `writes-against-mock.test.ts`: the send verbs against the mock's own handlers — a row held then released once its message is on the timeline; a refusal kept and cleared by a retry that reuses the row; a discard; an `unsupported` 409; an account the person does not hold; two concurrent retries of which exactly one wins; a retry and a discard of a row still in flight both refused; a row of somebody else's refused through this person; a delivered-but-unseen row discardable past the window.
- [x] Each of the three review fixes was checked by reverting it and confirming the new test fails, then restoring.
- [x] Browser, mock dev server driven with Playwright, screenshots reviewed. Send moves `Sending` → timeline with the header count rising; a failed send shows the error with Retry and Discard, and Retry lands it; a double-clicked Retry sends once and stays silent; a retry whose request fails shows its message with both buttons still enabled; a stranded row reads sensibly; a wedged row offers only Discard; a refusal under WhatsApp disappears on switching to Telegram; the account segment has no picker; `arvind-srivastav`, `sam-okafor`, `nadia-petrova` each render their correct state. Repeated under a `zh-CN` browser — reasons render translated (领英), no keys leak. No console or page errors.

## Not in this PR

- `no-conversation` has copy and a test but no fixture reaching it: WhatsApp and Telegram address the conversation by the account itself, so it is unreachable in mock mode exactly as it is on those channels in production. A channel that keys threads separately will reach it.
- No attachments, no draft persistence, no edit or unsend — the composer sends one line of text, which is what `SendMessageRequest` carries.
- The outbox poll is a fixed interval while anything is in flight rather than a stream. A live channel for the person page is its own change.
- The client's copy of the landing window decides only whether to offer Discard. If it drifts from the route's, the button appears a moment early or late and the 404 stays quiet; it never decides anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
