### PR TITLE
feat(people): open a person's memory profile from their dossier

### DIFF
--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -902,6 +902,11 @@ export function defaultSendAccount(accounts: readonly LinkedAccount[]): LinkedAc
  * what the dossier will show. A group conversation contributes to neither: a
  * timeline entry names no sender, so nothing said in a room of ten people is
  * attributable to one of them.
+ *
+ * `memoryPath` is the profile Rome has written about them, as a path under the
+ * memory root — the same address the memory file browser reads. Null when no
+ * profile has been written: nothing writes one when a person is created, so a
+ * path here means a file a reader can actually open.
  */
 export interface PersonResource {
   id: string;
@@ -910,6 +915,7 @@ export interface PersonResource {
   accounts: LinkedAccount[];
   messageCount: number;
   latest: AccountDynamic | null;
+  memoryPath: string | null;
 }
 
 /**

--- a/packages/core/src/people/resource.test.ts
+++ b/packages/core/src/people/resource.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, rs } from "@rstest/core";
+import * as pathsModule from "../paths.js" with { rstest: "importActual" };
+
+// The profile dir the memory tree hangs off, redirected at a temp dir so a
+// profile written here is this test's and not the machine's.
+const mockPaths = rs.hoisted(() => ({ profileDir: "/tmp/rome-test-profile" }));
+
+rs.mock("../paths.js", () => ({
+  ...pathsModule,
+  getProfileDir: rs.fn(() => mockPaths.profileDir),
+}));
+
+import { readPeople } from "./resource.js";
+import { buildTestDeps, createTestDb, type TestDb, type TestDeps } from "../test/helpers.js";
+import { seedBaseline } from "../test/seeds.js";
+
+// What `PersonResource.memoryPath` answers: the profile Rome wrote about
+// someone, addressed the way the memory file browser addresses it. The rest of
+// the serialization is exercised through the routes (`../api/routes/people.test.ts`).
+
+describe("A person's memory profile", () => {
+  let root: string;
+  let testDb: TestDb;
+  let deps: TestDeps;
+
+  const relationshipDir = () => join(mockPaths.profileDir, "memory", "relationship");
+  const writeProfile = (fileName: string) => {
+    mkdirSync(relationshipDir(), { recursive: true });
+    writeFileSync(join(relationshipDir(), fileName), "# Profile\n");
+  };
+  const memoryPathOf = async (displayName: string) =>
+    (await readPeople(deps)).find((person) => person.displayName === displayName)?.memoryPath;
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), "rome-person-memory-"));
+    mockPaths.profileDir = join(root, "profile");
+    testDb = createTestDb();
+    await seedBaseline(testDb.db);
+    deps = await buildTestDeps(testDb.db);
+  });
+
+  afterEach(() => {
+    testDb.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("answers the path stored on the row, which is how the guardian's is addressed", async () => {
+    writeProfile("GUARDIAN.md");
+    expect(await memoryPathOf("Guardian")).toBe("memory/relationship/GUARDIAN.md");
+  });
+
+  it("answers the convention every other profile is written under", async () => {
+    const id = await deps.personMappingRepo.create({
+      displayName: "Wei Chen",
+      bondLevel: "inner-circle",
+      approved: true,
+    });
+    writeProfile(`${id}.md`);
+
+    expect(await memoryPathOf("Wei Chen")).toBe(`memory/relationship/${id}.md`);
+  });
+
+  it("answers none for a person nobody has written a profile about", async () => {
+    // Creating a person writes no profile, so this is the ordinary case rather
+    // than a broken one — and a path served for it would be a link to nothing.
+    await deps.personMappingRepo.create({
+      displayName: "Nadia Petrova",
+      bondLevel: "acquaintance",
+      approved: true,
+    });
+
+    expect(await memoryPathOf("Nadia Petrova")).toBe(null);
+    expect(await memoryPathOf("Guardian")).toBe(null);
+  });
+});

--- a/packages/core/src/people/resource.test.ts
+++ b/packages/core/src/people/resource.test.ts
@@ -63,6 +63,22 @@ describe("A person's memory profile", () => {
     expect(await memoryPathOf("Wei Chen")).toBe(`memory/relationship/${id}.md`);
   });
 
+  it("answers none for a profile stored outside the relationship dir", async () => {
+    // The dashboard opens what this answers under the memory root, and only
+    // this one directory holds profiles — so a row pointing anywhere else falls
+    // back to the convention rather than handing out a path to link against.
+    const id = await deps.personMappingRepo.create({
+      displayName: "Wei Chen",
+      bondLevel: "inner-circle",
+      approved: true,
+    });
+    await deps.personMappingRepo.updatePerson(id, { profilePath: "memory/IDENTITY.md" });
+    mkdirSync(join(mockPaths.profileDir, "memory"), { recursive: true });
+    writeFileSync(join(mockPaths.profileDir, "memory", "IDENTITY.md"), "# Identity\n");
+
+    expect(await memoryPathOf("Wei Chen")).toBe(null);
+  });
+
   it("answers none for a person nobody has written a profile about", async () => {
     // Creating a person writes no profile, so this is the ordinary case rather
     // than a broken one — and a path served for it would be a link to nothing.

--- a/packages/core/src/people/resource.ts
+++ b/packages/core/src/people/resource.ts
@@ -9,8 +9,10 @@
 // account is linked to, not someone the guardian knows. It is excluded here,
 // once, so no route can serve it by forgetting to.
 
+import { existsSync } from "node:fs";
 import type { AccountSendState, PersonResource, TimelineEntry } from "@rome/api-types/people";
 import { STRANGER_PERSON_ID } from "../constants.js";
+import { resolveProfileMemoryPath } from "../profile-memory.js";
 import type { AccountNames } from "../channels/account-names.js";
 import type { Channels } from "../channels/channel.js";
 import type { MessageAccount } from "../channels/messages.js";
@@ -101,8 +103,28 @@ async function serialize(
         latestAt: latestAtOf(activity.perAccount, accountsByPerson[i], mapping),
       };
     }),
+    memoryPath: memoryPathOf(person),
     ...activity.perPerson[i],
   }));
+}
+
+/**
+ * The memory profile written about a person, or null when none is.
+ *
+ * Two ways a person's profile is addressed and one answer: the path stored on
+ * the row where something wrote one — the guardian's, at onboarding — and
+ * otherwise the convention every other profile is written under,
+ * `memory/relationship/<id>.md` (`memory/relationship/BONDS.md` states it).
+ *
+ * Answered only when the file is there. Creating a person writes no profile,
+ * and the agent writes one when it has something to remember, so a path served
+ * for a file nobody wrote is a link to nothing. That check is a stat of the
+ * local profile dir — the one thing here that runs per person, and the reason
+ * it is a stat rather than a read.
+ */
+function memoryPathOf(person: PersonRow): string | null {
+  const path = person.profilePath || `memory/relationship/${person.id}.md`;
+  return existsSync(resolveProfileMemoryPath(path)) ? path : null;
 }
 
 /**

--- a/packages/core/src/people/resource.ts
+++ b/packages/core/src/people/resource.ts
@@ -9,7 +9,7 @@
 // account is linked to, not someone the guardian knows. It is excluded here,
 // once, so no route can serve it by forgetting to.
 
-import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
 import type { AccountSendState, PersonResource, TimelineEntry } from "@rome/api-types/people";
 import { STRANGER_PERSON_ID } from "../constants.js";
 import { resolveProfileMemoryPath } from "../profile-memory.js";
@@ -75,7 +75,7 @@ async function serialize(
   // Independent of each other, and both reach the same channel mirrors: read
   // together, a mirror that folds its whole address book per call serves both
   // from one read of it instead of two.
-  const [accountsByPerson, names, sendStates] = await Promise.all([
+  const [accountsByPerson, names, sendStates, memoryPaths] = await Promise.all([
     timelineAccounts(
       deps,
       persons.map((person) => person.channelMappings),
@@ -85,6 +85,7 @@ async function serialize(
     // rather than stored: a channel that went down between two reads has to
     // change this answer, and nothing writes a row when it does.
     readSendStates(deps, refs),
+    memoryProfilePaths(persons),
   ]);
   const activity = await readActivity(personMessageStores(deps), accountsByPerson);
 
@@ -103,28 +104,46 @@ async function serialize(
         latestAt: latestAtOf(activity.perAccount, accountsByPerson[i], mapping),
       };
     }),
-    memoryPath: memoryPathOf(person),
+    memoryPath: memoryPaths[i],
     ...activity.perPerson[i],
   }));
 }
 
+/** Where every memory profile lives, as the memory file browser addresses it.
+ *  `memory/relationship/BONDS.md` states the rule. */
+const RELATIONSHIP_DIR = "memory/relationship";
+
 /**
- * The memory profile written about a person, or null when none is.
+ * The profile written about each of these people, in the order given — the path
+ * where one exists, null where none does.
  *
- * Two ways a person's profile is addressed and one answer: the path stored on
- * the row where something wrote one — the guardian's, at onboarding — and
- * otherwise the convention every other profile is written under,
- * `memory/relationship/<id>.md` (`memory/relationship/BONDS.md` states it).
+ * One read of the relationship directory answers the whole listing, so this
+ * costs the same whether it is given one person or every one of them, like the
+ * reads above it.
  *
- * Answered only when the file is there. Creating a person writes no profile,
- * and the agent writes one when it has something to remember, so a path served
- * for a file nobody wrote is a link to nothing. That check is a stat of the
- * local profile dir — the one thing here that runs per person, and the reason
- * it is a stat rather than a read.
+ * A profile is named either way it can be: by the path stored on the row, which
+ * is how the guardian's is addressed, and otherwise by the person's id. Both
+ * name a file in this one directory — a stored path pointing anywhere else is
+ * not honored, because the dashboard opens what this answers under the memory
+ * root and a path from outside it would be a link the file browser cannot
+ * resolve.
+ *
+ * Answered only for a file that is there. Creating a person writes no profile —
+ * the agent writes one when it has something to remember — so a path served for
+ * a file nobody wrote is a link to nothing.
  */
-function memoryPathOf(person: PersonRow): string | null {
-  const path = person.profilePath || `memory/relationship/${person.id}.md`;
-  return existsSync(resolveProfileMemoryPath(path)) ? path : null;
+async function memoryProfilePaths(persons: readonly PersonRow[]): Promise<(string | null)[]> {
+  const written = new Set(
+    await readdir(resolveProfileMemoryPath(RELATIONSHIP_DIR)).catch(() => []),
+  );
+
+  return persons.map((person) => {
+    const stored = person.profilePath?.startsWith(`${RELATIONSHIP_DIR}/`)
+      ? person.profilePath.slice(RELATIONSHIP_DIR.length + 1)
+      : null;
+    const fileName = stored ?? `${person.id}.md`;
+    return written.has(fileName) ? `${RELATIONSHIP_DIR}/${fileName}` : null;
+  });
 }
 
 /**

--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -108,6 +108,11 @@ function personResource(person: PersonFixture): PersonResource {
     // history GET /api/people/:id/messages pages.
     messageCount: entries.length,
     latest: latestDynamic(entries),
+    // The convention core answers with for a profile that exists
+    // (`memory/relationship/<id>.md`). Every fixture has one: the mock serves
+    // no memory tree to check against, so the honest choice is the one that
+    // leaves the roster's link on screen to exercise.
+    memoryPath: `memory/relationship/${person.id}.md`,
   };
 }
 

--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -88,6 +88,15 @@ function sendState(channel: string): AccountSendState {
 
 type PersonFixture = (typeof persons)[number];
 
+/**
+ * Who a memory profile has been written about — this store's stand-in for the
+ * relationship directory core reads to answer `memoryPath`.
+ *
+ * Not everyone, because nothing writes a profile when a person is created: both
+ * states the dossier's menu has to handle are on the fixtures.
+ */
+const MEMORY_PROFILES = new Set(["ray-oster", "mira-chen", "nadia-petrova"]);
+
 function personResource(person: PersonFixture): PersonResource {
   const entries = personTimeline(person.id) ?? [];
   return {
@@ -108,11 +117,7 @@ function personResource(person: PersonFixture): PersonResource {
     // history GET /api/people/:id/messages pages.
     messageCount: entries.length,
     latest: latestDynamic(entries),
-    // The convention core answers with for a profile that exists
-    // (`memory/relationship/<id>.md`). Every fixture has one: the mock serves
-    // no memory tree to check against, so the honest choice is the one that
-    // leaves the roster's link on screen to exercise.
-    memoryPath: `memory/relationship/${person.id}.md`,
+    memoryPath: MEMORY_PROFILES.has(person.id) ? `memory/relationship/${person.id}.md` : null,
   };
 }
 

--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -107,6 +107,7 @@
     "bond": "Bond",
     "linkAccount": "Link account…",
     "changeBond": "Change bond",
+    "memoryProfile": "Memory profile",
     "timeline": "Timeline",
     "timelineEmpty": "Nothing has happened on any channel yet.",
     "loadOlder": "Load older",

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -107,6 +107,7 @@
     "bond": "亲密度",
     "linkAccount": "关联账号…",
     "changeBond": "更改亲密度",
+    "memoryProfile": "记忆档案",
     "timeline": "时间线",
     "timelineEmpty": "各个渠道都还没有任何往来。",
     "loadOlder": "加载更早",

--- a/packages/web/src/pages/PeoplePage.test.tsx
+++ b/packages/web/src/pages/PeoplePage.test.tsx
@@ -76,6 +76,7 @@ const GUARDIAN: PersonResource = {
   accounts: [{ channel: "webchat", channelUserId: "wc-1", displayName: "wc-1" }],
   messageCount: 0,
   latest: null,
+  memoryPath: "memory/relationship/GUARDIAN.md",
 };
 
 const FRIEND: PersonResource = {
@@ -85,6 +86,7 @@ const FRIEND: PersonResource = {
   accounts: [{ channel: "telegram", channelUserId: "418820113", displayName: "wei_c" }],
   messageCount: 30,
   latest: { source: "telegram", timestamp: NOW - 600, preview: "on my way" },
+  memoryPath: "memory/relationship/wei-chen.md",
 };
 
 const QUIET_PERSON: PersonResource = {
@@ -94,6 +96,7 @@ const QUIET_PERSON: PersonResource = {
   accounts: [],
   messageCount: 0,
   latest: null,
+  memoryPath: null,
 };
 
 /**
@@ -189,6 +192,7 @@ const LINKEDIN_PERSON: PersonResource = {
   accounts: [{ channel: "linkedin", channelUserId: "ACoAAPriya01", displayName: "Priya Nair" }],
   messageCount: 4,
   latest: { source: "linkedin", timestamp: NOW - 900, preview: "sent you a note about the role" },
+  memoryPath: null,
 };
 
 /** The world both reads are served from, and every write applies to. */
@@ -282,6 +286,7 @@ function applyWrite(
       accounts: [],
       messageCount: 0,
       latest: null,
+      memoryPath: null,
     };
     world.people.push(person);
     for (const ref of refs) attach(world, person, ref);
@@ -1003,6 +1008,7 @@ describe("PeoplePage folds LinkedIn into the general surface", () => {
       ],
       messageCount: 8,
       latest: null,
+      memoryPath: null,
     };
     mockApi({ people: [GUARDIAN, WHATSAPP_PERSON, LINKEDIN_PERSON] });
     renderPage();

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -67,6 +67,7 @@ const PERSON: PersonResource = {
   ],
   messageCount: 12,
   latest: { source: "whatsapp", timestamp: NOW - 300, preview: "the landlord replies fast" },
+  memoryPath: "memory/relationship/wei-chen.md",
 };
 
 /** Reachable on one channel Rome mirrors and cannot write to — the composer's
@@ -86,6 +87,7 @@ const READ_ONLY_PERSON: PersonResource = {
   ],
   messageCount: 1,
   latest: null,
+  memoryPath: null,
 };
 
 const ENTRIES: TimelineEntry[] = [
@@ -120,6 +122,7 @@ const DUPLICATE: PersonResource = {
   accounts: [],
   messageCount: 2,
   latest: null,
+  memoryPath: null,
 };
 
 const UNPLACED: DirectoryAccount = {
@@ -419,6 +422,7 @@ describe("PersonDetailPage", () => {
         timestamp: NOW - 300,
         preview: "sent you a note about the role",
       },
+      memoryPath: null,
     };
     mockApi({
       person,
@@ -617,6 +621,34 @@ describe("PersonDetailPage management", () => {
     // An omitted field is one the update leaves alone, so a bond change must
     // not carry a name and blank it.
     expect(patch.body).toEqual({ bondLevel: "inner-circle" });
+  });
+
+  it("opens the memory profile Rome wrote about them, at the address Memory reads it from", async () => {
+    const user = userEvent.setup();
+    mockApi();
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("button", { name: "Actions for Wei Chen" }));
+
+    // A link out to Memory, not a fourth write: the profile is a file, and the
+    // editor, the history and the sync state are all on that page.
+    const item = await screen.findByRole("menuitem", { name: "Memory profile" });
+    expect(item.getAttribute("href")).toBe("/memory/relationship/wei-chen.md");
+  });
+
+  it("offers no memory profile for a person nobody has written one about", async () => {
+    const user = userEvent.setup();
+    // Creating a person writes no profile, so the read answers none — and an
+    // item that opened nothing would be on most people's menu.
+    mockApi({ person: { ...PERSON, memoryPath: null } });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Wei Chen" });
+    await user.click(screen.getByRole("button", { name: "Actions for Wei Chen" }));
+
+    expect(await screen.findByRole("menuitem", { name: "Link account\u2026" })).toBeTruthy();
+    expect(screen.queryByRole("menuitem", { name: "Memory profile" })).toBeNull();
   });
 
   it("links an account the directory holds onto this person", async () => {

--- a/packages/web/src/pages/people/manage.tsx
+++ b/packages/web/src/pages/people/manage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { MoreHorizontal } from "lucide-react";
 import {
@@ -42,6 +43,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { usePeople } from "@/hooks/use-people";
+import { getFileBrowserUrlPath } from "@/lib/file-browser-routing";
 import { ChannelPill } from "./channel-meta";
 import { MutationError } from "./triage";
 import { levelLabelKey } from "./rows";
@@ -141,6 +143,22 @@ export function PersonManagement({
             <DropdownMenuItem onSelect={() => setPicker("merge")}>
               {t("actions.mergeInto")}
             </DropdownMenuItem>
+            {person.memoryPath && (
+              <>
+                <DropdownMenuSeparator />
+                {/* Leaves for Memory rather than rendering the profile here: it
+                    is a file the guardian edits, and the editor, the history and
+                    the sync state are all there. Offered only when the read
+                    names one — nothing writes a profile when a person is
+                    created, so an item on every person would usually open
+                    nothing. */}
+                <DropdownMenuItem asChild>
+                  <Link to={getFileBrowserUrlPath("memory", person.memoryPath)}>
+                    {t("detail.memoryProfile")}
+                  </Link>
+                </DropdownMenuItem>
+              </>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       )}


### PR DESCRIPTION
## What this PR does

Rome writes a memory profile about the people it knows — `memory/relationship/<id>.md`, and the path stored on the guardian's row — and the dashboard reached none of them. Reading what Rome remembers about someone meant knowing the convention and finding the file by hand in Memory.

`GET /api/people` now answers where the profile is, and the dossier's ⋯ menu carries a **Memory profile** item that opens it.

## Design & Invariants

`PersonResource.memoryPath` is an address, not content: a path under the memory root, the same one the memory file browser takes. The dashboard follows it to Memory, where the editor, the file history and the sync state already live. Rendering the markdown beside the timeline would be a second reader of the file with none of them.

Every profile lives in `memory/relationship/` — `BONDS.md` states it — so one read of that directory answers the whole listing. The serializer takes the file name from the row's stored `profilePath` where it names a file there, otherwise from the person's id, and answers null unless that file is in the directory. Two things follow. Creating a person writes no profile — the agent writes one when it has something to remember — so a path for a file nobody wrote would be a link to nothing, and the menu item hangs off exactly this. And a stored path pointing outside that directory is not served: it resolves against the project root, which the dashboard cannot open under `/memory`. The read joins the address-book, display-name and send-state reads in one `Promise.all`, so the listing costs the same handful of reads however many people it holds.

The item sits in the dossier's ⋯ menu, which already holds every per-person gesture. Two alternatives lost: a control on each directory row, which puts a gesture on a view whose job is reading a contacts list; and a dialog rendering the file in place, which is the second reader above. The guardian's card carries no ⋯ menu at all, so their own profile is not reachable from here.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — new: `packages/core/src/people/resource.test.ts` (the stored path, the convention, a stored path outside the relationship dir, and none), two cases in `PersonDetailPage.test.tsx` (the item links to the file; absent when there is no profile)
- [x] Live `pnpm dev:all` stack: seeded three people and wrote a profile for one. `GET /api/people` answers `memory/relationship/wei-chen.md` for that one and `null` for the others, and `GET /api/memory/resolve` returns the file for that exact path.
- [x] Browser, mock mode: the menu reads Change bond ▸ · Link account… · Merge into another person… · Memory profile → `/memory/relationship/ray-oster.md`, and the directory rows are unchanged.

## Not in this PR

- The guardian's own profile — their card offers no ⋯ menu, and giving them one is a separate decision about that card.
- Creating a profile from the dashboard: the item appears only for a file that exists, and writing one stays the agent's.
- Memory-file handlers in `packages/web/mock` — the fixtures carry both states of `memoryPath`, so the item renders and hides in mock mode, but following it lands on a Memory page with no file API behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)