### PR TITLE
fix(web): hide the sidebar scrollbar while idle

### DIFF
--- a/packages/web/src/globals.css
+++ b/packages/web/src/globals.css
@@ -395,6 +395,28 @@
   padding-top: var(--rome-safe-area-top);
 }
 
+/* Overlay-style scrollbar for inner panes. The track keeps its width at all
+   times, so revealing the thumb never reflows the content beside it: only the
+   thumb's color changes, and only while the pointer or keyboard focus is
+   inside the scroller. macOS and iOS already hide idle scrollbars this way —
+   this makes Windows and Linux match instead of parking a permanent bar down
+   the edge of a pane nobody is scrolling.
+
+   Standard properties only, no `::-webkit-scrollbar` rules: styling that
+   pseudo-element opts Chrome out of overlay scrollbars entirely, which would
+   hand macOS a permanent 8px gutter it does not have today. Browsers too old
+   for `scrollbar-color` are the ones with auto-hiding overlay scrollbars
+   already, so the fallback is the behavior we are asking for. */
+@utility scrollbar-idle-hidden {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+
+  &:hover,
+  &:focus-within {
+    scrollbar-color: var(--color-border-strong) transparent;
+  }
+}
+
 /* Opt-in utilities for dashboard list rows on touch devices: reveal an action
    whose visual style depends on group-hover, and hold a row tall enough to tap.
    Pair `touch-show` with the `group-hover:...` classes on the same element.

--- a/packages/web/src/shell/RomeShellLayout.tsx
+++ b/packages/web/src/shell/RomeShellLayout.tsx
@@ -203,7 +203,7 @@ export function RomeShellLayout() {
                 </div>
               </div>
             )}
-            <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="min-h-0 flex-1 overflow-y-auto scrollbar-idle-hidden">
               {railMode ? (
                 <AppGrid collapsed onSearch={() => setChatSearchOpen(true)} />
               ) : (


### PR DESCRIPTION
## What this PR does

The sidebar's nav pane scrolls once the app list and recent chats outgrow it. On Windows and Linux, where scrollbars are real controls rather than overlays, that left a bar parked down the pane's right edge at all times, next to a list nobody was scrolling.

The pane now hides its scrollbar while idle and reveals it on hover or keyboard focus, matching what macOS and iOS already do for every scroller.

## Design & Invariants

The utility changes the thumb's color and nothing else. `scrollbar-width` stays `thin` in both states, so the track holds its width and the nav rows never shift sideways as the thumb fades in. Any future edit that toggles `scrollbar-width` or `display` to hide the bar reintroduces that reflow.

It sets the standard `scrollbar-color` and `scrollbar-width` only, with no `::-webkit-scrollbar` rules. Styling that pseudo-element opts Chrome out of overlay scrollbars entirely, which would hand macOS a permanent 8px gutter it does not have. The rejected alternative — a transparent `::-webkit-scrollbar-thumb` over a fixed 8px track — buys support on Chrome below 121 and Safari below 18.2 at exactly that cost, and those engines auto-hide overlay scrollbars on their own, so the fallback is already the behavior this PR asks for.

The utility lives in `packages/web/src/globals.css` rather than `@rome-os/ui/styles.css`, since only the dashboard shell uses it. A second consumer moves it to the kit.

## Test plan

- [x] `scripts/check-pr-title.sh "fix(web): hide the sidebar scrollbar while idle"`
- [ ] `pnpm typecheck` and `pnpm test:unit` — the working checkout has no `node_modules`, so CI is the first run
- [ ] `pnpm dev:all`, sidebar long enough to scroll: no bar at rest, a thumb on hover, and no horizontal shift in the nav rows either way
- [ ] Same check on macOS, confirming the pane keeps overlay scrollbars and gains no gutter

## Not in this PR

- The other scrollers that share the problem (file browser sidebar, trace drawer, app pickers) keep their default scrollbars until the utility proves itself on one pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
