### PR TITLE
docs(people): say that the outbox read is not a safe GET

### DIFF
--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -189,8 +189,23 @@ export function peopleRoutes(deps: ApiDeps): Hono {
         );
   });
 
-  /** Every send of this person's still in flight. Unpaged — an outbox long
-   *  enough to page is an incident rather than a listing. */
+  /**
+   * Every send of this person's still in flight. Unpaged — an outbox long
+   * enough to page is an incident rather than a listing.
+   *
+   * Deliberately not a safe GET. The read is what notices a message landing,
+   * so it clears the rows that have, and it is also what notices a send whose
+   * process died, so it marks those failed. That is the design — an outbox row
+   * is derived from a comparison against the timeline, and deriving it is the
+   * only moment anything is in a position to see the answer.
+   *
+   * The consequence to respect: this endpoint must not be prefetched,
+   * revalidated in the background, or wrapped in an HTTP cache on the
+   * assumption that a GET is free. Clearing a landed row and deleting it again
+   * are both idempotent, so a repeat is harmless there; stranding is the one
+   * transition that is not, and it is gated on an age no fresh row can meet.
+   * A caller that adds caching here is choosing that, not inheriting it.
+   */
   app.get("/people/:id/outbox", async (c) => {
     const person = await findPerson(deps, c.req.param("id"));
     if (!person) return c.json({ error: "Unknown person" }, 404);


### PR DESCRIPTION
## What this PR does

Split out of review on #208 — the finding landed after that PR had already merged, so the note missed the boat by about a minute.

`GET /api/people/:id/outbox` writes. It clears rows whose message has reached the timeline and marks a send whose process died `failed`, because deriving the outbox is the only moment anything is in a position to see either. That is the design, not a side effect that leaked in, but nothing said so at the route.

## Design & Invariants

The consequence worth writing down is which transition is not idempotent. Clearing a landed row and deleting it again are both repeatable, so a repeat of this GET is harmless. Stranding a `sending` row is not repeatable, and it is gated on an age no fresh row can meet — so the risk is not calling this twice, it is somebody wrapping it in an HTTP cache or a background revalidation on the assumption that a GET is free.

Comment only. No behaviour changes.

## Test plan

- [x] `pnpm --filter @rome/core typecheck`
- [x] `pnpm --filter @rome/core test:unit` — 4336 pass, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)