### PR TITLE
feat(web): compact the chat timeline

### DIFF
--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -1688,15 +1688,15 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
               480px on this column, so a gate keyed to it would show the rail at
               widths where the transcript has no gutter left. */}
           <div className="@container/transcript relative flex min-h-0 flex-1 flex-col">
-            {/* The right inset opens the timeline rail's lane. Without it the
+            {/* The left inset opens the timeline rail's lane. Without it the
                 transcript's own `max-w-5xl` body reaches the container edge
-                once the container drops under 1024px, and the dots would land
+                once the container drops under 1024px, and the markers would land
                 on the bubbles. Padding sits inside the scroller's border box,
                 so the scrollbar does not move — only the content shifts. The
                 query MUST match ChatTimelineRail's visibility gate. */}
             <div
               ref={attachScroller}
-              className="relative flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain @min-[48rem]/transcript:pr-8"
+              className="relative flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain @min-[48rem]/transcript:pl-8"
             >
               <MessageList
                 rows={rows}

--- a/packages/web/src/components/chat/ChatTimelineRail.test.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.test.tsx
@@ -261,6 +261,42 @@ describe("ChatTimelineRail", () => {
     expect(screen.getByRole("button", { name: "Show timeline" })).toBeTruthy();
   });
 
+  it("repositions the show control when the track resizes while hidden", () => {
+    let fire: (() => void) | null = null;
+    const RealRO = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      private readonly callback: () => void;
+
+      constructor(callback: () => void) {
+        this.callback = callback;
+        fire = callback;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {
+        if (fire === this.callback) fire = null;
+      }
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      const { container } = renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
+      expect(screen.getByRole("button", { name: "Hide timeline" }).style.top).toBe("214px");
+
+      fireEvent.click(screen.getByRole("button", { name: "Hide timeline" }));
+      const track = container.querySelector<HTMLElement>("[data-timeline-track]");
+      expect(track).not.toBeNull();
+      Object.defineProperty(track, "clientHeight", { value: 200, configurable: true });
+
+      act(() => {
+        fire?.();
+        rs.advanceTimersByTime(200);
+      });
+      expect(screen.getByRole("button", { name: "Show timeline" }).style.top).toBe("64px");
+    } finally {
+      globalThis.ResizeObserver = RealRO;
+    }
+  });
+
   it("keeps watching while hidden with nothing to show", () => {
     // A hidden rail that measured nothing — too narrow, too short — must stay
     // subscribed, or becoming eligible later leaves no Show control until the

--- a/packages/web/src/components/chat/ChatTimelineRail.test.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.test.tsx
@@ -24,11 +24,11 @@ const QUESTIONS: TimelineQuestion[] = [
   { messageId: "q4", text: "can we cache it?" },
 ];
 
-// The dots, excluding the hide control — which is a button too, but is
-// deliberately focusable and is not one of the questions. Hidden dots stay
+// The markers, excluding the hide control — which is a button too, but is
+// deliberately focusable and is not one of the questions. Hidden markers stay
 // mounted so the retract animates, and leave the a11y tree via aria-hidden —
 // which is exactly what getAllByRole filters on.
-function dots(): HTMLElement[] {
+function markers(): HTMLElement[] {
   return screen.getAllByRole("button").filter((el) => el.getAttribute("aria-expanded") === null);
 }
 
@@ -115,22 +115,20 @@ function renderRail(
 }
 
 describe("ChatTimelineRail", () => {
-  it("renders one dot per question, labelled with its text", () => {
+  it("renders one bar per question, labelled with its text", () => {
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    expect(dots()).toHaveLength(4);
+    expect(markers()).toHaveLength(4);
     expect(screen.getByRole("button", { name: "how do I ship this?" })).toBeTruthy();
   });
 
-  it("jumps to the question a dot points at", () => {
+  it("jumps to the question a marker points at", () => {
     const onJump = rs.fn();
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS, onJump);
     fireEvent.click(screen.getByRole("button", { name: "what broke the build?" }));
     expect(onJump).toHaveBeenCalledWith("q2");
   });
 
-  it("keeps every question clickable when they crowd together", () => {
-    // All four within 12px of content. They spread down the track instead of
-    // merging, so none becomes unreachable — the whole point of spreading.
+  it("keeps a compact rhythm regardless of message positions", () => {
     const onJump = rs.fn();
     renderRail(
       stubScroller([
@@ -142,7 +140,15 @@ describe("ChatTimelineRail", () => {
       QUESTIONS,
       onJump,
     );
-    expect(dots()).toHaveLength(4);
+    expect(markers().map((marker) => marker.style.top)).toEqual([
+      "238px",
+      "246px",
+      "254px",
+      "262px",
+    ]);
+    const navigation = screen.getByRole("navigation", { name: "Question timeline" });
+    expect(navigation.className).toContain("left-0");
+    expect(markers()[0].className).toContain("left-4");
     fireEvent.click(screen.getByRole("button", { name: "can we cache it?" }));
     expect(onJump).toHaveBeenCalledWith("q4");
   });
@@ -150,9 +156,14 @@ describe("ChatTimelineRail", () => {
   it("takes one tab stop for the whole column", () => {
     // Search cannot scroll to a message yet, so the rail is the only keyboard
     // route to an earlier question — but forty questions must not mean forty
-    // tab stops. Exactly one dot is tabbable; arrows reach the rest.
+    // tab stops. Exactly one marker is tabbable; arrows reach the rest.
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    expect(dots().map((d) => d.getAttribute("tabindex"))).toEqual(["0", "-1", "-1", "-1"]);
+    expect(markers().map((marker) => marker.getAttribute("tabindex"))).toEqual([
+      "0",
+      "-1",
+      "-1",
+      "-1",
+    ]);
     expect(
       screen.getByRole("button", { name: "Hide timeline" }).getAttribute("tabindex"),
     ).toBeNull();
@@ -160,12 +171,17 @@ describe("ChatTimelineRail", () => {
 
   it("moves between questions with the arrow keys", () => {
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    const all = dots();
+    const all = markers();
     all[0].focus();
 
     fireEvent.keyDown(all[0], { key: "ArrowDown" });
     expect(document.activeElement).toBe(all[1]);
-    expect(dots().map((d) => d.getAttribute("tabindex"))).toEqual(["-1", "0", "-1", "-1"]);
+    expect(markers().map((marker) => marker.getAttribute("tabindex"))).toEqual([
+      "-1",
+      "0",
+      "-1",
+      "-1",
+    ]);
 
     fireEvent.keyDown(all[1], { key: "ArrowUp" });
     expect(document.activeElement).toBe(all[0]);
@@ -179,7 +195,7 @@ describe("ChatTimelineRail", () => {
 
   it("stops at the ends rather than wrapping", () => {
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    const all = dots();
+    const all = markers();
     all[0].focus();
     fireEvent.keyDown(all[0], { key: "ArrowUp" });
     expect(document.activeElement).toBe(all[0]);
@@ -189,19 +205,21 @@ describe("ChatTimelineRail", () => {
     expect(document.activeElement).toBe(all[3]);
   });
 
-  it("takes hidden dots out of the tab order", () => {
+  it("takes hidden markers out of the tab order", () => {
     // They stay mounted so the retract animates, and carry aria-hidden — which
     // must never contain something focusable.
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
     fireEvent.click(screen.getByRole("button", { name: "Hide timeline" }));
-    const hiddenDots = [...document.querySelectorAll<HTMLElement>("[data-timeline-track] button")];
-    expect(hiddenDots).toHaveLength(4);
-    for (const dot of hiddenDots) {
-      expect(dot.getAttribute("tabindex")).toBe("-1");
+    const hiddenMarkers = [
+      ...document.querySelectorAll<HTMLElement>("[data-timeline-markers] button"),
+    ];
+    expect(hiddenMarkers).toHaveLength(4);
+    for (const marker of hiddenMarkers) {
+      expect(marker.getAttribute("tabindex")).toBe("-1");
     }
   });
 
-  it("renders no dots below the question floor", () => {
+  it("renders no markers below the question floor", () => {
     const { container } = renderRail(
       stubScroller(SPREAD_ANCHORS.slice(0, 2)),
       QUESTIONS.slice(0, 2),
@@ -209,27 +227,28 @@ describe("ChatTimelineRail", () => {
     expect(container.querySelectorAll("button")).toHaveLength(0);
   });
 
-  it("renders no dots when the transcript fits on one screen", () => {
+  it("renders no markers when the transcript fits on one screen", () => {
     const scroller = stubScroller(SPREAD_ANCHORS);
     Object.defineProperty(scroller, "scrollHeight", { value: 700, configurable: true });
     const { container } = renderRail(scroller, QUESTIONS);
     expect(container.querySelectorAll("button")).toHaveLength(0);
   });
 
-  it("renders no dots without a scroller", () => {
+  it("renders no markers without a scroller", () => {
     const { container } = renderRail(null, QUESTIONS);
     expect(container.querySelectorAll("button")).toHaveLength(0);
   });
 
-  it("hides the dots and offers to bring them back", () => {
+  it("hides the markers and offers to bring them back", () => {
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    expect(dots()).toHaveLength(4);
+    expect(markers()).toHaveLength(4);
+    expect(screen.getByRole("button", { name: "Hide timeline" }).style.top).toBe("214px");
 
     fireEvent.click(screen.getByRole("button", { name: "Hide timeline" }));
-    expect(dots()).toHaveLength(0);
+    expect(markers()).toHaveLength(0);
 
     fireEvent.click(screen.getByRole("button", { name: "Show timeline" }));
-    expect(dots()).toHaveLength(4);
+    expect(markers()).toHaveLength(4);
   });
 
   it("remembers a hide across mounts", () => {
@@ -238,7 +257,7 @@ describe("ChatTimelineRail", () => {
     cleanup();
 
     renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    expect(dots()).toHaveLength(0);
+    expect(markers()).toHaveLength(0);
     expect(screen.getByRole("button", { name: "Show timeline" })).toBeTruthy();
   });
 

--- a/packages/web/src/components/chat/ChatTimelineRail.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.tsx
@@ -4,18 +4,18 @@ import { useTranslation } from "react-i18next";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   layoutTimelineNodes,
-  MIN_NODE_GAP_PX,
   sameNodes,
   shouldShowTimeline,
   summarizeQuestion,
-  type MeasuredAnchor,
+  TIMELINE_NODE_STEP_PX,
   type TimelineNode,
   type TimelineQuestion,
 } from "@/components/chat/chat-timeline";
 
-// Re-measuring is trailing-debounced: a streamed reply grows the content on
-// every token, and measuring N anchors forces a layout flush each time.
+// Re-checking is trailing-debounced because a streamed reply can resize the
+// content on every token before the transcript crosses the visibility gate.
 const MEASURE_DEBOUNCE_MS = 150;
+const CONTROL_NODE_GAP_PX = 24;
 
 const EMPTY: TimelineNode[] = [];
 
@@ -36,8 +36,8 @@ export interface ChatTimelineRailProps {
   /**
    * The growing content wrapper inside the scroller. Observed separately
    * because content height changes do not resize the scroller itself, so a
-   * ResizeObserver on the scroller alone would never fire and the dots would go
-   * stale mid-conversation.
+   * ResizeObserver on the scroller alone would not notice when the transcript
+   * becomes long enough to need navigation.
    */
   content: HTMLElement | null;
   questions: TimelineQuestion[];
@@ -45,31 +45,28 @@ export interface ChatTimelineRailProps {
 }
 
 /**
- * A faint column of dots down the right gutter of the transcript — one per past
+ * A compact column of bars in the left gutter of the transcript — one per past
  * user question. Hovering names the question, clicking jumps to it.
  *
- * Deliberately the quietest thing on screen: 4px dots at 40% opacity and no
- * connecting line. Nothing here moves or resizes on its own — the only motion
- * is a dot growing under the cursor, which the reader asked for by pointing at
- * it. That is why there is no scroll-following "current position" dot: motion
- * nobody invited is what pulls the eye off the text.
+ * Deliberately the quietest thing on screen: short bars at 40% opacity and no
+ * connecting line. Their fixed rhythm represents question order, not rendered
+ * message height, so wrapping and streamed replies cannot reshape the index.
  */
 export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatTimelineRailProps) {
   const { t } = useTranslation("chat");
   const [nodes, setNodes] = useState<TimelineNode[]>(EMPTY);
   const [hidden, setHidden] = useState(readHidden);
-  // The dots are positioned as a percentage of THIS element, so the layout math
-  // is given this element's height rather than the scroller's. Measuring the
-  // track directly is what keeps the computed and painted positions in one
-  // coordinate space.
+  // The bars are positioned in this element's pixel coordinate space. Measuring
+  // the track directly lets the compact step tighten only when the column is
+  // truly saturated.
   const trackRef = useRef<HTMLDivElement | null>(null);
-  // The column is one composite control, not forty. Only the roving dot is in
-  // the tab order; arrows move between dots from there. Tabbing every dot would
+  // The column is one composite control, not forty. Only the roving bar is in
+  // the tab order; arrows move between bars from there. Tabbing every bar would
   // bury the rest of the page behind dozens of stops in exactly the long chats
   // this exists for, and dropping them from the tab order altogether would
   // leave the transcript with no keyboard route back to an earlier question.
   const [rovingIndex, setRovingIndex] = useState(0);
-  const dotRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const nodeRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   useEffect(() => {
     if (!scroller) {
@@ -78,7 +75,7 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
     }
     let timer = 0;
 
-    /** Lays the dots out, and reports whether there are any. */
+    /** Lays the question markers out, and reports whether there are any. */
     const measure = (): boolean => {
       const track = trackRef.current;
       // A zero-height track means the rail is CSS-hidden below its breakpoint,
@@ -96,28 +93,13 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
         setNodes((prev) => (prev.length === 0 ? prev : EMPTY));
         return false;
       }
-      // Rects rather than offsetTop: SelectableRow makes rows `relative` in
-      // share mode, which would silently re-parent offsetTop onto the row.
-      const base = scroller.getBoundingClientRect().top - scroller.scrollTop;
-      // One sweep into a map, rather than a selector query per question: it is
-      // a single DOM traversal instead of N, and it keeps message ids out of a
-      // selector string entirely.
-      const elements = new Map<string, HTMLElement>();
-      for (const el of scroller.querySelectorAll<HTMLElement>("[data-timeline-anchor]")) {
-        const id = el.getAttribute("data-timeline-anchor");
-        if (id) elements.set(id, el);
-      }
-      const anchors: MeasuredAnchor[] = [];
-      for (const question of questions) {
-        const el = elements.get(question.messageId);
-        if (!el) continue;
-        anchors.push({ messageId: question.messageId, top: el.getBoundingClientRect().top - base });
-      }
-      const next = layoutTimelineNodes(anchors, {
-        contentHeight: scroller.scrollHeight,
-        trackHeight: track.clientHeight,
-        minGapPx: MIN_NODE_GAP_PX,
-      });
+      const next = layoutTimelineNodes(
+        questions.map((question) => question.messageId),
+        {
+          trackHeight: track.clientHeight,
+          stepPx: TIMELINE_NODE_STEP_PX,
+        },
+      );
       setNodes((prev) => (sameNodes(prev, next) ? prev : next));
       return next.length > 0;
     };
@@ -130,17 +112,17 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
     // Always measure once, even while hidden: the node count is what decides
     // whether the show control renders at all, and skipping this would strand a
     // reader who hid the rail and then reloaded with no way to bring it back.
-    const anyDots = measure();
-    // With dots to keep, a hidden column has nothing left to stay in sync with,
+    const anyNodes = measure();
+    // With markers to keep, a hidden column has nothing left to stay in sync with,
     // and a streaming reply would otherwise drive a layout flush plus a
     // re-render every debounce tick for something not on screen. Unhiding
-    // re-runs this effect, so the dots are measured fresh when they return.
+    // re-runs this effect, so the markers are measured fresh when they return.
     //
-    // With NO dots the observer has to stay: the rail may still become eligible
+    // With NO markers the observer has to stay: the rail may still become eligible
     // — a wider viewport, a transcript that grows past two screens — and the
     // show control has to appear when it does rather than waiting for the next
     // message or a reload.
-    if (hidden && anyDots) return () => window.clearTimeout(timer);
+    if (hidden && anyNodes) return () => window.clearTimeout(timer);
 
     const observer = new ResizeObserver(schedule);
     observer.observe(scroller);
@@ -153,9 +135,9 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
 
   // Clamped rather than reset: questions arrive while the chat runs, and the
   // caret should not jump back to the top each time one does.
-  const activeDot = Math.min(rovingIndex, Math.max(nodes.length - 1, 0));
+  const activeNode = Math.min(rovingIndex, Math.max(nodes.length - 1, 0));
 
-  const onDotKeyDown = useCallback(
+  const onNodeKeyDown = useCallback(
     (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
       const last = nodes.length - 1;
       let next: number;
@@ -166,7 +148,7 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
       else return;
       event.preventDefault();
       setRovingIndex(next);
-      dotRefs.current[next]?.focus();
+      nodeRefs.current[next]?.focus();
     },
     [nodes.length],
   );
@@ -188,17 +170,13 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
   const empty = nodes.length === 0;
 
   return (
-    // A dot's centre sits 24px in from the container's right edge — far enough
-    // that its 14px hit target clears a 15px classic scrollbar entirely, so the
-    // scrollbar stays grabbable on Windows and Linux where it is a real control.
-    //
-    // The other side used to be the binding constraint: the transcript is
+    // A marker's centre sits in the middle of the 32px left lane. The transcript is
     // `mx-auto max-w-5xl`, so once the container drops under 1024px the body
-    // fills it and a bubble's edge runs straight into the dots. Chat now gives
-    // the scroller a matching right inset under the SAME query, which opens a
+    // fills it and a bubble's edge runs straight into the markers. Chat gives
+    // the scroller a matching left inset under the SAME query, which opens a
     // permanent lane for the rail — so this gate is only about whether the
-    // surface is big enough to be worth navigating, not about whether the dots
-    // fit. Keep the two queries in sync: Chat.tsx's `pr-8` is what makes any
+    // surface is big enough to be worth navigating, not about whether the markers
+    // fit. Keep the two queries in sync: Chat.tsx's `pl-8` is what makes any
     // width below 1024 safe.
     //
     // The container is `transcript`, declared on Chat's scroller wrapper — NOT
@@ -206,7 +184,7 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
     // trace drawer takes its 480px.
     //
     // Pointer events stay off the whole strip and are re-enabled only on the
-    // dots, so the native scrollbar and the composer's right edge remain
+    // markers, so the native scrollbar and the composer's right edge remain
     // grabbable underneath.
     <div
       // No landmark until there is a timeline inside it. Short chats are the
@@ -214,59 +192,56 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
       // user lands in and finds nothing.
       role={empty ? undefined : "navigation"}
       aria-label={empty ? undefined : t("timeline.label")}
-      className="group pointer-events-none absolute inset-y-0 right-0 z-10 hidden w-8 @min-[48rem]/transcript:block"
+      className="group pointer-events-none absolute inset-y-0 left-0 z-10 hidden w-8 @min-[48rem]/transcript:block"
     >
-      {/* One tab stop, unlike the dots — this is a real control, so it takes
-          focus and draws the design system's focus ring. It sits in the band the
-          track leaves free at the top, so it never shares a row with a dot. */}
-      {empty ? null : (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={toggleHidden}
-              aria-label={hidden ? t("timeline.show") : t("timeline.hide")}
-              aria-expanded={!hidden}
-              className="pointer-events-auto absolute top-6 right-6 flex size-6 -translate-y-1/2 translate-x-1/2 items-center justify-center rounded-full text-muted-foreground opacity-30 transition-opacity duration-200 ease-out group-hover:opacity-70 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring motion-reduce:transition-none"
-            >
-              {hidden ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="left" sideOffset={8}>
-            {hidden ? t("timeline.show") : t("timeline.hide")}
-          </TooltipContent>
-        </Tooltip>
-      )}
-      {/* Starts below the control's band and stops well above the sticky
-          composer, so no dot ever paints on either.
-
-          Hiding slides the column out to the right and fades it, rather than
-          unmounting it, so the effect runs in both directions. `visibility`
-          carries the safety: it flips discretely at the END of the transition,
-          so the dots stay painted while they slide away and stop taking pointer
-          events the instant they are gone. `aria-hidden` takes them out of the
-          accessibility tree at the same time. */}
-      <div
-        ref={trackRef}
-        data-timeline-track
-        aria-hidden={hidden}
-        className={`absolute top-16 right-0 bottom-32 w-8 transition-[opacity,translate,visibility] duration-200 ease-out motion-reduce:transition-none ${
-          hidden ? "invisible translate-x-6 opacity-0" : "visible translate-x-0 opacity-100"
-        }`}
-      >
-        {empty
-          ? null
-          : nodes.map((node, index) => {
-              const question = questions.find((q) => q.messageId === node.messageId);
-              if (!question) return null;
-              const label = summarizeQuestion(question.text);
-              return (
-                <Tooltip key={node.messageId}>
-                  <TooltipTrigger asChild>
-                    {/* A bare <button>, never the ui-kit Button: the /chat layout
+      {/* The control and markers share one coordinate space, so the eye follows
+          the compact group instead of staying stranded at the top of the rail. */}
+      <div ref={trackRef} data-timeline-track className="absolute top-16 bottom-32 left-0 w-8">
+        {empty ? null : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={toggleHidden}
+                aria-label={hidden ? t("timeline.show") : t("timeline.hide")}
+                aria-expanded={!hidden}
+                style={{ top: nodes[0].topPx - CONTROL_NODE_GAP_PX }}
+                className="pointer-events-auto absolute left-4 flex size-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground opacity-30 transition-opacity duration-200 ease-out group-hover:opacity-70 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring motion-reduce:transition-none"
+              >
+                {hidden ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={8}>
+              {hidden ? t("timeline.show") : t("timeline.hide")}
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {/* Hiding slides the markers out to the left and fades them, rather than
+            unmounting them, so the effect runs in both directions. `visibility`
+            carries the safety: it flips discretely at the END of the transition,
+            so the markers stop taking pointer events when they are gone.
+            `aria-hidden` removes them from the accessibility tree at the same
+            time, while the eye remains available to restore them. */}
+        <div
+          data-timeline-markers
+          aria-hidden={hidden}
+          className={`absolute inset-0 transition-[opacity,translate,visibility] duration-200 ease-out motion-reduce:transition-none ${
+            hidden ? "invisible -translate-x-6 opacity-0" : "visible translate-x-0 opacity-100"
+          }`}
+        >
+          {empty
+            ? null
+            : nodes.map((node, index) => {
+                const question = questions.find((q) => q.messageId === node.messageId);
+                if (!question) return null;
+                const label = summarizeQuestion(question.text);
+                return (
+                  <Tooltip key={node.messageId}>
+                    <TooltipTrigger asChild>
+                      {/* A bare <button>, never the ui-kit Button: the /chat layout
                     invariant sweep measures every [data-slot="button"] for
                     vertical centring and sibling-uniform heights, which a
-                    free-positioned dot fails by construction. The label is the
+                    free-positioned marker fails by construction. The label is the
                     question alone — Radix already wires the tooltip as
                     aria-describedby, so a "jump to" prefix would make a screen
                     reader add a prefix to a question it announces twice
@@ -274,33 +249,34 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
                     this is the name, so both carry the question. Naming the
                     action instead would not remove the repetition, only pad it.
 
-                    Focus is styled like hover, so the dot under the caret
-                    reads like the one under the cursor. Only the roving dot is
-                    tabbable; hidden dots leave the tab order entirely, so
+                    Focus is styled like hover, so the bar under the caret
+                    reads like the one under the cursor. Only the roving marker is
+                    tabbable; hidden markers leave the tab order entirely, so
                     nothing focusable ever sits inside `aria-hidden`. */}
-                    <button
-                      type="button"
-                      ref={(el) => {
-                        dotRefs.current[index] = el;
-                      }}
-                      tabIndex={hidden || index !== activeDot ? -1 : 0}
-                      aria-label={label}
-                      onKeyDown={(event) => onDotKeyDown(event, index)}
-                      onFocus={() => setRovingIndex(index)}
-                      onClick={() => onJump(node.messageId)}
-                      style={{ top: `${node.fraction * 100}%` }}
-                      className="pointer-events-auto absolute right-6 size-3.5 -translate-y-1/2 translate-x-1/2 rounded-full before:absolute before:inset-[5px] before:rounded-full before:scale-100 before:bg-muted-foreground before:opacity-40 before:transition-[opacity,scale] before:duration-200 before:ease-out motion-reduce:before:transition-none group-hover:before:opacity-70 hover:before:scale-150 hover:before:opacity-100 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring focus-visible:before:scale-150 focus-visible:before:opacity-100"
-                    />
-                  </TooltipTrigger>
-                  {/* The offset clears the dot: TooltipContent's arrow is 10px
+                      <button
+                        type="button"
+                        ref={(el) => {
+                          nodeRefs.current[index] = el;
+                        }}
+                        tabIndex={hidden || index !== activeNode ? -1 : 0}
+                        aria-label={label}
+                        onKeyDown={(event) => onNodeKeyDown(event, index)}
+                        onFocus={() => setRovingIndex(index)}
+                        onClick={() => onJump(node.messageId)}
+                        style={{ top: node.topPx }}
+                        className="pointer-events-auto absolute left-4 size-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full before:absolute before:top-1/2 before:left-1 before:h-0.5 before:w-2 before:-translate-y-1/2 before:origin-left before:rounded-full before:scale-x-100 before:bg-muted-foreground before:opacity-40 before:transition-[opacity,scale] before:duration-200 before:ease-out motion-reduce:before:transition-none group-hover:before:opacity-70 hover:before:scale-x-150 hover:before:opacity-100 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring focus-visible:before:scale-x-150 focus-visible:before:opacity-100"
+                      />
+                    </TooltipTrigger>
+                    {/* The offset clears the marker: TooltipContent's arrow is 10px
                   rotated 45°, which at the default offset of 0 would land on
-                  top of a 4px dot. */}
-                  <TooltipContent side="left" sideOffset={8}>
-                    {label}
-                  </TooltipContent>
-                </Tooltip>
-              );
-            })}
+                  top of the bar. */}
+                    <TooltipContent side="right" sideOffset={8}>
+                      {label}
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
+        </div>
       </div>
     </div>
   );

--- a/packages/web/src/components/chat/ChatTimelineRail.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.tsx
@@ -75,8 +75,8 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
     }
     let timer = 0;
 
-    /** Lays the question markers out, and reports whether there are any. */
-    const measure = (): boolean => {
+    /** Lays the question markers out. */
+    const measure = () => {
       const track = trackRef.current;
       // A zero-height track means the rail is CSS-hidden below its breakpoint,
       // where the sweep below can only ever produce nothing. Checking it first
@@ -91,7 +91,7 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
         })
       ) {
         setNodes((prev) => (prev.length === 0 ? prev : EMPTY));
-        return false;
+        return;
       }
       const next = layoutTimelineNodes(
         questions.map((question) => question.messageId),
@@ -101,7 +101,6 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
         },
       );
       setNodes((prev) => (sameNodes(prev, next) ? prev : next));
-      return next.length > 0;
     };
 
     const schedule = () => {
@@ -112,17 +111,11 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
     // Always measure once, even while hidden: the node count is what decides
     // whether the show control renders at all, and skipping this would strand a
     // reader who hid the rail and then reloaded with no way to bring it back.
-    const anyNodes = measure();
-    // With markers to keep, a hidden column has nothing left to stay in sync with,
-    // and a streaming reply would otherwise drive a layout flush plus a
-    // re-render every debounce tick for something not on screen. Unhiding
-    // re-runs this effect, so the markers are measured fresh when they return.
-    //
-    // With NO markers the observer has to stay: the rail may still become eligible
-    // — a wider viewport, a transcript that grows past two screens — and the
-    // show control has to appear when it does rather than waiting for the next
-    // message or a reload.
-    if (hidden && anyNodes) return () => window.clearTimeout(timer);
+    measure();
+    // The observer stays active while markers are hidden. The show control is
+    // positioned from the first node, so a resized track must update that node
+    // to keep the control reachable. It also lets an ineligible transcript grow
+    // into a timeline without waiting for another message or a reload.
 
     const observer = new ResizeObserver(schedule);
     observer.observe(scroller);

--- a/packages/web/src/components/chat/chat-timeline.test.ts
+++ b/packages/web/src/components/chat/chat-timeline.test.ts
@@ -6,7 +6,6 @@ import {
   sameNodes,
   shouldShowTimeline,
   summarizeQuestion,
-  type MeasuredAnchor,
 } from "./chat-timeline";
 
 const MAIN = "main";
@@ -51,7 +50,7 @@ describe("buildTimelineQuestions", () => {
 
   it("drops user turns that render no bubble", () => {
     // UserMessage returns null for a text-less turn (an interaction_result
-    // resolving an approval card), so a dot pointing at one would scroll
+    // resolving an approval card), so a marker pointing at one would scroll
     // nowhere.
     const resolution = msg("user", MAIN, [
       { type: "interaction_result", toolUseId: "t-1", output: { approved: true } },
@@ -92,129 +91,61 @@ describe("shouldShowTimeline", () => {
 });
 
 describe("layoutTimelineNodes", () => {
-  const opts = { contentHeight: 1000, trackHeight: 500, minGapPx: 8 };
+  const opts = { trackHeight: 500, stepPx: 8 };
 
-  it("places each dot at its share of the content height", () => {
-    const anchors: MeasuredAnchor[] = [
-      { messageId: "a", top: 0 },
-      { messageId: "b", top: 500 },
-    ];
-    expect(layoutTimelineNodes(anchors, opts)).toEqual([
-      { messageId: "a", fraction: 0 },
-      { messageId: "b", fraction: 0.5 },
+  it("places questions in a compact fixed rhythm", () => {
+    expect(layoutTimelineNodes(["a", "b", "c"], opts)).toEqual([
+      { messageId: "a", topPx: 242 },
+      { messageId: "b", topPx: 250 },
+      { messageId: "c", topPx: 258 },
     ]);
   });
 
-  it("pushes a crowded dot down instead of dropping it", () => {
-    // b is 4px below a on a 500px track — under the 8px floor. It moves to 8px
-    // (fraction 0.016) and stays clickable. This is the whole point: merging
-    // would make b unreachable while looking identical to a lossless dot.
-    const anchors: MeasuredAnchor[] = [
-      { messageId: "a", top: 0 },
-      { messageId: "b", top: 8 },
-    ];
-    const nodes = layoutTimelineNodes(anchors, opts);
-    expect(nodes).toHaveLength(2);
-    expect(nodes[0].fraction).toBe(0);
-    expect(nodes[1].fraction).toBeCloseTo(0.016, 5);
+  it("does not stretch a short sequence across the track", () => {
+    const nodes = layoutTimelineNodes(["a", "b"], opts);
+    expect(nodes.map((node) => node.topPx)).toEqual([246, 254]);
   });
 
-  it("keeps pushing across a dense run", () => {
-    const anchors: MeasuredAnchor[] = [
-      { messageId: "a", top: 0 },
-      { messageId: "b", top: 2 },
-      { messageId: "c", top: 4 },
-    ];
-    const nodes = layoutTimelineNodes(anchors, opts);
-    expect(nodes.map((n) => Math.round(n.fraction * 500))).toEqual([0, 8, 16]);
+  it("keeps every marker distinct up to the track's preferred capacity", () => {
+    const ids = Array.from({ length: 60 }, (_, i) => `q${i}`);
+    const ys = layoutTimelineNodes(ids, opts).map((node) => node.topPx);
+    expect(new Set(ys).size).toBe(60);
+    expect(ys[0]).toBe(14);
+    expect(ys[59]).toBe(486);
   });
 
-  it("ends the last dot at the foot of the track", () => {
-    const anchors: MeasuredAnchor[] = [
-      { messageId: "a", top: 1000 },
-      { messageId: "b", top: 1000 },
-    ];
-    const nodes = layoutTimelineNodes(anchors, opts);
-    expect(nodes.map((n) => Math.round(n.fraction * 500))).toEqual([492, 500]);
-  });
-
-  it("pulls a dense run at the bottom back up instead of stacking it", () => {
-    // Three questions in the last 1% of the transcript. A forward-only pass
-    // clamps the last two onto the same pixel, so one of them can never be
-    // clicked — while the track still has 484px of unused room above.
-    const anchors: MeasuredAnchor[] = [
-      { messageId: "a", top: 990 },
-      { messageId: "b", top: 995 },
-      { messageId: "c", top: 1000 },
-    ];
-    const nodes = layoutTimelineNodes(anchors, opts);
-    expect(nodes.map((n) => Math.round(n.fraction * 500))).toEqual([484, 492, 500]);
-  });
-
-  it("keeps every dot distinct up to the track's real capacity", () => {
-    // 60 questions all at the very bottom; a 500px track at an 8px gap holds
-    // 63, so none of them may share a position.
-    const anchors: MeasuredAnchor[] = Array.from({ length: 60 }, (_, i) => ({
-      messageId: `q${i}`,
-      top: 1000,
-    }));
-    const ys = layoutTimelineNodes(anchors, opts).map((n) => n.fraction * 500);
-    expect(new Set(ys.map((y) => Math.round(y))).size).toBe(60);
-    expect(Math.min(...ys)).toBeGreaterThanOrEqual(0);
-    expect(Math.max(...ys)).toBeCloseTo(500, 5);
-  });
-
-  it("tightens the gap rather than stacking once the track overflows", () => {
-    // 60 questions on a 400px track: at an 8px gap only 51 fit, so a fixed gap
-    // would clamp the surplus onto y=0 and make all but one unreachable.
-    const anchors: MeasuredAnchor[] = Array.from({ length: 60 }, (_, i) => ({
-      messageId: `q${i}`,
-      top: 1000,
-    }));
-    const nodes = layoutTimelineNodes(anchors, {
-      contentHeight: 1000,
-      trackHeight: 400,
-      minGapPx: 8,
-    });
-    const ys = nodes.map((n) => n.fraction * 400);
+  it("tightens the rhythm evenly when the track overflows", () => {
+    const ids = Array.from({ length: 60 }, (_, i) => `q${i}`);
+    const nodes = layoutTimelineNodes(ids, { trackHeight: 400, stepPx: 8 });
+    const ys = nodes.map((node) => node.topPx);
     expect(new Set(ys).size).toBe(60);
     expect(ys[0]).toBeCloseTo(0, 5);
     expect(ys[59]).toBeCloseTo(400, 5);
-    // Evenly spread across the track at the tightened gap.
     expect(ys[1] - ys[0]).toBeCloseTo(400 / 59, 5);
   });
 
   it("returns nothing before layout", () => {
-    expect(
-      layoutTimelineNodes([{ messageId: "a", top: 0 }], {
-        contentHeight: 0,
-        trackHeight: 500,
-        minGapPx: 8,
-      }),
-    ).toEqual([]);
+    expect(layoutTimelineNodes(["a"], { trackHeight: 0, stepPx: 8 })).toEqual([]);
+    expect(layoutTimelineNodes([], opts)).toEqual([]);
   });
 });
 
 describe("sameNodes", () => {
   it("ignores sub-pixel drift", () => {
-    expect(
-      sameNodes([{ messageId: "a", fraction: 0.5 }], [{ messageId: "a", fraction: 0.5005 }]),
-    ).toBe(true);
+    expect(sameNodes([{ messageId: "a", topPx: 8 }], [{ messageId: "a", topPx: 8.2 }])).toBe(true);
   });
 
   it("notices a real move", () => {
-    expect(
-      sameNodes([{ messageId: "a", fraction: 0.5 }], [{ messageId: "a", fraction: 0.6 }]),
-    ).toBe(false);
+    expect(sameNodes([{ messageId: "a", topPx: 8 }], [{ messageId: "a", topPx: 9 }])).toBe(false);
   });
 
   it("notices a new question", () => {
     expect(
       sameNodes(
-        [{ messageId: "a", fraction: 0 }],
+        [{ messageId: "a", topPx: 0 }],
         [
-          { messageId: "a", fraction: 0 },
-          { messageId: "b", fraction: 1 },
+          { messageId: "a", topPx: 0 },
+          { messageId: "b", topPx: 8 },
         ],
       ),
     ).toBe(false);

--- a/packages/web/src/components/chat/chat-timeline.ts
+++ b/packages/web/src/components/chat/chat-timeline.ts
@@ -1,20 +1,19 @@
 import { userMessageText } from "@/components/chat/chat-view";
 import type { ChatMessage } from "@/lib/chat-types";
 
-// The pure model behind the question timeline rail. It never touches the DOM:
-// the rail hands it measured pixels and gets back fractions. jsdom reports zero
-// for every rect, so this split is what makes the layout rules testable at all.
+// The pure model behind the question timeline rail. It never touches the DOM,
+// so the compact sequence and overflow rules stay testable without layout.
 
 /** Below this many questions the rail is not worth its pixels. */
 export const MIN_TIMELINE_QUESTIONS = 4;
 
-/** Minimum on-track distance between two dots, in px. */
-export const MIN_NODE_GAP_PX = 8;
+/** Preferred distance between adjacent question markers, in px. */
+export const TIMELINE_NODE_STEP_PX = 8;
 
 const SUMMARY_MAX_CHARS = 60;
 
 /** Sub-pixel drift that must not trigger a re-render. */
-const FRACTION_EPSILON = 0.002;
+const POSITION_EPSILON_PX = 0.5;
 
 export interface TimelineQuestion {
   messageId: string;
@@ -22,16 +21,9 @@ export interface TimelineQuestion {
   text: string;
 }
 
-/** A question's measured offset from the top of the scrollable content. */
-export interface MeasuredAnchor {
-  messageId: string;
-  top: number;
-}
-
 export interface TimelineNode {
   messageId: string;
-  /** 0..1 position down the TRACK — used directly as a CSS percentage. */
-  fraction: number;
+  topPx: number;
 }
 
 /**
@@ -82,72 +74,38 @@ export function shouldShowTimeline(
 }
 
 /**
- * Project anchors onto the track, pushing any dot that would crowd its
- * predecessor further down.
+ * Lay questions out in transcript order at a stable, compact rhythm.
  *
- * Spreading, not merging. Merging crowded dots into one node makes the
- * swallowed questions unreachable by click while looking identical to a
- * lossless dot — the rail would lie, in exactly the long conversations it
- * exists for. Spreading trades local positional fidelity for the guarantee that
- * every question stays individually clickable.
- *
- * Two passes, because one is not enough. The forward pass pushes each crowded
- * dot below its predecessor. On its own that collapses at the bottom edge: a
- * run of questions near the end of the transcript is pushed past the track and
- * clamped, so several dots land on the same pixel and all but one become
- * unclickable — the exact failure spreading exists to avoid. The backward pass
- * pulls such a run back up, which the track has room for whenever the dots fit
- * at all.
- *
- * When they do not fit — more questions than `trackHeight / minGapPx`, which a
- * long chat in a short window reaches — the gap tightens so the whole set still
- * spans the track. Every dot keeps a distinct centre and a sliver of itself to
- * click. Holding the gap fixed instead would push the surplus off the top and
- * clamp it there, stacking those questions on one pixel and making all but the
- * last unreachable.
+ * Rendered message height is deliberately absent from this contract. A marker
+ * represents one question, so wrapping, code blocks, media, and streamed reply
+ * growth must not change the navigation structure. When the preferred rhythm
+ * cannot fit, the step tightens evenly so every question remains represented.
  */
 export function layoutTimelineNodes(
-  anchors: MeasuredAnchor[],
-  opts: { contentHeight: number; trackHeight: number; minGapPx: number },
+  messageIds: string[],
+  opts: { trackHeight: number; stepPx: number },
 ): TimelineNode[] {
-  const { contentHeight, trackHeight, minGapPx } = opts;
-  if (contentHeight <= 0 || trackHeight <= 0) return [];
+  const { trackHeight, stepPx } = opts;
+  if (messageIds.length === 0 || trackHeight <= 0) return [];
 
-  const gap =
-    anchors.length > 1 ? Math.min(minGapPx, trackHeight / (anchors.length - 1)) : minGapPx;
+  const step = messageIds.length > 1 ? Math.min(stepPx, trackHeight / (messageIds.length - 1)) : 0;
+  const span = step * (messageIds.length - 1);
+  const start = (trackHeight - span) / 2;
 
-  const ys: number[] = [];
-  let floor = 0;
-  for (const anchor of anchors) {
-    const natural = Math.min(Math.max(anchor.top / contentHeight, 0), 1) * trackHeight;
-    const y = Math.max(natural, floor);
-    ys.push(y);
-    floor = y + gap;
-  }
-
-  let ceiling = trackHeight;
-  for (let i = ys.length - 1; i >= 0; i--) {
-    if (ys[i] > ceiling) ys[i] = ceiling;
-    ceiling = ys[i] - gap;
-  }
-
-  return ys.map((y, i) => ({
-    messageId: anchors[i].messageId,
-    fraction: Math.max(y, 0) / trackHeight,
+  return messageIds.map((messageId, index) => ({
+    messageId,
+    topPx: start + index * step,
   }));
 }
 
 /**
- * Whether a fresh measurement is worth committing. The rail re-measures on
- * every content resize, which during a streamed reply means many times a
- * second; without this the rail would re-render (and re-render every Radix
- * tooltip root) on drift too small to see.
+ * Whether a fresh layout is worth committing. ResizeObserver can report
+ * sub-pixel track changes, which should not re-render every tooltip root.
  */
 export function sameNodes(a: TimelineNode[], b: TimelineNode[]): boolean {
   if (a.length !== b.length) return false;
   return a.every(
     (node, i) =>
-      node.messageId === b[i].messageId &&
-      Math.abs(node.fraction - b[i].fraction) < FRACTION_EPSILON,
+      node.messageId === b[i].messageId && Math.abs(node.topPx - b[i].topPx) < POSITION_EPSILON_PX,
   );
 }


### PR DESCRIPTION
## What this PR does

The chat timeline distributed question markers according to rendered message height. Long replies created uneven gaps, and streamed content could reshape the index.

This change places each question in a compact sequence in the left transcript gutter. It centers the sequence vertically and keeps the visibility control directly above the first marker.

## Design & Invariants

- Each rendered user question keeps one marker in transcript order.
- Message height does not affect marker spacing.
- The sequence uses an 8px step and compresses evenly only when it exceeds the available height.
- The rail keeps tooltip, jump, keyboard, and hide or show behavior.
- Hidden markers leave the accessibility tree and tab order.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit`
- [x] `pnpm dev:all`
- [x] Verify the rail at 1440x500 in mock mode.
- [x] Verify the 24px gap between the visibility control and the first marker.
- [x] Verify tooltip direction, marker jumps, keyboard navigation, and hide or show behavior.
- [x] Confirm `/api/health` returns 200 after the stack restarts.
