### PR TITLE
feat(app-runtime): carry the rome session id in the action context

### DIFF
--- a/packages/app-runtime-sdk/src/index.ts
+++ b/packages/app-runtime-sdk/src/index.ts
@@ -1588,6 +1588,12 @@ export interface CurrentActionContext {
   callerAppId?: string;
   channelContext?: ThreadContext;
   sessionId?: string;
+  /** Durable Rome session id of the agent session that called this action.
+   * Present only for agent-initiated calls; a routine, hook, or app-initiated
+   * call has no agent session and leaves it undefined. Unlike `sessionId`
+   * (the runtime AgentSession handle) this is the id sessions are persisted
+   * and parented by. */
+  romeSessionId?: string;
   turnId?: string;
   agentName?: string;
   channelThreadKey?: string;

--- a/packages/app-runtime-sdk/src/index.ts
+++ b/packages/app-runtime-sdk/src/index.ts
@@ -1590,9 +1590,11 @@ export interface CurrentActionContext {
   sessionId?: string;
   /** Durable Rome session id of the agent session that called this action.
    * Present only for agent-initiated calls; a routine, hook, or app-initiated
-   * call has no agent session and leaves it undefined. Unlike `sessionId`
-   * (the runtime AgentSession handle) this is the id sessions are persisted
-   * and parented by. */
+   * call has no agent session and leaves it undefined. This is the id sessions
+   * are persisted and parented by, as opposed to `sessionId` (the runtime
+   * AgentSession handle). The two usually differ, but can coincide: a turn
+   * started without an explicit rome session id falls back to `sessionId`, so
+   * a consumer must not assume they are always distinct. */
   romeSessionId?: string;
   turnId?: string;
   agentName?: string;

--- a/packages/app-runtime-sdk/src/index.ts
+++ b/packages/app-runtime-sdk/src/index.ts
@@ -1592,9 +1592,10 @@ export interface CurrentActionContext {
    * Present only for agent-initiated calls; a routine, hook, or app-initiated
    * call has no agent session and leaves it undefined. This is the id sessions
    * are persisted and parented by, as opposed to `sessionId` (the runtime
-   * AgentSession handle). The two usually differ, but can coincide: a turn
-   * started without an explicit rome session id falls back to `sessionId`, so
-   * a consumer must not assume they are always distinct.
+   * AgentSession handle). They differ for top-level channel/webchat turns
+   * (thread conversation id vs. runtime handle) and coincide for subagent and
+   * forked sessions, whose rome session id is the agent session id itself; a
+   * consumer must not assume they are distinct.
    *
    * Distinct from `channelContext.romeSessionId`, which is the thread's stable
    * conversation id: this identifies the calling *agent session*. The two

--- a/packages/app-runtime-sdk/src/index.ts
+++ b/packages/app-runtime-sdk/src/index.ts
@@ -1594,7 +1594,14 @@ export interface CurrentActionContext {
    * are persisted and parented by, as opposed to `sessionId` (the runtime
    * AgentSession handle). The two usually differ, but can coincide: a turn
    * started without an explicit rome session id falls back to `sessionId`, so
-   * a consumer must not assume they are always distinct. */
+   * a consumer must not assume they are always distinct.
+   *
+   * Distinct from `channelContext.romeSessionId`, which is the thread's stable
+   * conversation id: this identifies the calling *agent session*. The two
+   * coincide for an ordinary top-level agent turn but diverge for a subagent
+   * or child session, whose agent session differs from the thread conversation
+   * it runs under. Use this field to parent work by the caller; use
+   * `channelContext.romeSessionId` to key the thread. */
   romeSessionId?: string;
   turnId?: string;
   agentName?: string;

--- a/packages/core/src/actions/approval-handler.ts
+++ b/packages/core/src/actions/approval-handler.ts
@@ -20,6 +20,7 @@ interface ApprovalPayload {
   channelContext?: ThreadContext;
   sharedContext?: Record<string, unknown>;
   sessionId?: string;
+  romeSessionId?: string;
   agentName?: string;
   channelThreadKey?: string;
 }
@@ -169,6 +170,7 @@ export class ApprovalHandler {
           channelContext: payload.channelContext,
           sharedContext: payload.sharedContext,
           sessionId: payload.sessionId,
+          romeSessionId: payload.romeSessionId,
           agentName: payload.agentName,
           channelThreadKey: payload.channelThreadKey,
         };

--- a/packages/core/src/actions/call-action.test.ts
+++ b/packages/core/src/actions/call-action.test.ts
@@ -88,6 +88,7 @@ describe("callAction", () => {
           channelContext: store?.channelContext,
           sharedContext: store?.sharedContext,
           sessionId: store?.sessionId,
+          romeSessionId: store?.romeSessionId,
           agentName: store?.agentName,
           channelThreadKey: store?.channelThreadKey,
         };
@@ -117,6 +118,7 @@ describe("callAction", () => {
           flags: { dryRun: true },
         },
         sessionId: "sess-42",
+        romeSessionId: "rome-sess-42",
         agentName: "main",
         channelThreadKey: "telegram:t-1",
       },
@@ -130,6 +132,7 @@ describe("callAction", () => {
         flags: { dryRun: true },
       },
       sessionId: "sess-42",
+      romeSessionId: "rome-sess-42",
       agentName: "main",
       channelThreadKey: "telegram:t-1",
     });
@@ -154,6 +157,7 @@ describe("callAction", () => {
           tenantId: "tenant-alpha",
         },
         sessionId: "sess-7",
+        romeSessionId: "rome-sess-7",
         agentName: "main",
         channelThreadKey: "webchat:thread-1",
       },
@@ -177,6 +181,7 @@ describe("callAction", () => {
             tenantId: "tenant-alpha",
           },
           sessionId: "sess-7",
+          romeSessionId: "rome-sess-7",
           agentName: "main",
           channelThreadKey: "webchat:thread-1",
         });

--- a/packages/core/src/actions/call-action.ts
+++ b/packages/core/src/actions/call-action.ts
@@ -35,6 +35,7 @@ export async function callAction(
       channelContext: store.channelContext,
       sharedContext: store.sharedContext,
       sessionId: store.sessionId,
+      romeSessionId: store.romeSessionId,
       agentName: store.agentName,
       channelThreadKey: store.channelThreadKey,
     },

--- a/packages/core/src/actions/context.ts
+++ b/packages/core/src/actions/context.ts
@@ -26,6 +26,9 @@ export interface ActionExecutionStore {
   channelContext?: ThreadContext;
   sharedContext?: Record<string, unknown>;
   sessionId?: string;
+  /** Durable Rome session id of the calling agent session. Undefined for
+   * routine / hook / app-initiated chains, which have no agent session. */
+  romeSessionId?: string;
   turnId?: string;
   agentName?: string;
   channelThreadKey?: string;
@@ -49,6 +52,7 @@ setCurrentActionContextResolver(() => {
     callerAppId: store.callerAppId,
     channelContext: store.channelContext,
     sessionId: store.sessionId,
+    romeSessionId: store.romeSessionId,
     turnId: store.turnId,
     agentName: store.agentName,
     channelThreadKey: store.channelThreadKey,

--- a/packages/core/src/actions/engine.test.ts
+++ b/packages/core/src/actions/engine.test.ts
@@ -1317,6 +1317,7 @@ describe("ActionEngine", () => {
             channelUserId: "u-1",
           },
           sessionId: "sess-7",
+          romeSessionId: "rome-sess-7",
           agentName: "main",
           channelThreadKey: "webchat:t-1",
         },
@@ -1334,6 +1335,7 @@ describe("ActionEngine", () => {
         rootArgs: { launch: true },
         channelContext: { channel: "webchat", threadId: "t-1", channelUserId: "u-1" },
         sessionId: "sess-7",
+        romeSessionId: "rome-sess-7",
         agentName: "main",
         channelThreadKey: "webchat:t-1",
       });

--- a/packages/core/src/actions/engine.test.ts
+++ b/packages/core/src/actions/engine.test.ts
@@ -384,6 +384,7 @@ describe("ActionEngine", () => {
       expect(store.channelContext).toBeUndefined();
       expect(store.sharedContext).toBeUndefined();
       expect(store.sessionId).toBeUndefined();
+      expect(store.romeSessionId).toBeUndefined();
       expect(store.agentName).toBeUndefined();
       expect(store.channelThreadKey).toBeUndefined();
     }, 30_000);
@@ -417,6 +418,7 @@ describe("ActionEngine", () => {
           tenantId: "tenant-alpha",
         },
         sessionId: "sess-99",
+        romeSessionId: "rome-sess-99",
         agentName: "main",
         channelThreadKey: "telegram:t-1",
       };
@@ -431,6 +433,7 @@ describe("ActionEngine", () => {
         channelContext: context.channelContext,
         sharedContext: context.sharedContext,
         sessionId: "sess-99",
+        romeSessionId: "rome-sess-99",
         agentName: "main",
         channelThreadKey: "telegram:t-1",
       });
@@ -1015,6 +1018,7 @@ describe("ActionEngine", () => {
           selectedProjectPath: "/tmp/projects/alpha",
         },
         sessionId: "sess-1",
+        romeSessionId: "rome-sess-1",
         agentName: "main",
       };
       const result = await rome.actionEngine.run("risky", { target: "prod" }, context);
@@ -1027,6 +1031,7 @@ describe("ActionEngine", () => {
         channelContext: context.channelContext,
         sharedContext: context.sharedContext,
         sessionId: "sess-1",
+        romeSessionId: "rome-sess-1",
         agentName: "main",
       });
     });

--- a/packages/core/src/actions/engine.ts
+++ b/packages/core/src/actions/engine.ts
@@ -139,6 +139,10 @@ export interface ActionRunContext {
   divergenceMode?: "fallthrough" | "strict";
   /** Session info for agent-level resumption on approval */
   sessionId?: string;
+  /** Durable Rome session id of the calling agent session, when one called.
+   * Distinct from `sessionId` (the runtime AgentSession handle): this is the
+   * id a child session is parented by. */
+  romeSessionId?: string;
   agentName?: string;
   channelThreadKey?: string;
   /** Allocated by AgentSession.sendTurn; stamped on `action:*` spans so the
@@ -435,6 +439,7 @@ export class ActionEngine {
         sharedContext: runContext?.sharedContext,
         hookInvocationContext: runContext?.hookInvocationContext,
         sessionId: runContext?.sessionId,
+        romeSessionId: runContext?.romeSessionId,
         agentName: runContext?.agentName,
         channelThreadKey: runContext?.channelThreadKey,
         turnId: runContext?.turnId,
@@ -761,6 +766,7 @@ export class ActionEngine {
       channelContext: context?.channelContext ?? parentStore?.channelContext,
       sharedContext: mergeSharedContext(parentStore?.sharedContext, context?.sharedContext),
       sessionId: context?.sessionId ?? parentStore?.sessionId,
+      romeSessionId: context?.romeSessionId ?? parentStore?.romeSessionId,
       turnId: context?.turnId ?? parentStore?.turnId,
       agentName: context?.agentName ?? parentStore?.agentName,
       channelThreadKey: context?.channelThreadKey ?? parentStore?.channelThreadKey,
@@ -925,6 +931,7 @@ export class ActionEngine {
       channelContext: invocation.context?.channelContext,
       sharedContext: invocation.context?.sharedContext,
       sessionId: invocation.context?.sessionId,
+      romeSessionId: invocation.context?.romeSessionId,
       turnId: invocation.context?.turnId,
       agentName: invocation.context?.agentName,
       channelThreadKey: invocation.context?.channelThreadKey,

--- a/packages/core/src/actions/engine.ts
+++ b/packages/core/src/actions/engine.ts
@@ -1749,6 +1749,7 @@ export class ActionEngine {
         channelContext: context?.channelContext,
         sharedContext: context?.sharedContext,
         sessionId: context?.sessionId,
+        romeSessionId: context?.romeSessionId,
         agentName: context?.agentName,
         channelThreadKey: context?.channelThreadKey,
       },

--- a/packages/core/src/apps/context.ts
+++ b/packages/core/src/apps/context.ts
@@ -271,6 +271,7 @@ export function createRomeAppContext(
         channelContext: store?.channelContext,
         sharedContext: store?.sharedContext,
         sessionId: store?.sessionId,
+        romeSessionId: store?.romeSessionId,
         agentName: store?.agentName,
         channelThreadKey: store?.channelThreadKey,
       });

--- a/packages/core/src/core/agent-runner.test.ts
+++ b/packages/core/src/core/agent-runner.test.ts
@@ -2688,6 +2688,93 @@ describe("AgentRunner", () => {
       ]);
     });
 
+    it("passes the turn's bound romeSessionId from openSession into action execution", async () => {
+      // Guards the origin hop: openSession builds executeAction as
+      // actionEngine.run({ romeSessionId: refs.getRomeSessionId(), ... }). The
+      // engine/store/SDK tests would all stay green if a TurnExecRefs refactor
+      // dropped that argument, leaving every agent call with romeSessionId
+      // undefined — this is the one test that fails when the id stops
+      // originating.
+      const observed: Array<{ sessionId?: string; romeSessionId?: string }> = [];
+      // "demo_action" is on test-main's allow-list, so it passes
+      // findPermittedAction and runs through the real makeExecuteAction hop.
+      actionRegistry.register({
+        config: {
+          name: "demo_action",
+          type: "system",
+          description: "Capture the rome session id from the action context",
+          complexity: "simple",
+          speed: "fast",
+          reliability: "high",
+          sideEffects: "read-only",
+        },
+        inputSchema: {},
+        execute: async () => {
+          const store = actionExecutionContext.getStore();
+          observed.push({ sessionId: store?.sessionId, romeSessionId: store?.romeSessionId });
+          return { status: "ok" };
+        },
+      });
+
+      const runImpl = async function* (
+        params: import("./agent-runner.js").ModelRunParams,
+      ): AsyncIterable<AgentMessage> {
+        yield {
+          type: "tool_use",
+          id: `tu-${params.prompt}`,
+          tool: "demo_action",
+          input: {},
+        };
+        await params.executeAction("demo_action", {});
+        yield {
+          type: "tool_result",
+          toolUseId: `tu-${params.prompt}`,
+          tool: "demo_action",
+          output: { ok: true },
+        };
+        yield { type: "result", content: `done ${params.prompt}` };
+      };
+      const provider: ModelProvider = {
+        id: "mock",
+        displayName: "mock-rome-session-origin",
+        builtinTools: new Set<string>(),
+        openSession: makeOpenSessionFromRun("mock", runImpl),
+      };
+      const runner = createRunner(provider);
+
+      // A turn bound to an explicit durable rome session id (a resolved
+      // conversation, as the channel adapters supply): the action context must
+      // carry that exact id — proving openSession passed refs.getRomeSessionId()
+      // — and it must be distinct from the ephemeral runtime handle, so a
+      // dropped origin argument (undefined) or a mix-up with sessionId both
+      // fail here.
+      const webchatRepo = new WebChatRepository(testDb.db);
+      const conversation = await webchatRepo.ensureChannelConversation({
+        channel: "discord",
+        threadId: "rome-session-origin",
+        agentName: "main",
+      });
+      await collectMessages(
+        runner.run({
+          agentName: "test-main",
+          prompt: "explicit",
+          channelThreadKey: "discord:rome-session-origin",
+          romeSessionId: conversation.id,
+          threadContext: {
+            channel: "discord",
+            threadId: "rome-session-origin",
+            channelUserId: "guardian",
+            threadType: "group",
+          },
+        }),
+      );
+
+      expect(observed).toHaveLength(1);
+      const [explicit] = observed;
+      expect(explicit?.romeSessionId).toBe(conversation.id);
+      expect(explicit?.romeSessionId).not.toBe(explicit?.sessionId);
+    });
+
     it("does not dispatch finished lifecycle events for turns that never started", async () => {
       const lifecycle = createLifecycleRecorder();
       const provider: ModelProvider = {

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -1133,6 +1133,7 @@ async function openSession(
             const result = await deps.actionEngine.run("create_routine", createArgs, {
               initiator: `agent:${key.agentName}`,
               sessionId: refs.sessionId,
+              romeSessionId: refs.getRomeSessionId(),
               agentName: key.agentName,
               channelThreadKey: key.channelThreadKey,
               turnId: refs.getTurnId(),
@@ -1192,6 +1193,7 @@ async function openSession(
               {
                 initiator: "system:handback-validate",
                 sessionId: refs.sessionId,
+                romeSessionId: refs.getRomeSessionId(),
                 agentName: key.agentName,
                 channelThreadKey: key.channelThreadKey,
                 turnId: refs.getTurnId(),

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -995,6 +995,7 @@ async function openSession(
             channelContext: refs.getThreadContext(),
             sharedContext: refs.getSharedContext(),
             sessionId: refs.sessionId,
+            romeSessionId: refs.getRomeSessionId(),
             agentName: key.agentName,
             channelThreadKey: key.channelThreadKey,
             turnId: refs.getTurnId(),


### PR DESCRIPTION
## What this PR does

An action running in a worker knows the runtime session id of its caller
(`sessionId`, the live `AgentSession` handle) but not the durable Rome
session id — the id sessions are persisted and parented by. Without it a
worker-side action cannot file work under the calling session.

This threads an optional `romeSessionId` from the calling agent session,
through the action engine, into the action-execution store, and out to the
`CurrentActionContext` a worker reads. The agent session already knows the
value; `openSession` now passes `refs.getRomeSessionId()` into
`actionEngine.run`, and the engine carries it alongside the existing
`sessionId` down every hop.

## Design & Invariants

- Additive and optional at every layer. `romeSessionId` is undefined for
  routine-, hook-, and app-initiated chains, which have no agent session,
  and undefined for existing callers that do not set it. No existing caller
  changes.
- `romeSessionId` is distinct from `sessionId`: the former is the durable id
  a child session is parented by, the latter the ephemeral runtime handle.
  The two travel together but mean different things.
- Inheritance mirrors the sibling fields: a nested call inherits
  `romeSessionId` from its parent store when the invocation does not set one
  (`context?.romeSessionId ?? parentStore?.romeSessionId`).

## Test plan

- [x] `pnpm typecheck` — passes.
- [x] `pnpm test:unit` — passes (full recursive run, incl. `@rome/core`).

## Not in this PR

- No consumer reads `romeSessionId` yet; this only makes the id available in
  the action context. Callers that file work under the calling session land
  separately.

Closes #247
