### PR TITLE
feat(people): pin the composer and regroup the person card

### DIFF
--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -106,6 +106,7 @@
     "back": "People",
     "bond": "Bond",
     "linkAccount": "Link account…",
+    "changeBond": "Change bond",
     "timeline": "Timeline",
     "timelineEmpty": "Nothing has happened on any channel yet.",
     "loadOlder": "Load older",
@@ -120,6 +121,7 @@
     "noAccounts": "No accounts yet"
   },
   "send": {
+    "to": "To",
     "segments": {
       "label": "Account",
       "all": "All",

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -106,6 +106,7 @@
     "back": "人物",
     "bond": "亲密度",
     "linkAccount": "关联账号…",
+    "changeBond": "更改亲密度",
     "timeline": "时间线",
     "timelineEmpty": "各个渠道都还没有任何往来。",
     "loadOlder": "加载更早",
@@ -120,6 +121,7 @@
     "noAccounts": "暂无账号"
   },
   "send": {
+    "to": "发送至",
     "segments": {
       "label": "账号",
       "all": "全部",

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -600,8 +600,13 @@ describe("PersonDetailPage management", () => {
     renderPage();
 
     await screen.findByRole("heading", { name: "Wei Chen" });
-    await user.click(screen.getByRole("combobox", { name: "Bond" }));
-    await user.click(await screen.findByRole("option", { name: "Inner circle" }));
+    await user.click(screen.getByRole("button", { name: "Actions for Wei Chen" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Change bond" }));
+    // Chosen by keyboard: a pointer leaving the submenu's trigger for the item
+    // closes the submenu in jsdom, where the pointer has no position to keep
+    // it inside the grace area. Enter on the focused item is the same select.
+    (await screen.findByRole("menuitemradio", { name: "Inner circle" })).focus();
+    await user.keyboard("{Enter}");
 
     const patch = await waitFor(() => {
       const call = calls.find((c) => c.method === "PATCH");
@@ -620,7 +625,8 @@ describe("PersonDetailPage management", () => {
     renderPage();
 
     await screen.findByRole("heading", { name: "Wei Chen" });
-    await user.click(screen.getByRole("button", { name: "Link account…" }));
+    await user.click(screen.getByRole("button", { name: "Actions for Wei Chen" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Link account…" }));
     await user.click(await screen.findByRole("button", { name: /Rachel Lim/ }));
 
     const link = await waitFor(() => {
@@ -643,7 +649,8 @@ describe("PersonDetailPage management", () => {
     renderPage();
 
     await screen.findByRole("heading", { name: "Wei Chen" });
-    await user.click(screen.getByRole("button", { name: "Link account…" }));
+    await user.click(screen.getByRole("button", { name: "Actions for Wei Chen" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Link account…" }));
     await user.click(await screen.findByRole("button", { name: /mira_c/ }));
 
     // The refusal names the owner rather than reading as a failed write.
@@ -670,7 +677,8 @@ describe("PersonDetailPage management", () => {
     renderPage();
 
     await screen.findByRole("heading", { name: "Wei Chen" });
-    await user.click(screen.getByRole("button", { name: "Merge into another person…" }));
+    await user.click(screen.getByRole("button", { name: "Actions for Wei Chen" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Merge into another person…" }));
     await user.click(await screen.findByRole("button", { name: /W\. Chen/ }));
 
     const merge = await waitFor(() => {
@@ -691,8 +699,13 @@ describe("PersonDetailPage management", () => {
     renderPage();
 
     await screen.findByRole("heading", { name: "Wei Chen" });
-    await user.click(screen.getByRole("combobox", { name: "Bond" }));
-    await user.click(await screen.findByRole("option", { name: "Inner circle" }));
+    await user.click(screen.getByRole("button", { name: "Actions for Wei Chen" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Change bond" }));
+    // Chosen by keyboard: a pointer leaving the submenu's trigger for the item
+    // closes the submenu in jsdom, where the pointer has no position to keep
+    // it inside the grace area. Enter on the focused item is the same select.
+    (await screen.findByRole("menuitemradio", { name: "Inner circle" })).focus();
+    await user.keyboard("{Enter}");
 
     expect(await screen.findByRole("alert")).toBeTruthy();
   });
@@ -738,7 +751,8 @@ describe("PersonDetailPage back link survives a merge", () => {
     renderPage("wei-chen", "/people/directory?level=inner-circle");
 
     await screen.findByRole("heading", { name: "Wei Chen" });
-    await user.click(screen.getByRole("button", { name: "Merge into another person…" }));
+    await user.click(screen.getByRole("button", { name: "Actions for Wei Chen" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Merge into another person…" }));
     await user.click(await screen.findByRole("button", { name: /W\. Chen/ }));
     await screen.findByRole("heading", { name: "W. Chen" });
 
@@ -792,6 +806,16 @@ describe("PersonDetailPage back link consumes the dossier's history entry", () =
 // request carries the account that was on screen, and the view that already
 // names an account offers no second choice.
 describe("PersonDetailPage, sending", () => {
+  it("pins the composer so a history longer than the screen scrolls under it", async () => {
+    mockApi();
+    renderPage();
+
+    // The box is a sticky floor at the bottom of the viewport, so it is on
+    // screen at every scroll position instead of only past the last row.
+    const box = await screen.findByRole("textbox", { name: "Message text" });
+    expect(box.closest(".sticky")).toBeTruthy();
+  });
+
   it("names the account it will send to before anything is typed", async () => {
     mockApi();
     renderPage();

--- a/packages/web/src/pages/PersonDetailPage.tsx
+++ b/packages/web/src/pages/PersonDetailPage.tsx
@@ -1,8 +1,9 @@
 import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft, CircleAlert } from "lucide-react";
-import { formatWhatsAppPhone } from "@rome/api-types/people";
+import { formatWhatsAppPhone, normalizeBondLevel } from "@rome/api-types/people";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PageShell, PageBody } from "@/shell/PageShell";
 import { Avatar } from "./people/avatar";
@@ -10,6 +11,7 @@ import { ChannelPill } from "./people/channel-meta";
 import { PersonConversation } from "./people/conversation";
 import { PersonManagement } from "./people/manage";
 import { PEOPLE_VIEW_PATH, personPath } from "./people/people-model";
+import { levelLabelKey } from "./people/rows";
 import { usePerson } from "./people/use-roster";
 
 /**
@@ -105,14 +107,30 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
   }
 
   return (
-    <PageShell>
-      <PageBody>
+    // The page fills the content column so the conversation can take whatever
+    // the header leaves, and the composer's floor reaches the viewport's foot.
+    <PageShell className="flex flex-1 flex-col">
+      <PageBody className="flex flex-1 flex-col">
         <BackLink onClick={back} />
 
-        <div className="flex flex-wrap items-start gap-4 rounded-14 border border-border bg-surface p-5 shadow-1">
-          <Avatar name={person.displayName} tone="bg-surface-muted text-muted-foreground" />
-          <div className="min-w-0 flex-1 basis-64">
-            <h1 className="text-title text-foreground">{person.displayName}</h1>
+        {/* One row at any width: the avatar, then who this is, then a menu of
+            what can be done to them. The bond reads as a badge on the name line
+            and is changed from the menu, so the card states the facts and keeps
+            every gesture in one place — nothing here has to stack or wrap into
+            pieces when the card is narrow. */}
+        <div className="flex items-start gap-4 rounded-14 border border-border bg-surface p-5 shadow-1">
+          <Avatar
+            name={person.displayName}
+            size="lg"
+            tone="bg-surface-muted text-muted-foreground"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <h1 className="text-title text-foreground">{person.displayName}</h1>
+              <Badge variant="outline">
+                {t(levelLabelKey(normalizeBondLevel(person.bondLevel)))}
+              </Badge>
+            </div>
             <p className="text-aux text-muted-foreground">
               {t("row.messageCount", { count: person.messageCount })}
             </p>

--- a/packages/web/src/pages/people/composer.tsx
+++ b/packages/web/src/pages/people/composer.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, SendHorizontal } from "lucide-react";
 import { canSend, type LinkedAccount, type PersonResource } from "@rome/api-types/people";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -131,7 +132,7 @@ export function Composer({
 
   return (
     <Floor>
-      <p className="mb-2 flex items-center gap-1.5 text-aux text-muted-foreground">
+      <p className="mb-2 flex items-center gap-2 text-aux text-muted-foreground">
         <span>{t("send.to")}</span>
         {onChangeTarget && options.length > 1 ? (
           <TargetMenu options={options} value={target} onChange={onChangeTarget} />
@@ -182,19 +183,17 @@ function refusalText(
   return t(sendRefusalKey(send, channel), { channel: channelLabel(t, channel) });
 }
 
-/** One chip's worth of target: the channel's glyph and name, and the handle. */
-const CHIP_CLASS =
-  "flex min-w-0 items-center gap-1 rounded-6 bg-surface-muted px-1.5 py-0.5 text-badge text-muted-foreground";
-
+/** One chip's worth of target: the channel's glyph and name, and the handle.
+ *  A `Badge`, so the chip's box comes from the badge tokens. */
 function TargetChip({ account }: { account: LinkedAccount }) {
   const { t } = useTranslation("people");
   return (
-    <span className={CHIP_CLASS}>
+    <Badge variant="muted" className="min-w-0">
       <ChannelGlyph channel={account.channel} />
       <span className="truncate">
         {channelLabel(t, account.channel)} · {accountHandle(account)}
       </span>
-    </span>
+    </Badge>
   );
 }
 
@@ -212,16 +211,18 @@ function TargetMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className={`${CHIP_CLASS} cursor-pointer outline-none transition-colors hover:text-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring aria-expanded:text-foreground`}
-        >
-          <ChannelGlyph channel={value.channel} />
-          <span className="truncate">
-            {channelLabel(t, value.channel)} · {accountHandle(value)}
-          </span>
-          <ChevronDown aria-hidden="true" className="size-3 shrink-0" />
-        </button>
+        <Badge variant="muted" asChild>
+          <button
+            type="button"
+            className="min-w-0 cursor-pointer outline-none transition-colors hover:text-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring aria-expanded:text-foreground"
+          >
+            <ChannelGlyph channel={value.channel} />
+            <span className="truncate">
+              {channelLabel(t, value.channel)} · {accountHandle(value)}
+            </span>
+            <ChevronDown aria-hidden="true" />
+          </button>
+        </Badge>
       </DropdownMenuTrigger>
       {/* Opens upward: the chip sits on a floor pinned to the bottom of the
           viewport, so below it there is nothing but the edge. */}

--- a/packages/web/src/pages/people/composer.tsx
+++ b/packages/web/src/pages/people/composer.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { PAGE_FLOOR } from "@/shell/PageShell";
 import { ChannelGlyph, channelLabel } from "./channel-meta";
 import { sendRefusalKey, type RefusedSendState } from "./send-copy";
 import { accountHandle } from "./send-model";
@@ -24,6 +25,11 @@ import { usePeopleWrites } from "./use-writes";
  * one, so a surface offering a preselected account has to show which one it
  * picked. `defaultSendAccount` decides the preselection, and it is the
  * contract's function rather than a rule restated here.
+ *
+ * The target takes its own line above the box, as a chip after "To". A chip
+ * beside the box cost it a third of the row for a label that is read once and
+ * typed past; on its own line it can carry the whole name and leave the box the
+ * full width, at every card width, with no stacking rule to switch.
  *
  * The picker appears only in the merged view, and only when more than one
  * account can be written to. Inside an account view the view is the target, so a
@@ -124,17 +130,18 @@ export function Composer({
   }
 
   return (
-    <div className="mt-4 border-t border-border pt-3">
-      <div className="flex items-center gap-2">
+    <Floor>
+      <p className="mb-2 flex items-center gap-1.5 text-aux text-muted-foreground">
+        <span>{t("send.to")}</span>
         {onChangeTarget && options.length > 1 ? (
           <TargetMenu options={options} value={target} onChange={onChangeTarget} />
         ) : (
-          <span className="flex shrink-0 items-center gap-1 rounded-8 bg-surface-muted px-2 py-1 text-badge text-muted-foreground">
-            <ChannelGlyph channel={target.channel} />
-            {channelLabel(t, target.channel)} · {accountHandle(target)}
-          </span>
+          <TargetChip account={target} />
         )}
+      </p>
+      <div className="flex items-center gap-2">
         <Input
+          size="sm"
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
           onKeyDown={(event) => {
@@ -161,7 +168,7 @@ export function Composer({
           {failed.refusal ? refusalText(t, failed.refusal, failed.account.channel) : failed.message}
         </p>
       )}
-    </div>
+    </Floor>
   );
 }
 
@@ -173,6 +180,22 @@ function refusalText(
   channel: string,
 ): string {
   return t(sendRefusalKey(send, channel), { channel: channelLabel(t, channel) });
+}
+
+/** One chip's worth of target: the channel's glyph and name, and the handle. */
+const CHIP_CLASS =
+  "flex min-w-0 items-center gap-1 rounded-6 bg-surface-muted px-1.5 py-0.5 text-badge text-muted-foreground";
+
+function TargetChip({ account }: { account: LinkedAccount }) {
+  const { t } = useTranslation("people");
+  return (
+    <span className={CHIP_CLASS}>
+      <ChannelGlyph channel={account.channel} />
+      <span className="truncate">
+        {channelLabel(t, account.channel)} · {accountHandle(account)}
+      </span>
+    </span>
+  );
 }
 
 /** The target, visible at rest and one click from being changed. */
@@ -189,13 +212,20 @@ function TargetMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button type="button" variant="outline" size="sm" className="shrink-0">
+        <button
+          type="button"
+          className={`${CHIP_CLASS} cursor-pointer outline-none transition-colors hover:text-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring aria-expanded:text-foreground`}
+        >
           <ChannelGlyph channel={value.channel} />
-          {channelLabel(t, value.channel)} · {accountHandle(value)}
-          <ChevronDown aria-hidden="true" />
-        </Button>
+          <span className="truncate">
+            {channelLabel(t, value.channel)} · {accountHandle(value)}
+          </span>
+          <ChevronDown aria-hidden="true" className="size-3 shrink-0" />
+        </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
+      {/* Opens upward: the chip sits on a floor pinned to the bottom of the
+          viewport, so below it there is nothing but the edge. */}
+      <DropdownMenuContent align="start" side="top">
         {options.map((account) => (
           <DropdownMenuItem
             key={`${account.channel}:${account.channelUserId}`}
@@ -215,6 +245,35 @@ function TargetMenu({
 
 function Note({ children }: { children: React.ReactNode }) {
   return (
-    <p className="mt-4 border-t border-border pt-3 text-aux text-muted-foreground">{children}</p>
+    <Floor>
+      <p className="text-aux text-muted-foreground">{children}</p>
+    </Floor>
+  );
+}
+
+/**
+ * The slot the composer sits in: a card floating over the bottom of the
+ * viewport.
+ *
+ * The timeline above it is as long as the history, so on any page that does
+ * not fit, the box would otherwise be below the fold: the reader scrolls to
+ * find it, and it moves every time older rows arrive. Sticky keeps it at the
+ * bottom edge while the section runs past, and `mt-auto` puts it there too
+ * when the section is shorter than the viewport, so there is one place it is.
+ * Both the text box and the refusal that takes its place render here, so the
+ * slot holds still across the two.
+ *
+ * A raised surface rather than a footer band, the same floor the chat
+ * composer rides: rows scroll under a translucent card instead of stopping at
+ * a solid edge. The outer slot lets pointer events through so the rows
+ * showing between the card and the viewport's edge stay clickable.
+ */
+function Floor({ children }: { children: React.ReactNode }) {
+  return (
+    <div className={`pointer-events-none sticky bottom-0 z-10 mt-auto pt-4 ${PAGE_FLOOR}`}>
+      <div className="pointer-events-auto rounded-16 border border-border bg-surface/95 p-3 shadow-10 backdrop-blur-md supports-[backdrop-filter]:bg-surface/80">
+        {children}
+      </div>
+    </div>
   );
 }

--- a/packages/web/src/pages/people/conversation.tsx
+++ b/packages/web/src/pages/people/conversation.tsx
@@ -61,7 +61,9 @@ export function PersonConversation({ person }: { person: PersonResource }) {
   const days = useMemo(() => groupByDay(entries), [entries]);
 
   return (
-    <section>
+    // A column that takes the rest of the page, so the composer's floor can sit
+    // at the bottom of the viewport even when the history above it is short.
+    <section className="flex flex-1 flex-col">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h2 className="text-section uppercase tracking-wide text-muted-foreground">
           {t("detail.timeline")}

--- a/packages/web/src/pages/people/manage.tsx
+++ b/packages/web/src/pages/people/manage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MoreHorizontal } from "lucide-react";
 import {
   accountRef,
   ASSIGNABLE_BOND_LEVELS,
@@ -19,14 +20,19 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import {
   Table,
   TableBody,
@@ -60,10 +66,14 @@ function handleOf(account: { channel: string; channelUserId: string }): string {
 }
 
 /**
- * The bond select, the two pickers, and whatever the last write said.
+ * The card's menu: the bond, the two pickers, and whatever the last write said.
+ *
+ * One ⋯ menu rather than controls laid on the card. The bond is a fact the
+ * header states beside the name, and changing it is a gesture like the other
+ * two, so it lives with them — as a submenu of levels, the current one marked.
  *
  * The guardian's bond does not move — the contract refuses it — so their card
- * reads the level rather than offering to change it.
+ * offers no menu at all: the badge reads the level and nothing changes it.
  */
 export function PersonManagement({
   person,
@@ -92,35 +102,47 @@ export function PersonManagement({
   }
 
   return (
-    <div className="flex flex-col items-stretch gap-2 sm:items-end">
-      {level === "guardian" ? (
-        <p className="text-aux text-muted-foreground sm:text-right">
-          {t("detail.bond")}: {t(levelLabelKey(level))}
-        </p>
-      ) : (
-        <Select value={level} disabled={savingBond} onValueChange={(next) => void handleBond(next)}>
-          <SelectTrigger aria-label={t("detail.bond")} className="w-full sm:w-48">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {ASSIGNABLE_BOND_LEVELS.map((value) => (
-              <SelectItem key={value} value={value}>
-                {t(levelLabelKey(value))}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      )}
-
+    <div className="flex shrink-0 flex-col items-end gap-2">
       {level !== "guardian" && (
-        <div className="flex flex-wrap gap-2 sm:justify-end">
-          <Button type="button" variant="outline" size="sm" onClick={() => setPicker("link")}>
-            {t("detail.linkAccount")}
-          </Button>
-          <Button type="button" variant="outline" size="sm" onClick={() => setPicker("merge")}>
-            {t("actions.mergeInto")}
-          </Button>
-        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            {/* A `Button` rather than `IconButton` for the `ghost` aria-expanded
+                paint, as on the directory's rows. */}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              disabled={savingBond}
+              aria-label={t("actions.rowMenu", { name: person.displayName })}
+            >
+              <MoreHorizontal aria-hidden="true" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>{t("detail.changeBond")}</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuRadioGroup
+                  value={level}
+                  onValueChange={(next) => void handleBond(next)}
+                >
+                  {ASSIGNABLE_BOND_LEVELS.map((value) => (
+                    <DropdownMenuRadioItem key={value} value={value}>
+                      {t(levelLabelKey(value))}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => setPicker("link")}>
+              {t("detail.linkAccount")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setPicker("merge")}>
+              {t("actions.mergeInto")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       )}
 
       <MutationError message={error} />

--- a/packages/web/src/shell/PageShell.tsx
+++ b/packages/web/src/shell/PageShell.tsx
@@ -7,6 +7,16 @@ import { cn } from "@/lib/utils";
 const PAGE_PADDING = "p-4 sm:p-6 lg:p-8";
 
 /**
+ * For a block that sticks to the bottom of the viewport: it takes over the
+ * page's bottom padding as its own, so it sits the same distance from the
+ * viewport's edge while stuck as it does at rest at the end of the page. A
+ * floor without this jumps by the page padding the moment the page's end
+ * scrolls into view. Kept beside `PAGE_PADDING` because the two have to agree
+ * step for step.
+ */
+export const PAGE_FLOOR = "-mb-4 pb-4 sm:-mb-6 sm:pb-6 lg:-mb-8 lg:pb-8";
+
+/**
  * The frame every routed page renders into.
  *
  * Deliberately full-bleed: it fills the column next to the nav sidebar and


### PR DESCRIPTION
## What this PR does

On a person's page, the composer sat at the end of the timeline. On any history longer than the screen it was below the fold, and it moved every time older rows arrived. Its target picker, "WhatsApp · +1 (415) 555-0142", took a third of the row and squeezed the text box.

The header card had the same problem in a different form. It wrapped its pieces one by one as the card narrowed, so the avatar could land on its own line above the name, and the bond select on its own line away from the two pickers it belongs with.

Now:

- The composer is a card floating over the bottom of the viewport. It sits in the same spot whether the history is short or long, and timeline rows scroll under it.
- The target is a chip after "To" on its own line, and the text box below takes the full width. The chip is the picker in the merged view, and its menu opens upward since the floor sits at the bottom edge.
- The header card is one row at any width: avatar, name with the bond as a badge, message count, account pills, and a menu in the corner. The menu holds Change bond as a submenu of levels with the current one checked, then Link account and Merge into.
- The text box, the buttons, and the select all sit on the `sm` control step, so one row has one height.

## Design & Invariants

The send contract's rule holds: the target is on screen before Send is pressed, and a send names its account. Moving the target to its own line keeps it visible at every width without a stacking rule.

The floor takes over the page's bottom padding as its own. `PAGE_FLOOR` in `PageShell.tsx` sits beside `PAGE_PADDING` because the two have to agree step for step. Without it the composer jumps by the page padding the moment the end of the page scrolls into view.

The guardian's card shows the bond badge and no menu. The contract refuses to move their bond, and the card offers nothing it cannot do.

Two other card layouts were prototyped and rejected: a toolbar of the three controls under the identity, and labelled facts with each control beside the fact it changes. Both still had a row that had to wrap or stack on a narrow card. One row with a menu has nothing to stack.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit:web` (36 files, 528 tests)
- [x] `biome check` on the changed files, `pnpm lint:prose`
- [x] Mock dashboard at 1440, 1200, 860, and 390 px wide: the composer stays pinned while rows scroll under it, sits at the bottom on a short history, and the card holds one row at every width
- [x] Mock dashboard: the ⋯ menu opens the bond submenu, and the target menu opens above the chip
- [ ] Against a live backend, change a bond from the menu and send a message

## Not in this PR

- A layout-invariants sweep of `/people/person/:id`. The e2e list covers `/people` only, and adding a person route needs a seeded person in that environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
