### PR TITLE
fix(core): migrate Codex forks to thread/revert

### DIFF
--- a/packages/core/src/core/agent-runner.test.ts
+++ b/packages/core/src/core/agent-runner.test.ts
@@ -786,7 +786,7 @@ describe("AgentRunner", () => {
 
     it("stays one-shot when the fork borrowed the source's thread", async () => {
       // Codex's borrowed exact fork reports the SOURCE thread id: it runs the
-      // turn in the parent conversation and rolls it back out. Persisting that
+      // turn in the parent conversation and reverts it out. Persisting that
       // would append every follow-up to the parent chat.
       const messages = await runForkAgainstLiveSession(
         () =>

--- a/packages/core/src/core/codex-app-server-provider.test.ts
+++ b/packages/core/src/core/codex-app-server-provider.test.ts
@@ -787,6 +787,54 @@ describe("CodexAppServerProvider", () => {
     await source.close();
   });
 
+  it("accepts an already-absent exact-fork revert boundary as clean", async () => {
+    requestMock.mockImplementation(async (method: string) => {
+      if (method === "thread/start") {
+        captured.onNotification?.("thread/started", { thread: { id: "source-thread" } });
+      }
+      if (method === "turn/start") {
+        const n = captured.onNotification!;
+        n("turn/started", { threadId: "source-thread", turn: { id: "missing-fork-turn" } });
+        n("item/completed", {
+          item: { type: "agentMessage", id: "m1", text: "fork answer", phase: "final_answer" },
+          threadId: "source-thread",
+          turnId: "missing-fork-turn",
+          completedAtMs: 0,
+        });
+        n("turn/completed", {
+          threadId: "source-thread",
+          turn: { id: "missing-fork-turn", status: "completed" },
+        });
+      }
+      if (method === "thread/revert") {
+        throw new Error("turn not found: missing-fork-turn");
+      }
+      return {};
+    });
+
+    const provider = new CodexAppServerProvider();
+    const source = await provider.openSession(
+      buildParams({ sessionId: "source-session", isNewSession: true }),
+    );
+    const fork = await source.fork({
+      sessionId: "fork-session",
+      mode: "ephemeral",
+      configurationMode: "exact",
+    });
+    const forkSession = await fork.open(buildForkOpenParams());
+    const collected = collectUntilTerminal(forkSession);
+    await forkSession.sendUserInput({ text: "feedback" });
+
+    expect((await collected).find((message) => message.type === "result")).toMatchObject({
+      content: "fork answer",
+    });
+    expect(requestMock.mock.calls.filter((call) => call[0] === "thread/revert")).toHaveLength(1);
+    await expect(source.fork({ sessionId: "next-fork", mode: "ephemeral" })).resolves.toBeDefined();
+
+    await forkSession.close();
+    await source.close();
+  });
+
   it("routes dynamic subagent calls in a borrowed exact fork to the fork executor", async () => {
     const sourceExecuteSubagent = rs.fn(async () => "source result");
     const forkExecuteSubagent = rs.fn(async () => ({

--- a/packages/core/src/core/codex-app-server-provider.test.ts
+++ b/packages/core/src/core/codex-app-server-provider.test.ts
@@ -249,7 +249,9 @@ describe("CodexAppServerProvider", () => {
       sandbox: "danger-full-access",
       approvalPolicy: "never",
       baseInstructions: "system",
+      historyMode: "paginated",
     });
+    expect(startCall![1]).not.toHaveProperty("skipGitRepoCheck");
     expect((startCall![1] as { config: Record<string, unknown> }).config).not.toHaveProperty(
       "mcp_servers",
     );
@@ -477,9 +479,11 @@ describe("CodexAppServerProvider", () => {
         approvalPolicy: "never",
         baseInstructions: "system",
         ephemeral: false,
-        dynamicTools: expect.arrayContaining([expect.objectContaining({ name: "execute_action" })]),
       }),
     );
+    const forkCall = requestMock.mock.calls.find((call) => call[0] === "thread/fork");
+    expect(forkCall?.[1]).not.toHaveProperty("dynamicTools");
+    expect(forkCall?.[1]).not.toHaveProperty("historyMode");
     expect(source.providerThreadId).toBe("source-thread");
     expect(fork).toMatchObject({
       sessionId: "fork-session",
@@ -531,10 +535,12 @@ describe("CodexAppServerProvider", () => {
         baseInstructions: "system",
         ephemeral: false,
         lastTurnId: "provider-turn-t2",
-        dynamicTools: expect.arrayContaining([expect.objectContaining({ name: "execute_action" })]),
       }),
     );
-    expect(requestMock).not.toHaveBeenCalledWith("thread/rollback", expect.anything());
+    const forkCall = requestMock.mock.calls.find((call) => call[0] === "thread/fork");
+    expect(forkCall?.[1]).not.toHaveProperty("dynamicTools");
+    expect(forkCall?.[1]).not.toHaveProperty("historyMode");
+    expect(requestMock).not.toHaveBeenCalledWith("thread/revert", expect.anything());
     expect(fork.providerThreadId).toBe("historical-fork-thread");
 
     await forkSession.close();
@@ -558,7 +564,7 @@ describe("CodexAppServerProvider", () => {
     );
     // Same model, prompt and cwd, branching at the current head: exactly the
     // shape that borrows today. A "thread" fork has to decline that, because a
-    // borrowed turn is rolled back out of the source and leaves nothing to
+    // borrowed turn is reverted out of the source and leaves nothing to
     // resume — and reports the source's own thread id.
     const fork = await source.fork({
       sessionId: "fork-session",
@@ -571,14 +577,14 @@ describe("CodexAppServerProvider", () => {
       "thread/fork",
       expect.objectContaining({ threadId: "source-thread", ephemeral: false }),
     );
-    expect(requestMock).not.toHaveBeenCalledWith("thread/rollback", expect.anything());
+    expect(requestMock).not.toHaveBeenCalledWith("thread/revert", expect.anything());
     expect(fork.providerThreadId).toBe("continuable-fork-thread");
 
     await forkSession.close();
     await source.close();
   });
 
-  it("runs a same-model exact fork on the source thread and rolls it back", async () => {
+  it("runs a same-model exact fork on the source thread and reverts it", async () => {
     requestMock.mockImplementation(async (method: string) => {
       if (method === "thread/start") {
         captured.onNotification?.("thread/started", { thread: { id: "source-thread" } });
@@ -624,9 +630,9 @@ describe("CodexAppServerProvider", () => {
       "turn/start",
       expect.objectContaining({ threadId: "source-thread" }),
     );
-    expect(requestMock).toHaveBeenCalledWith("thread/rollback", {
+    expect(requestMock).toHaveBeenCalledWith("thread/revert", {
       threadId: "source-thread",
-      numTurns: 1,
+      beforeTurnId: "hidden-fork-turn",
     });
     expect(fork.providerThreadId).toBe("source-thread");
     expect(source.providerThreadId).toBe("source-thread");
@@ -809,13 +815,10 @@ describe("CodexAppServerProvider", () => {
     });
     expect(startMock).toHaveBeenCalledTimes(2);
     expect(requestMock.mock.calls.filter((call) => call[0] === "initialize")).toHaveLength(2);
-    expect(requestMock).toHaveBeenCalledWith(
-      "thread/resume",
-      expect.objectContaining({
-        threadId: "thread-restart",
-        dynamicTools: expect.arrayContaining([expect.objectContaining({ name: "execute_action" })]),
-      }),
-    );
+    const resumeCall = requestMock.mock.calls.find((call) => call[0] === "thread/resume");
+    expect(resumeCall?.[1]).toMatchObject({ threadId: "thread-restart" });
+    expect(resumeCall?.[1]).not.toHaveProperty("dynamicTools");
+    expect(resumeCall?.[1]).not.toHaveProperty("historyMode");
     await session.close();
   });
 
@@ -833,7 +836,7 @@ describe("CodexAppServerProvider", () => {
       }
       // The real client rejects post-exit requests immediately instead of
       // leaving them pending (see AppServerClient.request).
-      if (method === "thread/rollback") throw new Error("codex app-server exited");
+      if (method === "thread/revert") throw new Error("codex app-server exited");
       return {};
     });
 
@@ -860,7 +863,7 @@ describe("CodexAppServerProvider", () => {
     await source.close();
   });
 
-  it("poisons the source session when exact-fork rollback fails", async () => {
+  it("poisons the source session when exact-fork revert fails", async () => {
     requestMock.mockImplementation(async (method: string) => {
       if (method === "thread/start") {
         captured.onNotification?.("thread/started", { thread: { id: "source-thread" } });
@@ -879,7 +882,7 @@ describe("CodexAppServerProvider", () => {
           turn: { id: "fork-turn", status: "completed" },
         });
       }
-      if (method === "thread/rollback") throw new Error("rollback rejected");
+      if (method === "thread/revert") throw new Error("revert rejected");
       return {};
     });
 
@@ -899,22 +902,20 @@ describe("CodexAppServerProvider", () => {
     const msgs = await collected;
 
     // Retried once, then gave up.
-    expect(requestMock.mock.calls.filter((c) => c[0] === "thread/rollback")).toHaveLength(2);
+    expect(requestMock.mock.calls.filter((c) => c[0] === "thread/revert")).toHaveLength(2);
     // The fork never observes success while its turn is still in the source.
     expect(msgs.find((m) => m.type === "result")).toBeUndefined();
     expect(msgs.find((m) => m.type === "error")).toMatchObject({
-      error: expect.stringContaining("rollback failed"),
+      error: expect.stringContaining("revert failed"),
     });
     // The source stream carries the contamination error…
     await expect(sourceEvents.next()).resolves.toMatchObject({
-      value: { type: "error", error: expect.stringContaining("rollback failed") },
+      value: { type: "error", error: expect.stringContaining("revert failed") },
     });
     // …and nothing may resume from the contaminated thread.
-    await expect(source.sendUserInput({ text: "next real turn" })).rejects.toThrow(
-      /rollback failed/,
-    );
+    await expect(source.sendUserInput({ text: "next real turn" })).rejects.toThrow(/revert failed/);
     await expect(source.fork({ sessionId: "fork-2", mode: "ephemeral" })).rejects.toThrow(
-      /rollback failed/,
+      /revert failed/,
     );
     expect(requestMock.mock.calls.filter((c) => c[0] === "turn/start")).toHaveLength(1);
 
@@ -925,7 +926,7 @@ describe("CodexAppServerProvider", () => {
   it("serializes a native thread/fork behind an in-flight borrowed exact-fork turn", async () => {
     // Deliver turn/completed manually so the borrowed turn stays mid-flight
     // while a native fork tries to snapshot the source thread. Snapshotting
-    // then would copy the not-yet-rolled-back borrowed turn into the child.
+    // then would copy the not-yet-reverted borrowed turn into the child.
     let finishBorrowedTurn!: () => void;
     requestMock.mockImplementation(async (method: string) => {
       if (method === "thread/start") {
@@ -980,17 +981,17 @@ describe("CodexAppServerProvider", () => {
     const nativeSession = await nativeOpen;
     await exactCollected;
 
-    // The snapshot only ran after the borrowed turn was rolled back.
+    // The snapshot only ran after the borrowed turn was reverted.
     const methods = requestMock.mock.calls.map((c) => c[0]);
-    expect(methods.indexOf("thread/rollback")).toBeGreaterThanOrEqual(0);
-    expect(methods.indexOf("thread/fork")).toBeGreaterThan(methods.indexOf("thread/rollback"));
+    expect(methods.indexOf("thread/revert")).toBeGreaterThanOrEqual(0);
+    expect(methods.indexOf("thread/fork")).toBeGreaterThan(methods.indexOf("thread/revert"));
 
     await nativeSession.close();
     await exactSession.close();
     await source.close();
   });
 
-  it("refuses a native fork snapshot opened after a failed exact-fork rollback", async () => {
+  it("refuses a native fork snapshot opened after a failed exact-fork revert", async () => {
     requestMock.mockImplementation(async (method: string) => {
       if (method === "thread/start") {
         captured.onNotification?.("thread/started", { thread: { id: "source-thread" } });
@@ -1003,7 +1004,7 @@ describe("CodexAppServerProvider", () => {
           turn: { id: "fork-turn", status: "completed" },
         });
       }
-      if (method === "thread/rollback") throw new Error("rollback rejected");
+      if (method === "thread/revert") throw new Error("revert rejected");
       return {};
     });
 
@@ -1028,7 +1029,7 @@ describe("CodexAppServerProvider", () => {
     // …but open() re-checks inside the lane: the borrowed turn is now a
     // permanent part of the source history, so no child may snapshot it.
     await expect(nativeFork.open(buildForkOpenParams({ model: "gpt-5.4-mini" }))).rejects.toThrow(
-      /rollback failed/,
+      /revert failed/,
     );
     expect(requestMock).not.toHaveBeenCalledWith("thread/fork", expect.anything());
 

--- a/packages/core/src/core/codex-app-server-provider.test.ts
+++ b/packages/core/src/core/codex-app-server-provider.test.ts
@@ -101,6 +101,7 @@ function usage(
     totalTokens: number;
     inputTokens: number;
     cachedInputTokens: number;
+    cacheWriteInputTokens: number;
     outputTokens: number;
     reasoningOutputTokens: number;
   }> = {},
@@ -108,6 +109,7 @@ function usage(
     totalTokens: number;
     inputTokens: number;
     cachedInputTokens: number;
+    cacheWriteInputTokens: number;
     outputTokens: number;
     reasoningOutputTokens: number;
   }> = {},
@@ -116,6 +118,7 @@ function usage(
     totalTokens: 10,
     inputTokens: 6,
     cachedInputTokens: 1,
+    cacheWriteInputTokens: 0,
     outputTokens: 4,
     reasoningOutputTokens: 0,
     ...overrides,
@@ -1182,6 +1185,7 @@ describe("CodexAppServerProvider", () => {
           uncached_input_tokens: 5,
           output_tokens: 4,
           cached_tokens: 1,
+          cache_write_tokens: 0,
           reasoning_tokens: 0,
         },
       },
@@ -1418,6 +1422,7 @@ describe("CodexAppServerProvider", () => {
               totalTokens: 110,
               inputTokens: 100,
               cachedInputTokens: 90,
+              cacheWriteInputTokens: 5,
               outputTokens: 10,
             }),
           });
@@ -1432,25 +1437,28 @@ describe("CodexAppServerProvider", () => {
               totalTokens: 110,
               inputTokens: 100,
               cachedInputTokens: 90,
+              cacheWriteInputTokens: 5,
               outputTokens: 10,
             }),
           });
           // `total` is cumulative for the whole Codex thread, while `last` is
           // only the latest API request. Two updates make this Rome turn's
-          // delta 400k input / 360k cached / 2k output tokens. Each request is
-          // below the long-context pricing threshold even though their
-          // aggregate is above it.
+          // delta 400k input / 340k cache-read / 20k cache-write / 2k output
+          // tokens. Each request is below the long-context pricing threshold
+          // even though their aggregate is above it.
           const firstRequestUsage = usage(
             {
               totalTokens: 201_000,
               inputTokens: 200_000,
-              cachedInputTokens: 180_000,
+              cachedInputTokens: 170_000,
+              cacheWriteInputTokens: 10_000,
               outputTokens: 1_000,
             },
             {
               totalTokens: 201_110,
               inputTokens: 200_100,
-              cachedInputTokens: 180_090,
+              cachedInputTokens: 170_090,
+              cacheWriteInputTokens: 10_005,
               outputTokens: 1_010,
             },
           );
@@ -1469,6 +1477,7 @@ describe("CodexAppServerProvider", () => {
               totalTokens: 110,
               inputTokens: 100,
               cachedInputTokens: 90,
+              cacheWriteInputTokens: 5,
               outputTokens: 10,
             }),
           });
@@ -1484,13 +1493,15 @@ describe("CodexAppServerProvider", () => {
               {
                 totalTokens: 201_000,
                 inputTokens: 200_000,
-                cachedInputTokens: 180_000,
+                cachedInputTokens: 170_000,
+                cacheWriteInputTokens: 10_000,
                 outputTokens: 1_000,
               },
               {
                 totalTokens: 402_110,
                 inputTokens: 400_100,
-                cachedInputTokens: 360_090,
+                cachedInputTokens: 340_090,
+                cacheWriteInputTokens: 20_005,
                 outputTokens: 2_010,
               },
             ),
@@ -1523,7 +1534,12 @@ describe("CodexAppServerProvider", () => {
     const firstResult = (await firstCollected).find((m) => m.type === "result");
     expect(firstResult).toMatchObject({
       accounting: {
-        usage: { inputTokens: 10, cacheReadTokens: 90, outputTokens: 10 },
+        usage: {
+          inputTokens: 5,
+          cacheReadTokens: 90,
+          cacheWriteTokens: 5,
+          outputTokens: 10,
+        },
       },
     });
 
@@ -1532,12 +1548,17 @@ describe("CodexAppServerProvider", () => {
     const secondResult = (await secondCollected).find((m) => m.type === "result");
     expect(secondResult).toMatchObject({
       accounting: {
-        usage: { inputTokens: 40_000, cacheReadTokens: 360_000, outputTokens: 2_000 },
+        usage: {
+          inputTokens: 40_000,
+          cacheReadTokens: 340_000,
+          cacheWriteTokens: 20_000,
+          outputTokens: 2_000,
+        },
       },
     });
     expect(
       (secondResult as { accounting?: { costUsd?: number } })?.accounting?.costUsd,
-    ).toBeCloseTo(0.44);
+    ).toBeCloseTo(0.555);
 
     await session.close();
   });

--- a/packages/core/src/core/codex-app-server-provider.test.ts
+++ b/packages/core/src/core/codex-app-server-provider.test.ts
@@ -485,10 +485,11 @@ describe("CodexAppServerProvider", () => {
         threadId: "source-thread",
         model: "gpt-5.4",
         cwd: null,
-        sandbox: "danger-full-access",
+        sandbox: "read-only",
         approvalPolicy: "never",
-        baseInstructions: "system",
+        baseInstructions: expect.stringContaining("<rome_isolated_fork>"),
         ephemeral: false,
+        excludeTurns: true,
       }),
     );
     const forkCall = requestMock.mock.calls.find((call) => call[0] === "thread/fork");
@@ -573,6 +574,21 @@ describe("CodexAppServerProvider", () => {
       ],
       success: false,
     });
+    expect(requestMock).toHaveBeenCalledWith(
+      "thread/fork",
+      expect.objectContaining({
+        sandbox: "read-only",
+        baseInstructions: expect.stringContaining("Do not invoke any tool"),
+      }),
+    );
+    expect(requestMock).toHaveBeenCalledWith(
+      "thread/resume",
+      expect.objectContaining({
+        threadId: "isolated-child",
+        sandbox: "read-only",
+        baseInstructions: expect.stringContaining("Do not invoke any tool"),
+      }),
+    );
     expect(sourceExecuteSubagent).not.toHaveBeenCalled();
 
     await forkSession.close();
@@ -705,7 +721,8 @@ describe("CodexAppServerProvider", () => {
     await source.close();
   });
 
-  it("runs a same-model exact fork on the source thread and reverts it", async () => {
+  it("retries a same-model exact fork revert at its stable turn boundary", async () => {
+    let revertAttempts = 0;
     requestMock.mockImplementation(async (method: string) => {
       if (method === "thread/start") {
         captured.onNotification?.("thread/started", { thread: { id: "source-thread" } });
@@ -728,6 +745,9 @@ describe("CodexAppServerProvider", () => {
           threadId: "source-thread",
           turn: { id: "hidden-fork-turn", status: "completed" },
         });
+      }
+      if (method === "thread/revert" && ++revertAttempts === 1) {
+        throw new Error("pre-mutation shutdown timeout");
       }
       return {};
     });
@@ -755,6 +775,7 @@ describe("CodexAppServerProvider", () => {
       threadId: "source-thread",
       beforeTurnId: "hidden-fork-turn",
     });
+    expect(revertAttempts).toBe(2);
     expect(fork.providerThreadId).toBe("source-thread");
     expect(source.providerThreadId).toBe("source-thread");
     expect(msgs.find((m) => m.type === "result")).toMatchObject({
@@ -1022,8 +1043,9 @@ describe("CodexAppServerProvider", () => {
     await forkSession.sendUserInput({ text: "feedback" });
     const msgs = await collected;
 
-    // Revert is not idempotent, so a failed request is not retried.
-    expect(requestMock.mock.calls.filter((c) => c[0] === "thread/revert")).toHaveLength(1);
+    // The stable turn-id boundary makes one retry safe: it can never remove an
+    // earlier source turn if the first request already applied the revert.
+    expect(requestMock.mock.calls.filter((c) => c[0] === "thread/revert")).toHaveLength(2);
     // The fork never observes success while its turn is still in the source.
     expect(msgs.find((m) => m.type === "result")).toBeUndefined();
     expect(msgs.find((m) => m.type === "error")).toMatchObject({

--- a/packages/core/src/core/codex-app-server-provider.test.ts
+++ b/packages/core/src/core/codex-app-server-provider.test.ts
@@ -55,10 +55,17 @@ rs.mock("./codex/app-server-client.js", () => ({
       request: async (method: string, params: unknown) => {
         const result = await requestMock(method, params);
         if (method === "thread/start" && !(result as { thread?: unknown } | undefined)?.thread) {
-          return { thread: { id: captured.lastStartedThreadId ?? "thr-1" } };
+          return {
+            thread: {
+              id: captured.lastStartedThreadId ?? "thr-1",
+              historyMode: (params as { historyMode?: unknown }).historyMode ?? null,
+            },
+          };
         }
         if (method === "thread/resume" && !(result as { thread?: unknown } | undefined)?.thread) {
-          return { thread: { id: (params as { threadId: string }).threadId } };
+          return {
+            thread: { id: (params as { threadId: string }).threadId, historyMode: "paginated" },
+          };
         }
         return result;
       },
@@ -582,6 +589,49 @@ describe("CodexAppServerProvider", () => {
     );
     expect(requestMock).not.toHaveBeenCalledWith("thread/revert", expect.anything());
     expect(fork.providerThreadId).toBe("continuable-fork-thread");
+
+    await forkSession.close();
+    await source.close();
+  });
+
+  it("uses a native fork when a resumed source still has legacy history", async () => {
+    requestMock.mockImplementation(async (method: string, requestParams: unknown) => {
+      if (method === "thread/resume") {
+        const threadId = (requestParams as { threadId: string }).threadId;
+        return {
+          thread: {
+            id: threadId,
+            historyMode: threadId === "legacy-source" ? "legacy" : "paginated",
+          },
+        };
+      }
+      if (method === "thread/fork") {
+        return { thread: { id: "legacy-child", historyMode: "paginated" } };
+      }
+      return {};
+    });
+
+    const provider = new CodexAppServerProvider();
+    const source = await provider.openSession(
+      buildParams({
+        sessionId: "source-session",
+        isNewSession: false,
+        providerThreadId: "legacy-source",
+      }),
+    );
+    const fork = await source.fork({
+      sessionId: "fork-session",
+      mode: "ephemeral",
+      configurationMode: "exact",
+    });
+    const forkSession = await fork.open(buildForkOpenParams());
+
+    expect(requestMock).toHaveBeenCalledWith(
+      "thread/fork",
+      expect.objectContaining({ threadId: "legacy-source" }),
+    );
+    expect(requestMock).not.toHaveBeenCalledWith("thread/revert", expect.anything());
+    expect(fork.providerThreadId).toBe("legacy-child");
 
     await forkSession.close();
     await source.close();

--- a/packages/core/src/core/codex-app-server-provider.test.ts
+++ b/packages/core/src/core/codex-app-server-provider.test.ts
@@ -511,6 +511,74 @@ describe("CodexAppServerProvider", () => {
     await source.close();
   });
 
+  it("fails closed when an isolated native fork calls a tool inherited from its source", async () => {
+    const sourceExecuteSubagent = rs.fn(async () => "source result");
+    let dynamicResponse: unknown;
+    requestMock.mockImplementation(async (method: string, requestParams: unknown) => {
+      if (method === "thread/start") {
+        return { thread: { id: "source-thread", historyMode: "paginated" } };
+      }
+      if (method === "thread/fork") {
+        return { thread: { id: "isolated-child", historyMode: "paginated" } };
+      }
+      if (method === "turn/start") {
+        const payload = requestParams as { threadId: string };
+        const n = captured.onNotification!;
+        n("turn/started", {
+          threadId: payload.threadId,
+          turn: { id: "isolated-turn" },
+        });
+        dynamicResponse = await captured.onServerRequest?.("item/tool/call", {
+          threadId: payload.threadId,
+          turnId: "isolated-turn",
+          callId: "call-source-tool",
+          namespace: null,
+          tool: "source_researcher",
+          arguments: { prompt: "inspect" },
+        });
+        n("turn/completed", {
+          threadId: payload.threadId,
+          turn: { id: "isolated-turn", status: "completed" },
+        });
+      }
+      return {};
+    });
+
+    const provider = new CodexAppServerProvider();
+    const source = await provider.openSession(
+      buildParams({
+        sessionId: "source-session",
+        subagentTools: [
+          {
+            name: "source_researcher",
+            description: "Research for the source",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+        executeSubagent: sourceExecuteSubagent,
+      }),
+    );
+    const fork = await source.fork({ sessionId: "isolated-session", mode: "ephemeral" });
+    const forkSession = await fork.open(buildForkOpenParams());
+    const collected = collectUntilTerminal(forkSession);
+    await forkSession.sendUserInput({ text: "try the inherited tool" });
+    await collected;
+
+    expect(dynamicResponse).toEqual({
+      contentItems: [
+        {
+          type: "inputText",
+          text: "Dynamic tool is disabled in this fork: source_researcher",
+        },
+      ],
+      success: false,
+    });
+    expect(sourceExecuteSubagent).not.toHaveBeenCalled();
+
+    await forkSession.close();
+    await source.close();
+  });
+
   it("materializes an exact fork at the selected historical provider turn", async () => {
     requestMock.mockImplementation(async (method: string) => {
       if (method === "thread/start") {
@@ -1245,6 +1313,46 @@ describe("CodexAppServerProvider", () => {
       "turn/start",
       expect.objectContaining({ threadId: "thr-1", effort: "high" }),
     );
+    await session.close();
+  });
+
+  it("treats a missing cache-write field in compatibility usage notifications as zero", async () => {
+    requestMock.mockImplementation(async (method: string) => {
+      if (method === "thread/start") {
+        captured.onNotification?.("thread/started", { thread: { id: "thr-legacy-usage" } });
+      }
+      if (method === "turn/start") {
+        const n = captured.onNotification!;
+        const legacyUsage = usage();
+        delete (legacyUsage.last as Partial<typeof legacyUsage.last>).cacheWriteInputTokens;
+        delete (legacyUsage.total as Partial<typeof legacyUsage.total>).cacheWriteInputTokens;
+        n("turn/started", {
+          threadId: "thr-legacy-usage",
+          turn: { id: "turn-legacy-usage" },
+        });
+        n("thread/tokenUsage/updated", {
+          threadId: "thr-legacy-usage",
+          turnId: "turn-legacy-usage",
+          usage: legacyUsage,
+        });
+        n("turn/completed", {
+          threadId: "thr-legacy-usage",
+          turn: { id: "turn-legacy-usage", status: "completed" },
+        });
+      }
+      return {};
+    });
+
+    const session = await new CodexAppServerProvider().openSession(buildParams());
+    const collected = collectUntilTerminal(session);
+    await session.sendUserInput({ text: "legacy usage" });
+
+    expect((await collected).find((message) => message.type === "result")).toMatchObject({
+      accounting: {
+        usage: { cacheWriteTokens: 0 },
+        rawUsage: { cache_write_tokens: 0 },
+      },
+    });
     await session.close();
   });
 

--- a/packages/core/src/core/codex-app-server-provider.test.ts
+++ b/packages/core/src/core/codex-app-server-provider.test.ts
@@ -904,8 +904,8 @@ describe("CodexAppServerProvider", () => {
     await forkSession.sendUserInput({ text: "feedback" });
     const msgs = await collected;
 
-    // Retried once, then gave up.
-    expect(requestMock.mock.calls.filter((c) => c[0] === "thread/revert")).toHaveLength(2);
+    // Revert is not idempotent, so a failed request is not retried.
+    expect(requestMock.mock.calls.filter((c) => c[0] === "thread/revert")).toHaveLength(1);
     // The fork never observes success while its turn is still in the source.
     expect(msgs.find((m) => m.type === "result")).toBeUndefined();
     expect(msgs.find((m) => m.type === "error")).toMatchObject({

--- a/packages/core/src/core/codex-app-server-provider.ts
+++ b/packages/core/src/core/codex-app-server-provider.ts
@@ -140,6 +140,28 @@ function buildThreadConfig(
   };
 }
 
+const ISOLATED_FORK_INSTRUCTION = `<rome_isolated_fork>
+This is an isolated side-channel turn. Do not invoke any tool, even if provider metadata lists tools inherited from the source thread. Answer only from the inherited conversation and the user prompt.
+</rome_isolated_fork>`;
+
+/**
+ * Codex 0.153.4 cannot replace a source thread's dynamic-tool catalog during
+ * thread/fork. Make that provider limitation an explicit, read-only degrade:
+ * the model is instructed not to call inherited tools and the runtime rejects
+ * them, while the fork remains usable for recap/title side-channel turns.
+ */
+function constrainIsolatedFork(
+  overrides: ThreadConfigurationOverrides,
+): ThreadConfigurationOverrides {
+  return {
+    ...overrides,
+    sandbox: "read-only",
+    baseInstructions: [overrides.baseInstructions, ISOLATED_FORK_INSTRUCTION]
+      .filter((value): value is string => typeof value === "string" && value.length > 0)
+      .join("\n\n"),
+  };
+}
+
 /** commentary → "commentary"; final_answer → "final"; null/absent → undefined
  *  (legacy model / phase unknown → not promoted by the UI). */
 function mapPhase(phase: MessagePhase | null | undefined): "commentary" | "final" | undefined {
@@ -406,7 +428,10 @@ export class CodexAppServerProvider implements ModelProvider {
 
   private async openSessionWithInheritedDynamicTools(
     params: ModelSessionParams,
-    inheritedDynamicToolDefinitions?: readonly DynamicToolSpec[],
+    inheritedFork?: {
+      dynamicToolDefinitions: readonly DynamicToolSpec[];
+      isolated: boolean;
+    },
   ): Promise<ModelSession> {
     const modelName = stripLegacyReasoningSuffix(params.model);
     const outputValidator = params.outputSchema
@@ -418,12 +443,22 @@ export class CodexAppServerProvider implements ModelProvider {
     // execution is selected from the active turn runtime so a borrowed exact
     // fork can reuse the source thread with fork callbacks.
     const configuredRomeTools = createRomeDynamicTools(params);
-    const romeTools = inheritedDynamicToolDefinitions
+    const romeTools = inheritedFork
       ? alignRomeDynamicToolsToInheritedCatalog(
           configuredRomeTools,
-          inheritedDynamicToolDefinitions,
+          inheritedFork.dynamicToolDefinitions,
         )
       : configuredRomeTools;
+    if (inheritedFork?.isolated) {
+      const disabledToolNames = inheritedFork.dynamicToolDefinitions
+        .map((definition) => definition.name)
+        .filter((name) => !configuredRomeTools.hasTool(name));
+      if (disabledToolNames.length > 0) {
+        log.warn("codex isolated fork inherited disabled dynamic tools", {
+          toolNames: disabledToolNames,
+        });
+      }
+    }
 
     const sink = new AgentMessageSink();
     // Image-generation trace. The app-server delivers it as `imageGeneration`
@@ -757,7 +792,8 @@ export class CodexAppServerProvider implements ModelProvider {
       },
     };
 
-    const threadConfig = buildThreadConfig(params, modelName, romeTools);
+    let threadConfig = buildThreadConfig(params, modelName, romeTools);
+    if (inheritedFork?.isolated) threadConfig = constrainIsolatedFork(threadConfig);
 
     const openedThread = await this.appServerManager.openThread(
       threadConfig,
@@ -1090,32 +1126,38 @@ export class CodexAppServerProvider implements ModelProvider {
               revertTurn: async (threadIdToRevert, beforeTurnId) => {
                 // Revert is the only thing keeping the borrowed turn out of
                 // the source conversation, so its failure cannot be a plain
-                // turn error. Do not retry: thread/revert is boundary-based,
-                // not idempotent (the boundary turn disappears on success),
-                // so a lost response leaves the source state uncertain.
+                // turn error. The turn-id boundary prevents a retry from
+                // removing an earlier source turn: after a successful first
+                // request the boundary is gone and a second request fails
+                // closed. Retry once so pre-mutation shutdown/drain failures
+                // can recover; if both attempts fail, source state is still
+                // uncertain and the session must be poisoned.
                 const revertParams: ThreadRevertParams = {
                   threadId: threadIdToRevert,
                   beforeTurnId,
                 };
-                try {
-                  await this.appServerManager.requestForThread(
-                    threadIdToRevert,
-                    Method.threadRevert,
-                    revertParams,
-                  );
-                  return;
-                } catch (err) {
-                  const lastMessage = err instanceof Error ? err.message : String(err);
-                  log.warn("codex exact-fork revert failed", { error: lastMessage });
-                  // The fork's turn is now permanently part of the source
-                  // thread, or its state is uncertain after a transport loss.
-                  // Poison the session so nothing resumes from potentially
-                  // contaminated history, and surface the failure on the
-                  // source events stream (out-of-turn, like Notify.error).
-                  contaminatedReason = `codex exact-fork revert failed, source thread may retain the fork turn: ${lastMessage}`;
-                  if (!closed) sink.push({ type: "error", error: contaminatedReason });
-                  throw new Error(contaminatedReason);
+                let lastMessage = "unknown error";
+                for (let attempt = 1; attempt <= 2; attempt++) {
+                  try {
+                    await this.appServerManager.requestForThread(
+                      threadIdToRevert,
+                      Method.threadRevert,
+                      revertParams,
+                    );
+                    return;
+                  } catch (err) {
+                    lastMessage = err instanceof Error ? err.message : String(err);
+                    log.warn("codex exact-fork revert failed", { attempt, error: lastMessage });
+                  }
                 }
+                // The fork's turn may now be part of the source thread, or a
+                // response may have been lost after a successful mutation.
+                // Poison the session so nothing resumes from uncertain
+                // history, and surface the failure on the source events
+                // stream (out-of-turn, like Notify.error).
+                contaminatedReason = `codex exact-fork revert failed, source thread state is uncertain: ${lastMessage}`;
+                if (!closed) sink.push({ type: "error", error: contaminatedReason });
+                throw new Error(contaminatedReason);
               },
               interrupt: async (reason) => await interruptOwnerTurn(forkParams.sessionId, reason),
             });
@@ -1132,10 +1174,14 @@ export class CodexAppServerProvider implements ModelProvider {
           // not-yet-reverted turn into the child. Contamination is
           // re-checked inside the lane because a queued snapshot would
           // otherwise run immediately after the failed revert that set it.
-          const forkThreadConfiguration = buildThreadConfigurationOverrides(
+          const isolatedNativeFork = forkParams.configurationMode !== "exact";
+          let forkThreadConfiguration = buildThreadConfigurationOverrides(
             openParams,
             stripLegacyReasoningSuffix(openParams.model),
           );
+          if (isolatedNativeFork) {
+            forkThreadConfiguration = constrainIsolatedFork(forkThreadConfiguration);
+          }
           const forkRes = await turnCoordinator.run(async () => {
             if (contaminatedReason) throw new Error(contaminatedReason);
             const nativeForkParams: ThreadForkParams = {
@@ -1143,6 +1189,7 @@ export class CodexAppServerProvider implements ModelProvider {
               ...(forkParams.sourceCheckpoint ? { lastTurnId: forkParams.sourceCheckpoint } : {}),
               ...forkThreadConfiguration,
               ephemeral: false,
+              excludeTurns: true,
             };
             return await this.appServerManager.requestForThread<
               { thread?: { id?: string } } | undefined
@@ -1163,7 +1210,10 @@ export class CodexAppServerProvider implements ModelProvider {
                 sourceCheckpoint: forkParams.sourceCheckpoint,
               },
             },
-            romeTools.definitions,
+            {
+              dynamicToolDefinitions: romeTools.definitions,
+              isolated: isolatedNativeFork,
+            },
           );
         },
       };

--- a/packages/core/src/core/codex-app-server-provider.ts
+++ b/packages/core/src/core/codex-app-server-provider.ts
@@ -213,6 +213,7 @@ function toSdkUsage(u: TokenUsageBreakdown | undefined): Usage | undefined {
   return {
     input_tokens: u.inputTokens,
     cached_input_tokens: u.cachedInputTokens,
+    cache_write_input_tokens: u.cacheWriteInputTokens,
     output_tokens: u.outputTokens,
     reasoning_output_tokens: u.reasoningOutputTokens,
     total_tokens: u.totalTokens,
@@ -224,6 +225,7 @@ function tokenUsageBreakdownEquals(left: TokenUsageBreakdown, right: TokenUsageB
     left.totalTokens === right.totalTokens &&
     left.inputTokens === right.inputTokens &&
     left.cachedInputTokens === right.cachedInputTokens &&
+    left.cacheWriteInputTokens === right.cacheWriteInputTokens &&
     left.outputTokens === right.outputTokens &&
     left.reasoningOutputTokens === right.reasoningOutputTokens
   );
@@ -243,6 +245,7 @@ function updateTurnUsage(turn: ActiveTurn, update: ThreadTokenUsage): void {
         totalTokens: usage.totalTokens + last.totalTokens,
         inputTokens: usage.inputTokens + last.inputTokens,
         cachedInputTokens: usage.cachedInputTokens + last.cachedInputTokens,
+        cacheWriteInputTokens: usage.cacheWriteInputTokens + last.cacheWriteInputTokens,
         outputTokens: usage.outputTokens + last.outputTokens,
         reasoningOutputTokens: usage.reasoningOutputTokens + last.reasoningOutputTokens,
       }

--- a/packages/core/src/core/codex-app-server-provider.ts
+++ b/packages/core/src/core/codex-app-server-provider.ts
@@ -51,7 +51,10 @@ import {
   type AgentMessageDeltaNotification,
   type MessagePhase,
   type ReasoningEffort,
+  type ThreadConfigurationOverrides,
+  type ThreadForkParams,
   type ThreadItem,
+  type ThreadRevertParams,
   type ThreadStartParams,
   type TokenUsageBreakdown,
   type ThreadTokenUsage,
@@ -116,11 +119,17 @@ function buildThreadConfig(
     cwd: params.workingDir ?? null,
     sandbox: "danger-full-access",
     approvalPolicy: "never",
-    skipGitRepoCheck: true,
     baseInstructions: params.systemPrompt,
     config,
+    historyMode: "paginated",
     dynamicTools: romeTools.definitions.length > 0 ? [...romeTools.definitions] : null,
   };
+}
+
+/** Strip thread/start-only fields before calling thread/fork. */
+function buildThreadForkOverrides(config: ThreadStartParams): ThreadConfigurationOverrides {
+  const { dynamicTools: _dynamicTools, historyMode: _historyMode, ...overrides } = config;
+  return overrides;
 }
 
 /** commentary → "commentary"; final_answer → "final"; null/absent → undefined
@@ -1016,7 +1025,7 @@ export class CodexAppServerProvider implements ModelProvider {
           const targetIsCurrentHead =
             forkParams.sourceCheckpoint === undefined ||
             forkParams.sourceCheckpoint === lastCompletedTurnCheckpoint;
-          // Borrowing runs the turn inside the source thread and rolls it back
+          // Borrowing runs the turn inside the source thread and reverts it
           // (a temporary workaround for openai/codex#24704 — see
           // codex/borrowed-exact-fork.ts). That leaves nothing to resume and
           // reports the source's own thread id, so a fork that asked to be
@@ -1043,35 +1052,36 @@ export class CodexAppServerProvider implements ModelProvider {
               openParams,
               runExclusive: async (work) => await turnCoordinator.run(work),
               runTurn: async (input, runtime) => await runOne([input], runtime),
-              rollbackTurn: async (threadIdToRollback) => {
-                // Rollback is the only thing keeping the borrowed turn out of
+              revertTurn: async (threadIdToRevert, beforeTurnId) => {
+                // Revert is the only thing keeping the borrowed turn out of
                 // the source conversation, so its failure cannot be a plain
-                // turn error. An error response means the rollback was not
+                // turn error. An error response means the revert was not
                 // applied (stdio JSON-RPC; a response is only lost when the
                 // process died, and then the retry rejects locally without
-                // re-sending), so one retry cannot double-rollback.
+                // re-sending), so one retry is idempotent at the same boundary.
                 let lastMessage = "unknown error";
                 for (let attempt = 1; attempt <= 2; attempt++) {
                   try {
+                    const revertParams: ThreadRevertParams = {
+                      threadId: threadIdToRevert,
+                      beforeTurnId,
+                    };
                     await this.appServerManager.requestForThread(
-                      threadIdToRollback,
-                      Method.threadRollback,
-                      {
-                        threadId: threadIdToRollback,
-                        numTurns: 1,
-                      },
+                      threadIdToRevert,
+                      Method.threadRevert,
+                      revertParams,
                     );
                     return;
                   } catch (err) {
                     lastMessage = err instanceof Error ? err.message : String(err);
-                    log.warn("codex exact-fork rollback failed", { attempt, error: lastMessage });
+                    log.warn("codex exact-fork revert failed", { attempt, error: lastMessage });
                   }
                 }
                 // The fork's turn is now permanently part of the source
                 // thread. Poison the session so nothing resumes from the
                 // contaminated history, and surface the failure on the source
                 // events stream (out-of-turn, like Notify.error).
-                contaminatedReason = `codex exact-fork rollback failed, source thread retains the fork turn: ${lastMessage}`;
+                contaminatedReason = `codex exact-fork revert failed, source thread retains the fork turn: ${lastMessage}`;
                 if (!closed) sink.push({ type: "error", error: contaminatedReason });
                 throw new Error(contaminatedReason);
               },
@@ -1087,9 +1097,9 @@ export class CodexAppServerProvider implements ModelProvider {
           //
           // The snapshot goes through the turn lane: a borrowed exact fork may
           // be mid-turn, and a thread/fork issued then would copy its
-          // not-yet-rolled-back turn into the child. Contamination is
+          // not-yet-reverted turn into the child. Contamination is
           // re-checked inside the lane because a queued snapshot would
-          // otherwise run immediately after the failed rollback that set it.
+          // otherwise run immediately after the failed revert that set it.
           const forkRomeTools = createRomeDynamicTools(openParams);
           const forkThreadConfig = buildThreadConfig(
             openParams,
@@ -1098,14 +1108,15 @@ export class CodexAppServerProvider implements ModelProvider {
           );
           const forkRes = await turnCoordinator.run(async () => {
             if (contaminatedReason) throw new Error(contaminatedReason);
-            return await this.appServerManager.requestForThread<
-              { thread?: { id?: string } } | undefined
-            >(source, Method.threadFork, {
+            const nativeForkParams: ThreadForkParams = {
               threadId: source,
               ...(forkParams.sourceCheckpoint ? { lastTurnId: forkParams.sourceCheckpoint } : {}),
-              ...forkThreadConfig,
+              ...buildThreadForkOverrides(forkThreadConfig),
               ephemeral: false,
-            });
+            };
+            return await this.appServerManager.requestForThread<
+              { thread?: { id?: string } } | undefined
+            >(source, Method.threadFork, nativeForkParams);
           });
           forkedId = forkRes?.thread?.id;
           if (!forkedId) throw new Error("codex thread/fork did not return a thread id");

--- a/packages/core/src/core/codex-app-server-provider.ts
+++ b/packages/core/src/core/codex-app-server-provider.ts
@@ -237,13 +237,18 @@ function notificationTokenUsage(
   return notification.tokenUsage ?? notification.usage;
 }
 
+/** Compatibility for older local stubs/binaries that predate the field. */
+function cacheWriteTokens(u: TokenUsageBreakdown): number {
+  return u.cacheWriteInputTokens ?? 0;
+}
+
 /** App-server token usage (camelCase) → the snake_case shape buildOpenAiAccounting reads. */
 function toSdkUsage(u: TokenUsageBreakdown | undefined): Usage | undefined {
   if (!u) return undefined;
   return {
     input_tokens: u.inputTokens,
     cached_input_tokens: u.cachedInputTokens,
-    cache_write_input_tokens: u.cacheWriteInputTokens ?? 0,
+    cache_write_input_tokens: cacheWriteTokens(u),
     output_tokens: u.outputTokens,
     reasoning_output_tokens: u.reasoningOutputTokens,
     total_tokens: u.totalTokens,
@@ -255,10 +260,15 @@ function tokenUsageBreakdownEquals(left: TokenUsageBreakdown, right: TokenUsageB
     left.totalTokens === right.totalTokens &&
     left.inputTokens === right.inputTokens &&
     left.cachedInputTokens === right.cachedInputTokens &&
-    (left.cacheWriteInputTokens ?? 0) === (right.cacheWriteInputTokens ?? 0) &&
+    cacheWriteTokens(left) === cacheWriteTokens(right) &&
     left.outputTokens === right.outputTokens &&
     left.reasoningOutputTokens === right.reasoningOutputTokens
   );
+}
+
+function isMissingRevertBoundary(error: unknown, beforeTurnId: string): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("turn not found") && message.includes(beforeTurnId);
 }
 
 /**
@@ -273,7 +283,7 @@ function updateTurnUsage(turn: ActiveTurn, update: ThreadTokenUsage): void {
   // cannot poison the turn total with NaN.
   const last: TokenUsageBreakdown = {
     ...update.last,
-    cacheWriteInputTokens: update.last.cacheWriteInputTokens ?? 0,
+    cacheWriteInputTokens: cacheWriteTokens(update.last),
   };
   const usage = turn.usage;
   turn.usage = usage
@@ -449,13 +459,21 @@ export class CodexAppServerProvider implements ModelProvider {
           inheritedFork.dynamicToolDefinitions,
         )
       : configuredRomeTools;
-    if (inheritedFork?.isolated) {
-      const disabledToolNames = inheritedFork.dynamicToolDefinitions
+    if (inheritedFork) {
+      const inheritedToolNames = new Set(
+        inheritedFork.dynamicToolDefinitions.map((definition) => definition.name),
+      );
+      const disabledInheritedToolNames = [...inheritedToolNames].filter(
+        (name) => !configuredRomeTools.hasTool(name),
+      );
+      const droppedConfiguredToolNames = configuredRomeTools.definitions
         .map((definition) => definition.name)
-        .filter((name) => !configuredRomeTools.hasTool(name));
-      if (disabledToolNames.length > 0) {
-        log.warn("codex isolated fork inherited disabled dynamic tools", {
-          toolNames: disabledToolNames,
+        .filter((name) => !inheritedToolNames.has(name));
+      if (disabledInheritedToolNames.length > 0 || droppedConfiguredToolNames.length > 0) {
+        log.warn("codex native fork dynamic tool catalogs differ", {
+          isolated: inheritedFork.isolated,
+          disabledInheritedToolNames,
+          droppedConfiguredToolNames,
         });
       }
     }
@@ -1146,6 +1164,17 @@ export class CodexAppServerProvider implements ModelProvider {
                     );
                     return;
                   } catch (err) {
+                    if (isMissingRevertBoundary(err, beforeTurnId)) {
+                      // The borrowed turn was never persisted, or an earlier
+                      // request already removed this exact boundary. Upstream
+                      // reloads the paginated runtime before returning this
+                      // error, so the source history is clean in either case.
+                      log.info("codex exact-fork revert boundary already absent", {
+                        attempt,
+                        beforeTurnId,
+                      });
+                      return;
+                    }
                     lastMessage = err instanceof Error ? err.message : String(err);
                     log.warn("codex exact-fork revert failed", { attempt, error: lastMessage });
                   }

--- a/packages/core/src/core/codex-app-server-provider.ts
+++ b/packages/core/src/core/codex-app-server-provider.ts
@@ -46,12 +46,12 @@ import {
   Notify,
   isAgentMessageItem,
   isReasoningItem,
+  toThreadConfigurationOverrides,
   type ItemCompletedNotification,
   type ItemStartedNotification,
   type AgentMessageDeltaNotification,
   type MessagePhase,
   type ReasoningEffort,
-  type ThreadConfigurationOverrides,
   type ThreadForkParams,
   type ThreadItem,
   type ThreadRevertParams,
@@ -124,12 +124,6 @@ function buildThreadConfig(
     historyMode: "paginated",
     dynamicTools: romeTools.definitions.length > 0 ? [...romeTools.definitions] : null,
   };
-}
-
-/** Strip thread/start-only fields before calling thread/fork. */
-function buildThreadForkOverrides(config: ThreadStartParams): ThreadConfigurationOverrides {
-  const { dynamicTools: _dynamicTools, historyMode: _historyMode, ...overrides } = config;
-  return overrides;
 }
 
 /** commentary → "commentary"; final_answer → "final"; null/absent → undefined
@@ -732,11 +726,12 @@ export class CodexAppServerProvider implements ModelProvider {
 
     const threadConfig = buildThreadConfig(params, modelName, romeTools);
 
-    threadId = await this.appServerManager.openThread(
+    const openedThread = await this.appServerManager.openThread(
       threadConfig,
       binding,
       params.isNewSession === false ? params.providerThreadId : undefined,
     );
+    threadId = openedThread.threadId;
     session.providerThreadId = threadId;
 
     const sourceRuntime: CodexTurnRuntime = {
@@ -1035,7 +1030,10 @@ export class CodexAppServerProvider implements ModelProvider {
           // persisted must take the native path instead, whatever it costs in
           // uncached prefix. Every other fork keeps the cheap path.
           const borrowSourceThread =
-            mode === "ephemeral" && compatibility.eligible && targetIsCurrentHead;
+            mode === "ephemeral" &&
+            compatibility.eligible &&
+            targetIsCurrentHead &&
+            openedThread.historyMode === "paginated";
           log.info("codex fork strategy selected", {
             strategy: borrowSourceThread ? "borrow_source_thread" : "native_thread_fork",
             configurationMode: forkParams.configurationMode,
@@ -1044,6 +1042,7 @@ export class CodexAppServerProvider implements ModelProvider {
             sameModel: compatibility.sameModel,
             sameSystemPrompt: compatibility.sameSystemPrompt,
             sameWorkingDir: compatibility.sameWorkingDir,
+            sourceHistoryMode: openedThread.historyMode,
           });
 
           if (borrowSourceThread) {
@@ -1111,7 +1110,7 @@ export class CodexAppServerProvider implements ModelProvider {
             const nativeForkParams: ThreadForkParams = {
               threadId: source,
               ...(forkParams.sourceCheckpoint ? { lastTurnId: forkParams.sourceCheckpoint } : {}),
-              ...buildThreadForkOverrides(forkThreadConfig),
+              ...toThreadConfigurationOverrides(forkThreadConfig),
               ephemeral: false,
             };
             return await this.appServerManager.requestForThread<

--- a/packages/core/src/core/codex-app-server-provider.ts
+++ b/packages/core/src/core/codex-app-server-provider.ts
@@ -46,12 +46,13 @@ import {
   Notify,
   isAgentMessageItem,
   isReasoningItem,
-  toThreadConfigurationOverrides,
   type ItemCompletedNotification,
   type ItemStartedNotification,
   type AgentMessageDeltaNotification,
+  type DynamicToolSpec,
   type MessagePhase,
   type ReasoningEffort,
+  type ThreadConfigurationOverrides,
   type ThreadForkParams,
   type ThreadItem,
   type ThreadRevertParams,
@@ -79,7 +80,11 @@ import { CODEX_AUTH_REVOKED_CODE, isCodexAuthRevokedError } from "./codex-auth-r
 import { markCodexAuthRevoked } from "../lib/codex-cli-auth.js";
 import { createLogger } from "../logger.js";
 import type { CodexTurnRuntime } from "./codex/turn-runtime.js";
-import { createRomeDynamicTools, type RomeDynamicTools } from "./codex/rome-dynamic-tools.js";
+import {
+  alignRomeDynamicToolsToInheritedCatalog,
+  createRomeDynamicTools,
+  type RomeDynamicTools,
+} from "./codex/rome-dynamic-tools.js";
 import {
   compileOutputSchema,
   formatOutputSchemaErrors,
@@ -102,11 +107,10 @@ function normalizeEffort(effort: ModelReasoningEffort | undefined): ReasoningEff
   return DEFAULT_EFFORT;
 }
 
-function buildThreadConfig(
+function buildThreadConfigurationOverrides(
   params: ModelSessionForkOpenParams,
   model: string,
-  romeTools: RomeDynamicTools,
-): ThreadStartParams {
+): ThreadConfigurationOverrides {
   const config: Record<string, unknown> = {
     model_reasoning_summary: "detailed",
     hide_agent_reasoning: false,
@@ -121,6 +125,16 @@ function buildThreadConfig(
     approvalPolicy: "never",
     baseInstructions: params.systemPrompt,
     config,
+  };
+}
+
+function buildThreadConfig(
+  params: ModelSessionForkOpenParams,
+  model: string,
+  romeTools: RomeDynamicTools,
+): ThreadStartParams {
+  return {
+    ...buildThreadConfigurationOverrides(params, model),
     historyMode: "paginated",
     dynamicTools: romeTools.definitions.length > 0 ? [...romeTools.definitions] : null,
   };
@@ -207,7 +221,7 @@ function toSdkUsage(u: TokenUsageBreakdown | undefined): Usage | undefined {
   return {
     input_tokens: u.inputTokens,
     cached_input_tokens: u.cachedInputTokens,
-    cache_write_input_tokens: u.cacheWriteInputTokens,
+    cache_write_input_tokens: u.cacheWriteInputTokens ?? 0,
     output_tokens: u.outputTokens,
     reasoning_output_tokens: u.reasoningOutputTokens,
     total_tokens: u.totalTokens,
@@ -219,7 +233,7 @@ function tokenUsageBreakdownEquals(left: TokenUsageBreakdown, right: TokenUsageB
     left.totalTokens === right.totalTokens &&
     left.inputTokens === right.inputTokens &&
     left.cachedInputTokens === right.cachedInputTokens &&
-    left.cacheWriteInputTokens === right.cacheWriteInputTokens &&
+    (left.cacheWriteInputTokens ?? 0) === (right.cacheWriteInputTokens ?? 0) &&
     left.outputTokens === right.outputTokens &&
     left.reasoningOutputTokens === right.reasoningOutputTokens
   );
@@ -232,7 +246,13 @@ function tokenUsageBreakdownEquals(left: TokenUsageBreakdown, right: TokenUsageB
  * turn instead of replacing the prior value with the newest one.
  */
 function updateTurnUsage(turn: ActiveTurn, update: ThreadTokenUsage): void {
-  const last = update.last;
+  // Compatibility notifications from older local app-server stubs predate
+  // this 0.153.4 field. Normalize them before arithmetic so a missing value
+  // cannot poison the turn total with NaN.
+  const last: TokenUsageBreakdown = {
+    ...update.last,
+    cacheWriteInputTokens: update.last.cacheWriteInputTokens ?? 0,
+  };
   const usage = turn.usage;
   turn.usage = usage
     ? {
@@ -381,6 +401,13 @@ export class CodexAppServerProvider implements ModelProvider {
   }
 
   async openSession(params: ModelSessionParams): Promise<ModelSession> {
+    return await this.openSessionWithInheritedDynamicTools(params);
+  }
+
+  private async openSessionWithInheritedDynamicTools(
+    params: ModelSessionParams,
+    inheritedDynamicToolDefinitions?: readonly DynamicToolSpec[],
+  ): Promise<ModelSession> {
     const modelName = stripLegacyReasoningSuffix(params.model);
     const outputValidator = params.outputSchema
       ? compileOutputSchema(params.outputSchema)
@@ -390,7 +417,13 @@ export class CodexAppServerProvider implements ModelProvider {
     // app-server dynamic tools. The provider-visible catalog is thread-scoped;
     // execution is selected from the active turn runtime so a borrowed exact
     // fork can reuse the source thread with fork callbacks.
-    const romeTools = createRomeDynamicTools(params);
+    const configuredRomeTools = createRomeDynamicTools(params);
+    const romeTools = inheritedDynamicToolDefinitions
+      ? alignRomeDynamicToolsToInheritedCatalog(
+          configuredRomeTools,
+          inheritedDynamicToolDefinitions,
+        )
+      : configuredRomeTools;
 
     const sink = new AgentMessageSink();
     // Image-generation trace. The app-server delivers it as `imageGeneration`
@@ -1099,18 +1132,16 @@ export class CodexAppServerProvider implements ModelProvider {
           // not-yet-reverted turn into the child. Contamination is
           // re-checked inside the lane because a queued snapshot would
           // otherwise run immediately after the failed revert that set it.
-          const forkRomeTools = createRomeDynamicTools(openParams);
-          const forkThreadConfig = buildThreadConfig(
+          const forkThreadConfiguration = buildThreadConfigurationOverrides(
             openParams,
             stripLegacyReasoningSuffix(openParams.model),
-            forkRomeTools,
           );
           const forkRes = await turnCoordinator.run(async () => {
             if (contaminatedReason) throw new Error(contaminatedReason);
             const nativeForkParams: ThreadForkParams = {
               threadId: source,
               ...(forkParams.sourceCheckpoint ? { lastTurnId: forkParams.sourceCheckpoint } : {}),
-              ...toThreadConfigurationOverrides(forkThreadConfig),
+              ...forkThreadConfiguration,
               ephemeral: false,
             };
             return await this.appServerManager.requestForThread<
@@ -1119,18 +1150,21 @@ export class CodexAppServerProvider implements ModelProvider {
           });
           forkedId = forkRes?.thread?.id;
           if (!forkedId) throw new Error("codex thread/fork did not return a thread id");
-          return await this.openSession({
-            ...openParams,
-            sessionId: forkParams.sessionId,
-            isNewSession: false,
-            providerThreadId: forkedId,
-            fork: {
-              sourceSessionId: params.sessionId,
-              sourceProviderThreadId: source,
-              mode,
-              sourceCheckpoint: forkParams.sourceCheckpoint,
+          return await this.openSessionWithInheritedDynamicTools(
+            {
+              ...openParams,
+              sessionId: forkParams.sessionId,
+              isNewSession: false,
+              providerThreadId: forkedId,
+              fork: {
+                sourceSessionId: params.sessionId,
+                sourceProviderThreadId: source,
+                mode,
+                sourceCheckpoint: forkParams.sourceCheckpoint,
+              },
             },
-          });
+            romeTools.definitions,
+          );
         },
       };
     };

--- a/packages/core/src/core/codex-app-server-provider.ts
+++ b/packages/core/src/core/codex-app-server-provider.ts
@@ -1058,35 +1058,32 @@ export class CodexAppServerProvider implements ModelProvider {
               revertTurn: async (threadIdToRevert, beforeTurnId) => {
                 // Revert is the only thing keeping the borrowed turn out of
                 // the source conversation, so its failure cannot be a plain
-                // turn error. An error response means the revert was not
-                // applied (stdio JSON-RPC; a response is only lost when the
-                // process died, and then the retry rejects locally without
-                // re-sending), so one retry is idempotent at the same boundary.
-                let lastMessage = "unknown error";
-                for (let attempt = 1; attempt <= 2; attempt++) {
-                  try {
-                    const revertParams: ThreadRevertParams = {
-                      threadId: threadIdToRevert,
-                      beforeTurnId,
-                    };
-                    await this.appServerManager.requestForThread(
-                      threadIdToRevert,
-                      Method.threadRevert,
-                      revertParams,
-                    );
-                    return;
-                  } catch (err) {
-                    lastMessage = err instanceof Error ? err.message : String(err);
-                    log.warn("codex exact-fork revert failed", { attempt, error: lastMessage });
-                  }
+                // turn error. Do not retry: thread/revert is boundary-based,
+                // not idempotent (the boundary turn disappears on success),
+                // so a lost response leaves the source state uncertain.
+                const revertParams: ThreadRevertParams = {
+                  threadId: threadIdToRevert,
+                  beforeTurnId,
+                };
+                try {
+                  await this.appServerManager.requestForThread(
+                    threadIdToRevert,
+                    Method.threadRevert,
+                    revertParams,
+                  );
+                  return;
+                } catch (err) {
+                  const lastMessage = err instanceof Error ? err.message : String(err);
+                  log.warn("codex exact-fork revert failed", { error: lastMessage });
+                  // The fork's turn is now permanently part of the source
+                  // thread, or its state is uncertain after a transport loss.
+                  // Poison the session so nothing resumes from potentially
+                  // contaminated history, and surface the failure on the
+                  // source events stream (out-of-turn, like Notify.error).
+                  contaminatedReason = `codex exact-fork revert failed, source thread may retain the fork turn: ${lastMessage}`;
+                  if (!closed) sink.push({ type: "error", error: contaminatedReason });
+                  throw new Error(contaminatedReason);
                 }
-                // The fork's turn is now permanently part of the source
-                // thread. Poison the session so nothing resumes from the
-                // contaminated history, and surface the failure on the source
-                // events stream (out-of-turn, like Notify.error).
-                contaminatedReason = `codex exact-fork revert failed, source thread retains the fork turn: ${lastMessage}`;
-                if (!closed) sink.push({ type: "error", error: contaminatedReason });
-                throw new Error(contaminatedReason);
               },
               interrupt: async (reason) => await interruptOwnerTurn(forkParams.sessionId, reason),
             });

--- a/packages/core/src/core/codex/app-server-binary.integration.test.ts
+++ b/packages/core/src/core/codex/app-server-binary.integration.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "@rstest/core";
+import { AppServerClient } from "./app-server-client.js";
+import { Method } from "./app-server-protocol.js";
+
+/**
+ * Smoke the bundled Codex binary, not a mocked JSON-RPC peer. This pins the
+ * paginated-history contract that Rome's borrowed exact forks depend on.
+ */
+describe("bundled Codex app-server", () => {
+  it("starts an Astra thread and reverts its borrowed turn", async () => {
+    const home = await mkdtemp(join(tmpdir(), "rome-codex-app-server-"));
+    const client = new AppServerClient({
+      cwd: home,
+      env: {
+        HOME: home,
+        CODEX_HOME: home,
+        PATH: process.env.PATH ?? "",
+      },
+      onNotification: () => undefined,
+      onServerRequest: () => ({}),
+    });
+
+    try {
+      client.start();
+      await client.request(Method.initialize, {
+        clientInfo: { name: "rome-test", title: "Rome test", version: "0" },
+        capabilities: { experimentalApi: true },
+      });
+      client.notify(Method.initialized, {});
+
+      const started = (await client.request(Method.threadStart, {
+        model: "gpt-6-astra",
+        cwd: home,
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+        baseInstructions: "Integration-test thread; do not modify files.",
+        config: {
+          model_reasoning_summary: "detailed",
+          hide_agent_reasoning: false,
+        },
+        historyMode: "paginated",
+        dynamicTools: null,
+      })) as {
+        thread: { id: string; model: string; historyMode: string; turns: unknown[] };
+      };
+      expect(started.thread).toMatchObject({
+        model: "gpt-6-astra",
+        historyMode: "paginated",
+      });
+
+      const turnStarted = (await client.request(Method.turnStart, {
+        threadId: started.thread.id,
+        input: [{ type: "text", text: "Reply with ok.", text_elements: [] }],
+        model: "gpt-6-astra",
+        effort: "low",
+        approvalPolicy: "never",
+      })) as { turn: { id: string } };
+
+      const reverted = (await client.request(Method.threadRevert, {
+        threadId: started.thread.id,
+        beforeTurnId: turnStarted.turn.id,
+      })) as { thread: { id: string; historyMode: string; turns: unknown[] } };
+      expect(reverted.thread).toMatchObject({
+        id: started.thread.id,
+        historyMode: "paginated",
+        turns: [],
+      });
+    } finally {
+      client.close();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await rm(home, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
+    }
+  });
+});

--- a/packages/core/src/core/codex/app-server-binary.integration.test.ts
+++ b/packages/core/src/core/codex/app-server-binary.integration.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "@rstest/core";
@@ -12,6 +13,66 @@ import { Method } from "./app-server-protocol.js";
 describe("bundled Codex app-server", () => {
   it("starts an Astra thread and reverts its borrowed turn", async () => {
     const home = await mkdtemp(join(tmpdir(), "rome-codex-app-server-"));
+    const modelServer = createServer((request, response) => {
+      if (request.method !== "POST" || !request.url?.endsWith("/responses")) {
+        response.writeHead(404).end();
+        return;
+      }
+      const events = [
+        { type: "response.created", response: { id: "resp-1" } },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            role: "assistant",
+            id: "msg-1",
+            content: [{ type: "output_text", text: "ok" }],
+          },
+        },
+        {
+          type: "response.completed",
+          response: {
+            id: "resp-1",
+            usage: {
+              input_tokens: 0,
+              input_tokens_details: null,
+              output_tokens: 0,
+              output_tokens_details: null,
+              total_tokens: 0,
+            },
+          },
+        },
+      ];
+      const body = events
+        .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+        .join("");
+      response.writeHead(200, { "content-type": "text/event-stream" }).end(body);
+    });
+    await new Promise<void>((resolve) => modelServer.listen(0, "127.0.0.1", resolve));
+    const address = modelServer.address();
+    if (!address || typeof address === "string") throw new Error("mock model server did not bind");
+    await writeFile(
+      join(home, "config.toml"),
+      [
+        'model = "gpt-6-astra"',
+        'approval_policy = "never"',
+        'sandbox_mode = "danger-full-access"',
+        'model_provider = "rome_test"',
+        "",
+        "[model_providers.rome_test]",
+        'name = "Rome test provider"',
+        `base_url = "http://127.0.0.1:${address.port}/v1"`,
+        'wire_api = "responses"',
+        "request_max_retries = 0",
+        "stream_max_retries = 0",
+        "",
+      ].join("\n"),
+    );
+
+    let resolveTurnCompleted!: (params: { threadId: string; turn: { id: string } }) => void;
+    const turnCompleted = new Promise<{ threadId: string; turn: { id: string } }>((resolve) => {
+      resolveTurnCompleted = resolve;
+    });
     const client = new AppServerClient({
       cwd: home,
       env: {
@@ -19,7 +80,11 @@ describe("bundled Codex app-server", () => {
         CODEX_HOME: home,
         PATH: process.env.PATH ?? "",
       },
-      onNotification: () => undefined,
+      onNotification: (method, params) => {
+        if (method === "turn/completed") {
+          resolveTurnCompleted(params as { threadId: string; turn: { id: string } });
+        }
+      },
       onServerRequest: () => ({}),
     });
 
@@ -58,18 +123,31 @@ describe("bundled Codex app-server", () => {
         effort: "low",
         approvalPolicy: "never",
       })) as { turn: { id: string } };
+      await expect(turnCompleted).resolves.toMatchObject({
+        threadId: started.thread.id,
+        turn: { id: turnStarted.turn.id },
+      });
+
+      const beforeRevert = (await client.request(Method.threadTurnsList, {
+        threadId: started.thread.id,
+      })) as { data: Array<{ id: string }> };
+      expect(beforeRevert.data.map((turn) => turn.id)).toEqual([turnStarted.turn.id]);
 
       const reverted = (await client.request(Method.threadRevert, {
         threadId: started.thread.id,
         beforeTurnId: turnStarted.turn.id,
-      })) as { thread: { id: string; historyMode: string; turns: unknown[] } };
+      })) as { thread: { id: string; historyMode: string } };
       expect(reverted.thread).toMatchObject({
         id: started.thread.id,
         historyMode: "paginated",
-        turns: [],
       });
+      const afterRevert = (await client.request(Method.threadTurnsList, {
+        threadId: started.thread.id,
+      })) as { data: unknown[] };
+      expect(afterRevert.data).toEqual([]);
     } finally {
       client.close();
+      await new Promise<void>((resolve) => modelServer.close(() => resolve()));
       await new Promise((resolve) => setTimeout(resolve, 100));
       await rm(home, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
     }

--- a/packages/core/src/core/codex/app-server-binary.integration.test.ts
+++ b/packages/core/src/core/codex/app-server-binary.integration.test.ts
@@ -69,8 +69,14 @@ describe("bundled Codex app-server", () => {
       ].join("\n"),
     );
 
-    let resolveTurnCompleted!: (params: { threadId: string; turn: { id: string } }) => void;
-    const turnCompleted = new Promise<{ threadId: string; turn: { id: string } }>((resolve) => {
+    let resolveTurnCompleted!: (params: {
+      threadId: string;
+      turn: { id: string; status: string };
+    }) => void;
+    const turnCompleted = new Promise<{
+      threadId: string;
+      turn: { id: string; status: string };
+    }>((resolve) => {
       resolveTurnCompleted = resolve;
     });
     const client = new AppServerClient({
@@ -82,7 +88,9 @@ describe("bundled Codex app-server", () => {
       },
       onNotification: (method, params) => {
         if (method === "turn/completed") {
-          resolveTurnCompleted(params as { threadId: string; turn: { id: string } });
+          resolveTurnCompleted(
+            params as { threadId: string; turn: { id: string; status: string } },
+          );
         }
       },
       onServerRequest: () => ({}),
@@ -125,7 +133,7 @@ describe("bundled Codex app-server", () => {
       })) as { turn: { id: string } };
       await expect(turnCompleted).resolves.toMatchObject({
         threadId: started.thread.id,
-        turn: { id: turnStarted.turn.id },
+        turn: { id: turnStarted.turn.id, status: "completed" },
       });
 
       const beforeRevert = (await client.request(Method.threadTurnsList, {
@@ -151,5 +159,5 @@ describe("bundled Codex app-server", () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
       await rm(home, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 });
     }
-  });
+  }, 30_000);
 });

--- a/packages/core/src/core/codex/app-server-client.test.ts
+++ b/packages/core/src/core/codex/app-server-client.test.ts
@@ -43,8 +43,8 @@ describe("AppServerClient", () => {
     await expect(inflight).rejects.toThrow(/exited/);
     expect(onExit).toHaveBeenCalledWith(1);
     // …and later requests reject immediately instead of pending forever —
-    // the borrowed exact-fork rollback depends on this to not hang.
-    await expect(client.request("thread/rollback", {})).rejects.toThrow(/exited/);
+    // the borrowed exact-fork revert depends on this to not hang.
+    await expect(client.request("thread/revert", {})).rejects.toThrow(/exited/);
   });
 
   it("turns a stdin EPIPE into one transport exit instead of an unhandled error", async () => {

--- a/packages/core/src/core/codex/app-server-manager.test.ts
+++ b/packages/core/src/core/codex/app-server-manager.test.ts
@@ -29,9 +29,18 @@ class FakeConnection implements CodexAppServerConnection {
 
   async request(method: string, params?: unknown): Promise<unknown> {
     this.requests.push({ method, params });
-    if (method === "thread/start") return { thread: { id: this.nextThreadId() } };
+    if (method === "thread/start") {
+      return {
+        thread: {
+          id: this.nextThreadId(),
+          historyMode: (params as ThreadStartParams).historyMode ?? "legacy",
+        },
+      };
+    }
     if (method === "thread/resume") {
-      return { thread: { id: (params as { threadId: string }).threadId } };
+      return {
+        thread: { id: (params as { threadId: string }).threadId, historyMode: "paginated" },
+      };
     }
     if (method === "thread/unsubscribe") return { status: "unsubscribed" };
     return {};
@@ -100,11 +109,13 @@ describe("CodexAppServerManager", () => {
     const alpha = binding("alpha");
     const beta = binding("beta");
 
-    const [threadA, threadB] = await Promise.all([
+    const [openedA, openedB] = await Promise.all([
       manager.openThread(config("rome_alpha"), alpha),
       manager.openThread(config("rome_beta"), beta),
       manager.warmup(),
     ]).then(([a, b]) => [a, b]);
+    const threadA = openedA.threadId;
+    const threadB = openedB.threadId;
 
     expect(clients).toHaveLength(1);
     expect(clients[0].started).toBe(1);
@@ -112,6 +123,8 @@ describe("CodexAppServerManager", () => {
       1,
     );
     expect(threadA).not.toBe(threadB);
+    expect(openedA.historyMode).toBe("paginated");
+    expect(openedB.historyMode).toBe("paginated");
 
     clients[0].options.onNotification("item/agentMessage/delta", {
       threadId: threadA,
@@ -228,7 +241,8 @@ describe("CodexAppServerManager", () => {
     const callbacks = binding("source");
     const globalExit = rs.fn();
     manager.onExit(globalExit);
-    const threadId = await manager.openThread(config("rome_source"), callbacks);
+    const opened = await manager.openThread(config("rome_source"), callbacks);
+    const threadId = opened.threadId;
 
     clients[0].options.onExit?.(137);
     expect(callbacks.exits).toHaveLength(1);

--- a/packages/core/src/core/codex/app-server-manager.test.ts
+++ b/packages/core/src/core/codex/app-server-manager.test.ts
@@ -50,6 +50,7 @@ function config(toolName: string): ThreadStartParams {
   return {
     model: "gpt-5.4-mini",
     cwd: "/workspace",
+    historyMode: "paginated",
     dynamicTools: [
       {
         type: "function",
@@ -242,10 +243,9 @@ describe("CodexAppServerManager", () => {
       "thread/resume",
       "turn/start",
     ]);
-    expect(clients[1].requests[1].params).toMatchObject({
-      threadId,
-      dynamicTools: [expect.objectContaining({ name: "rome_source" })],
-    });
+    expect(clients[1].requests[1].params).toMatchObject({ threadId });
+    expect(clients[1].requests[1].params).not.toHaveProperty("dynamicTools");
+    expect(clients[1].requests[1].params).not.toHaveProperty("historyMode");
     manager.close();
   });
 

--- a/packages/core/src/core/codex/app-server-manager.test.ts
+++ b/packages/core/src/core/codex/app-server-manager.test.ts
@@ -257,7 +257,7 @@ describe("CodexAppServerManager", () => {
       "thread/resume",
       "turn/start",
     ]);
-    expect(clients[1].requests[1].params).toMatchObject({ threadId });
+    expect(clients[1].requests[1].params).toMatchObject({ threadId, excludeTurns: true });
     expect(clients[1].requests[1].params).not.toHaveProperty("dynamicTools");
     expect(clients[1].requests[1].params).not.toHaveProperty("historyMode");
     manager.close();

--- a/packages/core/src/core/codex/app-server-manager.ts
+++ b/packages/core/src/core/codex/app-server-manager.ts
@@ -6,6 +6,7 @@ import {
   ServerRequestMethod,
   type DynamicToolCallParams,
   type DynamicToolCallResponse,
+  type ThreadResumeParams,
   type ThreadStartParams,
 } from "./app-server-protocol.js";
 
@@ -65,6 +66,12 @@ function threadIdFromResponse(result: unknown, method: string): string {
 function threadIdFromParams(params: unknown): string | null {
   const threadId = (params as { threadId?: unknown } | undefined)?.threadId;
   return typeof threadId === "string" && threadId ? threadId : null;
+}
+
+/** Strip thread/start-only fields before calling the narrower resume method. */
+function buildThreadResumeParams(threadId: string, config: ThreadStartParams): ThreadResumeParams {
+  const { dynamicTools: _dynamicTools, historyMode: _historyMode, ...overrides } = config;
+  return { threadId, ...overrides };
 }
 
 export class CodexAppServerManager {
@@ -133,10 +140,10 @@ export class CodexAppServerManager {
     const connection = await this.ensureConnection();
     const method = resumeThreadId ? Method.threadResume : Method.threadStart;
     const startedAt = Date.now();
-    const result = await connection.client.request(method, {
-      ...(resumeThreadId ? { threadId: resumeThreadId } : {}),
-      ...config,
-    });
+    const result = await connection.client.request(
+      method,
+      resumeThreadId ? buildThreadResumeParams(resumeThreadId, config) : config,
+    );
     const threadId = threadIdFromResponse(result, method);
     if (resumeThreadId && threadId !== resumeThreadId) {
       throw new Error(
@@ -215,10 +222,10 @@ export class CodexAppServerManager {
     if (!binding.resumePromise) {
       binding.resumePromise = (async () => {
         const startedAt = Date.now();
-        const result = await connection.client.request(Method.threadResume, {
-          threadId,
-          ...binding.config,
-        });
+        const result = await connection.client.request(
+          Method.threadResume,
+          buildThreadResumeParams(threadId, binding.config),
+        );
         const resumedThreadId = threadIdFromResponse(result, Method.threadResume);
         if (resumedThreadId !== threadId) {
           throw new Error(

--- a/packages/core/src/core/codex/app-server-manager.ts
+++ b/packages/core/src/core/codex/app-server-manager.ts
@@ -4,8 +4,10 @@ import { AppServerClient, type AppServerClientOptions } from "./app-server-clien
 import {
   Method,
   ServerRequestMethod,
+  toThreadConfigurationOverrides,
   type DynamicToolCallParams,
   type DynamicToolCallResponse,
+  type ThreadHistoryMode,
   type ThreadResumeParams,
   type ThreadStartParams,
 } from "./app-server-protocol.js";
@@ -24,6 +26,7 @@ export type CodexAppServerExitListener = (error: Error) => void;
 interface StoredThreadBinding {
   callbacks: CodexThreadBinding;
   config: ThreadStartParams;
+  handle: CodexThreadHandle;
   generation: number;
   resumePromise: Promise<void> | null;
 }
@@ -38,6 +41,12 @@ export interface CodexAppServerConnection {
   request(method: string, params?: unknown): Promise<unknown>;
   notify(method: string, params?: unknown): void;
   close(): void;
+}
+
+/** Mutable because a cold resume can migrate the persisted history mode. */
+export interface CodexThreadHandle {
+  threadId: string;
+  historyMode: ThreadHistoryMode | null;
 }
 
 export interface CodexAppServerManagerOptions {
@@ -55,12 +64,18 @@ function defaultCodexEnvironment(): Record<string, string> {
   return env;
 }
 
-function threadIdFromResponse(result: unknown, method: string): string {
-  const threadId = (result as { thread?: { id?: unknown } } | undefined)?.thread?.id;
+function threadFromResponse(result: unknown, method: string): CodexThreadHandle {
+  const thread = (result as { thread?: { id?: unknown; historyMode?: unknown } } | undefined)
+    ?.thread;
+  const threadId = thread?.id;
   if (typeof threadId !== "string" || !threadId) {
     throw new Error(`codex ${method} did not return a thread id`);
   }
-  return threadId;
+  const historyMode =
+    thread?.historyMode === "legacy" || thread?.historyMode === "paginated"
+      ? thread.historyMode
+      : null;
+  return { threadId, historyMode };
 }
 
 function threadIdFromParams(params: unknown): string | null {
@@ -68,10 +83,8 @@ function threadIdFromParams(params: unknown): string | null {
   return typeof threadId === "string" && threadId ? threadId : null;
 }
 
-/** Strip thread/start-only fields before calling the narrower resume method. */
 function buildThreadResumeParams(threadId: string, config: ThreadStartParams): ThreadResumeParams {
-  const { dynamicTools: _dynamicTools, historyMode: _historyMode, ...overrides } = config;
-  return { threadId, ...overrides };
+  return { threadId, ...toThreadConfigurationOverrides(config) };
 }
 
 export class CodexAppServerManager {
@@ -135,7 +148,7 @@ export class CodexAppServerManager {
     config: ThreadStartParams,
     callbacks: CodexThreadBinding,
     resumeThreadId?: string,
-  ): Promise<string> {
+  ): Promise<CodexThreadHandle> {
     if (this.closed) throw new Error("codex app-server manager is closed");
     const connection = await this.ensureConnection();
     const method = resumeThreadId ? Method.threadResume : Method.threadStart;
@@ -144,7 +157,8 @@ export class CodexAppServerManager {
       method,
       resumeThreadId ? buildThreadResumeParams(resumeThreadId, config) : config,
     );
-    const threadId = threadIdFromResponse(result, method);
+    const handle = threadFromResponse(result, method);
+    const threadId = handle.threadId;
     if (resumeThreadId && threadId !== resumeThreadId) {
       throw new Error(
         `codex thread/resume returned unexpected thread id ${threadId} (wanted ${resumeThreadId})`,
@@ -156,6 +170,7 @@ export class CodexAppServerManager {
     this.bindings.set(threadId, {
       callbacks,
       config,
+      handle,
       generation: connection.generation,
       resumePromise: null,
     });
@@ -165,7 +180,7 @@ export class CodexAppServerManager {
       generation: connection.generation,
       durationMs: Date.now() - startedAt,
     });
-    return threadId;
+    return handle;
   }
 
   async requestForThread<T>(threadId: string, method: string, params: unknown): Promise<T> {
@@ -226,12 +241,14 @@ export class CodexAppServerManager {
           Method.threadResume,
           buildThreadResumeParams(threadId, binding.config),
         );
-        const resumedThreadId = threadIdFromResponse(result, Method.threadResume);
+        const resumed = threadFromResponse(result, Method.threadResume);
+        const resumedThreadId = resumed.threadId;
         if (resumedThreadId !== threadId) {
           throw new Error(
             `codex thread/resume returned unexpected thread id ${resumedThreadId} (wanted ${threadId})`,
           );
         }
+        binding.handle.historyMode = resumed.historyMode;
         binding.generation = connection.generation;
         log.info("codex thread resumed after shared app-server restart", {
           threadId,

--- a/packages/core/src/core/codex/app-server-manager.ts
+++ b/packages/core/src/core/codex/app-server-manager.ts
@@ -84,7 +84,11 @@ function threadIdFromParams(params: unknown): string | null {
 }
 
 function buildThreadResumeParams(threadId: string, config: ThreadStartParams): ThreadResumeParams {
-  return { threadId, ...toThreadConfigurationOverrides(config) };
+  return {
+    threadId,
+    ...toThreadConfigurationOverrides(config),
+    excludeTurns: true,
+  };
 }
 
 export class CodexAppServerManager {

--- a/packages/core/src/core/codex/app-server-protocol.ts
+++ b/packages/core/src/core/codex/app-server-protocol.ts
@@ -73,6 +73,7 @@ export interface TokenUsageBreakdown {
   totalTokens: number;
   inputTokens: number;
   cachedInputTokens: number;
+  cacheWriteInputTokens: number;
   outputTokens: number;
   reasoningOutputTokens: number;
 }

--- a/packages/core/src/core/codex/app-server-protocol.ts
+++ b/packages/core/src/core/codex/app-server-protocol.ts
@@ -227,6 +227,8 @@ export interface DynamicToolCallResponse {
 
 export interface ThreadResumeParams extends ThreadConfigurationOverrides {
   threadId: string;
+  /** Skip deprecated full-history hydration; Rome pages history separately. */
+  excludeTurns?: boolean;
 }
 
 export interface ThreadForkParams extends ThreadConfigurationOverrides {
@@ -236,6 +238,8 @@ export interface ThreadForkParams extends ThreadConfigurationOverrides {
   /** Exclude this provider turn and every later turn from the fork. */
   beforeTurnId?: string | null;
   ephemeral?: boolean;
+  /** Skip deprecated full-history hydration; Rome does not consume returned turns. */
+  excludeTurns?: boolean;
 }
 
 export interface ThreadRevertParams {

--- a/packages/core/src/core/codex/app-server-protocol.ts
+++ b/packages/core/src/core/codex/app-server-protocol.ts
@@ -201,6 +201,14 @@ export interface DynamicToolSpec {
   deferLoading?: boolean;
 }
 
+/** Remove fields accepted only by thread/start before resume/fork requests. */
+export function toThreadConfigurationOverrides(
+  config: ThreadStartParams,
+): ThreadConfigurationOverrides {
+  const { dynamicTools: _dynamicTools, historyMode: _historyMode, ...overrides } = config;
+  return overrides;
+}
+
 export interface DynamicToolCallParams {
   threadId: string;
   turnId: string;
@@ -277,6 +285,7 @@ export const Method = {
   threadResume: "thread/resume",
   threadFork: "thread/fork",
   threadRevert: "thread/revert",
+  threadTurnsList: "thread/turns/list",
   threadUnsubscribe: "thread/unsubscribe",
   turnStart: "turn/start",
   turnSteer: "turn/steer",

--- a/packages/core/src/core/codex/app-server-protocol.ts
+++ b/packages/core/src/core/codex/app-server-protocol.ts
@@ -2,7 +2,7 @@
 //
 // These shapes are transcribed from the authoritative TypeScript bindings the
 // installed codex binary emits via `codex app-server generate-ts` (v2 surface,
-// codex-cli 0.130.0). We vendor only what the CodexAppServerProvider consumes
+// codex-cli 0.153.4). We vendor only what the CodexAppServerProvider consumes
 // rather than depend on a generated package — the binary has no published TS
 // SDK for app-server. Keep field names exact: they are the wire contract.
 //
@@ -156,11 +156,25 @@ export interface InitializeParams {
   capabilities?: Record<string, unknown> | null;
 }
 
-export type AskForApproval = "untrusted" | "on-failure" | "on-request" | "never";
+export type AskForApproval =
+  | "untrusted"
+  | "on-request"
+  | {
+      granular: {
+        sandbox_approval: boolean;
+        rules: boolean;
+        skill_approval: boolean;
+        request_permissions: boolean;
+        mcp_elicitations: boolean;
+      };
+    }
+  | "never";
 export type SandboxMode = "read-only" | "workspace-write" | "danger-full-access";
-export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+export type ReasoningEffort = string;
+export type ThreadHistoryMode = "legacy" | "paginated";
 
-export interface ThreadStartParams {
+/** Configuration overrides shared by thread/start, thread/resume, and thread/fork. */
+export interface ThreadConfigurationOverrides {
   model?: string | null;
   cwd?: string | null;
   approvalPolicy?: AskForApproval | null;
@@ -170,7 +184,11 @@ export interface ThreadStartParams {
   config?: Record<string, unknown> | null;
   /** The system prompt. */
   baseInstructions?: string | null;
-  skipGitRepoCheck?: boolean | null;
+}
+
+export interface ThreadStartParams extends ThreadConfigurationOverrides {
+  /** Persisted history contract for the new thread. */
+  historyMode?: ThreadHistoryMode | null;
   dynamicTools?: DynamicToolSpec[] | null;
 }
 
@@ -198,25 +216,26 @@ export interface DynamicToolCallResponse {
   success: boolean;
 }
 
-export interface ThreadResumeParams extends ThreadStartParams {
+export interface ThreadResumeParams extends ThreadConfigurationOverrides {
   threadId: string;
 }
 
-export interface ThreadForkParams extends ThreadStartParams {
+export interface ThreadForkParams extends ThreadConfigurationOverrides {
   threadId: string;
   /** Include this provider turn as the fork's final inherited turn. */
-  lastTurnId?: string;
+  lastTurnId?: string | null;
+  /** Exclude this provider turn and every later turn from the fork. */
+  beforeTurnId?: string | null;
   ephemeral?: boolean;
 }
 
-export interface ThreadRollbackParams {
+export interface ThreadRevertParams {
   threadId: string;
   /**
-   * Number of turns to remove from the end of the thread. Must be >= 1.
-   * Deprecated upstream, but still the only app-server primitive that can
-   * restore a borrowed exact-fork thread on Codex 0.144.x.
+   * Replace a paginated thread's durable history with the prefix before this
+   * turn, excluding it and every later turn. Local file changes are untouched.
    */
-  numTurns: number;
+  beforeTurnId: string;
 }
 
 export type UserInput =
@@ -256,7 +275,7 @@ export const Method = {
   threadStart: "thread/start",
   threadResume: "thread/resume",
   threadFork: "thread/fork",
-  threadRollback: "thread/rollback",
+  threadRevert: "thread/revert",
   threadUnsubscribe: "thread/unsubscribe",
   turnStart: "turn/start",
   turnSteer: "turn/steer",

--- a/packages/core/src/core/codex/borrowed-exact-fork.test.ts
+++ b/packages/core/src/core/codex/borrowed-exact-fork.test.ts
@@ -70,8 +70,8 @@ describe("evaluateBorrowedExactFork", () => {
 });
 
 describe("createBorrowedExactForkSession", () => {
-  it("scopes dynamic tools to the fork runtime and rolls back", async () => {
-    const rollbackTurn = rs.fn(async () => undefined);
+  it("scopes dynamic tools to the fork runtime and reverts before the borrowed turn", async () => {
+    const revertTurn = rs.fn(async () => undefined);
     let hasForkActionTool = false;
     const session = await createBorrowedExactForkSession({
       providerId: "openai",
@@ -84,7 +84,7 @@ describe("createBorrowedExactForkSession", () => {
         await runtime.beforeTerminal?.({ threadId: "source-thread", turnId: "fork-turn" });
         runtime.sink.push({ type: "result", content: "done" });
       },
-      rollbackTurn,
+      revertTurn,
       interrupt: async () => undefined,
     });
 
@@ -97,7 +97,7 @@ describe("createBorrowedExactForkSession", () => {
     await session.close();
 
     expect(hasForkActionTool).toBe(true);
-    expect(rollbackTurn).toHaveBeenCalledWith("source-thread");
+    expect(revertTurn).toHaveBeenCalledWith("source-thread", "fork-turn");
   });
 
   // A webchat-sourced exact fork opens with supportsInteractiveSurface: true
@@ -129,7 +129,7 @@ describe("createBorrowedExactForkSession", () => {
         confirmRes = await runtime.romeTools.callTool("confirm_output", {});
         runtime.sink.push({ type: "result", content: "done" });
       },
-      rollbackTurn: async () => undefined,
+      revertTurn: async () => undefined,
       interrupt: async () => undefined,
     });
 

--- a/packages/core/src/core/codex/borrowed-exact-fork.ts
+++ b/packages/core/src/core/codex/borrowed-exact-fork.ts
@@ -1,6 +1,6 @@
 // Temporary adapter for https://github.com/openai/codex/issues/24704.
 //
-// Codex app-server 0.144.x rebuilds a native thread/fork under fresh response
+// Codex app-server rebuilds a native thread/fork under fresh response
 // continuation and prompt-cache lineage. The transcript is identical, but the
 // inherited suffix is billed as uncached. For a same-configuration exact fork,
 // Rome borrows the source thread for one serialized turn and rolls that turn
@@ -8,7 +8,7 @@
 //
 // Once app-server preserves cache lineage natively, delete this module and the
 // provider branch that calls it. The remaining workaround seams are deliberately
-// easy to find: CodexTurnRuntime.beforeTerminal and Method.threadRollback.
+// easy to find: CodexTurnRuntime.beforeTerminal and Method.threadRevert.
 
 import type {
   ModelSession,
@@ -71,7 +71,7 @@ export interface CreateBorrowedExactForkSessionArgs {
   openParams: ModelSessionForkOpenParams;
   runExclusive<T>(work: () => Promise<T>): Promise<T>;
   runTurn(input: ModelUserInput, runtime: CodexTurnRuntime): Promise<void>;
-  rollbackTurn(threadId: string): Promise<void>;
+  revertTurn(threadId: string, beforeTurnId: string): Promise<void>;
   interrupt(reason?: string): Promise<void>;
 }
 
@@ -105,9 +105,9 @@ export async function createBorrowedExactForkSession(
     imageTracker,
     romeTools,
     isClosed: () => closed,
-    // Rollback happens before the result/error event, so consumers can never
+    // Revert happens before the result/error event, so consumers can never
     // observe success while the source conversation still contains the turn.
-    beforeTerminal: async ({ threadId }) => await args.rollbackTurn(threadId),
+    beforeTerminal: async ({ threadId, turnId }) => await args.revertTurn(threadId, turnId),
   };
 
   return {

--- a/packages/core/src/core/codex/common.test.ts
+++ b/packages/core/src/core/codex/common.test.ts
@@ -8,22 +8,24 @@ describe("buildOpenAiAccounting", () => {
       usage: {
         input_tokens: 1000,
         cached_input_tokens: 300,
+        cache_write_input_tokens: 200,
         output_tokens: 40,
         reasoning_output_tokens: 15,
       },
     });
 
     expect(accounting.usage).toEqual({
-      inputTokens: 700,
+      inputTokens: 500,
       outputTokens: 40,
       cacheReadTokens: 300,
-      cacheWriteTokens: 0,
+      cacheWriteTokens: 200,
     });
     expect(accounting.rawUsage).toEqual({
       input_tokens: 1000,
-      uncached_input_tokens: 700,
+      uncached_input_tokens: 500,
       output_tokens: 40,
       cached_tokens: 300,
+      cache_write_tokens: 200,
       reasoning_tokens: 15,
     });
   });
@@ -32,6 +34,7 @@ describe("buildOpenAiAccounting", () => {
     const usage: Usage = {
       input_tokens: 50,
       cached_input_tokens: 80,
+      cache_write_input_tokens: 10,
       output_tokens: 0,
       reasoning_output_tokens: 0,
     };

--- a/packages/core/src/core/codex/common.ts
+++ b/packages/core/src/core/codex/common.ts
@@ -13,6 +13,7 @@ import {
 export type Usage = {
   input_tokens: number;
   cached_input_tokens: number;
+  cache_write_input_tokens: number;
   output_tokens: number;
   reasoning_output_tokens: number;
 };
@@ -54,7 +55,8 @@ interface BuildOpenAiAccountingArgs {
 function normalizeOpenAiUsage(usage: Usage | undefined) {
   const sdkInputTokens = usage?.input_tokens ?? 0;
   const cacheReadTokens = usage?.cached_input_tokens ?? 0;
-  const inputTokens = Math.max(0, sdkInputTokens - cacheReadTokens);
+  const cacheWriteTokens = usage?.cache_write_input_tokens ?? 0;
+  const inputTokens = Math.max(0, sdkInputTokens - cacheReadTokens - cacheWriteTokens);
   const outputTokens = usage?.output_tokens ?? 0;
   const reasoningTokens = usage?.reasoning_output_tokens ?? 0;
   return {
@@ -64,7 +66,7 @@ function normalizeOpenAiUsage(usage: Usage | undefined) {
       inputTokens,
       outputTokens,
       cacheReadTokens,
-      cacheWriteTokens: 0,
+      cacheWriteTokens,
     },
     rawUsage: usage
       ? {
@@ -72,6 +74,7 @@ function normalizeOpenAiUsage(usage: Usage | undefined) {
           uncached_input_tokens: inputTokens,
           output_tokens: outputTokens,
           cached_tokens: cacheReadTokens,
+          cache_write_tokens: cacheWriteTokens,
           reasoning_tokens: reasoningTokens,
         }
       : undefined,

--- a/packages/core/src/core/codex/rome-dynamic-tools.test.ts
+++ b/packages/core/src/core/codex/rome-dynamic-tools.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, rs } from "@rstest/core";
 import type { RomeMcpGroup, RomeMcpServer } from "../mcp/server.js";
-import { createRomeDynamicToolsFromServer } from "./rome-dynamic-tools.js";
+import {
+  alignRomeDynamicToolsToInheritedCatalog,
+  createRomeDynamicToolsFromServer,
+} from "./rome-dynamic-tools.js";
 
 function fakeServer(definitions: Partial<Record<RomeMcpGroup, readonly string[]>>): RomeMcpServer {
   return {
@@ -80,5 +83,38 @@ describe("Rome dynamic tools", () => {
       response: { success: false },
       traceOutput: { isError: true },
     });
+  });
+
+  it("keeps a native fork aligned with its inherited catalog but fails closed for disabled tools", async () => {
+    const sourceTools = createRomeDynamicToolsFromServer(
+      fakeServer({ subagents: ["source_researcher"] }),
+    );
+    const forkServer = fakeServer({ actions: ["fork_action"] });
+    const forkTools = alignRomeDynamicToolsToInheritedCatalog(
+      createRomeDynamicToolsFromServer(forkServer),
+      sourceTools.definitions,
+    );
+
+    expect(forkTools.definitions).toEqual(sourceTools.definitions);
+    expect(forkTools.hasTool("source_researcher")).toBe(true);
+    expect(forkTools.hasTool("fork_action")).toBe(false);
+    await expect(forkTools.callTool("source_researcher", { prompt: "inspect" })).resolves.toEqual({
+      response: {
+        contentItems: [
+          {
+            type: "inputText",
+            text: "Dynamic tool is disabled in this fork: source_researcher",
+          },
+        ],
+        success: false,
+      },
+      traceOutput: {
+        content: [
+          { type: "text", text: "Dynamic tool is disabled in this fork: source_researcher" },
+        ],
+        isError: true,
+      },
+    });
+    expect(forkServer.callTool).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/core/codex/rome-dynamic-tools.ts
+++ b/packages/core/src/core/codex/rome-dynamic-tools.ts
@@ -57,6 +57,35 @@ export function createRomeDynamicTools(params: ModelSessionForkOpenParams): Rome
   return createRomeDynamicToolsFromServer(createRomeMcpServerForSession(params));
 }
 
+/**
+ * `thread/fork` inherits the source thread's dynamic-tool definitions and the
+ * current app-server protocol has no fork/resume field that can replace them.
+ * Keep the child binding's advertised catalog identical to that inherited
+ * catalog, while still enforcing the fork's Rome-side runtime permissions.
+ *
+ * An isolated fork therefore rejects an inherited source-only tool explicitly
+ * instead of letting the manager report it as unknown (or accidentally routing
+ * it through the source session's callbacks).
+ */
+export function alignRomeDynamicToolsToInheritedCatalog(
+  runtimeTools: RomeDynamicTools,
+  inheritedDefinitions: readonly DynamicToolSpec[],
+): RomeDynamicTools {
+  const definitions = [...inheritedDefinitions];
+  const inheritedNames = new Set(definitions.map((definition) => definition.name));
+  return {
+    definitions,
+    hasTool: (name) => inheritedNames.has(name),
+    async callTool(name, input, context) {
+      if (!inheritedNames.has(name)) return errorResult(`Unknown dynamic tool: ${name}`);
+      if (!runtimeTools.hasTool(name)) {
+        return errorResult(`Dynamic tool is disabled in this fork: ${name}`);
+      }
+      return await runtimeTools.callTool(name, input, context);
+    },
+  };
+}
+
 export function createRomeDynamicToolsFromServer(server: RomeMcpServer): RomeDynamicTools {
   const groupByName = new Map<string, RomeMcpGroup>();
   const definitions: DynamicToolSpec[] = [];

--- a/packages/core/src/core/codex/turn-runtime.ts
+++ b/packages/core/src/core/codex/turn-runtime.ts
@@ -17,7 +17,7 @@ export interface CodexTurnRuntime {
   /**
    * Optional provider operation that must finish after the model turn but
    * before Rome exposes its terminal event. The borrowed exact-fork adapter
-   * uses this seam to restore source history with thread/rollback.
+   * uses this seam to restore source history with thread/revert.
    */
   beforeTerminal?: (turn: { threadId: string; turnId: string }) => Promise<void>;
 }


### PR DESCRIPTION
## Summary
- migrate borrowed exact-fork cleanup from deprecated `thread/rollback` to paginated `thread/revert`
- opt new Codex threads into `historyMode: "paginated"`, pass the actual borrowed turn id as `beforeTurnId`, and route unmigrated legacy threads through native forks
- refresh the vendored app-server protocol subset for Codex 0.153.4 and stop sending removed/start-only fields to resume/fork
- preserve Codex 0.153.4's `cacheWriteInputTokens` through aggregation, telemetry, and 1.25× cache-write pricing
- add a real bundled-binary integration smoke test with a local Responses server that completes an Astra turn, reverts it, and verifies paginated history

## Why
Follow-up to #242 and its automated review. Codex 0.153.4 defaults new threads to paginated history, where `thread/rollback` is rejected. This keeps Rome's cache-preserving exact-fork workaround compatible and its new cache-write accounting accurate before the v1.1.7 image is cut.

## Validation
- `pnpm typecheck`
- `pnpm --filter @rome/core lint` (passes; one pre-existing warning in `src/apps/migrate-to-lockfile.ts`)
- `pnpm --filter @rome/core exec ../../scripts/test-env.sh rstest codex-app-server-provider.test borrowed-exact-fork.test app-server-manager.test app-server-client.test` (48 tests)
- `pnpm --filter @rome/core exec ../../scripts/test-env.sh rstest codex-app-server-provider.test codex/common.test` (38 tests)
- `pnpm --filter @rome/core exec ../../scripts/test-env.sh rstest codex-app-server-provider.test app-server-manager.test app-server-binary.integration.test` (41 tests; real Codex 0.153.4 binary)