### PR TITLE
fix(core): submit the Claude login code as a bracketed paste so long codes land

### DIFF
--- a/packages/core/src/claude-login-code.test.ts
+++ b/packages/core/src/claude-login-code.test.ts
@@ -9,12 +9,19 @@ const CODE =
   "TEST.left+SEGMENT/ABCDEFGHIJKLMNOPQRSTUVWXYZ012345#TEST~right=SEGMENT_abcdefghijklmnopqrstuvwxyz6789";
 
 describe("formatClaudeLoginCodeInput", () => {
-  it("submits sanitized codes as raw terminal input plus Enter", () => {
-    expect(formatClaudeLoginCodeInput(CODE)).toBe(`${CODE}\r`);
+  // The code rides in a bracketed-paste envelope so the Ink prompt on CLI 2.1.251
+  // takes it as one paste and reads the trailing Enter as a submit. A bare
+  // `${code}\r` write hangs for realistic (~130-char) codes: the TUI folds the
+  // burst's Enter into the pasted text instead of submitting. Sanitized codes
+  // never contain ESC, so the paste sentinels cannot appear inside the code.
+  const paste = (code: string) => `\x1b[200~${code}\x1b[201~\r`;
+
+  it("submits sanitized codes inside a bracketed-paste envelope plus Enter", () => {
+    expect(formatClaudeLoginCodeInput(CODE)).toBe(paste(CODE));
   });
 
   it("strips accidental surrounding and wrapped whitespace", () => {
-    expect(formatClaudeLoginCodeInput(`  ${CODE.replace("#", "\n#")}  `)).toBe(`${CODE}\r`);
+    expect(formatClaudeLoginCodeInput(`  ${CODE.replace("#", "\n#")}  `)).toBe(paste(CODE));
   });
 });
 

--- a/packages/core/src/claude-login-code.ts
+++ b/packages/core/src/claude-login-code.ts
@@ -148,11 +148,18 @@ export function extractClaudeLoginCode(raw: string): string {
 
 /**
  * Format a validated Claude OAuth code as terminal input for the Ink TUI.
- * Control characters are rejected during validation, so writing the sanitized
- * text plus carriage return is deterministic and cannot accidentally include
- * bracketed-paste sentinel bytes in the submitted code.
+ *
+ * The code rides inside a bracketed-paste envelope (`ESC[200~` … `ESC[201~`)
+ * followed by a carriage return. CLI 2.1.251's Ink "Paste code here" prompt
+ * treats a single burst of many characters as a paste and folds a trailing
+ * `\r` in that same burst into the pasted text instead of submitting — so a
+ * bare `${code}\r` write hangs for realistic (~130-char) codes while short
+ * ones happen to submit. The `ESC[201~` terminator ends the paste explicitly,
+ * so the following `\r` reads as a clean submit keypress regardless of length.
+ * Validation rejects control characters, so the code can never contain ESC and
+ * thus cannot forge the paste sentinels.
  */
 export function formatClaudeLoginCodeInput(raw: string): string {
   const code = extractClaudeLoginCode(raw);
-  return `${code}\r`;
+  return `\x1b[200~${code}\x1b[201~\r`;
 }


### PR DESCRIPTION
## What this PR does

After the sign-in URL appears (#231), pasting a real OAuth code left the Claude login dialog spinning forever and the login never completed. The submit handler wrote `${code}\r` in one PTY write; CLI 2.1.251's Ink "Paste code here" prompt reads a single burst of many characters as a paste and folds a trailing `\r` in that same burst into the pasted text instead of submitting. Short codes stayed under the paste heuristic and submitted (surfacing a 400), so the hang only affected realistic ~130-char codes — the CLI sat at the prompt, never exchanged, never errored, and no credentials were written.

The fix wraps the code in a bracketed-paste envelope (`ESC[200~` … `ESC[201~`) before the carriage return. The terminator ends the paste explicitly, so the following `\r` reads as a submit keypress at any length. Distinct from #231, which fixed prompt parsing and first let users reach this step.

## Design & Invariants

- Validation already rejects control characters, so the code can never contain ESC and cannot forge the paste sentinels — the envelope is unambiguous.
- Length-independent by construction: the fix removes the paste-heuristic dependence rather than tuning a threshold.

## Test plan

- [x] `pnpm --filter @rome/core test:unit` — `formatClaudeLoginCodeInput` now asserts the bracketed-paste envelope; full suite green (4352).
- [x] In-container pty driver against the real 2.1.251 CLI: `code\r` hangs for a 138-char code (and still hangs at cols=400, ruling out line wrapping) while the bracketed form submits; short codes unaffected.
- [x] End to end in the dev stack: a real OAuth code that previously spun forever now completes the login (`claude auth status` → logged in); the same long fake code that hung now reaches the CLI and surfaces the expected 400.

## Not in this PR

- The dialog does not auto-detect the completed login (it polls cached status, which refreshes only on process exit — and `claude /login` no longer exits — or hourly), so it keeps spinning until a manual Refresh. Tracked as a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)