### PR TITLE
feat(people): show a row's triage buttons on hover

### DIFF
--- a/packages/web/src/pages/people/rows.tsx
+++ b/packages/web/src/pages/people/rows.tsx
@@ -78,7 +78,10 @@ export function StreamRow({ row, onOpen }: { row: PeopleRow; onOpen?: () => void
  *
  * `actions` is whatever gesture the page offers for the position it is in:
  * placing it, or taking a dismissal back. The gestures themselves are
- * `people/triage.tsx`; the row only says where they go.
+ * `people/triage.tsx`; the row only says where they go. They show on the row
+ * under the pointer, or holding focus, so a screen of rows reads as evidence
+ * rather than as a wall of buttons. Hover is not a thing on touch screens, so
+ * there they stay put.
  */
 export function UnknownRow({ row, actions }: { row: PeopleRow; actions?: React.ReactNode }) {
   const { t } = useTranslation("people");
@@ -88,7 +91,7 @@ export function UnknownRow({ row, actions }: { row: PeopleRow; actions?: React.R
     <div
       className={cn(
         ROW_BASE,
-        "grid-cols-[2rem_minmax(0,1fr)_auto] sm:grid-cols-[2rem_minmax(10rem,1.1fr)_minmax(0,1.6fr)_auto]",
+        "group grid-cols-[2rem_minmax(0,1fr)_auto] hover:bg-surface sm:grid-cols-[2rem_minmax(10rem,1.1fr)_minmax(0,1.6fr)_auto]",
       )}
     >
       <Avatar name={row.displayName} />
@@ -114,7 +117,11 @@ export function UnknownRow({ row, actions }: { row: PeopleRow; actions?: React.R
         <span className="font-mono text-badge tabular-nums text-subtle-foreground">
           {timeAgo(t, row.latest?.timestamp ?? null)}
         </span>
-        {actions}
+        {actions && (
+          <span className="touch-show flex items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:transition-none">
+            {actions}
+          </span>
+        )}
       </span>
     </div>
   );


### PR DESCRIPTION
## What this PR does

Every row in the Latest view's Unknown and Stranger groups carries its buttons all the time: Create, Link and Treat as stranger on each unplaced sender, Restore on each dismissed one. Eight rows put twenty-four buttons on one screen, and the buttons out-shout the evidence the row is there to show.

This PR shows a row's buttons only while the pointer is on the row or a button on it holds focus. The row also gets a hover background so the reveal has a visible cue. The Directory view is untouched, since its rows already fold the gestures into one row menu.

## Design & Invariants

- The buttons stay in the DOM and hide by opacity, so keyboard users reach them by tabbing, and screen readers see the row unchanged.
- Touch devices have no hover, so there the buttons stay visible through the existing `touch-show` utility.
- The row decides where its actions go and when they show; `people/triage.tsx` still owns the gestures themselves.

## Test plan

- [x] `pnpm --filter rome-web typecheck`
- [x] `pnpm --filter rome-web test src/pages/PeoplePage.test.tsx` — 39 pass
- [x] Mock app under headless Chromium: the action wrapper measures opacity 0 at rest and 1 on hover for Unknown rows and the Stranger row's Restore button; tabbing onto a Create button reveals it
- [x] Screenshots: the rest state shows only evidence per row, and hover shows the three buttons on the hovered row alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)