### PR TITLE
fix(core): strip CHA cursor escapes so the Claude login watcher sees 2.1.251 prompts

### DIFF
--- a/packages/core/src/claude-login-watch.test.ts
+++ b/packages/core/src/claude-login-watch.test.ts
@@ -26,9 +26,10 @@ afterEach(() => {
 });
 
 // The real shapes printed by the `claude /login` first-run wizard (an Ink TUI):
-// words are positioned with cursor-forward (CUF, `\x1b[1C`) escapes instead of
-// spaces, and the sign-in URL is an OSC-8 hyperlink whose target holds the full
-// URL (terminated by BEL) followed by wrapped, truncated visible text.
+// words are positioned with cursor escapes instead of spaces — cursor-forward
+// (CUF, `\x1b[1C`) and, on newer CLIs, also column-absolute (CHA, `\x1b[9G`) —
+// and the sign-in URL is an OSC-8 hyperlink whose target holds the full URL
+// (terminated by BEL) followed by wrapped, truncated visible text.
 const URL =
   "https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e" +
   "&response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.com%2Foauth%2Fcode%2Fcallback" +
@@ -67,6 +68,22 @@ const LOGIN_OUTPUT =
   "Select login method:\x1b[K\r\n" +
   "\x1b[38;2;177;185;249m❯\x1b[4CClaude account with subscription · \x1b[38;2;153;153;153mPro, Max, Team, or Enterprise\r\n";
 
+// CLI 2.1.251 shapes, captured from a live `claude /login` PTY run. The theme
+// screen positions words with CHA (`\x1b[9G`) and ends rendered lines with
+// CR CR LF; the login screen keeps real spaces inside its phrases and joins
+// lines with CR + CUF + CUD — the same stream mixes both escape families, so
+// only the theme fixture exercises the CHA→space stripping.
+const THEME_OUTPUT_CHA =
+  "\x1b[2GLet's\x1b[8Gget\x1b[12Gstarted.\r\r\n" +
+  "\x1b[2G\x1b[1mChoose\x1b[9Gthe\x1b[13Gtext\x1b[18Gstyle\x1b[24Gthat\x1b[29Glooks\x1b[35Gbest\x1b[40Gwith\x1b[45Gyour\x1b[50Gterminal\x1b[22m\r\r\n" +
+  "\x1b[2G\x1b[38;2;177;185;249m❯\x1b[4G\x1b[38;2;153;153;153m2.\x1b[7G\x1b[38;2;78;186;101mDark\x1b[12Gmode\x1b[17G✔\x1b[39m\r\r\n";
+
+const LOGIN_OUTPUT_CHA =
+  "\x1b[1mClaude Code can be used with your Claude subscription or billed based on API \r\x1b[1C\x1b[1B" +
+  "usage through your Console account.\r\x1b[1C\x1b[1B\x1b[22m\x1b[K\r\x1b[1C\x1b[1B" +
+  "Select login method:\x1b[K\r\x1b[1C\x1b[2B" +
+  "\x1b[38;2;177;185;249m❯\x1b[7GClaude account with subscription · \x1b[38;2;153;153;153mPro, Max, Team, or Enterprise\r\r\n";
+
 const NOT_LOGGED_IN_OUTPUT =
   "\x1b[2m╭─── Claude Code v2.1.251 ─────────────────────────────────────────────────────╮\r\n" +
   "\x1b[2m│\x1b[22m Opus 4.7 (1M context) · API Usage Billing                            \x1b[2m│\r\n" +
@@ -87,6 +104,10 @@ const UNPARSEABLE_POST_PICKER_OUTPUT =
 describe("stripAnsi", () => {
   it("turns cursor-forward escapes into spaces so glued words separate", () => {
     expect(stripAnsi("Choose\x1b[1Cthe\x1b[1Ctext\x1b[1Cstyle")).toBe("Choose the text style");
+  });
+
+  it("turns column-absolute escapes into spaces so glued words separate", () => {
+    expect(stripAnsi("Choose\x1b[9Gthe\x1b[13Gtext\x1b[18Gstyle")).toBe("Choose the text style");
   });
 
   it("drops OSC-8 hyperlinks and CSI colour codes", () => {
@@ -313,6 +334,13 @@ describe("createClaudeLoginWatcher", () => {
       watcher.push(THEME_OUTPUT); // redraw — must not press again
       watcher.push(LOGIN_OUTPUT);
       watcher.push(LOGIN_OUTPUT); // redraw — must not press again
+      expect(sends).toEqual(["\r", "\r"]);
+    });
+
+    it("advances theme then login on CHA-positioned screens (CLI 2.1.251)", () => {
+      const { sends, watcher } = collect();
+      watcher.push(THEME_OUTPUT_CHA);
+      watcher.push(LOGIN_OUTPUT_CHA);
       expect(sends).toEqual(["\r", "\r"]);
     });
 

--- a/packages/core/src/claude-login-watch.ts
+++ b/packages/core/src/claude-login-watch.ts
@@ -11,12 +11,14 @@
  * rejected code needs no nudge).
  *
  * The first-run wizard is an Ink TUI, so its output differs from the old plain
- * `claude auth login` text: it colourises, positions words with cursor-forward
- * (CUF) escapes instead of spaces, and may print the sign-in URL either as an
- * OSC-8 hyperlink or as a wrapped plain URL. `stripAnsi` therefore turns CUF
- * into a space (so glued words separate for text matching) and drops the
- * OSC/CSI noise; the URL parser first tries the OSC-8 target and then rebuilds
- * the wrapped plain URL from its physical terminal lines.
+ * `claude auth login` text: it colourises, positions words with cursor escapes
+ * instead of spaces — cursor-forward (CUF) historically, with column-absolute
+ * (CHA) joining it in CLI 2.1.251, and one stream can carry both — and may
+ * print the sign-in URL either as an OSC-8 hyperlink or as a wrapped plain
+ * URL. `stripAnsi` therefore turns CUF and CHA into a space (so glued words
+ * separate for text matching) and drops the OSC/CSI noise; the URL parser
+ * first tries the OSC-8 target and then rebuilds the wrapped plain URL from
+ * its physical terminal lines.
  *
  * Deliberately fail-open: a parser miss (CLI reword) emits nothing and sends no
  * key, so the flow degrades to the modal's "sign-in URL never arrived" timeout
@@ -29,14 +31,14 @@ export type ClaudeLoginEvent =
   | { type: "auth_error"; message: string };
 
 // Strip the escape soup the Ink TUI emits so plain text can be matched. Order
-// matters: OSC first (hyperlinks/window titles), then CUF→space (so
+// matters: OSC first (hyperlinks/window titles), then CUF/CHA→space (so
 // cursor-positioned words don't glue together), then the remaining CSI and
 // two-char escapes, then any stray ESC. Each branch is anchored on ESC (\x1b),
 // so URL/text characters survive.
 export function stripAnsi(s: string): string {
   return s
     .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "") // OSC … terminated by BEL or ST
-    .replace(/\x1b\[[0-9]*C/g, " ") // CUF (cursor forward) → single space
+    .replace(/\x1b\[[0-9]*[CG]/g, " ") // CUF / CHA (cursor positioning) → single space
     .replace(/\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g, "") // other CSI sequences
     .replace(/\x1b[@-Z\\-_=>78]/g, "") // two-char (Fe/Fs) escapes, incl. DECSC/DECRC
     .replace(/\x1b/g, ""); // any stray ESC left over


### PR DESCRIPTION
## What this PR does

Claude Code 2.1.251 (#185) positions wizard words with column-absolute CHA escapes (`ESC[9G`) alongside the cursor-forward CUF (`ESC[1C`) that 2.1.89 used exclusively. `stripAnsi` in `claude-login-watch.ts` converted only CUF to a space; CHA fell to the generic CSI branch and was deleted, gluing prompts into `Choosethetextstyle` / `Darkmode`. No prompt regex matched, the watcher never auto-advanced the theme picker, the sign-in URL never appeared, and every login on the new CLI timed out with "Sign-in is taking longer than expected."

The fix treats CHA like CUF in `stripAnsi`. Test fixtures for the 2.1.251 wizard screens are captured bytes from a live `claude /login` PTY run, not hand-written approximations — the hand-edited fixture is why the 2.1.89→2.1.251 bump stayed green while the flow was broken.

## Design & Invariants

- The watcher stays fail-open: a parser miss emits nothing and sends no key, degrading to the modal's timeout rather than acting on a misread screen.
- Only row-preserving horizontal-motion escapes become spaces. Row-moving escapes (CUU/CUD/CUP) stay deleted — turning them into spaces would corrupt `extractPlainAuthUrl`'s line structure.
- `ENTER` stays `"\r"`. 2.1.251 defers each keypress's render until the next stdin event; the watcher's existing 1.5s retry supplies it (verified live: the screen advances on attempt 2).

## Test plan

- [x] `pnpm --filter @rome/core test:unit -- claude-login-watch` — new CHA cases fail before the fix, pass after; full suite green.
- [x] Replayed a captured 2.1.251 `claude /login` PTY stream through the watcher: theme prompt matches, auto-Enter fires, `auth_url` emitted with the unchanged `https://claude.com/cai/oauth/authorize?` OSC-8 target.
- [x] End to end in `pnpm dev:all` (image ships CLI 2.1.251): the login dialog's "Open sign-in page" enables within seconds, and a well-formed bad code surfaces the CLI's OAuth 400 in the dialog.

## Not in this PR

- Column-1 CHA (`ESC[G`/`ESC[1G`) also becomes a space; if a terminal path wraps the plain-text (non-OSC-8) URL with it, the URL splits and the flow falls back to the timeout — normalizing column-1 CHA to `\r` is cheap hardening once a capture shows that shape.
- Duplicate `auth_error` per Ink repaint of a still-visible error line — pre-existing, bounded to UI state.
- Separator-insensitive prompt anchors (e.g. `/Choose\W*the\W*text\W*style/i`) so the next renderer change in the CLI cannot re-glue prompts silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)