### PR TITLE
fix(web): detect Claude login completion via a provider-scoped live refresh

### DIFF
--- a/packages/core/src/api/routes/ai-tools.test.ts
+++ b/packages/core/src/api/routes/ai-tools.test.ts
@@ -361,7 +361,28 @@ describe("AI tools status API", () => {
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual(refreshed);
-      expect(refresh).toHaveBeenCalledWith();
+      // No `?provider` → a full refresh (undefined is the "all providers" case).
+      expect(refresh).toHaveBeenCalledWith(undefined);
+    } finally {
+      testDb.close();
+    }
+  });
+
+  it("scopes the refresh to one provider when ?provider is given", async () => {
+    const testDb = createTestDb();
+    try {
+      const deps = await buildTestDeps(testDb.db);
+      const refresh = rs
+        .spyOn(deps.aiToolState, "refresh")
+        .mockResolvedValue(deps.aiToolState.get());
+      const app = new Hono().route("/", aiToolsRoutes(deps));
+
+      await app.request("/ai-tools/refresh?provider=anthropic", { method: "POST" });
+      expect(refresh).toHaveBeenLastCalledWith("anthropic");
+
+      // An unknown provider falls back to a full refresh rather than erroring.
+      await app.request("/ai-tools/refresh?provider=bogus", { method: "POST" });
+      expect(refresh).toHaveBeenLastCalledWith(undefined);
     } finally {
       testDb.close();
     }

--- a/packages/core/src/api/routes/ai-tools.ts
+++ b/packages/core/src/api/routes/ai-tools.ts
@@ -74,7 +74,15 @@ export function aiToolsRoutes(
 
   app.post("/ai-tools/refresh", async (c) => {
     try {
-      return c.json(await deps.aiToolState.refresh());
+      // Optional `provider` scopes the refresh to one tool. The login dialog
+      // polls `?provider=anthropic` so an unrelated slow Codex probe can never
+      // stall Claude login detection; no provider refreshes everything (the
+      // manual Refresh button). `refresh(provider)` is already ordered against
+      // revocation via the shared per-provider in-flight lock.
+      const providerParam = c.req.query("provider");
+      const provider =
+        providerParam === "anthropic" || providerParam === "openai" ? providerParam : undefined;
+      return c.json(await deps.aiToolState.refresh(provider));
     } catch (err) {
       return c.json({ error: err instanceof Error ? err.message : "Refresh failed" }, 500);
     }

--- a/packages/web/src/components/terminal-modal.test.tsx
+++ b/packages/web/src/components/terminal-modal.test.tsx
@@ -1,0 +1,83 @@
+// @rstest-environment jsdom
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, rs } from "@rstest/core";
+import i18n from "@/i18n";
+import TerminalModal from "./terminal-modal";
+
+// Minimal WebSocket stand-in: the modal only needs `onopen` to fire so it
+// enters the "connected" state and starts polling. It never renders raw output.
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: ((event: { reason?: string }) => void) | null = null;
+  constructor() {
+    MockWebSocket.instances.push(this);
+  }
+  send() {}
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+}
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+});
+
+afterEach(() => {
+  cleanup();
+  rs.restoreAllMocks();
+  rs.useRealTimers();
+  MockWebSocket.instances = [];
+});
+
+describe("TerminalModal Claude login completion", () => {
+  it("detects a completed login by re-probing the provider-scoped refresh, not cached status", async () => {
+    rs.useFakeTimers();
+    (globalThis as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = MockWebSocket;
+
+    const calls: Array<{ url: string; method: string }> = [];
+    rs.spyOn(globalThis, "fetch").mockImplementation((async (input, init) => {
+      const url = String(input);
+      calls.push({ url, method: init?.method ?? "GET" });
+      if (url.startsWith("/api/ai-tools/refresh")) {
+        return Response.json({ claude: { loggedIn: true }, codex: { loggedIn: false } });
+      }
+      throw new Error(`unexpected request: ${url}`);
+    }) as typeof fetch);
+
+    const onClose = rs.fn();
+    render(<TerminalModal preset="claude-login" onClose={onClose} />);
+
+    // Drive the socket open so the modal starts its completion poll.
+    await act(async () => {
+      MockWebSocket.instances[0]?.onopen?.();
+    });
+
+    // First poll tick fires the re-probe.
+    await act(async () => {
+      await rs.advanceTimersByTimeAsync(2000);
+    });
+
+    const refreshCalls = calls.filter((c) => c.url.startsWith("/api/ai-tools/refresh"));
+    expect(refreshCalls.length).toBeGreaterThan(0);
+    expect(refreshCalls.every((c) => c.method === "POST")).toBe(true);
+    // Scoped to Claude's provider so an unrelated slow probe can't stall it.
+    expect(refreshCalls.every((c) => c.url === "/api/ai-tools/refresh?provider=anthropic")).toBe(
+      true,
+    );
+    // The cached status endpoint must not be the completion signal.
+    expect(calls.some((c) => c.url === "/api/ai-tools/status")).toBe(false);
+
+    // Success lands, then the dialog closes itself after the success beat.
+    await act(async () => {
+      await rs.advanceTimersByTimeAsync(1200);
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/terminal-modal.tsx
+++ b/packages/web/src/components/terminal-modal.tsx
@@ -39,8 +39,8 @@ function getTerminalWebSocketUrl(preset: string): string {
  * Native dialog for the PTY-backed Claude login flow. The terminal itself is
  * never shown: the modal opens the WebSocket that runs `claude /login`, shows
  * instructions with a button to open the parsed sign-in page, and takes the
- * pasted callback link or code. Completion is detected by polling
- * `/api/ai-tools/status`. (Logout is non-interactive and handled inline on the
+ * pasted callback link or code. Completion is detected by re-probing
+ * `/api/ai-tools/refresh`. (Logout is non-interactive and handled inline on the
  * Settings button, so it never opens this dialog.)
  */
 export default function TerminalModal({ preset, onClose }: TerminalModalProps) {
@@ -61,10 +61,21 @@ export default function TerminalModal({ preset, onClose }: TerminalModalProps) {
   // One auth-status probe; flips authComplete when the desired state is reached.
   // Reused by the poll and by the PTY-exit handler — the process can exit the
   // instant login persists, before the next poll tick, so we re-check on exit.
+  //
+  // Re-probes live via POST /ai-tools/refresh scoped to this provider, rather
+  // than reading GET /ai-tools/status. The cached status only refreshes when the
+  // PTY process exits or on the hourly timer, but `claude /login` on CLI 2.1.251
+  // does not exit after a successful login, so a cached read would keep the
+  // dialog spinning on a login that already succeeded. Scoping to the provider
+  // keeps an unrelated slow probe from stalling detection.
   const checkAuthOnce = useCallback(
     async (signal?: AbortSignal) => {
       try {
-        const res = await fetch("/api/ai-tools/status", { signal });
+        const refreshProvider = providerKey === "claude" ? "anthropic" : "openai";
+        const res = await fetch(`/api/ai-tools/refresh?provider=${refreshProvider}`, {
+          method: "POST",
+          signal,
+        });
         const data = await res.json();
         const toolStatus = data[providerKey] as AIToolStatus | undefined;
         if (toolStatus?.loggedIn === true) setAuthComplete(true);
@@ -75,14 +86,22 @@ export default function TerminalModal({ preset, onClose }: TerminalModalProps) {
     [providerKey],
   );
 
-  // Poll auth status while the session is live.
+  // Poll auth status while the session is live. Each tick is scheduled only
+  // after the previous probe settles, so a slow probe cannot pile requests up.
   useEffect(() => {
     if (status !== "connected") return;
     const controller = new AbortController();
-    const interval = setInterval(() => checkAuthOnce(controller.signal), POLL_INTERVAL_MS);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
+    const tick = async () => {
+      await checkAuthOnce(controller.signal);
+      if (!cancelled) timer = setTimeout(tick, POLL_INTERVAL_MS);
+    };
+    timer = setTimeout(tick, POLL_INTERVAL_MS);
     return () => {
+      cancelled = true;
       controller.abort();
-      clearInterval(interval);
+      if (timer) clearTimeout(timer);
     };
   }, [status, checkAuthOnce]);
 


### PR DESCRIPTION
## What this PR does

After #238 let a real OAuth code complete the login, the Claude login dialog still spun forever and never closed — the user had to dismiss it and click Refresh before Claude showed "Connected". The completion poll read `GET /ai-tools/status`, whose cache only refreshes when the login PTY process exits or on the hourly timer. CLI 2.1.251's `claude /login` does not exit after a successful login (it drops into the interactive session), so the cached read never flipped even though the login had already succeeded.

The dialog now polls `POST /ai-tools/refresh` scoped to its provider (`?provider=anthropic`), and schedules each tick only after the previous settles. Scoping reuses the existing per-provider refresh, so a slow or stuck Codex probe cannot stall Claude login detection.

## Design & Invariants

- Reuses `refresh(provider)`, which is already ordered against `markAuthRevoked` through the shared per-provider in-flight lock — no new endpoint, no second writer to Claude state, no new concurrency surface.
- `POST /ai-tools/refresh` with no `provider` is unchanged (full refresh, as the manual Refresh button uses); an unknown value falls back to a full refresh rather than erroring.

## Test plan

- [x] `pnpm --filter @rome/core test` — route test asserts `?provider=anthropic` calls `refresh("anthropic")` and an unknown value falls back to a full refresh.
- [x] `pnpm --filter rome-web test` — terminal-modal test asserts the poll hits the scoped refresh (never the cached status) and closes on `loggedIn: true`; full suite green (1359).
- [x] End to end in the dev stack: the open dialog polls `POST /ai-tools/refresh?provider=anthropic`; a real login (verified by the reporter) closes the dialog on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)