### PR TITLE
feat: add GPT-6 Astra to the model selector with its pricing

### DIFF
--- a/packages/core/src/core/model-resolver.test.ts
+++ b/packages/core/src/core/model-resolver.test.ts
@@ -175,7 +175,10 @@ describe("ModelResolver", () => {
     });
   });
 
-  it("keeps explicit Sol/Luna exact and never falls back", async () => {
+  it("keeps explicit Astra/Sol/Luna exact and never falls back", async () => {
+    await expect(
+      resolver().getModelProvider({ tier: "large", selectionId: "gpt-6-astra" }),
+    ).resolves.toMatchObject({ modelProvider: codex, model: "gpt-6-astra" });
     await expect(
       resolver().getModelProvider({ tier: "large", selectionId: "gpt-5-6-sol" }),
     ).resolves.toMatchObject({ modelProvider: codex, model: "gpt-5.6-sol" });
@@ -193,6 +196,9 @@ describe("ModelResolver", () => {
     });
     await expect(
       unavailable.getModelProvider({ tier: "large", selectionId: "gpt-5-6-sol" }),
+    ).rejects.toThrow("Selected model is unavailable");
+    await expect(
+      unavailable.getModelProvider({ tier: "large", selectionId: "gpt-6-astra" }),
     ).rejects.toThrow("Selected model is unavailable");
   });
 
@@ -358,6 +364,13 @@ describe("ModelResolver", () => {
   it("denies an exact request for a model whose access was lost", async () => {
     const noEntitlements = resolver({
       codex: { loggedIn: true, quotaExhausted: false, solAccess: false, lunaAccess: false },
+    });
+    await expect(
+      noEntitlements.getModelProvider({ exact: { providerId: "openai", model: "gpt-6-astra" } }),
+    ).rejects.toMatchObject({
+      code: "model_unavailable",
+      provider: "openai",
+      reason: "model_access_denied",
     });
     await expect(
       noEntitlements.getModelProvider({ exact: { providerId: "openai", model: "gpt-5.6-sol" } }),

--- a/packages/core/src/core/model-resolver.ts
+++ b/packages/core/src/core/model-resolver.ts
@@ -173,9 +173,13 @@ export function createModelResolver(options: CreateModelResolverOptions): ModelR
     );
   };
 
-  /** Throws when the model is entitlement-gated (Sol/Luna) and access is lost. */
+  /**
+   * Throws when the model is entitlement-gated and access is lost. Astra ships
+   * to the same paid plans as Sol, so it rides the Sol entitlement.
+   */
   const requireModelAccess = (model: string, codex: AIToolStateValue["codex"]): void => {
     const denied =
+      (model === "gpt-6-astra" && !codex.solAccess) ||
       (model === "gpt-5.6-sol" && !codex.solAccess) ||
       (model === "gpt-5.6-luna" && !codex.lunaAccess);
     if (!denied) return;

--- a/packages/core/src/core/model-selector.test.ts
+++ b/packages/core/src/core/model-selector.test.ts
@@ -39,6 +39,10 @@ describe("webchat model selector", () => {
   });
 
   it("maps GPT selections to the Codex provider", () => {
+    expect(resolveWebchatLargeModelSelection("gpt-6-astra")).toMatchObject({
+      providerId: "openai",
+      model: "gpt-6-astra",
+    });
     expect(resolveWebchatLargeModelSelection("gpt-5-6-sol")).toMatchObject({
       providerId: "openai",
       model: "gpt-5.6-sol",

--- a/packages/core/src/core/model-selector.ts
+++ b/packages/core/src/core/model-selector.ts
@@ -13,6 +13,7 @@ export type WebchatLargeModelSelectionId =
   | "claude-sonnet"
   | "claude-haiku"
   | "claude-fable"
+  | "gpt-6-astra"
   | "gpt-5-6-sol"
   | "gpt-5-6-terra"
   | "gpt-5-6-luna";
@@ -60,6 +61,11 @@ export const WEBCHAT_LARGE_MODEL_SELECTIONS: Record<ModelSelectionId, WebchatLar
       id: "claude-fable",
       providerId: "anthropic",
       model: "claude-fable-5-1[1m]",
+    },
+    "gpt-6-astra": {
+      id: "gpt-6-astra",
+      providerId: "openai",
+      model: "gpt-6-astra",
     },
     "gpt-5-6-sol": {
       id: "gpt-5-6-sol",

--- a/packages/core/src/core/provider-accounting.test.ts
+++ b/packages/core/src/core/provider-accounting.test.ts
@@ -140,6 +140,34 @@ describe("provider-accounting", () => {
     );
   });
 
+  it("calculates GPT-6 Astra costs with cache pricing", () => {
+    const usage = {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      cacheWriteTokens: 1_000_000,
+    };
+
+    expect(calculateImpliedCostUsd("openai", "gpt-6-astra", usage)).toBeCloseTo(73.5);
+    expect(calculateImpliedCostUsd("openai", "gpt-6-astra:high", usage)).toBeCloseTo(73.5);
+  });
+
+  it("applies the long-context input and output multipliers to GPT-6 Astra", () => {
+    const impliedCostUsd = calculateImpliedCostUsd(
+      "openai",
+      "gpt-6-astra",
+      {
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+        cacheReadTokens: 1_000_000,
+        cacheWriteTokens: 1_000_000,
+      },
+      { input_tokens: 272_001 },
+    );
+
+    expect(impliedCostUsd).toBeCloseTo(122);
+  });
+
   it("calculates GPT-5.6 Sol, Terra, and Luna costs with cache pricing", () => {
     const usage = {
       inputTokens: 1_000_000,

--- a/packages/core/src/core/provider-accounting.ts
+++ b/packages/core/src/core/provider-accounting.ts
@@ -72,7 +72,11 @@ function getAnthropicCacheWriteMultiplier(rawUsage?: Record<string, unknown>): n
   return ANTHROPIC_5_MINUTE_CACHE_WRITE_MULTIPLIER;
 }
 
-function openAi56Rates(
+// OpenAI's Codex-era rate card: cache reads at 0.1x and cache writes at
+// 1.25x the input rate, with the whole request billed at long-context
+// multipliers once the prompt passes 272K input tokens. GPT-5.6 and GPT-6
+// publish the same rules, so one helper serves both generations.
+function openAiLongContextRates(
   inputUsdPerMillion: number,
   outputUsdPerMillion: number,
   rawUsage?: Record<string, unknown>,
@@ -166,19 +170,24 @@ const PRICING_RULES: PricingRule[] = [
   // previously recorded rows.
   {
     provider: "openai",
+    matchesModel: (model) => matchesModelAlias(model, "gpt-6-astra"),
+    resolveRates: (rawUsage) => openAiLongContextRates(10, 50, rawUsage),
+  },
+  {
+    provider: "openai",
     matchesModel: (model) =>
       matchesModelAlias(model, "gpt-5.6-sol") || matchesModelAlias(model, "gpt-5.6"),
-    resolveRates: (rawUsage) => openAi56Rates(5, 30, rawUsage),
+    resolveRates: (rawUsage) => openAiLongContextRates(5, 30, rawUsage),
   },
   {
     provider: "openai",
     matchesModel: (model) => matchesModelAlias(model, "gpt-5.6-terra"),
-    resolveRates: (rawUsage) => openAi56Rates(2.5, 15, rawUsage),
+    resolveRates: (rawUsage) => openAiLongContextRates(2.5, 15, rawUsage),
   },
   {
     provider: "openai",
     matchesModel: (model) => matchesModelAlias(model, "gpt-5.6-luna"),
-    resolveRates: (rawUsage) => openAi56Rates(1, 6, rawUsage),
+    resolveRates: (rawUsage) => openAiLongContextRates(1, 6, rawUsage),
   },
   {
     provider: "openai",

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -247,6 +247,7 @@
       "sonnet": "Sonnet",
       "haiku": "Haiku",
       "fable": "Fable",
+      "gpt6Astra": "GPT-6 Astra",
       "gpt56Sol": "GPT-5.6 Sol",
       "gpt56Terra": "GPT-5.6 Terra",
       "gpt56Luna": "GPT-5.6 Luna"

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -247,6 +247,7 @@
       "sonnet": "Sonnet",
       "haiku": "Haiku",
       "fable": "Fable",
+      "gpt6Astra": "GPT-6 Astra",
       "gpt56Sol": "GPT-5.6 Sol",
       "gpt56Terra": "GPT-5.6 Terra",
       "gpt56Luna": "GPT-5.6 Luna"

--- a/packages/web/src/lib/chat-constants.ts
+++ b/packages/web/src/lib/chat-constants.ts
@@ -12,6 +12,7 @@ export const LARGE_MODEL_OPTIONS = [
   { id: "claude-sonnet", labelKey: "modelSelector.options.sonnet" },
   { id: "claude-haiku", labelKey: "modelSelector.options.haiku" },
   { id: "claude-fable", labelKey: "modelSelector.options.fable" },
+  { id: "gpt-6-astra", labelKey: "modelSelector.options.gpt6Astra" },
   { id: "gpt-5-6-sol", labelKey: "modelSelector.options.gpt56Sol" },
   { id: "gpt-5-6-terra", labelKey: "modelSelector.options.gpt56Terra" },
   { id: "gpt-5-6-luna", labelKey: "modelSelector.options.gpt56Luna" },


### PR DESCRIPTION
## What this PR does

OpenAI shipped GPT-6 Astra on September 3 and the webchat model selector had no way to pick it: the selection catalog, the Codex entitlement gate, and the pricing rules all stopped at GPT-5.6. A guardian who wanted Astra had no option, and any Astra usage recorded through Codex would have carried no implied cost because no pricing rule matched the model id.

This adds `gpt-6-astra` as a selection on the OpenAI provider, prices it at the published rate card, and gates it on the same entitlement as Sol.

## Design & Invariants

- **Selection stays exact.** `gpt-6-astra` resolves to exactly that model on the Codex provider and never falls back, matching the precedence in [docs/concepts/sessions.md](docs/concepts/sessions.md): explicit selection wins over the pin and the tier.
- **Pricing follows OpenAI's published rate card.** $10 input, $50 output, $1 cached input, $12.50 cache write per million tokens, with the whole request billed at 2x input and cache and 1.5x output once the prompt passes 272K input tokens. Those are the same rules GPT-5.6 uses, so the helper is renamed from `openAi56Rates` to `openAiLongContextRates` rather than duplicated. Sources: [OpenAI's model page](https://developers.openai.com/api/docs/models/gpt-6-astra) and [the launch announcement](https://community.openai.com/t/introducing-gpt-6-astra-the-most-intelligent-and-aligned-model-in-the-world/1394703).
- **Astra rides the Sol entitlement.** It ships to the same paid plans, so a lost entitlement fails closed with `model_access_denied` instead of surfacing a raw Codex error. Auto-tier resolution is unchanged: the large tier still resolves to Sol.
- **Ordering.** The GPT group lists Astra first, then Sol, Terra, Luna, keeping the descending-capability order the group already had.

## Test plan

- [x] `pnpm --filter @rome/core test:unit model-selector provider-accounting model-resolver` (39 passed, including new Astra cost, long-context, selection, and entitlement cases)
- [x] `pnpm --filter rome-web test i18n` (en and zh-CN key parity)
- [x] `pnpm --filter @rome/core typecheck` and `pnpm --filter rome-web typecheck`
- [x] Mock mode in headless Chromium: enabled the selector under Settings, Advanced, opened the chat model menu, confirmed "GPT-6 Astra" renders above "GPT-5.6 Sol", selected it, and confirmed the trigger label and the persisted `webchatLargeModel` both read `gpt-6-astra`
- [ ] A live Codex turn on `gpt-6-astra` against a ChatGPT plan that has received the Astra rollout

## Not in this PR

- Routing the large auto tier to Astra: it costs 2.5x Sol, so that is a separate cost decision.
- Re-checking the GPT-5.6 rates: third-party coverage of the Astra launch cites lower promotional Sol, Terra, and Luna prices than the ones in this file, but OpenAI's pricing page could not be fetched to confirm, so they are left as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
