### PR TITLE
fix(ui): read the UI role on a small Input

### DIFF
--- a/docs/ui/semantic-token/typography.md
+++ b/docs/ui/semantic-token/typography.md
@@ -21,7 +21,7 @@ Each role names what the text is, never a size or a look. The roster covers a he
 - `text-display` — Used for the one hero moment on a screen, such as the home greeting. Not used for a second element on the same screen.
 - `text-title` — Used for the heading a page or dialog carries once, at the top. Not used for a section inside one.
 - `text-section` — Used for the heading of a section, card, or panel inside a surface. Not used for a single control's label.
-- `text-body` — Used for prose someone reads as content: chat messages, paragraphs, text typed into a field. Not used for controls or labels. A field on the 28px control step is the single exception and reads `text-ui`; see Constraints.
+- `text-body` — Used for prose someone reads as content: chat messages, paragraphs, text typed into a field. Not used for controls or labels. A field on the 28px control step is the single exception and reads `text-ui`. Constraints covers why.
 - `text-ui` — Used for controls: sidebar rows, menu items, buttons, tabs, their labels, and both rows of a compact callout such as an alert. Not used for prose.
 - `text-badge` — Used for text inside a compact labeled container: chips, tags, badges, status pills, and counters. Not used for metadata that annotates other content, which stays `text-aux`.
 - `text-aux` — Used for metadata that annotates other content: timestamps, uncontained counts, group headers, and captions. Not used for compact labeled containers. A column of times or counts adds `tabular-nums`.

--- a/docs/ui/semantic-token/typography.md
+++ b/docs/ui/semantic-token/typography.md
@@ -21,7 +21,7 @@ Each role names what the text is, never a size or a look. The roster covers a he
 - `text-display` — Used for the one hero moment on a screen, such as the home greeting. Not used for a second element on the same screen.
 - `text-title` — Used for the heading a page or dialog carries once, at the top. Not used for a section inside one.
 - `text-section` — Used for the heading of a section, card, or panel inside a surface. Not used for a single control's label.
-- `text-body` — Used for prose someone reads as content: chat messages, paragraphs, text typed into a field. Not used for controls or labels.
+- `text-body` — Used for prose someone reads as content: chat messages, paragraphs, text typed into a field. Not used for controls or labels. A field on the 28px control step is the single exception and reads `text-ui`; see Constraints.
 - `text-ui` — Used for controls: sidebar rows, menu items, buttons, tabs, their labels, and both rows of a compact callout such as an alert. Not used for prose.
 - `text-badge` — Used for text inside a compact labeled container: chips, tags, badges, status pills, and counters. Not used for metadata that annotates other content, which stays `text-aux`.
 - `text-aux` — Used for metadata that annotates other content: timestamps, uncontained counts, group headers, and captions. Not used for compact labeled containers. A column of times or counts adds `tabular-nums`.
@@ -50,7 +50,7 @@ Letter spacing is 0 in every role.
 - Hierarchy comes from size, weight, position, and color. Never compose a second type utility onto a role. For emphasis, use color or position. `[mech]`
 - Every role's line box lands on the 4px spacing grid. Retuning a size means taking the line height step cut for it, never carrying the old one across. `[mech]`
 - If a size feels wrong, the role choice is wrong or the role mapping needs tuning. Retune on the specimen page, never at the call site. `[human]`
-- A field reads Body, which sits at the 16px threshold mobile Safari zooms below. No surface restores a size exception. `[human]`
+- A field reads Body, which sits at the 16px threshold mobile Safari zooms below. The one exception is the 28px control step: a field there reads UI, because it sits in a compact row beside a Button and a SelectTrigger already on UI, and Body left it two points larger than everything around it. That step is below the 44px touch minimum and so is never a touch target — a field a thumb is meant to hit takes the 36px step, which keeps Body. No surface restores a size exception of its own. `[human]`
 - Each role declares all four properties explicitly. A role nested under an inherited weight or letter-spacing utility still renders as drawn. `[mech]`
 - Every control declares a role, including an icon-only one. Without one it falls back to the document size, which an em-sized glyph or tooltip resolves against. `[mech]`
 - The roster of seven is the contract. Components bind to role names, so a value change never touches a call site. An eighth role enters through a roster decision, never as a new size at a call site. `[human]`

--- a/packages/ui/src/control-scale-overrides.test.tsx
+++ b/packages/ui/src/control-scale-overrides.test.tsx
@@ -290,6 +290,10 @@ describe("control scale", () => {
     // the threshold under which iOS Safari zooms a focused field, so no width
     // needs one. Its 20px line box is the controls' own, so a field on the
     // denser role would gain nothing back.
+    //
+    // The exception is by size, not by width: the 28px step reads UI, asserted
+    // in `control-typography-roles.test.tsx`. Sizes are the axis a field's role
+    // varies on; breakpoints stay one role, which is what this asserts.
     render(<Input aria-label="Search" />);
     const cls = screen.getByRole("textbox", { name: "Search" }).className;
 

--- a/packages/ui/src/control-typography-roles.test.tsx
+++ b/packages/ui/src/control-typography-roles.test.tsx
@@ -29,6 +29,19 @@ describe("control typography roles", () => {
     expect(screen.getByRole("button", { name: "Close" }).classList).toContain("text-ui");
   });
 
+  // The 28px step is the roster's one field exception: it sits in a compact row
+  // beside a Button and a SelectTrigger already on UI, so it reads UI too. The
+  // negative half matters as much as the positive — the role lives in the base
+  // class and is displaced by tailwind-merge, not replaced at the source, so a
+  // regression shows up as both roles surviving rather than as the wrong one.
+  it("uses UI for a text field on the 28px step", () => {
+    render(<Input aria-label="Filter" size="sm" />);
+
+    const classes = screen.getByRole("textbox", { name: "Filter" }).classList;
+    expect(classes).toContain("text-ui");
+    expect(classes).not.toContain("text-body");
+  });
+
   it("uses Body for text fields at every viewport width", () => {
     render(
       <>

--- a/packages/ui/src/input.tsx
+++ b/packages/ui/src/input.tsx
@@ -37,8 +37,16 @@ const iconSizeClass = {
 } as const;
 
 const inputVariants = cva(
-  // Body is 16px at every breakpoint, which keeps focused fields above iOS
-  // Safari's viewport-zoom threshold without a responsive exception.
+  // Body is the field default, and it is 16px at every breakpoint — no
+  // responsive exception — which keeps a focused field above iOS Safari's
+  // viewport-zoom threshold. `sm` overrides it to UI; see that variant.
+  //
+  // The role stays in the base rather than moving onto each size, because
+  // `size` admits `null` and cva emits no variant class for it. A null-size
+  // field would otherwise declare no role at all and fall back to the document
+  // size. `text-ui` on `sm` wins from here by order: cva concatenates base
+  // before variants, and `cn` runs tailwind-merge over the result, where both
+  // roles sit in the font-size group because `cn` registers them there.
   "w-full min-w-0 border border-input bg-transparent text-body transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-ui file:text-foreground placeholder:text-muted-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:outline-solid aria-invalid:outline-2 aria-invalid:outline-offset-0 aria-invalid:outline-destructive dark:bg-input/30 dark:disabled:bg-input/80",
   {
     variants: {
@@ -47,7 +55,22 @@ const inputVariants = cva(
       // row. Height is explicit and the border sits inside the box, so focus
       // and invalid borders never shift layout.
       size: {
-        sm: "h-[var(--control-h-sm)] rounded-[var(--control-r-sm)] px-[var(--control-px-start-sm)]",
+        /**
+         * The one field step that reads UI rather than Body. 28px is a
+         * compact-density row — a filter bar, a toolbar — where the field sits
+         * beside a `sm` Button and a `sm` SelectTrigger, both on UI. Body left
+         * the field two points larger than every control next to it, which is
+         * the one place the size difference reads as a mistake instead of as
+         * prose. Body and UI share a 20px line box, so this changes the glyph
+         * and nothing about the vertical fit.
+         *
+         * The tradeoff is deliberate: 14px is under mobile Safari's zoom
+         * threshold, so a `sm` field zooms the viewport on focus. 28px is
+         * already well below the 44px touch minimum, so this step is not a
+         * touch target — reach for `md`, which stays on Body, for any field a
+         * thumb is meant to hit.
+         */
+        sm: "h-[var(--control-h-sm)] rounded-[var(--control-r-sm)] px-[var(--control-px-start-sm)] text-ui",
         md: SIZE_MD,
         /** @deprecated Spelling of `md` that predates the shared vocabulary. */
         default: SIZE_MD,


### PR DESCRIPTION
## What this PR does

A text field on the 28px control step read Body (16px) while every other control on that step — `Button`, `SelectTrigger`, `SegmentedControl` — read UI (14px). In a compact row the field came out two points larger than everything beside it. `zillow-rentals` shows it directly: two `<Input size="sm">` filters sitting next to a `<SelectTrigger size="sm">`, with the field text visibly bigger than the sort control.

The size was not an oversight. `docs/ui/semantic-token/typography.md` held it as a `[human]` constraint — "A field reads Body, which sits at the 16px threshold mobile Safari zooms below. No surface restores a size exception." This PR narrows that rule to exempt the 28px step, and amends the doc rather than working around it.

## Design & Invariants

- **The exception is by size, not by width.** A field's role still does not vary across breakpoints; `sm` is the only step that leaves Body. The existing "Body at every breakpoint" assertion stays, with a comment naming the axis the exception lives on.
- **Vertical fit is unchanged.** Body and UI deliberately share a 20px line box, so this moves the glyph and nothing else. The step's height, radius, and padding are untouched.
- **The role stays in the base class, displaced rather than replaced.** `size` admits `null`, and cva emits no variant class for it — a null-size field would declare no role at all and fall back to the document size, breaking "every control declares a role". So the base keeps `text-body` and `sm` appends `text-ui`, which wins because cva concatenates base before variants and `cn` runs tailwind-merge over the result. Both roles are registered in the font-size group via `TYPOGRAPHY_ROLES`, so the merge resolves as last-wins instead of leaving both intact. The test asserts both directions for that reason: a regression here surfaces as *both* roles surviving, not as the wrong one winning.
- **The accepted cost:** 14px is under mobile Safari's zoom-on-focus threshold, so a `sm` field now zooms the viewport when focused. The 28px step is already well below the 44px touch minimum and so is never a touch target — `md` stays on Body and remains the step for any field a thumb is meant to hit. The doc records this so the next reader does not rediscover it as a bug.

An alternative was to deprecate `sm` on `Input` the way `lg` already is, since the repo had no in-tree call site. Rejected: installed apps do use it, and a compact filter bar is a real composition the kit should serve.

## Test plan

- [x] `pnpm --filter @rome-os/ui test` — 556 pass, including the new `uses UI for a text field on the 28px step`
- [x] Confirmed the new test fails without the fix (reverted the variant, saw it go red, restored)
- [x] `pnpm --filter rome-web test` — 1360 pass, including the field-typography assertions in `project-selector` and `control-typography-roles`
- [x] `pnpm --filter @rome-os/ui build` — consumers read `dist/`, so the kit is rebuilt
- [x] Measured in the running dashboard: `sm` field was 16px against a 14px `sm` button, both in a 20px line box; rendered the `zillow-rentals` filter-bar composition before and after and confirmed the field now matches the Select beside it
- [ ] `pnpm typecheck` — `example_apps/morning-brief` fails to resolve `@rome-os/app-web-sdk`, and `rome-desktop`'s suite fails on a missing Electron binary. Both reproduce on a clean tree at this commit's base and are unrelated to this change.

## Not in this PR

- `Textarea` has no size variants, so it stays on Body throughout — nothing to decide there yet.
- The `zillow-rentals` app is not rebuilt here; it picks the change up from the kit on its next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
