### PR TITLE
feat(ui): add a Timestamp component

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -7,8 +7,8 @@ each copying shadcn components by hand and drifting apart.
 > **Status: filling up.** The publish rail, the CSS canon (`./styles.css`), the
 > [control primitives](#controls), the [floating family](#floating-family),
 > [`Alert`](#alert), [`Card`](#card), [`Spinner`](#spinner),
-> [`Toaster`](#toaster), [`Calendar`](#calendar), [`Command`](#command), and
-> [`Markdown`](#markdown) are in. The remaining containers land in follow-up
+> [`Timestamp`](#timestamp), [`Toaster`](#toaster), [`Calendar`](#calendar),
+> [`Command`](#command), and [`Markdown`](#markdown) are in. The remaining containers land in follow-up
 > tickets. The app scaffold (`packages/app-template/template`) depends on the
 > published package, so a release here reaches external apps.
 
@@ -224,6 +224,45 @@ import { Spinner } from "@rome-os/ui/spinner";
   it — `disabled={busy}` is an attribute the caller passes anyway, and the size
   match above keeps the width stable — so a prop would only add a second way to
   say the same thing.
+
+### `Timestamp`
+
+An instant rendered inline as text, in the zone the user configured rather
+than the one the browser happens to be in.
+
+```tsx
+import { Timestamp, TimestampProvider } from "@rome-os/ui/timestamp";
+
+// Once, at the host's root, with the zone the user configured.
+<TimestampProvider timeZone={guardianTimezone}>
+  <App />
+</TimestampProvider>;
+
+// Anywhere below it.
+<Timestamp value={session.createdAt} />; // "3 minutes ago", and it keeps counting
+<Timestamp value={run.finishedAt} format="datetime" />; // "Sep 3, 2026, 3:04 PM"
+```
+
+- `value` is anything `new Date()` accepts, or nothing. Empty or unparseable
+  renders `fallback` (an em dash by default), so a nullable API field needs no
+  guard at the call site.
+- `format` is `relative` (the default), `time`, `date`, `datetime`, `full`, or
+  an `Intl.DateTimeFormatOptions` object for a layout the presets do not cover.
+- `relative` is live. The element re-renders at the moment its wording changes
+  and not before: at the minute mark, then once a minute, hourly past an hour,
+  and at local midnight once the label is a calendar day. Under a day the
+  wording is elapsed time, rounded to the nearest unit; from a day up it is
+  calendar days in the zone, so "yesterday" means the previous local date
+  whatever the hour.
+- Zone and locale resolve prop first, then provider, then the browser. A zone
+  the runtime cannot resolve falls back to the browser's. `useTimestampSettings()`
+  returns the resolved pair for anything else on the page that formats a date,
+  so an axis label agrees with the timestamps beside it.
+- Renders a `<time dateTime="…">`, and every layout but `full` carries the
+  `full` rendering as its `title`, so hovering a relative or a clock-only label
+  shows the exact moment. Pass `title` to replace that.
+- `formatTimestamp(value, { format, timeZone, locale, now })` is the same
+  rendering as a plain string, for tests and code outside React.
 
 ### `Calendar`
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -143,6 +143,10 @@
       "types": "./dist/textarea.d.ts",
       "default": "./dist/textarea.js"
     },
+    "./timestamp": {
+      "types": "./dist/timestamp.d.ts",
+      "default": "./dist/timestamp.js"
+    },
     "./toggle": {
       "types": "./dist/toggle.d.ts",
       "default": "./dist/toggle.js"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -139,5 +139,19 @@ export { Switch } from "./switch.js";
 export { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./table.js";
 export { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs.js";
 export { Textarea } from "./textarea.js";
+export {
+  formatTimestamp,
+  Timestamp,
+  TimestampProvider,
+  useTimestampSettings,
+  type FormatTimestampOptions,
+  type ResolvedTimestampSettings,
+  type TimestampFormat,
+  type TimestampPreset,
+  type TimestampProps,
+  type TimestampProviderProps,
+  type TimestampSettings,
+  type TimestampValue,
+} from "./timestamp.js";
 export { Toggle, type ToggleProps } from "./toggle.js";
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip.js";

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -44,6 +44,7 @@
 @source "./table.tsx";
 @source "./tabs.tsx";
 @source "./textarea.tsx";
+@source "./timestamp.tsx";
 @source "./toggle.tsx";
 @source "./tooltip.tsx";
 

--- a/packages/ui/src/timestamp.test.tsx
+++ b/packages/ui/src/timestamp.test.tsx
@@ -1,0 +1,254 @@
+import { act, cleanup, render, renderHook, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, rs } from "@rstest/core";
+import {
+  formatTimestamp,
+  Timestamp,
+  TimestampProvider,
+  useTimestampSettings,
+} from "./timestamp.js";
+
+afterEach(() => {
+  cleanup();
+  rs.useRealTimers();
+});
+
+// ICU joins a clock and its day period with U+202F in newer releases and a
+// plain space in older ones; the assertions care about the words, not the gap.
+function plain(text: string | null): string | null {
+  return text === null ? null : text.replace(/[  ]/g, " ");
+}
+
+// 15:04:05 UTC — 00:04 the next day in Tokyo, 11:04 the same morning in New York.
+const INSTANT = "2026-09-03T15:04:05.000Z";
+const EN = "en-US";
+
+function relative(value: string | number, now: string, timeZone = "UTC"): string | null {
+  return plain(
+    formatTimestamp(value, { format: "relative", timeZone, locale: EN, now: Date.parse(now) }),
+  );
+}
+
+describe("formatTimestamp", () => {
+  it("renders each preset in the given zone", () => {
+    const tokyo = (format: "time" | "date" | "datetime" | "full") =>
+      plain(formatTimestamp(INSTANT, { format, timeZone: "Asia/Tokyo", locale: EN }));
+
+    expect(tokyo("time")).toBe("12:04 AM");
+    expect(tokyo("date")).toBe("Sep 4, 2026");
+    expect(tokyo("datetime")).toBe("Sep 4, 2026, 12:04 AM");
+    expect(tokyo("full")).toBe("Friday, September 4, 2026 at 12:04 AM GMT+9");
+  });
+
+  it("moves the calendar day with the zone", () => {
+    const newYork = plain(
+      formatTimestamp(INSTANT, { format: "datetime", timeZone: "America/New_York", locale: EN }),
+    );
+    expect(newYork).toBe("Sep 3, 2026, 11:04 AM");
+  });
+
+  it("takes raw Intl options for a layout the presets lack", () => {
+    const text = plain(
+      formatTimestamp(INSTANT, {
+        format: { weekday: "short", hour: "numeric" },
+        timeZone: "UTC",
+        locale: EN,
+      }),
+    );
+    expect(text).toBe("Thu, 3 PM");
+  });
+
+  it("accepts a Date, an ISO string, and epoch milliseconds alike", () => {
+    const options = { format: "date" as const, timeZone: "UTC", locale: EN };
+    const fromString = formatTimestamp(INSTANT, options);
+
+    expect(formatTimestamp(new Date(INSTANT), options)).toBe(fromString);
+    expect(formatTimestamp(Date.parse(INSTANT), options)).toBe(fromString);
+  });
+
+  it("returns null for nothing or for text that is not a date", () => {
+    expect(formatTimestamp(null)).toBeNull();
+    expect(formatTimestamp(undefined)).toBeNull();
+    expect(formatTimestamp("last tuesday")).toBeNull();
+  });
+
+  it("falls back to the runtime zone when the zone does not resolve", () => {
+    const runtimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const expected = formatTimestamp(INSTANT, { format: "full", timeZone: runtimeZone });
+
+    expect(formatTimestamp(INSTANT, { format: "full", timeZone: "Mars/Olympus_Mons" })).toBe(
+      expected,
+    );
+  });
+
+  describe("relative", () => {
+    const NOW = "2026-09-03T12:00:00.000Z";
+
+    it("reads as now inside a minute either side", () => {
+      expect(relative("2026-09-03T11:59:30.000Z", NOW)).toBe("now");
+      expect(relative("2026-09-03T12:00:30.000Z", NOW)).toBe("now");
+    });
+
+    it("counts minutes, then hours, rounding to the nearest unit", () => {
+      expect(relative("2026-09-03T11:55:00.000Z", NOW)).toBe("5 minutes ago");
+      expect(relative("2026-09-03T10:31:00.000Z", NOW)).toBe("1 hour ago");
+      expect(relative("2026-09-03T10:30:00.000Z", NOW)).toBe("2 hours ago");
+      expect(relative("2026-09-02T13:00:00.000Z", NOW)).toBe("23 hours ago");
+      expect(relative("2026-09-03T14:00:00.000Z", NOW)).toBe("in 2 hours");
+    });
+
+    it("switches to calendar days in the zone once a day has passed", () => {
+      // 25.5 hours before 01:00 UTC on the 3rd is 23:30 UTC on the 1st — two
+      // dates back in UTC, but 08:30 on the 2nd in Tokyo, one date back.
+      const now = "2026-09-03T01:00:00.000Z";
+      const value = "2026-09-01T23:30:00.000Z";
+
+      expect(relative(value, now, "UTC")).toBe("2 days ago");
+      expect(relative(value, now, "Asia/Tokyo")).toBe("yesterday");
+    });
+
+    it("names tomorrow by date too", () => {
+      expect(relative("2026-09-04T18:00:00.000Z", NOW)).toBe("tomorrow");
+    });
+
+    it("climbs through weeks, months, and years", () => {
+      expect(relative("2026-08-24T12:00:00.000Z", NOW)).toBe("last week");
+      expect(relative("2026-08-14T12:00:00.000Z", NOW)).toBe("3 weeks ago");
+      expect(relative("2026-07-20T12:00:00.000Z", NOW)).toBe("last month");
+      expect(relative("2026-03-03T12:00:00.000Z", NOW)).toBe("6 months ago");
+      expect(relative("2025-07-30T12:00:00.000Z", NOW)).toBe("last year");
+      expect(relative("2028-09-10T12:00:00.000Z", NOW)).toBe("in 2 years");
+    });
+  });
+});
+
+describe("Timestamp", () => {
+  it("renders a <time> carrying the ISO instant and the full rendering as its title", () => {
+    render(<Timestamp value={INSTANT} format="date" timeZone="Asia/Tokyo" locale={EN} />);
+    const time = screen.getByText("Sep 4, 2026");
+
+    expect(time.tagName).toBe("TIME");
+    expect(time.getAttribute("datetime")).toBe(INSTANT);
+    expect(plain(time.getAttribute("title"))).toBe("Friday, September 4, 2026 at 12:04 AM GMT+9");
+  });
+
+  it("carries no title in the full layout, and the caller's title elsewhere", () => {
+    render(
+      <>
+        <Timestamp value={INSTANT} format="full" timeZone="UTC" locale={EN} />
+        <Timestamp value={INSTANT} format="time" timeZone="UTC" locale={EN} title="sent" />
+      </>,
+    );
+
+    expect(screen.getByText(/September 3, 2026/).hasAttribute("title")).toBe(false);
+    expect(screen.getByTitle("sent").textContent?.replace(/[  ]/g, " ")).toBe("3:04 PM");
+  });
+
+  it("renders the fallback, with no dateTime, when the value is empty or not a date", () => {
+    render(
+      <>
+        <Timestamp value={null} data-testid="empty" />
+        <Timestamp value="soon" fallback="unknown" data-testid="bad" />
+      </>,
+    );
+
+    expect(screen.getByTestId("empty").textContent).toBe("—");
+    expect(screen.getByTestId("empty").hasAttribute("datetime")).toBe(false);
+    expect(screen.getByTestId("bad").textContent).toBe("unknown");
+  });
+
+  it("takes the zone from the provider, and a prop over the provider", () => {
+    render(
+      <TimestampProvider timeZone="Asia/Tokyo" locale={EN}>
+        <Timestamp value={INSTANT} format="date" data-testid="provided" />
+        <Timestamp value={INSTANT} format="date" timeZone="America/New_York" data-testid="own" />
+      </TimestampProvider>,
+    );
+
+    expect(screen.getByTestId("provided").textContent).toBe("Sep 4, 2026");
+    expect(screen.getByTestId("own").textContent).toBe("Sep 3, 2026");
+  });
+
+  it("forwards the ref to the <time> in both branches", () => {
+    const dated = createRef<HTMLTimeElement>();
+    const empty = createRef<HTMLTimeElement>();
+    render(
+      <>
+        <Timestamp ref={dated} value={INSTANT} format="date" />
+        <Timestamp ref={empty} value={null} />
+      </>,
+    );
+
+    expect(dated.current?.tagName).toBe("TIME");
+    expect(empty.current?.tagName).toBe("TIME");
+  });
+
+  it("re-renders a relative label on its own as the clock moves", () => {
+    rs.useFakeTimers();
+    rs.setSystemTime(new Date("2026-09-03T12:00:00.000Z"));
+    render(<Timestamp value="2026-09-03T11:59:30.000Z" timeZone="UTC" locale={EN} />);
+    const time = screen.getByRole("time");
+
+    expect(time.textContent).toBe("now");
+
+    // 30 seconds on, the entry is a minute old — and nothing fires before that.
+    act(() => rs.advanceTimersByTime(29_000));
+    expect(time.textContent).toBe("now");
+    act(() => rs.advanceTimersByTime(1_000));
+    expect(time.textContent).toBe("1 minute ago");
+
+    // The next flip is at the rounding point, 90 seconds old.
+    act(() => rs.advanceTimersByTime(29_000));
+    expect(time.textContent).toBe("1 minute ago");
+    act(() => rs.advanceTimersByTime(1_000));
+    expect(time.textContent).toBe("2 minutes ago");
+  });
+
+  it("flips a calendar-day label at local midnight in the zone", () => {
+    rs.useFakeTimers();
+    // 23:30 in Tokyo on the 3rd; the entry is from the morning of the 2nd.
+    rs.setSystemTime(new Date("2026-09-03T14:30:00.000Z"));
+    render(<Timestamp value="2026-09-02T00:00:00.000Z" timeZone="Asia/Tokyo" locale={EN} />);
+    const time = screen.getByRole("time");
+
+    expect(time.textContent).toBe("yesterday");
+    act(() => rs.advanceTimersByTime(30 * 60_000 - 1));
+    expect(time.textContent).toBe("yesterday");
+    act(() => rs.advanceTimersByTime(1));
+    expect(time.textContent).toBe("2 days ago");
+  });
+
+  it("stops ticking once unmounted", () => {
+    rs.useFakeTimers();
+    rs.setSystemTime(new Date("2026-09-03T12:00:00.000Z"));
+    const { unmount } = render(<Timestamp value="2026-09-03T11:59:30.000Z" timeZone="UTC" />);
+
+    expect(rs.getTimerCount()).toBe(1);
+    unmount();
+    expect(rs.getTimerCount()).toBe(0);
+  });
+
+  it("holds no timer for an absolute layout", () => {
+    rs.useFakeTimers();
+    render(<Timestamp value={INSTANT} format="datetime" timeZone="UTC" />);
+
+    expect(rs.getTimerCount()).toBe(0);
+  });
+});
+
+describe("useTimestampSettings", () => {
+  it("returns the provider's zone, and the runtime's without one", () => {
+    const provided = renderHook(() => useTimestampSettings(), {
+      wrapper: ({ children }) => (
+        <TimestampProvider timeZone="Asia/Tokyo" locale={EN}>
+          {children}
+        </TimestampProvider>
+      ),
+    });
+    const bare = renderHook(() => useTimestampSettings());
+
+    expect(provided.result.current).toEqual({ timeZone: "Asia/Tokyo", locale: EN });
+    expect(bare.result.current.timeZone).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    expect(bare.result.current.locale).toBeUndefined();
+  });
+});

--- a/packages/ui/src/timestamp.test.tsx
+++ b/packages/ui/src/timestamp.test.tsx
@@ -48,14 +48,15 @@ describe("formatTimestamp", () => {
   });
 
   it("takes raw Intl options for a layout the presets lack", () => {
-    const text = plain(
-      formatTimestamp(INSTANT, {
-        format: { weekday: "short", hour: "numeric" },
-        timeZone: "UTC",
-        locale: EN,
-      }),
+    const options: Intl.DateTimeFormatOptions = { weekday: "short", hour: "numeric" };
+    const text = formatTimestamp(INSTANT, { format: options, timeZone: "UTC", locale: EN });
+
+    // ICU builds differ on the punctuation between a weekday and a clock, so
+    // the pin is Intl's own rendering of the same options, not a literal.
+    expect(text).toBe(
+      new Intl.DateTimeFormat(EN, { ...options, timeZone: "UTC" }).format(new Date(INSTANT)),
     );
-    expect(text).toBe("Thu, 3 PM");
+    expect(text).toMatch(/^Thu.*3 PM$/);
   });
 
   it("accepts a Date, an ISO string, and epoch milliseconds alike", () => {

--- a/packages/ui/src/timestamp.tsx
+++ b/packages/ui/src/timestamp.tsx
@@ -1,0 +1,323 @@
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  useEffect,
+  useReducer,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
+import { cn } from "./cn.js";
+
+/** The named layouts a `Timestamp` renders. `relative` is the live one:
+ * "3 minutes ago", "yesterday", "in 2 hours", re-rendered as the clock moves. */
+export type TimestampPreset = "relative" | "time" | "date" | "datetime" | "full";
+
+/** A preset name, or raw `Intl.DateTimeFormat` options for a layout the
+ * presets do not cover. Options never tick; only `relative` does. */
+export type TimestampFormat = TimestampPreset | Intl.DateTimeFormatOptions;
+
+/** Anything `new Date()` accepts, or nothing. An ISO string is the common case
+ * since that is what the API returns; a number is epoch milliseconds. */
+export type TimestampValue = Date | string | number | null | undefined;
+
+export interface TimestampSettings {
+  /** IANA zone every `Timestamp` below renders in, e.g. "Asia/Tokyo". A value
+   * the runtime cannot resolve falls back to the browser's zone. */
+  timeZone?: string;
+  /** BCP 47 locale for the wording and the calendar. Defaults to the
+   * runtime's locale. */
+  locale?: string;
+}
+
+const TimestampContext = createContext<TimestampSettings>({});
+
+export interface TimestampProviderProps extends TimestampSettings {
+  children?: ReactNode;
+}
+
+/** Sets the zone and locale for every `Timestamp` in its subtree. A host mounts
+ * one at its root with the user's configured zone; a `Timestamp` prop still
+ * wins over the provider for a single element. */
+export function TimestampProvider({ timeZone, locale, children }: TimestampProviderProps) {
+  return (
+    <TimestampContext.Provider value={{ timeZone, locale }}>{children}</TimestampContext.Provider>
+  );
+}
+
+export interface ResolvedTimestampSettings {
+  timeZone: string;
+  locale: string | undefined;
+}
+
+/** The zone and locale a `Timestamp` at this point in the tree would use,
+ * for callers that format a date some other way (an axis label, a filename)
+ * and need to agree with the timestamps beside it. */
+export function useTimestampSettings(): ResolvedTimestampSettings {
+  const settings = useContext(TimestampContext);
+  return { timeZone: resolveTimeZone(settings.timeZone), locale: settings.locale };
+}
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+const PRESETS: Record<Exclude<TimestampPreset, "relative">, Intl.DateTimeFormatOptions> = {
+  time: { hour: "numeric", minute: "2-digit" },
+  date: { year: "numeric", month: "short", day: "numeric" },
+  datetime: { year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" },
+  full: {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  },
+};
+
+// Probing a zone means constructing a formatter, which is the slow part of
+// Intl, and every render of every Timestamp asks about the same one or two.
+const zoneValidity = new Map<string, boolean>();
+
+function isValidTimeZone(timeZone: string): boolean {
+  let valid = zoneValidity.get(timeZone);
+  if (valid === undefined) {
+    try {
+      new Intl.DateTimeFormat("en-US", { timeZone });
+      valid = true;
+    } catch {
+      valid = false;
+    }
+    zoneValidity.set(timeZone, valid);
+  }
+  return valid;
+}
+
+function resolveTimeZone(candidate: string | undefined): string {
+  if (candidate && isValidTimeZone(candidate)) return candidate;
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+function toMillis(value: TimestampValue): number | null {
+  if (value === null || value === undefined) return null;
+  const ms = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function dateFormatter(
+  locale: string | undefined,
+  timeZone: string,
+  options: Intl.DateTimeFormatOptions,
+): Intl.DateTimeFormat {
+  const key = `${locale ?? ""}|${timeZone}|${JSON.stringify(options)}`;
+  let formatter = formatterCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat(locale, { ...options, timeZone });
+    formatterCache.set(key, formatter);
+  }
+  return formatter;
+}
+
+// Read back as numbers, so the locale only has to be one with ASCII digits.
+const CALENDAR_PARTS: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+  hourCycle: "h23",
+};
+
+interface ZonedClock {
+  /** Days since the epoch of the calendar day this instant falls on in the zone. */
+  dayNumber: number;
+  /** Milliseconds elapsed since that day's local midnight. */
+  msIntoDay: number;
+}
+
+function zonedClock(ms: number, timeZone: string): ZonedClock {
+  const parts = dateFormatter("en-US", timeZone, CALENDAR_PARTS).formatToParts(ms);
+  const read = (type: Intl.DateTimeFormatPartTypes) =>
+    Number(parts.find((part) => part.type === type)?.value ?? 0);
+  const dayNumber = Math.floor(Date.UTC(read("year"), read("month") - 1, read("day")) / DAY);
+  const subSecond = ((ms % 1000) + 1000) % 1000;
+  const msIntoDay = (read("hour") * 3600 + read("minute") * 60 + read("second")) * 1000 + subSecond;
+  return { dayNumber, msIntoDay };
+}
+
+interface ElapsedTier {
+  unit: Intl.RelativeTimeFormatUnit;
+  size: number;
+  /** The tier ends where the rounded count reaches this. */
+  limit: number;
+  /** The distance at which the tier begins, i.e. where the one below ends. */
+  floor: number;
+}
+
+const ELAPSED_TIERS: readonly ElapsedTier[] = [
+  { unit: "minute", size: MINUTE, limit: 60, floor: MINUTE },
+  { unit: "hour", size: HOUR, limit: 24, floor: 59.5 * MINUTE },
+];
+
+interface RelativeParts {
+  value: number;
+  unit: Intl.RelativeTimeFormatUnit;
+  /** Milliseconds until the label may read differently. */
+  refreshIn: number;
+}
+
+/**
+ * Splits a target instant into the (value, unit) pair `Intl.RelativeTimeFormat`
+ * renders, plus how long that pair stays true.
+ *
+ * Under a day the tier is elapsed time, rounded to the nearest unit, so
+ * "1 hour ago" covers 30 to 89 minutes. From a day up the tier is calendar
+ * days in the zone: "yesterday" means the previous local date, whatever the
+ * hour, so an entry from 11 pm reads "yesterday" at 1 am rather than
+ * "2 hours ago" turning into "today". That is the one place the zone enters
+ * relative wording, and it is why the zone is a parameter here at all.
+ *
+ * `refreshIn` is the distance to the next rounding point of the current tier,
+ * or to the next local midnight once the tier is calendar days. For a future
+ * target the distance shrinks instead of growing, so the next point is the
+ * rounding point below, clamped at the tier's floor.
+ */
+function relativeParts(target: number, now: number, timeZone: string): RelativeParts {
+  const delta = target - now;
+  const abs = Math.abs(delta);
+  const past = delta < 0;
+
+  if (abs < MINUTE) {
+    return { value: 0, unit: "second", refreshIn: MINUTE + delta };
+  }
+
+  for (const tier of ELAPSED_TIERS) {
+    const n = Math.round(abs / tier.size);
+    if (n < tier.limit) {
+      const nextPoint = past ? (n + 0.5) * tier.size : Math.max((n - 0.5) * tier.size, tier.floor);
+      return { value: past ? -n : n, unit: tier.unit, refreshIn: Math.abs(nextPoint - abs) };
+    }
+  }
+
+  const clock = zonedClock(now, timeZone);
+  const days = zonedClock(target, timeZone).dayNumber - clock.dayNumber;
+  const refreshIn = DAY - clock.msIntoDay;
+  const absDays = Math.abs(days);
+  if (absDays < 7) return { value: days, unit: "day", refreshIn };
+  if (absDays < 30) return { value: Math.round(days / 7), unit: "week", refreshIn };
+  const months = Math.round(days / 30.44);
+  if (Math.abs(months) < 12) return { value: months, unit: "month", refreshIn };
+  return { value: Math.round(days / 365.25), unit: "year", refreshIn };
+}
+
+export interface FormatTimestampOptions {
+  format?: TimestampFormat;
+  timeZone?: string;
+  locale?: string;
+  /** The instant `relative` measures from. Defaults to `Date.now()`. */
+  now?: number;
+}
+
+/** The text a `Timestamp` with the same props renders, or `null` when `value`
+ * is empty or not a date. The zone falls back the same way the component's does. */
+export function formatTimestamp(
+  value: TimestampValue,
+  options: FormatTimestampOptions = {},
+): string | null {
+  const ms = toMillis(value);
+  if (ms === null) return null;
+  const timeZone = resolveTimeZone(options.timeZone);
+  const format = options.format ?? "relative";
+  if (format === "relative") {
+    const { value: amount, unit } = relativeParts(ms, options.now ?? Date.now(), timeZone);
+    return new Intl.RelativeTimeFormat(options.locale, { numeric: "auto" }).format(amount, unit);
+  }
+  const dateOptions = typeof format === "string" ? PRESETS[format] : format;
+  return dateFormatter(options.locale, timeZone, dateOptions).format(ms);
+}
+
+export interface TimestampProps extends Omit<ComponentProps<"time">, "dateTime" | "children"> {
+  value: TimestampValue;
+  /** Defaults to `relative`. */
+  format?: TimestampFormat;
+  /** Overrides the provider's zone for this element only. */
+  timeZone?: string;
+  /** Overrides the provider's locale for this element only. */
+  locale?: string;
+  /** Rendered when `value` is empty or not a date. Defaults to an em dash. */
+  fallback?: ReactNode;
+}
+
+/**
+ * An instant, rendered inline as text in the user's zone.
+ *
+ * Renders a `<time>` whose `dateTime` carries the ISO instant, so the machine
+ * value survives whatever the visible text rounds away. Every layout but
+ * `full` also gets the `full` rendering as its `title`, so hovering a relative
+ * or a clock-only label shows the exact moment; pass `title` to replace that.
+ *
+ * `relative` schedules its own re-render for the moment the wording would
+ * change and no sooner: once at the minute mark for a fresh entry, once a
+ * minute after that, hourly past an hour, and at local midnight once the label
+ * is a calendar day. A list of a thousand of these holds a thousand timers,
+ * each idle until its own boundary.
+ */
+export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(function Timestamp(
+  { value, format = "relative", timeZone, locale, fallback = "—", title, className, ...rest },
+  ref,
+) {
+  const settings = useContext(TimestampContext);
+  const zone = resolveTimeZone(timeZone ?? settings.timeZone);
+  const resolvedLocale = locale ?? settings.locale;
+  const ms = toMillis(value);
+  const live = format === "relative" && ms !== null;
+
+  // `now` is read during render rather than kept in state so a re-render for
+  // any other reason (new data, a parent update) also picks up the current
+  // clock; the reducer exists only to force one at the scheduled boundary.
+  const [tick, forceRender] = useReducer((n: number) => n + 1, 0);
+  const now = Date.now();
+
+  useEffect(() => {
+    if (!live) return;
+    const { refreshIn } = relativeParts(ms, Date.now(), zone);
+    const id = setTimeout(forceRender, Math.max(refreshIn, 1000));
+    return () => clearTimeout(id);
+  }, [live, ms, zone, tick]);
+
+  if (ms === null) {
+    // Still a <time>, without `dateTime`, so the forwarded ref is the element
+    // type the props promise whether or not the value parsed.
+    return (
+      <time ref={ref} title={title} className={cn("whitespace-nowrap", className)} {...rest}>
+        {fallback}
+      </time>
+    );
+  }
+
+  const text = formatTimestamp(ms, { format, timeZone: zone, locale: resolvedLocale, now });
+  const hover =
+    title !== undefined
+      ? title
+      : format === "full"
+        ? undefined
+        : (formatTimestamp(ms, { format: "full", timeZone: zone, locale: resolvedLocale }) ??
+          undefined);
+
+  return (
+    <time
+      ref={ref}
+      dateTime={new Date(ms).toISOString()}
+      title={hover}
+      className={cn("whitespace-nowrap tabular-nums", className)}
+      {...rest}
+    >
+      {text}
+    </time>
+  );
+});

--- a/packages/web/mock/handlers/index.ts
+++ b/packages/web/mock/handlers/index.ts
@@ -861,7 +861,47 @@ const actionCatalog: ActionCatalogEntry[] = [
   },
 ];
 
-const settings: SettingsMap = {};
+// A zone unlikely to match the browser's, so the dashboard's timestamps
+// visibly follow the stored setting rather than the machine's clock.
+const settings: SettingsMap = { guardianTimezone: "Asia/Tokyo" };
+
+// Triage activity for the Inbox page. Offsets rather than fixed dates, so the
+// entries stay recent whenever the mock is opened.
+const sentinelLog = [
+  {
+    id: "sl_01",
+    channel: "telegram",
+    channelUserId: "tg:4471",
+    displayName: "Priya Natarajan",
+    text: "Hi! Is this the number for the plumber quote?",
+    action: "replied",
+    response: "This line belongs to Rome, Mia's assistant. I've passed your note along.",
+    reviewed: false,
+    createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+  },
+  {
+    id: "sl_02",
+    channel: "whatsapp",
+    channelUserId: "wa:15550001",
+    displayName: null,
+    text: "URGENT: your account will be suspended, click here",
+    action: "escalated",
+    response: null,
+    reviewed: false,
+    createdAt: new Date(Date.now() - 3 * 3_600_000).toISOString(),
+  },
+  {
+    id: "sl_03",
+    channel: "discord",
+    channelUserId: "dc:8812",
+    displayName: "sam_k",
+    text: "gg, rematch tomorrow?",
+    action: "ignored",
+    response: null,
+    reviewed: true,
+    createdAt: new Date(Date.now() - 2 * 86_400_000 - 3_600_000).toISOString(),
+  },
+];
 
 // Projects file-browser fixture. The tree endpoint returns the children of the
 // requested path (root when no `path` param), so directories carry their
@@ -1167,6 +1207,12 @@ export const handlers = [
   }),
   http.get("/api/actions", () => HttpResponse.json({ actions: actionCatalog })),
   http.get("/api/settings", () => HttpResponse.json(settings)),
+  http.get("/api/sentinel-log", () => HttpResponse.json(sentinelLog)),
+  http.post("/api/sentinel-log/:id/review", ({ params }) => {
+    const entry = sentinelLog.find((candidate) => candidate.id === params.id);
+    if (entry) entry.reviewed = true;
+    return HttpResponse.json({ ok: true });
+  }),
   // Several surfaces write a setting back on mount (last-used project, composer
   // preferences), so a read-only /api/settings makes the dashboard log a failed
   // write on every load.

--- a/packages/web/src/components/guardian-timestamp-provider.tsx
+++ b/packages/web/src/components/guardian-timestamp-provider.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import { TimestampProvider } from "@rome-os/ui/timestamp";
+import { useSettings } from "@/hooks/use-settings";
+
+/** Mounts the kit's `TimestampProvider` with the guardian's configured zone
+ * (the `guardianTimezone` setting, the same one the routine scheduler
+ * resolves floating schedules against). While settings load, or when no zone
+ * is stored, every `Timestamp` renders in the browser's zone. */
+export function GuardianTimestampProvider({ children }: { children: ReactNode }) {
+  const { data } = useSettings();
+  const timeZone = data?.guardianTimezone;
+  return (
+    <TimestampProvider timeZone={typeof timeZone === "string" ? timeZone : undefined}>
+      {children}
+    </TimestampProvider>
+  );
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
+import { GuardianTimestampProvider } from "./components/guardian-timestamp-provider";
 import { ThemeProvider } from "./hooks/use-theme";
 import { initAnalytics } from "./lib/analytics";
 import { injectThemeCss } from "./lib/theme";
@@ -23,9 +24,11 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
+        <GuardianTimestampProvider>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </GuardianTimestampProvider>
       </ThemeProvider>
     </QueryClientProvider>
   </StrictMode>,

--- a/packages/web/src/pages/InboxPage.tsx
+++ b/packages/web/src/pages/InboxPage.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { FieldDescription, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { Timestamp } from "@rome-os/ui/timestamp";
 import { PageShell, PageBody } from "@/shell/PageShell";
 
 // ── Types ──────────────────────────────────────────────
@@ -215,9 +216,11 @@ function TriageActivitySection({
                     {entry.action}
                   </span>
                 </div>
-                <span className="text-aux text-subtle-foreground">
-                  {new Date(entry.createdAt).toLocaleString()}
-                </span>
+                <Timestamp
+                  value={entry.createdAt}
+                  format="datetime"
+                  className="text-aux text-subtle-foreground"
+                />
               </div>
 
               {entry.text && <p className="mb-1 text-body text-foreground">{entry.text}</p>}

--- a/packages/web/src/pages/SessionsOverview.tsx
+++ b/packages/web/src/pages/SessionsOverview.tsx
@@ -22,18 +22,12 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@rome-os/ui/spinner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { RomeSessionRecord } from "@/lib/chat-types";
 import { artifactLocalName } from "@/lib/artifact-name";
 import { cn } from "@/lib/utils";
+import { Timestamp } from "@rome-os/ui/timestamp";
 import { SessionsTrendChart } from "./SessionsTrendChart";
-import {
-  costCoverage,
-  formatCompactNumber,
-  formatCost,
-  formatOutcome,
-  formatRelativeDate,
-} from "./sessions-format";
+import { costCoverage, formatCompactNumber, formatCost, formatOutcome } from "./sessions-format";
 
 const METRIC_LABELS: Record<SessionsMetric, string> = {
   runs: "Runs",
@@ -176,9 +170,7 @@ function RecentSessions({
               </span>
             </span>
             <span className="shrink-0 text-right text-aux text-muted-foreground">
-              <span className="block">
-                {formatRelativeDate(session.activityAt ?? session.createdAt)}
-              </span>
+              <Timestamp value={session.activityAt ?? session.createdAt} className="block" />
               <span className="mt-1 block tabular-nums">
                 {formatCompactNumber(session.stats.usage.totalTokens)} tokens
               </span>
@@ -339,14 +331,7 @@ export function SessionsOverview({
     {
       id: "activity",
       header: "Last activity",
-      cell: (group) => (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span>{formatRelativeDate(group.lastActivityAt)}</span>
-          </TooltipTrigger>
-          <TooltipContent>{new Date(group.lastActivityAt).toLocaleString()}</TooltipContent>
-        </Tooltip>
-      ),
+      cell: (group) => <Timestamp value={group.lastActivityAt} />,
     },
   ];
 
@@ -540,7 +525,7 @@ export function SessionsOverview({
                 </div>
                 <div className="mt-3 flex items-center justify-between gap-4 text-aux text-muted-foreground">
                   <span className="truncate">{formatOutcome(group.outcomes)}</span>
-                  <span className="shrink-0">{formatRelativeDate(group.lastActivityAt)}</span>
+                  <Timestamp value={group.lastActivityAt} className="shrink-0" />
                 </div>
               </button>
             ))

--- a/packages/web/src/pages/SessionsPage.tsx
+++ b/packages/web/src/pages/SessionsPage.tsx
@@ -31,6 +31,7 @@ import {
 import { DataTable, type DataTableColumn } from "@/components/ui/data-table";
 import { EmptyState, EmptyStateIcon, EmptyStateTitle } from "@/components/ui/empty-state";
 import { Spinner } from "@rome-os/ui/spinner";
+import { Timestamp } from "@rome-os/ui/timestamp";
 import {
   TraceDrawer,
   traceDrawerContentInsetClass,
@@ -76,7 +77,6 @@ import {
   formatCost,
   formatDate,
   formatOutcome,
-  formatRelativeDate,
   SESSION_TYPE_LABELS,
   sourceLabel,
 } from "./sessions-format";
@@ -421,14 +421,7 @@ function SessionsIndexPage({
         header: "Last activity",
         className: "w-28 whitespace-nowrap",
         headerClassName: "w-28",
-        cell: (session) => (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span>{formatRelativeDate(session.activityAt ?? session.createdAt)}</span>
-            </TooltipTrigger>
-            <TooltipContent>{formatDate(session.activityAt ?? session.createdAt)}</TooltipContent>
-          </Tooltip>
-        ),
+        cell: (session) => <Timestamp value={session.activityAt ?? session.createdAt} />,
       },
     ],
     [],
@@ -792,9 +785,10 @@ function SessionsIndexPage({
                       </div>
                       <div className="mt-3 flex items-center justify-between gap-4 text-aux text-muted-foreground">
                         <span className="truncate">{formatOutcome(session.stats.outcomes)}</span>
-                        <span className="shrink-0">
-                          {formatRelativeDate(session.activityAt ?? session.createdAt)}
-                        </span>
+                        <Timestamp
+                          value={session.activityAt ?? session.createdAt}
+                          className="shrink-0"
+                        />
                       </div>
                     </button>
                   ))

--- a/packages/web/src/pages/dev/gallery/sections/display.tsx
+++ b/packages/web/src/pages/dev/gallery/sections/display.tsx
@@ -35,6 +35,7 @@ import {
   AvatarGroupCount,
 } from "@/components/ui/avatar";
 import { Spinner } from "@rome-os/ui/spinner";
+import { Timestamp, TimestampProvider } from "@rome-os/ui/timestamp";
 import { Markdown } from "@rome-os/ui/markdown";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
@@ -63,6 +64,20 @@ const BADGE_VARIANTS = [
   "outline",
 ] as const;
 
+// One instant for the layout and zone specimens: late enough in the UTC day
+// that Tokyo and New York disagree on the date.
+const SAMPLE_INSTANT = "2026-09-03T15:04:05Z";
+
+const RELATIVE_OFFSETS: ReadonlyArray<readonly [label: string, offsetMs: number]> = [
+  ["30 seconds ago", -30_000],
+  ["5 minutes ago", -5 * 60_000],
+  ["3 hours ago", -3 * 3_600_000],
+  ["30 hours ago", -30 * 3_600_000],
+  ["12 days ago", -12 * 86_400_000],
+  ["in 2 hours", 2 * 3_600_000],
+  ["in 400 days", 400 * 86_400_000],
+];
+
 const ROWS = [
   { id: "ses_01J9Z4", app: "Bookkeeper", status: "Done", duration: "1m 04s" },
   { id: "ses_01J9Z5", app: "Marketer", status: "Running", duration: "12s" },
@@ -71,6 +86,7 @@ const ROWS = [
 
 export function DisplaySection() {
   const [selectedTile, setSelectedTile] = useState("private");
+  const [mountedAt] = useState(() => Date.now());
   // Prose paints from inherited tokens on its own; Mermaid is the one part that
   // needs handing an explicit sRGB palette, because its color parser can't read
   // the OKLCH primitives Slate and Ember dark are built on.
@@ -446,6 +462,68 @@ export function DisplaySection() {
               </Row>
             </Item>
           </Row>
+        </Specimen>
+      </Component>
+
+      <Component id="timestamp" name="Timestamp" source="@rome-os/ui/timestamp">
+        <Specimen
+          label="Timestamp — relative"
+          note="The default layout. Each label re-renders on its own at the moment its wording changes; hover for the exact instant. The offsets are from when this page mounted."
+        >
+          <Row>
+            {RELATIVE_OFFSETS.map(([label, offset]) => (
+              <Item key={label} label={label}>
+                <Timestamp value={mountedAt + offset} />
+              </Item>
+            ))}
+          </Row>
+        </Specimen>
+        <Specimen
+          label="Timestamp — layouts"
+          note="One instant in every preset, plus raw Intl options for anything the presets lack."
+        >
+          <Row>
+            <Item label="time">
+              <Timestamp value={SAMPLE_INSTANT} format="time" />
+            </Item>
+            <Item label="date">
+              <Timestamp value={SAMPLE_INSTANT} format="date" />
+            </Item>
+            <Item label="datetime">
+              <Timestamp value={SAMPLE_INSTANT} format="datetime" />
+            </Item>
+            <Item label="full">
+              <Timestamp value={SAMPLE_INSTANT} format="full" />
+            </Item>
+            <Item label="{ weekday, hour }">
+              <Timestamp value={SAMPLE_INSTANT} format={{ weekday: "short", hour: "numeric" }} />
+            </Item>
+            <Item label="null → fallback">
+              <Timestamp value={null} />
+            </Item>
+          </Row>
+        </Specimen>
+        <Specimen
+          label="Timestamp — zones"
+          note="The same instant under a provider set to Tokyo. A prop overrides the provider for one element; the last one shows the browser's own zone."
+        >
+          <TimestampProvider timeZone="Asia/Tokyo">
+            <Row>
+              <Item label="provider · Asia/Tokyo">
+                <Timestamp value={SAMPLE_INSTANT} format="datetime" />
+              </Item>
+              <Item label="prop · America/New_York">
+                <Timestamp value={SAMPLE_INSTANT} format="datetime" timeZone="America/New_York" />
+              </Item>
+              <Item label="prop · browser zone">
+                <Timestamp
+                  value={SAMPLE_INSTANT}
+                  format="datetime"
+                  timeZone={Intl.DateTimeFormat().resolvedOptions().timeZone}
+                />
+              </Item>
+            </Row>
+          </TimestampProvider>
         </Specimen>
       </Component>
 


### PR DESCRIPTION
## What this PR does

The dashboard formats dates six different ways, each in the browser's zone, and none of them read the `guardianTimezone` setting that onboarding stores and the routine scheduler resolves against. A guardian who set Tokyo sees Inbox rows dated in whatever zone their laptop happens to be in.

This adds `Timestamp` to `@rome-os/ui`: an instant rendered inline as a `<time>` in the user's configured zone, with a live `relative` layout, four absolute presets (`time`, `date`, `datetime`, `full`), and raw `Intl.DateTimeFormatOptions` for anything else. The dashboard mounts `TimestampProvider` at its root from the stored setting, and the Inbox triage log plus the Sessions surfaces move onto the component.

## Design & Invariants

- Zone and locale resolve prop, then provider, then browser. A zone the runtime cannot resolve falls back to the browser's rather than throwing in render.
- A relative label re-renders at the moment its wording changes and not before: at the minute mark, then once a minute, hourly past an hour, and at local midnight once the label is a calendar day. Each element holds one idle timer.
- Under a day the relative wording is elapsed time rounded to the nearest unit. From a day up it is calendar days in the configured zone, so "yesterday" means the previous local date whatever the hour. That is the one place the zone enters relative wording.
- The `dateTime` attribute always carries the ISO instant, and every layout but `full` carries the `full` rendering as its `title`, so the exact moment is one hover away from a rounded label.
- `formatTimestamp` is the same rendering as a plain string, for tests and code outside React.
- The dashboard provider is a thin adapter over the settings query. An app in a Shadow DOM has its own React tree and mounts its own provider; how the SDK feeds it the zone is not decided here.

## Test plan

- [x] `pnpm --filter @rome-os/ui test` — 21 new tests: presets per zone, calendar-day switching in Tokyo versus UTC, week/month/year tiers, provider and prop precedence, fake-timer ticks at the minute boundary and at Tokyo midnight, timer cleanup on unmount.
- [x] `pnpm typecheck`, `pnpm test:unit`, `pnpm --filter rome-web test`, `biome check`, `pnpm lint:prose`.
- [x] `pnpm start:web:mock`: the Inbox triage log renders in Tokyo time from the mock's `guardianTimezone`, and the gallery's Timestamp section shows relative ticking and the same instant across zones, checked in headless Chromium.

## Not in this PR

- Feeding the guardian's zone to apps through the app-web SDK. Apps render in their own React tree, so the dashboard's provider does not reach them.
- Moving the Activity and People pages' `timeAgo` helpers onto the component. They render translated strings through i18next, and the kit formats through `Intl`, so that swap needs a decision about which owns the wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)