### PR TITLE
refactor(memory): give the relationship-profile location one source of truth

### DIFF
--- a/packages/core/src/api/routes/onboard.ts
+++ b/packages/core/src/api/routes/onboard.ts
@@ -6,7 +6,12 @@ import { v4 as uuidv4 } from "uuid";
 import { guardianAuth, persons, settings } from "../../db/schema.js";
 import { STRANGER_PERSON_ID, STRANGER_PERSON_DISPLAY_NAME } from "../../constants.js";
 import { generatePersonSlug } from "../../db/repositories/person-mapping.js";
-import { ensureProfileMemoryInitialized } from "../../profile-memory.js";
+import {
+  ensureProfileMemoryInitialized,
+  getGuardianProfileFile,
+  getRelationshipDir,
+  GUARDIAN_PROFILE_PATH,
+} from "../../profile-memory.js";
 import { COOKIE_NAME, hashPassword, issueGuardianSession, verifySession } from "../../lib/auth.js";
 import { resolveAndRecordAccount } from "../../lib/guardian-auth-state.js";
 import { resolveBootstrapState } from "../../lib/bootstrap-state.js";
@@ -184,7 +189,7 @@ export function onboardRoutes(deps: ApiDeps): Hono {
         id: guardianPersonId,
         displayName: guardianName,
         bondLevel: "guardian",
-        profilePath: "memory/relationship/GUARDIAN.md",
+        profilePath: GUARDIAN_PROFILE_PATH,
         approved: true,
         createdAt: new Date(),
       })
@@ -192,10 +197,10 @@ export function onboardRoutes(deps: ApiDeps): Hono {
 
     if (profile) {
       const profileMemoryDir = ensureProfileMemoryInitialized();
-      const memoryDir = join(profileMemoryDir, "relationship");
+      const relationshipDir = getRelationshipDir();
 
       try {
-        mkdirSync(memoryDir, { recursive: true });
+        mkdirSync(relationshipDir, { recursive: true });
 
         const guardianLines = ["# Guardian Profile", ""];
         guardianLines.push(`**Name:** ${guardianName}`, "");
@@ -213,7 +218,7 @@ export function onboardRoutes(deps: ApiDeps): Hono {
           guardianLines.push("## Interests", "", profile.interests.join(", "), "");
         }
         if (guardianLines.length > 2) {
-          writeFileSync(join(memoryDir, "GUARDIAN.md"), guardianLines.join("\n"));
+          writeFileSync(getGuardianProfileFile(), guardianLines.join("\n"));
         }
 
         mkdirSync(profileMemoryDir, { recursive: true });

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -10,7 +10,7 @@ import {
 } from "@opentelemetry/api";
 import { createLogger } from "../../logger.js";
 import { logInboundChannelMessage } from "../../telemetry.js";
-import { resolveProfileMemoryPath } from "../../profile-memory.js";
+import { getGuardianProfileFile } from "../../profile-memory.js";
 import { toWebchatSessionResponse, type TraceableAgentMessage } from "../helpers.js";
 import { AgentTraceRecorder } from "../../core/agent-trace-recorder.js";
 import {
@@ -1545,7 +1545,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
    */
   const readGuardianProfile = (): string | null => {
     try {
-      const path = resolveProfileMemoryPath("memory/relationship/GUARDIAN.md");
+      const path = getGuardianProfileFile();
       if (!existsSync(path)) return null;
       const content = readFileSync(path, "utf-8").trim();
       return content || null;

--- a/packages/core/src/people/merge.ts
+++ b/packages/core/src/people/merge.ts
@@ -7,10 +7,10 @@
 // without another writer landing in between; this turns the reason it gives
 // back into the sentence a caller reads.
 //
-// What a merge does NOT touch: the merged-away person's profile file
-// (`memory/relationship/<id>.md`) and anything else written in memory. A
-// filesystem write cannot join the transaction the links move in, so folding
-// the prose in here would reintroduce the half-done state merge exists to rule
+// What a merge does NOT touch: the merged-away person's profile file in the
+// relationship directory, and anything else written in memory. A filesystem
+// write cannot join the transaction the links move in, so folding the prose in
+// here would reintroduce the half-done state merge exists to rule
 // out — and concatenating two hand-written profiles states both sides of every
 // disagreement as fact. The file stays where it is, unreferenced and readable,
 // for the guardian or the agent to fold in as prose.

--- a/packages/core/src/people/resource.ts
+++ b/packages/core/src/people/resource.ts
@@ -12,7 +12,7 @@
 import { readdir } from "node:fs/promises";
 import type { AccountSendState, PersonResource, TimelineEntry } from "@rome/api-types/people";
 import { STRANGER_PERSON_ID } from "../constants.js";
-import { resolveProfileMemoryPath } from "../profile-memory.js";
+import { getRelationshipDir, personProfileFileName, RELATIONSHIP_DIR } from "../profile-memory.js";
 import type { AccountNames } from "../channels/account-names.js";
 import type { Channels } from "../channels/channel.js";
 import type { MessageAccount } from "../channels/messages.js";
@@ -109,10 +109,6 @@ async function serialize(
   }));
 }
 
-/** Where every memory profile lives, as the memory file browser addresses it.
- *  `memory/relationship/BONDS.md` states the rule. */
-const RELATIONSHIP_DIR = "memory/relationship";
-
 /**
  * The profile written about each of these people, in the order given — the path
  * where one exists, null where none does.
@@ -133,15 +129,13 @@ const RELATIONSHIP_DIR = "memory/relationship";
  * a file nobody wrote is a link to nothing.
  */
 async function memoryProfilePaths(persons: readonly PersonRow[]): Promise<(string | null)[]> {
-  const written = new Set(
-    await readdir(resolveProfileMemoryPath(RELATIONSHIP_DIR)).catch(() => []),
-  );
+  const written = new Set(await readdir(getRelationshipDir()).catch(() => []));
 
   return persons.map((person) => {
     const stored = person.profilePath?.startsWith(`${RELATIONSHIP_DIR}/`)
       ? person.profilePath.slice(RELATIONSHIP_DIR.length + 1)
       : null;
-    const fileName = stored ?? `${person.id}.md`;
+    const fileName = stored ?? personProfileFileName(person.id);
     return written.has(fileName) ? `${RELATIONSHIP_DIR}/${fileName}` : null;
   });
 }

--- a/packages/core/src/profile-memory.test.ts
+++ b/packages/core/src/profile-memory.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it, rs, beforeEach } from "@rstest/core";
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 rs.mock("./paths.js", () => ({
@@ -12,7 +19,11 @@ rs.mock("./paths.js", () => ({
 }));
 
 import { getProfileDir, getProfileMemoryDir, getProjectRoot, getCoreRoot } from "./paths.js";
-import { ensureProfileMemoryInitialized, resolveProfileMemoryPath } from "./profile-memory.js";
+import {
+  ensureProfileMemoryInitialized,
+  RELATIONSHIP_DIR,
+  resolveProfileMemoryPath,
+} from "./profile-memory.js";
 
 const mockedGetProfileDir = rs.mocked(getProfileDir);
 const mockedGetProfileMemoryDir = rs.mocked(getProfileMemoryDir);
@@ -150,5 +161,36 @@ describe("profile-memory", () => {
       join(profileDir, "memory", "IDENTITY.md"),
     );
     expect(resolveProfileMemoryPath("CHARTER.md")).toBe(join(projectRoot, "CHARTER.md"));
+  });
+});
+
+// The package's own source, walked to see who else names the relationship dir.
+const SRC_DIR = resolve(fileURLToPath(import.meta.url), "..");
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    if (!entry.name.endsWith(".ts") || entry.name.endsWith(".test.ts")) return [];
+    return [path];
+  });
+}
+
+describe("where relationship profiles live", () => {
+  // Onboarding writes the guardian's profile there, the people read answers
+  // where a person's is, and webchat reads the guardian's back — each one an
+  // address that has to agree with the others. A second copy of the string is
+  // not caught by anything: it keeps working once the folder moves, and answers
+  // about a file nobody writes any more. So the string lives in this module,
+  // and every reader and writer in the package imports it.
+  //
+  // Tests are excluded: one asserting the convention has to spell it out, or it
+  // asserts the constant against itself.
+  it("is stated in this module and nowhere else in the package", () => {
+    const statedIn = sourceFiles(SRC_DIR)
+      .filter((file) => readFileSync(file, "utf-8").includes(RELATIONSHIP_DIR))
+      .map((file) => relative(SRC_DIR, file));
+
+    expect(statedIn).toEqual(["profile-memory.ts"]);
   });
 });

--- a/packages/core/src/profile-memory.ts
+++ b/packages/core/src/profile-memory.ts
@@ -129,3 +129,38 @@ export function resolveProfileMemoryPath(filePath: string): string {
 
   return resolve(getProjectRoot(), filePath);
 }
+
+/**
+ * Where every memory profile lives, as the memory file browser addresses it:
+ * one folder under the memory root holding one file per person. The template's
+ * `relationship/BONDS.md` states the same convention to the agent that writes
+ * the profiles.
+ *
+ * Read it from here rather than spelling it again — a second literal keeps
+ * working after this folder moves, and answers about a file nobody writes any
+ * more.
+ */
+export const RELATIONSHIP_DIR = "memory/relationship";
+
+/**
+ * The guardian's profile, which is named for the role rather than for their
+ * person id: onboarding writes it before there is anything to key it by, and
+ * every surface that reads the guardian reads this one name. It is what
+ * `persons.profile_path` holds for the guardian row.
+ */
+export const GUARDIAN_PROFILE_PATH = `${RELATIONSHIP_DIR}/GUARDIAN.md`;
+
+/** How everyone else's profile is named: by the id of the person it is about. */
+export function personProfileFileName(personId: string): string {
+  return `${personId}.md`;
+}
+
+/** The relationship directory on disk, for reading or writing the files in it. */
+export function getRelationshipDir(): string {
+  return resolveProfileMemoryPath(RELATIONSHIP_DIR);
+}
+
+/** The guardian's profile on disk. */
+export function getGuardianProfileFile(): string {
+  return resolveProfileMemoryPath(GUARDIAN_PROFILE_PATH);
+}

--- a/packages/core/src/test/seeds.ts
+++ b/packages/core/src/test/seeds.ts
@@ -7,6 +7,7 @@ import { SettingsRepository } from "../db/repositories/settings.js";
 import { WebhookInvocationsRepository } from "../db/repositories/webhook-invocations.js";
 import { ActionExecutionsRepository } from "../db/repositories/action-executions.js";
 import { STRANGER_PERSON_ID } from "../constants.js";
+import { GUARDIAN_PROFILE_PATH } from "../profile-memory.js";
 
 /**
  * Unified, deterministic baseline seed.
@@ -88,7 +89,7 @@ async function seedPersonsBaseline(db: DrizzleDb) {
   await repo.createWithId(guardianId, {
     displayName: "Guardian",
     bondLevel: "guardian",
-    profilePath: "memory/relationship/GUARDIAN.md",
+    profilePath: GUARDIAN_PROFILE_PATH,
     approved: true,
   });
   await repo.addChannelMapping(guardianId, "telegram", "tg-guardian", "Guardian");


### PR DESCRIPTION
## What this PR does

Rome keeps a memory profile about each person it knows. They all live in one folder under the memory root, in a file named for the person — except the guardian's, which has a name of its own. Four places inside `@rome/core` stated that address as their own string: onboarding when it writes the guardian's profile and records where it put it, the people read when it answers where a person's profile is, webchat when it reads the guardian's back, and the baseline seed. Nothing connected them, so moving the folder meant finding all four and fixing them together — and a missed one keeps working while answering about a file nobody writes any more.

The address now lives in `packages/core/src/profile-memory.ts`, which already owns memory-tree layout (`resolveProfileMemoryPath`, the template dir, the git repo at the memory root): the directory, the guardian's file, and how everyone else's is named. Every reader and writer in the package imports it.

## Design & Invariants

The module answers the question two ways, because callers ask it two ways. `RELATIONSHIP_DIR` and `GUARDIAN_PROFILE_PATH` are memory-relative — the form `persons.profile_path` stores and the memory file browser addresses. `getRelationshipDir()` and `getGuardianProfileFile()` are the same two resolved on disk, for the code that reads and writes the files. This matches how `paths.ts` already splits the two, so no caller has to remember which side of `resolveProfileMemoryPath` it is on.

A shared constant only holds if nothing quietly re-states the string. `profile-memory.test.ts` scans the package's own source and asserts the literal appears in exactly one module. Test files are excluded: a test asserting the convention has to spell it out, or it asserts the constant against itself.

Onboarding also stopped reaching the folder a second way — `join(profileMemoryDir, \"relationship\")` — so there is one path into it rather than two that happen to agree.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — passes unchanged, including `people/resource.test.ts` (reads a profile through the stored path and through the convention) and the routes' own coverage
- [x] The guard fails when a second file reintroduces the literal: added `// memory/relationship` to `constants.ts`, ran the file, got `expected [ 'constants.ts', 'profile-memory.ts' ] to deeply equal [ 'profile-memory.ts' ]`, reverted
- [x] `pnpm dev:all`, rome container reached `Rome started`, onboarded a fresh guardian through `/api/onboard/create-account` → `/setup` → `/complete`; `GET /api/people` answered `memoryPath: memory/relationship/GUARDIAN.md`, and `GET /api/memory/resolve` resolved that path to the file onboarding had just written

## Not in this PR

- `rome_apps/inbox`, which reads the guardian's profile with its own literal. An app consumes `@rome-os/app-runtime`, not `@rome/core`, so a core constant does not reach it; whether the runtime SDK should carry this address is a separate question.
- `packages/core/memory.example/relationship/BONDS.md`, which documents the convention to the agent. It ships to profiles rather than being read by code.
- The convention itself. Every path this answers is the path it answered before.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)