### PR TITLE
perf(core): read sentinel senders as a projection, not an aggregate

### DIFF
--- a/packages/core/src/db/repositories/sentinel-log.test.ts
+++ b/packages/core/src/db/repositories/sentinel-log.test.ts
@@ -78,6 +78,35 @@ describe("SentinelLogRepository", () => {
     expect(unreviewed[0].id).toBe(id2);
   });
 
+  describe("listSenders()", () => {
+    it("answers one row per sender, however many messages the log holds", async () => {
+      await repo.create(makeEntry({ messageId: "msg-1", channel: "telegram", channelUserId: "a" }));
+      await repo.create(makeEntry({ messageId: "msg-2", channel: "telegram", channelUserId: "a" }));
+      await repo.create(makeEntry({ messageId: "msg-3", channel: "telegram", channelUserId: "b" }));
+      await repo.create(makeEntry({ messageId: "msg-4", channel: "whatsapp", channelUserId: "a" }));
+
+      const senders = await repo.listSenders();
+      expect(
+        senders
+          .map((sender) => `${sender.channel}:${sender.channelUserId}`)
+          .sort((left, right) => left.localeCompare(right)),
+      ).toEqual(["telegram:a", "telegram:b", "whatsapp:a"]);
+    });
+
+    it("carries the address alone, and nothing derived from a message", async () => {
+      await repo.create(makeEntry());
+
+      // The callers are account reads: they name an account and preview nothing,
+      // so a newest message or a count here would be work no reader renders.
+      const [sender] = await repo.listSenders();
+      expect(Object.keys(sender).sort()).toEqual(["channel", "channelUserId"]);
+    });
+
+    it("answers nothing for an empty log", async () => {
+      expect(await repo.listSenders()).toEqual([]);
+    });
+  });
+
   it("findByChannelUser() returns entries for specific sender", async () => {
     await repo.create(makeEntry({ messageId: "msg-1", channelUserId: "user-A" }));
     await repo.create(makeEntry({ messageId: "msg-2", channelUserId: "user-A" }));

--- a/packages/core/src/db/repositories/sentinel-log.ts
+++ b/packages/core/src/db/repositories/sentinel-log.ts
@@ -3,16 +3,10 @@ import { v4 as uuid } from "uuid";
 import { sentinelLog } from "../schema.js";
 import type { DrizzleDb } from "../index.js";
 
-/** What the triage record holds about one sender, summed over their rows. */
-export interface SentinelSenderActivity {
+/** One sender the triage record has seen, as the account reads name them. */
+export interface SentinelSender {
   channel: string;
   channelUserId: string;
-  /** The name on their newest message, or null when no message carried one. */
-  displayName: string | null;
-  lastMessage: string | null;
-  /** Unix seconds, or null for a sender the log holds no timestamp for. */
-  lastMessageAt: number | null;
-  messageCount: number;
 }
 
 export class SentinelLogRepository {
@@ -81,39 +75,27 @@ export class SentinelLogRepository {
   }
 
   /**
-   * What each sender has said, one row per (channel, channel user id): the
-   * newest message and when it landed, and how many rows the log holds for
-   * them.
+   * Every sender the log has seen, one row per (channel, channel user id), in
+   * no particular order.
    *
-   * The triage record is the only history Rome keeps for a channel it mirrors
-   * no address book for, so this is what a directory read joins against a
-   * mirror's own activity.
+   * The triage record is the only record Rome keeps for a channel it mirrors no
+   * address book for, so this is what tells an account read that a sender is an
+   * account at all, and that is the whole of what such a read wants: it names an
+   * account and previews nothing, and the stream's preview is a `Messages`
+   * store's own answer. So nothing is summed over a sender's rows here — a
+   * newest message or a count would be work no reader renders.
    *
    * Read whole rather than one sender at a time, for the reason
    * {@link listLatestDisplayNames} gives.
    */
-  async listSenderActivity(): Promise<SentinelSenderActivity[]> {
-    // Bare display_name/text ride SQLite's guarantee that with a lone MAX()
-    // aggregate the other selected columns come from the row that supplied the
-    // max — i.e. the newest message names the sender.
+  async listSenders(): Promise<SentinelSender[]> {
     const rows = (await this.db.all(sql`
-      SELECT
-        channel,
-        channel_user_id AS channelUserId,
-        display_name AS displayName,
-        text AS lastMessage,
-        MAX(created_at) AS lastMessageAt,
-        COUNT(*) AS messageCount
+      SELECT DISTINCT channel, channel_user_id AS channelUserId
       FROM sentinel_log
-      GROUP BY channel, channel_user_id
     `)) as Array<Record<string, unknown>>;
     return rows.map((row) => ({
       channel: String(row.channel),
       channelUserId: String(row.channelUserId),
-      displayName: (row.displayName as string | null) ?? null,
-      lastMessage: (row.lastMessage as string | null) ?? null,
-      lastMessageAt: row.lastMessageAt == null ? null : Number(row.lastMessageAt),
-      messageCount: Number(row.messageCount ?? 0),
     }));
   }
 

--- a/packages/core/src/people/account-directory.test.ts
+++ b/packages/core/src/people/account-directory.test.ts
@@ -1,0 +1,125 @@
+// What the account reads ask the triage record for.
+//
+// The triage record is the only source that says an account exists on a channel
+// Rome mirrors no address book for, so both reads enumerate its senders. Neither
+// renders anything derived from what a sender said: the directory previews
+// nothing at all, and the stream's preview comes from a `Messages` store
+// (timeline-sources.ts), read in its own second pass. So these tests pin the
+// question the reads ask — which senders exist — and that they ask no other.
+
+import { afterEach, beforeEach, describe, expect, it } from "@rstest/core";
+import { eq } from "drizzle-orm";
+import { sentinelLog } from "../db/schema.js";
+import { SentinelLogRepository } from "../db/repositories/sentinel-log.js";
+import { buildTestDeps, createTestDb, type TestDb, type TestDeps } from "../test/helpers.js";
+import { seedBaseline } from "../test/seeds.js";
+import {
+  readAccountDirectory,
+  readAccountStream,
+  type AccountDirectoryDeps,
+} from "./account-directory.js";
+
+/** A Telegram sender the triage record is the only record of: no address book
+ *  mirrors the channel, and no link names the address. */
+const SENDER = "tg-sender";
+
+describe("the account reads over the triage record", () => {
+  let testDb: TestDb;
+  let deps: TestDeps;
+  /** Which methods the reads called on the triage record, in call order. */
+  let asked: string[];
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    await seedBaseline(testDb.db);
+    deps = await buildTestDeps(testDb.db);
+
+    // Two rows for the one sender, so a read that folds them wrong shows up as a
+    // duplicate row rather than as the same answer either way.
+    const first = await deps.sentinelLogRepo.create({
+      messageId: "msg-tg-1",
+      channel: "telegram",
+      channelUserId: SENDER,
+      displayName: "Sandy Sender",
+      text: "first line",
+      action: "ignored",
+    });
+    await deps.sentinelLogRepo.create({
+      messageId: "msg-tg-2",
+      channel: "telegram",
+      channelUserId: SENDER,
+      displayName: "Sandy Sender",
+      text: "second line",
+      action: "ignored",
+    });
+    // `create` files a row at the moment it runs, so both land in the same
+    // second and neither is the newer. Backdating one puts them in an order, so
+    // which line a preview shows is an answer rather than a tie.
+    await testDb.db
+      .update(sentinelLog)
+      .set({ createdAt: new Date("2026-08-17T09:00:00Z") })
+      .where(eq(sentinelLog.id, first));
+
+    asked = [];
+  });
+
+  afterEach(() => testDb.close());
+
+  /**
+   * The deps with the triage record behind a double that answers the senders and
+   * records what it was asked.
+   *
+   * Only the projection is on the double, so a read reaching past it fails
+   * outright instead of being noticed after the fact by a caller that already
+   * got its answer.
+   */
+  function watched(): AccountDirectoryDeps {
+    const log = new SentinelLogRepository(testDb.db);
+    return {
+      ...deps,
+      sentinelLogRepo: {
+        listSenders: () => {
+          asked.push("listSenders");
+          return log.listSenders();
+        },
+      },
+    };
+  }
+
+  const find = <T extends { channel: string; channelUserId: string }>(accounts: T[]) =>
+    accounts.find((account) => account.channel === "telegram" && account.channelUserId === SENDER);
+
+  it("enumerates the directory's senders through the projection alone", async () => {
+    await readAccountDirectory(watched());
+    expect(asked).toEqual(["listSenders"]);
+  });
+
+  it("enumerates the stream's senders through the projection alone", async () => {
+    await readAccountStream(watched());
+    expect(asked).toEqual(["listSenders"]);
+  });
+
+  it("lists a sender as one account, named by what it last called itself", async () => {
+    const sandy = find(await readAccountDirectory(watched()))!;
+    expect(sandy.addresses).toEqual([SENDER]);
+    // The name is the triage record's, but read through `AccountNames`, which is
+    // what answers for every channel — a mirror's name first, this second.
+    expect(sandy.displayName).toBe("Sandy Sender");
+    expect(sandy.state).toBe("unlinked");
+  });
+
+  it("previews the sender's newest line on the stream", async () => {
+    // What a message store answers, not an aggregate the account read carried:
+    // the two rows are one account, previewing the later of them.
+    const sandy = find(await readAccountStream(watched()))!;
+    expect(sandy.latest.preview).toBe("second line");
+    expect(sandy.latest.source).toBe("telegram");
+  });
+
+  it("lists exactly the accounts it lists with the real repository", async () => {
+    const ref = (account: { channel: string; channelUserId: string }) =>
+      `${account.channel}:${account.channelUserId}`;
+    const doubled = (await readAccountDirectory(watched())).map(ref).sort();
+    expect(doubled).toEqual((await readAccountDirectory(deps)).map(ref).sort());
+  });
+});

--- a/packages/core/src/people/account-directory.ts
+++ b/packages/core/src/people/account-directory.ts
@@ -35,7 +35,7 @@ export interface AccountDirectoryDeps {
    *  the stream reads a history from. */
   channels: Channels;
   personMappingRepo: Pick<PersonMappingRepository, "findAllWithMappings">;
-  sentinelLogRepo: Pick<SentinelLogRepository, "listSenderActivity">;
+  sentinelLogRepo: Pick<SentinelLogRepository, "listSenders">;
   accountNames: Pick<AccountNames, "displayNames">;
   /** Where the message stores live. Read by the stream alone — the contacts
    *  list never reaches a history. */
@@ -165,7 +165,7 @@ async function observeAccounts(deps: AccountDirectoryDeps): Promise<DirectoryAcc
     // Rome mirrors no address book for has no other row saying the account
     // exists. Only that it saw them is read here; what they said is a message
     // store's answer.
-    deps.sentinelLogRepo.listSenderActivity(),
+    deps.sentinelLogRepo.listSenders(),
     // One statement, so an account moving between two people mid-read cannot
     // land under both of them.
     deps.personMappingRepo.findAllWithMappings(),


### PR DESCRIPTION
## What this PR does

`SentinelLogRepository.listSenderActivity()` computed, per sender, the newest message text, its timestamp, and a `COUNT(*)`. The account reads — the directory and the stream, through `observeAccounts` — asked for all of it and used none of it. They want one fact: which senders the log has seen, so an account on a channel Rome mirrors no address book for is an account at all. The directory previews nothing, and the stream's preview is a `Messages` store's own answer, read in its own second pass.

Since #69 retired the identities union, that read was the only caller left. So this replaces the aggregate with the projection the caller wants: `listSenders()`, a `SELECT DISTINCT channel, channel_user_id` with no `MAX`, no `COUNT`, and no `GROUP BY`.

## Design & Invariants

- The triage record answers exactly one question for an account read: which senders exist. Everything derived from what a sender said comes from a `Messages` store (`people/timeline-sources.ts`), and a row on either surface renders only what some read computed.
- The fallback name a sender-only account renders under is unchanged, and stays where it already lived: `listLatestDisplayNames`, read through `AccountNames` and only where a mirror leaves a name unanswered. The issue described the projection as carrying that name, but the directory never read it off `listSenderActivity` — it reads `AccountNames` — so carrying it here would be the same discarded work in a new shape.
- `listSenderActivity` and `SentinelSenderActivity` are deleted rather than reduced: no caller remains.
- Regression means either account read answering a different set of accounts, or a sender-only account losing its name or its preview.

## Test plan

- [x] `packages/core/src/db/repositories/sentinel-log.test.ts` — `listSenders()` answers one row per sender however many messages the log holds, carries `channel` and `channelUserId` and no other key, and answers nothing for an empty log.
- [x] `packages/core/src/people/account-directory.test.ts` (new) — both reads reach the triage record through `listSenders` and nothing else, via a double carrying only that method; a sender the log is the only record of lists as one account under the name it last sent; the stream previews that sender's newest line; and the doubled read lists exactly the accounts the real repository does.
- [x] Written failing first: both files failed on `listSenderActivity is not a function` before the implementation landed.
- [x] `pnpm --filter @rome/core typecheck`
- [x] `pnpm --filter @rome/core test:unit` — 4317 passed. Two files fail to load in this sandbox on an unbuilt `node-pty` native module (`auth-me.test.ts`, `terminal-server.test.ts`), which has no build toolchain; both are unrelated to this diff.
- [x] `biome check` on the four touched files.
- [ ] `pnpm lint:prose` — `vale` is not on PATH in this sandbox; CI covers it.

Closes rome-os/rome#117

🤖 Generated with [Claude Code](https://claude.com/claude-code)