### PR TITLE
test(web): serve the memory dir in mock mode

### DIFF
--- a/docs/dashboard-mock-mode.md
+++ b/docs/dashboard-mock-mode.md
@@ -2,7 +2,7 @@
 
 `pnpm --filter rome-web dev:mock` (from the root, `pnpm start:web:mock`) serves the full dashboard SPA with no backend at http://localhost:3200. An MSW service worker answers `/api` calls from fixtures in `packages/web/mock/handlers/`.
 
-`index.ts` holds the shell probes (`/api/health`, `/api/bootstrap`), chat, the projects file browser, and the connection routes. It composes the per-surface modules beside it: `apps.ts`, `activity.ts`, `people.ts`, `routines.ts`, `settings.ts`. The connection ledger itself lives in `connections-store.ts`, because the People page's send routes have to see a grant the Connections page revoked. Unhandled requests pass through the normal dev proxy. With a real backend running on `INTERNAL_API_PORT`, mock mode therefore doubles as an "override one endpoint" tool.
+`index.ts` holds the shell probes (`/api/health`, `/api/bootstrap`), chat, and the connection routes. It composes the per-surface modules beside it: `apps.ts`, `activity.ts`, `people.ts`, `routines.ts`, `settings.ts`. The two file browsers go through `file-browser.ts`, an in-memory filesystem the projects tree and the memory dir (`memory-files.ts`) are each served from — `/api/projects` and `/api/memory` are the same routes over a different root, so one factory answers both. The connection ledger itself lives in `connections-store.ts`, because the People page's send routes have to see a grant the Connections page revoked. Unhandled requests pass through the normal dev proxy. With a real backend running on `INTERNAL_API_PORT`, mock mode therefore doubles as an "override one endpoint" tool.
 
 Mock mode is a separate entry (`mock/rsbuild.config.ts` plus `mock/main.tsx`) rather than a dev branch in the SPA. `pnpm build` only reads the root config, so MSW and the fixtures never reach a production bundle.
 
@@ -52,6 +52,8 @@ Sending is out of scope. There is no model behind it, so `POST /turns` is unhand
 Interactive login flows (Claude and Codex device and browser round-trips) are deliberately unhandled. There is no fixture equivalent of a third-party redirect, so their modals surface their own failure.
 
 Embedded `rome_apps` surfaces need the real backend, since `/app-assets` is module federation. Exercise those in `dev:all` rather than here.
+
+The mock filesystem is text. Its tree has no bytes behind it, so upload refuses and the asset and download routes are unhandled — a file browser in mock mode reads, edits, creates, renames, moves and deletes, and moves no binaries.
 
 Fixtures are typed against the same types the fetch sites parse into, either `@rome/api-types` or the web-local type. An API contract change is therefore likely to break `pnpm typecheck` in `mock/handlers/` instead of drifting silently. The caveat is that an empty collection fixture only pins the container shape, not its element type.
 

--- a/packages/web/mock/handlers/file-browser.ts
+++ b/packages/web/mock/handlers/file-browser.ts
@@ -1,0 +1,245 @@
+import { http, HttpResponse, type HttpHandler } from "msw";
+import type {
+  BrowserFile,
+  HistoryEntry,
+  ResolveResult,
+  SearchResult,
+} from "@/components/file-browser/store/types";
+import type { FileBrowserTreeNode } from "@/lib/file-browser-tree";
+
+/**
+ * The in-memory filesystem behind a file-browser surface — `/api/projects` and
+ * `/api/memory` are the same routes over two different roots, so both are
+ * served from one factory here.
+ *
+ * The store is mutable, the way the rest of mock mode's writes are: saving a
+ * file, creating one, renaming, moving and deleting all change what the next
+ * read returns. Editing a memory profile and navigating away therefore keeps
+ * the edit, which is what makes the autosave path on `MemoryPage` reachable.
+ *
+ * Everything in it is text. A fixture tree has no bytes behind it, so the
+ * asset, download and upload routes — the three that only exist to move real
+ * bytes — are out of scope, and upload answers with that rather than
+ * pretending.
+ */
+export interface MockFsNode {
+  children?: MockFsNode[];
+  /** File bodies only; a directory ignores it. */
+  content?: string;
+  name: string;
+  path: string;
+  type: "file" | "directory";
+}
+
+/** Convenience constructors, so a fixture tree reads as a directory listing
+ *  instead of a wall of repeated `path`/`type` keys. */
+export function dir(path: string, children: MockFsNode[]): MockFsNode {
+  return { children, name: baseName(path), path, type: "directory" };
+}
+
+export function file(path: string, content: string): MockFsNode {
+  return { content, name: baseName(path), path, type: "file" };
+}
+
+function baseName(path: string): string {
+  return path.split("/").pop() ?? path;
+}
+
+function parentPathOf(path: string): string {
+  return path.slice(0, path.lastIndexOf("/"));
+}
+
+function findNode(nodes: MockFsNode[], path: string): MockFsNode | undefined {
+  for (const node of nodes) {
+    if (node.path === path) return node;
+    const match = node.children ? findNode(node.children, path) : undefined;
+    if (match) return match;
+  }
+  return undefined;
+}
+
+function collectFiles(nodes: MockFsNode[]): MockFsNode[] {
+  return nodes.flatMap((node) =>
+    node.type === "file" ? [node] : collectFiles(node.children ?? []),
+  );
+}
+
+/**
+ * The fixture nests every level inline, but the real /tree honors `depth` —
+ * the store loads the root at depth 2 and each expanded folder at depth 1, so
+ * serving the full subtree would make lazy-per-level loading untestable here.
+ * A directory at the depth limit comes back with no `children` key at all,
+ * which is what the store reads as "not loaded yet".
+ */
+function toTreeNodes(nodes: MockFsNode[], depth: number): FileBrowserTreeNode[] {
+  return nodes.map(({ name, path, type, children }) => {
+    if (type !== "directory") return { name, path, type };
+    if (depth <= 1) return { name, path, type };
+    return { name, path, type, children: toTreeNodes(children ?? [], depth - 1) };
+  });
+}
+
+function browserFile(node: MockFsNode): BrowserFile {
+  const content = node.content ?? "";
+  return {
+    assetUrl: null,
+    content,
+    editable: true,
+    kind: "text",
+    mimeType: node.path.endsWith(".md") ? "text/markdown" : "text/plain",
+    path: node.path,
+    size: new TextEncoder().encode(content).length,
+  };
+}
+
+export interface FileBrowserFixtureOptions {
+  /** e.g. "/api/memory" — the routes the surface's store fetches. */
+  apiBasePath: string;
+  /** e.g. "memory" — the path prefix every node in `tree` carries. */
+  logicalRoot: string;
+  tree: MockFsNode[];
+}
+
+export function fileBrowserHandlers({
+  apiBasePath,
+  logicalRoot,
+  tree,
+}: FileBrowserFixtureOptions): HttpHandler[] {
+  /** The list a path's node lives in, or would live in once created. */
+  const siblingsOf = (path: string): MockFsNode[] | null => {
+    const parentPath = parentPathOf(path);
+    if (!parentPath || parentPath === logicalRoot) return tree;
+    const parent = findNode(tree, parentPath);
+    if (!parent || parent.type !== "directory") return null;
+    parent.children ??= [];
+    return parent.children;
+  };
+
+  /** Re-path a moved or renamed node's whole subtree. */
+  const repath = (node: MockFsNode, nextPath: string): void => {
+    node.path = nextPath;
+    node.name = baseName(nextPath);
+    for (const child of node.children ?? []) {
+      repath(child, `${nextPath}/${child.name}`);
+    }
+  };
+
+  const detach = (path: string): MockFsNode | null => {
+    const siblings = siblingsOf(path);
+    const index = siblings?.findIndex((node) => node.path === path) ?? -1;
+    if (!siblings || index < 0) return null;
+    return siblings.splice(index, 1)[0] ?? null;
+  };
+
+  const notFound = () => HttpResponse.json({ error: "not found" }, { status: 404 });
+
+  return [
+    http.get(`${apiBasePath}/tree`, ({ request }) => {
+      const params = new URL(request.url).searchParams;
+      const path = params.get("path");
+      const requestedDepth = Number(params.get("depth"));
+      const depth = Number.isFinite(requestedDepth) && requestedDepth > 0 ? requestedDepth : 1;
+      const nodes = !path || path === logicalRoot ? tree : (findNode(tree, path)?.children ?? []);
+      return HttpResponse.json(toTreeNodes(nodes, depth));
+    }),
+    // useUrlSelectionSync resolves the URL's path on load, so without this a
+    // deep link to a file 404s before anything renders. It is also how the
+    // dossier's "Memory profile" link opens a person's profile.
+    http.get(`${apiBasePath}/resolve`, ({ request }) => {
+      const path = new URL(request.url).searchParams.get("path") ?? "";
+      const node = findNode(tree, path);
+      if (path === logicalRoot) {
+        return HttpResponse.json({ type: "directory", path } satisfies ResolveResult);
+      }
+      if (!node) return HttpResponse.json({ type: "missing", path } satisfies ResolveResult);
+      if (node.type === "directory") {
+        return HttpResponse.json({ type: "directory", path: node.path } satisfies ResolveResult);
+      }
+      const { assetUrl, editable, kind, mimeType, size } = browserFile(node);
+      return HttpResponse.json({
+        type: "file",
+        path: node.path,
+        assetUrl,
+        editable,
+        kind,
+        mimeType,
+        size,
+      } satisfies ResolveResult);
+    }),
+    http.get(`${apiBasePath}/file`, ({ request }) => {
+      const path = new URL(request.url).searchParams.get("path") ?? "";
+      const node = findNode(tree, path);
+      if (!node || node.type !== "file") return notFound();
+      return HttpResponse.json(browserFile(node));
+    }),
+    // The save the editor autosaves through. Keeping the write means a reopened
+    // file shows what was typed into it rather than the fixture body.
+    http.put(`${apiBasePath}/file`, async ({ request }) => {
+      const body = (await request.json()) as { content: string; path: string };
+      const node = findNode(tree, body.path);
+      if (!node || node.type !== "file") return notFound();
+      node.content = body.content;
+      return HttpResponse.json({ message: "Saved" });
+    }),
+    http.post(`${apiBasePath}/file`, async ({ request }) => {
+      // Drag-and-drop upload posts multipart instead of JSON. There are no
+      // bytes behind this tree, so it refuses rather than inventing a file.
+      if (!request.headers.get("content-type")?.includes("application/json")) {
+        return HttpResponse.json({ error: "Upload isn't mocked." }, { status: 501 });
+      }
+      const body = (await request.json()) as { path: string; type: "file" | "folder" };
+      const siblings = siblingsOf(body.path);
+      if (!siblings) return notFound();
+      if (findNode(tree, body.path)) {
+        return HttpResponse.json({ error: "Already exists." }, { status: 409 });
+      }
+      siblings.push(body.type === "folder" ? dir(body.path, []) : file(body.path, ""));
+      return HttpResponse.json({ path: body.path });
+    }),
+    // One route, two writes: `name` renames in place, `parentPath` moves.
+    http.patch(`${apiBasePath}/file`, async ({ request }) => {
+      const body = (await request.json()) as {
+        name?: string;
+        parentPath?: string;
+        path: string;
+      };
+      const source = findNode(tree, body.path);
+      if (!source) return notFound();
+      const targetParent = body.name ? parentPathOf(body.path) : (body.parentPath ?? logicalRoot);
+      const nextPath = `${targetParent}/${body.name ?? source.name}`;
+      if (nextPath === body.path) return HttpResponse.json({ path: body.path });
+      if (findNode(tree, nextPath)) {
+        return HttpResponse.json({ error: "Already exists." }, { status: 409 });
+      }
+      const siblings = siblingsOf(nextPath);
+      if (!siblings) return notFound();
+      const node = detach(body.path);
+      if (!node) return notFound();
+      repath(node, nextPath);
+      siblings.push(node);
+      return HttpResponse.json({ path: nextPath });
+    }),
+    http.delete(`${apiBasePath}/file`, ({ request }) => {
+      const path = new URL(request.url).searchParams.get("path") ?? "";
+      return detach(path) ? HttpResponse.json({ message: "Deleted" }) : notFound();
+    }),
+    http.get(`${apiBasePath}/search`, ({ request }) => {
+      const query = new URL(request.url).searchParams.get("q")?.toLowerCase() ?? "";
+      if (!query) return HttpResponse.json([] as SearchResult[]);
+      const results = collectFiles(tree).flatMap((node) => {
+        const lines = (node.content ?? "").split("\n");
+        const index = lines.findIndex((line) => line.toLowerCase().includes(query));
+        if (index < 0 && !node.path.toLowerCase().includes(query)) return [];
+        return [{ content: lines[Math.max(index, 0)] ?? "", file: node.path, line: index + 1 }];
+      });
+      return HttpResponse.json(results);
+    }),
+    // The fixture tree has no git behind it, so history is legitimately empty.
+    http.get(`${apiBasePath}/history`, () => HttpResponse.json([] as HistoryEntry[])),
+    // Keep the file-browser watch EventSource connected without emitting events.
+    http.get(`${apiBasePath}/events`, () => {
+      const stream = new ReadableStream({ start() {} });
+      return new HttpResponse(stream, { headers: { "Content-Type": "text/event-stream" } });
+    }),
+  ];
+}

--- a/packages/web/mock/handlers/index.ts
+++ b/packages/web/mock/handlers/index.ts
@@ -37,17 +37,12 @@ import type {
   SyncStatus,
 } from "@/lib/sync-api";
 import type { ActionCatalogEntry } from "@/hooks/use-action-catalog";
-import type {
-  BrowserFile,
-  HistoryEntry,
-  ResolveResult,
-  SearchResult,
-} from "@/components/file-browser/store/types";
-import type { FileBrowserTreeNode } from "@/lib/file-browser-tree";
 import { activityHandlers, approvalCardId } from "./activity";
 import { appHandlers } from "./apps";
 import { appKeysHandlers } from "./app-keys";
 import { connections } from "./connections-store";
+import { dir, file, fileBrowserHandlers, type MockFsNode } from "./file-browser";
+import { memoryFileHandlers } from "./memory-files";
 import { channelMirrorHandlers } from "./people";
 import { peopleHandlers } from "./people-api";
 import { routineHandlers } from "./routines";
@@ -903,75 +898,30 @@ const sentinelLog = [
   },
 ];
 
-// Projects file-browser fixture. The tree endpoint returns the children of the
-// requested path (root when no `path` param), so directories carry their
-// children inline and the handler slices into this structure.
-const projectsTree: FileBrowserTreeNode[] = [
-  {
-    name: "demo-app",
-    path: "projects/demo-app",
-    type: "directory",
-    children: [
-      {
-        name: "src",
-        path: "projects/demo-app/src",
-        type: "directory",
-        children: [{ name: "index.ts", path: "projects/demo-app/src/index.ts", type: "file" }],
-      },
-      { name: "README.md", path: "projects/demo-app/README.md", type: "file" },
-      { name: "notes.txt", path: "projects/demo-app/notes.txt", type: "file" },
-    ],
-  },
-  {
-    name: "research",
-    path: "projects/research",
-    type: "directory",
-    children: [{ name: "papers.md", path: "projects/research/papers.md", type: "file" }],
-  },
-  { name: "todo.md", path: "projects/todo.md", type: "file" },
+// Projects file-browser fixture. `./file-browser.ts` serves it — the same
+// factory the memory dir goes through, since both are the same routes over a
+// different root.
+const mockBody = (path: string) =>
+  `# ${path.split("/").pop()}\n\nMock file content for the dashboard mock mode.\n`;
+
+const projectsTree: MockFsNode[] = [
+  dir("projects/demo-app", [
+    dir("projects/demo-app/src", [
+      file("projects/demo-app/src/index.ts", mockBody("projects/demo-app/src/index.ts")),
+    ]),
+    file("projects/demo-app/README.md", mockBody("projects/demo-app/README.md")),
+    file("projects/demo-app/notes.txt", mockBody("projects/demo-app/notes.txt")),
+  ]),
+  dir("projects/research", [
+    file("projects/research/papers.md", mockBody("projects/research/papers.md")),
+  ]),
+  file("projects/todo.md", mockBody("projects/todo.md")),
 ];
 
-function findTreeNode(nodes: FileBrowserTreeNode[], path: string): FileBrowserTreeNode | undefined {
-  for (const node of nodes) {
-    if (node.path === path) return node;
-    const match = node.children ? findTreeNode(node.children, path) : undefined;
-    if (match) return match;
-  }
-  return undefined;
-}
-
-function collectFiles(nodes: FileBrowserTreeNode[]): FileBrowserTreeNode[] {
-  return nodes.flatMap((node) =>
-    node.type === "file" ? [node] : collectFiles(node.children ?? []),
-  );
-}
-
-/**
- * The fixture nests every level inline, but the real /tree honors `depth` —
- * the store loads the root at depth 2 and each expanded folder at depth 1, so
- * serving the full subtree would make lazy-per-level loading untestable here.
- * A directory at the depth limit comes back with no `children` key at all,
- * which is what the store reads as "not loaded yet".
- */
-function trimToDepth(nodes: FileBrowserTreeNode[], depth: number): FileBrowserTreeNode[] {
-  return nodes.map((node) => {
-    if (node.type !== "directory") return node;
-    if (depth <= 1) {
-      const { children: _children, ...withoutChildren } = node;
-      return withoutChildren;
-    }
-    return { ...node, children: trimToDepth(node.children ?? [], depth - 1) };
-  });
-}
-
-const mockFile = (node: FileBrowserTreeNode): BrowserFile => ({
-  assetUrl: null,
-  content: `# ${node.name}\n\nMock file content for the dashboard mock mode.\n`,
-  editable: true,
-  kind: "text",
-  mimeType: "text/plain",
-  path: node.path,
-  size: 64,
+const projectFileHandlers = fileBrowserHandlers({
+  apiBasePath: "/api/projects",
+  logicalRoot: "projects",
+  tree: projectsTree,
 });
 
 /**
@@ -1167,6 +1117,10 @@ export const handlers = [
     const created: ProjectOption = { name: body.name, path: body.name };
     return HttpResponse.json(created);
   }),
+  // The Memory page's folder panel leads with this read, so an unhandled
+  // status leaves the landing view spinning on the dev proxy. Unlinked, which
+  // is the state a fresh instance is in and the one that offers Connect.
+  http.get("/api/sync/status", () => HttpResponse.json({ state: "unlinked" } satisfies SyncStatus)),
   http.get("/api/sync/sources", () => HttpResponse.json({ sources: syncSources })),
   http.get("/api/sync/groups", () => HttpResponse.json({ groups: syncGroups })),
   // The write half of the connect flow: picking an existing repo POSTs
@@ -1221,63 +1175,6 @@ export const handlers = [
     return HttpResponse.json(settings);
   }),
   http.get("/api/system/upgrade/status/snapshot", () => HttpResponse.json(upgradeStatus())),
-  http.get("/api/projects/tree", ({ request }) => {
-    const params = new URL(request.url).searchParams;
-    const path = params.get("path");
-    const requestedDepth = Number(params.get("depth"));
-    const depth = Number.isFinite(requestedDepth) && requestedDepth > 0 ? requestedDepth : 1;
-    const nodes =
-      !path || path === "projects"
-        ? projectsTree
-        : (findTreeNode(projectsTree, path)?.children ?? []);
-    return HttpResponse.json(trimToDepth(nodes, depth));
-  }),
-  http.get("/api/projects/file", ({ request }) => {
-    const path = new URL(request.url).searchParams.get("path") ?? "";
-    const node = findTreeNode(projectsTree, path);
-    if (!node || node.type !== "file") {
-      return HttpResponse.json({ error: "not found" }, { status: 404 });
-    }
-    return HttpResponse.json(mockFile(node));
-  }),
-  // useUrlSelectionSync resolves the URL's path on load, so without this a
-  // deep link to a file 404s before anything renders.
-  http.get("/api/projects/resolve", ({ request }) => {
-    const path = new URL(request.url).searchParams.get("path") ?? "";
-    const node = findTreeNode(projectsTree, path);
-    if (!node) return HttpResponse.json({ type: "missing", path } satisfies ResolveResult);
-    if (node.type === "directory") {
-      return HttpResponse.json({ type: "directory", path: node.path } satisfies ResolveResult);
-    }
-    const { assetUrl, editable, kind, mimeType, size } = mockFile(node);
-    return HttpResponse.json({
-      type: "file",
-      path: node.path,
-      assetUrl,
-      editable,
-      kind,
-      mimeType,
-      size,
-    } satisfies ResolveResult);
-  }),
-  http.get("/api/projects/search", ({ request }) => {
-    const query = new URL(request.url).searchParams.get("q")?.toLowerCase() ?? "";
-    const results: SearchResult[] = query
-      ? collectFiles(projectsTree)
-          .filter((node) => node.path.toLowerCase().includes(query))
-          .map((node) => ({ content: mockFile(node).content ?? "", file: node.path, line: 1 }))
-      : [];
-    return HttpResponse.json(results);
-  }),
-  // The fixture tree has no git behind it, so history is legitimately empty.
-  http.get("/api/projects/history", () => HttpResponse.json([] as HistoryEntry[])),
-  // Keep the file-browser watch EventSource connected without emitting events.
-  http.get("/api/projects/events", () => {
-    const stream = new ReadableStream({ start() {} });
-    return new HttpResponse(stream, {
-      headers: { "Content-Type": "text/event-stream" },
-    });
-  }),
   http.get("/api/agents", () => HttpResponse.json({ agents: [{ name: "build" }] })),
   http.get("/api/connections", () => HttpResponse.json(connections)),
   // An authorized grant is what puts Disconnect on a card, so seeding the three
@@ -1349,4 +1246,8 @@ export const handlers = [
   ...routineHandlers,
   ...settingsHandlers,
   ...appKeysHandlers,
+  // The two file-browser surfaces, each an in-memory filesystem: the projects
+  // dir and the memory dir a person's dossier links into.
+  ...projectFileHandlers,
+  ...memoryFileHandlers,
 ];

--- a/packages/web/mock/handlers/memory-files.ts
+++ b/packages/web/mock/handlers/memory-files.ts
@@ -1,0 +1,187 @@
+import { dir, file, fileBrowserHandlers, type MockFsNode } from "./file-browser";
+
+/**
+ * The memory dir the Memory page browses — the fixture counterpart of the tree
+ * core seeds from `packages/core/memory.example`, filled in as if Rome had been
+ * running for a while against the People fixtures.
+ *
+ * The relationship profiles are the reason this exists: a person's dossier
+ * links to `memory/relationship/<person-id>.md`, and that link led nowhere in
+ * mock mode until this tree served it. `memoryProfilePath` below is what keeps
+ * the two surfaces from disagreeing about who has a profile.
+ */
+
+/**
+ * Today's journal entry, dated off the browser's clock like the People
+ * fixtures' relative timestamps — a literal date would read as months stale
+ * within a release.
+ */
+const now = new Date();
+const year = String(now.getFullYear());
+const month = String(now.getMonth() + 1).padStart(2, "0");
+const day = String(now.getDate()).padStart(2, "0");
+
+const journalEntry = file(
+  `memory/journal/${year}/${month}/${day}.md`,
+  `# ${year}-${month}-${day}\n\n` +
+    "- Ray asked about the Saturday hike again. Held off on committing — the weather call is Friday.\n" +
+    "- Mira sent the clinic's intake form. Filed under topics/health.md.\n" +
+    "- Nadia changed numbers. Nothing written down until the guardian confirms it.\n",
+);
+
+export const memoryTree: MockFsNode[] = [
+  dir("memory/journal", [
+    dir(`memory/journal/${year}`, [dir(`memory/journal/${year}/${month}`, [journalEntry])]),
+  ]),
+  dir("memory/projects", [
+    dir("memory/projects/default", [
+      file(
+        "memory/projects/default/PROJECT.md",
+        "# Default\n\n" +
+          "The catch-all project. Anything without a home lands here until it earns one.\n\n" +
+          "## Status\n\nNothing in flight.\n",
+      ),
+    ]),
+  ]),
+  dir("memory/relationship", [
+    file(
+      "memory/relationship/BONDS.md",
+      "# Relationship Bonds\n\n" +
+        "Tier definitions live in the seeded template; this copy carries the roster.\n\n" +
+        "## Inner Circle\n\n" +
+        "- [ray-oster](ray-oster.md) — climbing partner, ten years\n" +
+        "- [nadia-petrova](nadia-petrova.md) — sister-in-law\n\n" +
+        "## Acquaintance\n\n" +
+        "- [mira-chen](mira-chen.md) — neighbour, runs the building's group chat\n\n" +
+        "## Other\n\n" +
+        "<!-- Nobody yet. -->\n",
+    ),
+    file(
+      "memory/relationship/GUARDIAN.md",
+      "# Guardian Profile\n\n" +
+        "**Name:** Mock Guardian\n\n" +
+        "**Timezone:** America/Los_Angeles\n\n" +
+        "## Communication Preferences\n\n" +
+        "- Short replies. Five lines is the ceiling for a summary.\n" +
+        "- No messages before 09:00 local unless something is on fire.\n\n" +
+        "## Important Dates\n\n" +
+        "- Birthday: March 4\n",
+    ),
+    file(
+      "memory/relationship/mira-chen.md",
+      "# Mira Chen\n\n" +
+        "## Overview\n\n" +
+        "| Field           | Value                                  |\n" +
+        "|-----------------|----------------------------------------|\n" +
+        "| **Name**        | Mira Chen                              |\n" +
+        "| **Known Since** | 2025-11                                |\n" +
+        "| **Bond Level**  | Acquaintance                           |\n" +
+        "| **Relation**    | Neighbour, two floors up               |\n\n" +
+        "## Channel Mappings\n\n" +
+        "| Channel  | ID / Handle    |\n" +
+        "|----------|----------------|\n" +
+        "| WhatsApp | +1 415 555 0188 |\n\n" +
+        "## Notes\n\n" +
+        "Runs the building's group chat. Messages in bursts and expects a same-day reply.\n\n" +
+        "## Interaction History\n\n" +
+        "- Sent the clinic intake form, unprompted.\n" +
+        "- Asked twice about the package left in the lobby.\n",
+    ),
+    file(
+      "memory/relationship/nadia-petrova.md",
+      "# Nadia Petrova\n\n" +
+        "## Overview\n\n" +
+        "| Field           | Value                        |\n" +
+        "|-----------------|------------------------------|\n" +
+        "| **Name**        | Nadia Petrova                |\n" +
+        "| **Known Since** | 2019                         |\n" +
+        "| **Bond Level**  | Inner Circle                 |\n" +
+        "| **Relation**    | Sister-in-law                |\n\n" +
+        "## Channel Mappings\n\n" +
+        "None. Everything with Nadia happens off Rome, so nothing here is\n" +
+        "reachable — the profile is the only record.\n\n" +
+        "## Important Dates\n\n" +
+        "- Birthday: September 21\n\n" +
+        "## Notes\n\n" +
+        "Changed numbers recently. Ask the guardian before writing the new one down.\n",
+    ),
+    file(
+      "memory/relationship/ray-oster.md",
+      "# Ray Oster\n\n" +
+        "## Overview\n\n" +
+        "| Field           | Value                          |\n" +
+        "|-----------------|--------------------------------|\n" +
+        "| **Name**        | Ray Oster                      |\n" +
+        "| **Known Since** | 2016                           |\n" +
+        "| **Bond Level**  | Inner Circle                   |\n" +
+        "| **Relation**    | Climbing partner, ten years    |\n\n" +
+        "## Channel Mappings\n\n" +
+        "| Channel  | ID / Handle     |\n" +
+        "|----------|-----------------|\n" +
+        "| Telegram | 418820113       |\n" +
+        "| WhatsApp | +1 415 555 0142 |\n\n" +
+        "## Preferences\n\n" +
+        "- Goes by Ray, never Raymond.\n" +
+        "- Plans by voice note; a written plan gets read late.\n\n" +
+        "## Important Dates\n\n" +
+        "- Birthday: June 12\n\n" +
+        "## Notes\n\n" +
+        "Proposes a Saturday hike most weeks and cancels about half of them.\n" +
+        "Weather is the deciding factor, and the call comes Friday evening.\n\n" +
+        "## Interaction History\n\n" +
+        "- Asked about the Saturday hike, again.\n" +
+        "- Sent photos from the Tahoe trip.\n",
+    ),
+  ]),
+  dir("memory/topics", [
+    file(
+      "memory/topics/health.md",
+      "# Health\n\n" +
+        "## Providers\n\n" +
+        "- Primary care: Bay Ridge Clinic. Intake form on file since this week.\n\n" +
+        "## Notes\n\n" +
+        "Nothing ongoing. This file exists so the routing rule in MEMORY.md has\n" +
+        "somewhere real to point.\n",
+    ),
+  ]),
+  file(
+    "memory/IDENTITY.md",
+    "# Identity\n\n**Agent Name:** Rome\n\n" +
+      "Answers to Rome. Writes the way the guardian asked for: short, plain, no\n" +
+      "throat-clearing.\n",
+  ),
+  file(
+    "memory/MEMORY.md",
+    "# Memory\n\n" +
+      "The always-on index. Frequently-used facts live here inline; everything\n" +
+      "else is a one-line pointer to the file that owns it.\n\n" +
+      "## Topics\n\n" +
+      "- [Health](topics/health.md) — providers, intake paperwork\n\n" +
+      "## Key Facts\n\n" +
+      "- Lives in San Francisco, works from home Tuesdays and Thursdays.\n" +
+      "- Climbs with [Ray](relationship/ray-oster.md) most Saturdays.\n\n" +
+      "## Preferences\n\n" +
+      "- Concise replies. Summaries stay under five lines.\n" +
+      "- Nothing before 09:00 local.\n\n" +
+      "## Top of Mind\n\n" +
+      "- Whether Saturday's hike is on. The call comes Friday evening.\n",
+  ),
+];
+
+/**
+ * Where a person's profile lives, or null when nothing has been written about
+ * them — the fixture stand-in for the relationship-dir read core answers
+ * `memoryPath` from. Reading it off the tree is what keeps the dossier's
+ * "Memory profile" link from pointing at a file the browser cannot open.
+ */
+export function memoryProfilePath(personId: string): string | null {
+  const path = `memory/relationship/${personId}.md`;
+  const relationships = memoryTree.find((node) => node.path === "memory/relationship");
+  return relationships?.children?.some((node) => node.path === path) ? path : null;
+}
+
+export const memoryFileHandlers = fileBrowserHandlers({
+  apiBasePath: "/api/memory",
+  logicalRoot: "memory",
+  tree: memoryTree,
+});

--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -37,6 +37,7 @@ import {
   type TimelinePage,
 } from "@rome/api-types/people";
 import { talkConnections } from "./connections-store";
+import { memoryProfilePath } from "./memory-files";
 import {
   accountTimeline,
   nameForAccount,
@@ -88,15 +89,6 @@ function sendState(channel: string): AccountSendState {
 
 type PersonFixture = (typeof persons)[number];
 
-/**
- * Who a memory profile has been written about — this store's stand-in for the
- * relationship directory core reads to answer `memoryPath`.
- *
- * Not everyone, because nothing writes a profile when a person is created: both
- * states the dossier's menu has to handle are on the fixtures.
- */
-const MEMORY_PROFILES = new Set(["ray-oster", "mira-chen", "nadia-petrova"]);
-
 function personResource(person: PersonFixture): PersonResource {
   const entries = personTimeline(person.id) ?? [];
   return {
@@ -117,7 +109,11 @@ function personResource(person: PersonFixture): PersonResource {
     // history GET /api/people/:id/messages pages.
     messageCount: entries.length,
     latest: latestDynamic(entries),
-    memoryPath: MEMORY_PROFILES.has(person.id) ? `memory/relationship/${person.id}.md` : null,
+    // Read off the memory tree (./memory-files.ts) rather than a list here, so
+    // the dossier only offers the link for a profile the Memory page can open.
+    // Not everyone has one, because nothing writes a profile when a person is
+    // created: both states the dossier's menu handles are on the fixtures.
+    memoryPath: memoryProfilePath(person.id),
   };
 }
 


### PR DESCRIPTION
## What this PR does

The Memory page had nothing behind it in mock mode. `/api/memory` was unhandled, so the file browser fell through to the dev proxy and rendered empty, and the "Memory profile" link a person's dossier gained in #226 led nowhere — the one surface that link exists to open was the one surface a developer without a backend could not see.

`/api/memory` and `/api/projects` are the same file-browser routes over a different root, so both now go through one in-memory filesystem in `mock/handlers/file-browser.ts`. The memory dir's fixture (`mock/handlers/memory-files.ts`) is shaped like the tree core seeds from `packages/core/memory.example`, filled in as if Rome had been running against the People fixtures: `MEMORY.md`, `IDENTITY.md`, a relationship profile per person who has one, a topic file, a project summary, and today's journal entry.

`/api/sync/status` comes along because the Memory page's landing view leads with it — the folder panel's backup card would otherwise spin on the dev proxy.

## Design & Invariants

**The filesystem is a store, not a payload.** Saving, creating, renaming, moving and deleting mutate the tree, so a reopened file shows what was typed into it. That is what makes `MemoryPage`'s autosave path reachable without a backend, and it is the same rule the rest of mock mode's writes already follow.

**Who has a memory profile is read off the tree, not listed twice.** `personResource` answers `memoryPath` from `memoryProfilePath()`, which looks the file up in the fixture. A dossier cannot offer a link the Memory page then 404s on, and deleting a profile from the fixture cannot leave the two surfaces disagreeing.

**The tree is text.** A fixture has no bytes behind it, so upload refuses with a 501 and the asset and download routes stay unhandled rather than inventing a file. Everything else a file browser does — read, edit, create, rename, move, delete, search — is served.

The alternative was a second copy of the six projects handlers pointed at a memory fixture. It was rejected for the reason the mock-mode doc gives about restating core: two copies of the same route family drift, and nothing fails when only one of them is updated.

## Test plan

- [x] `pnpm --filter rome-web typecheck`
- [x] `pnpm --filter rome-web test` — 1360 tests, 162 files
- [x] `pnpm lint:prose`
- [x] `pnpm start:web:mock`, deep link to `/memory/relationship/ray-oster.md` — the profile renders, the tree lazy-loads per level, no console errors
- [x] Same session, through the page's own fetch: `/api/people` reports `memory/relationship/ray-oster.md` for Ray and `null` for Hollis Park; resolve opens it; a PUT then a GET returns the edited body; create, rename and move report the new path and a deleted path 404s; search hits three files
- [x] `/projects/demo-app/README.md` still renders — the projects browser moved onto the shared factory

## Not in this PR

- Upload, asset and download for either root — they exist to move bytes a fixture tree does not have.
- History stays empty, as it already was for projects: there is no git behind the tree.