### PR TITLE
feat(core): read a session's latest turn outcome and transcript tail

### DIFF
--- a/packages/core/src/db/repositories/webchat.test.ts
+++ b/packages/core/src/db/repositories/webchat.test.ts
@@ -1468,6 +1468,176 @@ describe("WebChatRepository", () => {
     });
   });
 
+  describe("detached child status reads", () => {
+    // Mirrors what AgentTraceRecorder writes for one child turn: a user row, a
+    // trace whose blocks bracket the turn, and (when the turn produced one) an
+    // assistant row.
+    async function recordTurn(
+      sessionId: string,
+      turnId: string,
+      options: {
+        at: string;
+        prompt: string;
+        reply?: string;
+        turnEnd?: "completed" | "error" | "interrupted";
+        error?: string;
+      },
+    ) {
+      rs.setSystemTime(new Date(options.at));
+      const blocks: unknown[] = [{ type: "turn_start", turnId, userPrompt: options.prompt }];
+      if (options.reply !== undefined) blocks.push({ type: "result", content: options.reply });
+      if (options.error !== undefined) blocks.push({ type: "error", error: options.error });
+      if (options.turnEnd) blocks.push({ type: "turn_end", turnId, status: options.turnEnd });
+      await repo.appendTraceBlocks({
+        messageId: `trace:${sessionId}:${turnId}`,
+        sessionId,
+        turnId,
+        startSeq: 0,
+        blocks,
+        transcriptMessages: [
+          {
+            id: `transcript:${sessionId}:${turnId}:user`,
+            sessionId,
+            role: "user",
+            content: JSON.stringify([{ type: "text", content: options.prompt }]),
+            turnId,
+          },
+          ...(options.reply !== undefined
+            ? [
+                {
+                  id: `transcript:${sessionId}:${turnId}:assistant`,
+                  sessionId,
+                  role: "assistant" as const,
+                  content: JSON.stringify([{ type: "text", content: options.reply }]),
+                  turnId,
+                },
+              ]
+            : []),
+        ],
+      });
+    }
+
+    beforeEach(() => {
+      rs.useFakeTimers();
+    });
+
+    it("reports the newest turn's outcome, not the first one's", async () => {
+      await repo.createSession("child-many", "Child");
+      await recordTurn("child-many", "turn-1", {
+        at: "2030-01-01T00:00:00.000Z",
+        prompt: "first",
+        reply: "first answer",
+        turnEnd: "completed",
+      });
+      await recordTurn("child-many", "turn-2", {
+        at: "2030-01-01T01:00:00.000Z",
+        prompt: "second",
+        reply: "second answer",
+        turnEnd: "completed",
+      });
+
+      await expect(repo.getLatestTurnOutcome("child-many")).resolves.toEqual({
+        turnId: "turn-2",
+        turnEndStatus: "completed",
+        error: null,
+        reply: "second answer",
+      });
+    });
+
+    it("reports the last-written turn when two land in the same second", async () => {
+      // createdAt stores whole seconds, so back-to-back turns tie on it. The
+      // ids are uuids, which makes an id tiebreak a coin flip.
+      await repo.createSession("child-fast", "Child");
+      await recordTurn("child-fast", "turn-1", {
+        at: "2030-01-01T00:00:00.000Z",
+        prompt: "first",
+        reply: "first answer",
+        turnEnd: "completed",
+      });
+      await recordTurn("child-fast", "turn-2", {
+        at: "2030-01-01T00:00:00.900Z",
+        prompt: "second",
+        reply: "second answer",
+        turnEnd: "error",
+        error: "model refused",
+      });
+
+      await expect(repo.getLatestTurnOutcome("child-fast")).resolves.toEqual({
+        turnId: "turn-2",
+        turnEndStatus: "error",
+        error: "model refused",
+        reply: "second answer",
+      });
+      await expect(repo.getRecentTranscript("child-fast", 2)).resolves.toEqual([
+        { role: "user", turnId: "turn-2", text: "second", createdAt: expect.any(Date) },
+        { role: "assistant", turnId: "turn-2", text: "second answer", createdAt: expect.any(Date) },
+      ]);
+    });
+
+    it("carries the terminal error text of a failed turn", async () => {
+      await repo.createSession("child-failed", "Child");
+      await recordTurn("child-failed", "turn-1", {
+        at: "2030-01-01T00:00:00.000Z",
+        prompt: "go",
+        turnEnd: "error",
+        error: "model refused",
+      });
+
+      await expect(repo.getLatestTurnOutcome("child-failed")).resolves.toEqual({
+        turnId: "turn-1",
+        turnEndStatus: "error",
+        error: "model refused",
+        reply: null,
+      });
+    });
+
+    it("leaves turnEndStatus null for a turn that never closed", async () => {
+      await repo.createSession("child-cut", "Child");
+      await recordTurn("child-cut", "turn-1", {
+        at: "2030-01-01T00:00:00.000Z",
+        prompt: "go",
+      });
+
+      await expect(repo.getLatestTurnOutcome("child-cut")).resolves.toEqual({
+        turnId: "turn-1",
+        turnEndStatus: null,
+        error: null,
+        reply: null,
+      });
+    });
+
+    it("returns null for a session that has recorded no turn", async () => {
+      await repo.createSession("child-empty", "Child");
+      await expect(repo.getLatestTurnOutcome("child-empty")).resolves.toBeNull();
+      await expect(repo.getLatestTurnOutcome("no-such-session")).resolves.toBeNull();
+    });
+
+    it("returns the last N chat rows oldest-first and never a trace row", async () => {
+      await repo.createSession("child-tail", "Child");
+      await recordTurn("child-tail", "turn-1", {
+        at: "2030-01-01T00:00:00.000Z",
+        prompt: "one",
+        reply: "answer one",
+        turnEnd: "completed",
+      });
+      await recordTurn("child-tail", "turn-2", {
+        at: "2030-01-01T01:00:00.000Z",
+        prompt: "two",
+        reply: "answer two",
+        turnEnd: "completed",
+      });
+
+      await expect(repo.getRecentTranscript("child-tail", 3)).resolves.toEqual([
+        { role: "assistant", turnId: "turn-1", text: "answer one", createdAt: expect.any(Date) },
+        { role: "user", turnId: "turn-2", text: "two", createdAt: expect.any(Date) },
+        { role: "assistant", turnId: "turn-2", text: "answer two", createdAt: expect.any(Date) },
+      ]);
+      await expect(repo.getRecentTranscript("child-tail", 100)).resolves.toHaveLength(4);
+      await expect(repo.getRecentTranscript("child-tail", 0)).resolves.toEqual([]);
+      await expect(repo.getRecentTranscript("child-tail", -1)).resolves.toEqual([]);
+    });
+  });
+
   it("groups messages by turnId so concurrent turns render in turn order", async () => {
     // Reproduces the user-A / user-B / reply-A / reply-B insertion pattern
     // that happens when two POSTs race on the same session. With turnId

--- a/packages/core/src/db/repositories/webchat.ts
+++ b/packages/core/src/db/repositories/webchat.ts
@@ -266,6 +266,42 @@ function extractTranscriptText(content: string): string {
   return texts.join("\n").replace(/\s+/g, " ").trim();
 }
 
+/** The text a stored message row reads as: its `text` parts joined by newline,
+ * whitespace untouched. Empty string when the row holds no text part or does
+ * not parse. Unlike extractTranscriptText this preserves the original layout,
+ * so a caller can hand the result back verbatim. */
+function messagePartsToText(content: string): string {
+  let blocks: unknown;
+  try {
+    blocks = JSON.parse(content);
+  } catch {
+    return "";
+  }
+  if (!Array.isArray(blocks)) return "";
+  const texts: string[] = [];
+  for (const block of blocks) {
+    if (!block || typeof block !== "object") continue;
+    if ((block as { type?: unknown }).type !== "text") continue;
+    const text = (block as { content?: unknown }).content;
+    if (typeof text === "string") texts.push(text);
+  }
+  return texts.join("\n");
+}
+
+/** Reads one string field off a stored JSON trace block. Null when the block
+ * does not parse or the field is absent or not a string. */
+function readJsonStringField(content: string | undefined, field: string): string | null {
+  if (content === undefined) return null;
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (!parsed || typeof parsed !== "object") return null;
+    const value = (parsed as Record<string, unknown>)[field];
+    return typeof value === "string" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Confirms every lowercased `term` occurs in `text` (case-insensitive) and
  * returns a single-line snippet cut around the earliest hit, ellipsized on
@@ -2253,6 +2289,120 @@ export class WebChatRepository {
       id: stub.id,
       content: mergeTraceContent(stub.content, await this.getTraceBlockContents(stub.id)),
     };
+  }
+
+  /**
+   * The session's newest recorded turn and how it ended, or null when the
+   * session has recorded none. Newest means last written, not largest
+   * createdAt: createdAt stores whole seconds, so back-to-back turns tie. `turnEndStatus` is `'completed' | 'error' |
+   * 'interrupted'` when the turn wrote its closing bracket, and null when it
+   * never did — a turn cut short by a process exit leaves it null forever.
+   * `error` carries the text of the turn's last terminal error block, `reply`
+   * the text of its assistant transcript row; both are null when absent.
+   */
+  async getLatestTurnOutcome(sessionId: string): Promise<{
+    turnId: string;
+    turnEndStatus: string | null;
+    error: string | null;
+    reply: string | null;
+  } | null> {
+    const traceRows = await this.db
+      .select({ id: romeAgentMessages.id, turnId: romeAgentMessages.turnId })
+      .from(romeAgentMessages)
+      .where(
+        and(
+          eq(romeAgentMessages.sessionId, sessionId),
+          eq(romeAgentMessages.role, "trace"),
+          isNotNull(romeAgentMessages.turnId),
+        ),
+      )
+      .orderBy(sql`rowid DESC`)
+      .limit(1);
+    const trace = traceRows[0];
+    if (!trace?.turnId) return null;
+
+    const [turnEndRows, errorRows, replyRows] = await Promise.all([
+      this.db
+        .select({ content: romeAgentTraceBlocks.content })
+        .from(romeAgentTraceBlocks)
+        .where(
+          and(
+            eq(romeAgentTraceBlocks.messageId, trace.id),
+            sql`json_extract(${romeAgentTraceBlocks.content}, '$.type') = 'turn_end'`,
+          ),
+        )
+        .orderBy(desc(romeAgentTraceBlocks.seq))
+        .limit(1),
+      this.db
+        .select({ content: romeAgentTraceBlocks.content })
+        .from(romeAgentTraceBlocks)
+        .where(
+          and(
+            eq(romeAgentTraceBlocks.messageId, trace.id),
+            sql`json_extract(${romeAgentTraceBlocks.content}, '$.type') = 'error'`,
+          ),
+        )
+        .orderBy(desc(romeAgentTraceBlocks.seq))
+        .limit(1),
+      this.db
+        .select({ content: romeAgentMessages.content })
+        .from(romeAgentMessages)
+        .where(
+          and(
+            eq(romeAgentMessages.sessionId, sessionId),
+            eq(romeAgentMessages.turnId, trace.turnId),
+            eq(romeAgentMessages.role, "assistant"),
+          ),
+        )
+        .orderBy(sql`rowid DESC`)
+        .limit(1),
+    ]);
+
+    return {
+      turnId: trace.turnId,
+      turnEndStatus: readJsonStringField(turnEndRows[0]?.content, "status"),
+      error: readJsonStringField(errorRows[0]?.content, "error"),
+      reply: replyRows[0] ? messagePartsToText(replyRows[0].content) : null,
+    };
+  }
+
+  /** The session's last `limit` visible chat rows (user prompts + assistant
+   * replies, no trace), oldest-first. Empty for `limit <= 0`.
+   *
+   * Ordering mirrors getHistoryMessages, inverted so the tail can be taken with
+   * a LIMIT: turns sort by their earliest row, and rows sort within a turn by
+   * insertion. It keys on rowid rather than createdAt because createdAt stores
+   * whole seconds, and a whole turn regularly lands inside one. */
+  async getRecentTranscript(
+    sessionId: string,
+    limit: number,
+  ): Promise<Array<{ role: string; turnId: string | null; text: string; createdAt: Date }>> {
+    if (limit <= 0) return [];
+    const rows = await this.db
+      .select({
+        role: romeAgentMessages.role,
+        turnId: romeAgentMessages.turnId,
+        content: romeAgentMessages.content,
+        createdAt: romeAgentMessages.createdAt,
+      })
+      .from(romeAgentMessages)
+      .where(
+        and(
+          eq(romeAgentMessages.sessionId, sessionId),
+          inArray(romeAgentMessages.role, ["user", "assistant"]),
+        ),
+      )
+      .orderBy(
+        sql`MIN(rowid) OVER (PARTITION BY COALESCE(${romeAgentMessages.turnId}, ${romeAgentMessages.id})) DESC`,
+        sql`rowid DESC`,
+      )
+      .limit(limit);
+    return rows.reverse().map((row) => ({
+      role: row.role,
+      turnId: row.turnId,
+      text: messagePartsToText(row.content),
+      createdAt: row.createdAt,
+    }));
   }
 
   async getMessageContent(id: string) {


### PR DESCRIPTION
## What this PR does

A caller outside a session had no way to learn how that session's newest turn ended, or to read the tail of its transcript. The detached subagent work that follows needs both: a parent has to poll a child's outcome and quote its last exchanges without holding the child's stream.

This ports two repository methods and their helpers from `prototype/engineer-bot` onto `main`, nothing else from that branch:

- `getLatestTurnOutcome(sessionId)` returns the newest turn's id, how it closed, its last terminal error text, and its assistant reply text.
- `getRecentTranscript(sessionId, limit)` returns the last `limit` visible chat rows, oldest-first, with trace rows excluded.

Closes #245

## Design & Invariants

- **Newest means last written, not largest `createdAt`.** `createdAt` stores whole seconds, so back-to-back turns tie on it and a uuid tiebreak is a coin flip. Both methods order on `rowid`.
- **A turn that never closed reports `turnEndStatus: null`.** A process exit mid-turn leaves no `turn_end` block, and the method reports that rather than inventing a status.
- **Transcript text is handed back verbatim.** A new `messagePartsToText` helper joins text parts by newline and leaves whitespace alone, unlike `extractTranscriptText`, which collapses it for search snippets.
- **`getRecentTranscript` mirrors `getHistoryMessages` ordering, inverted.** Turns sort by their earliest row and rows sort within a turn by insertion, so a `LIMIT` takes a clean tail across concurrent turns.

## Test plan

- [x] `pnpm typecheck` in the devShell
- [x] `pnpm test:unit` in the devShell; `webchat.test.ts` passes with the six new cases covering newest-turn selection, same-second ties, failed and unclosed turns, empty sessions, and the tail ordering and limit edge cases
- [ ] Not exercised in a running instance: nothing calls these methods yet

## Not in this PR

- The detached subagent work that consumes these reads; it lands separately once this merges.
- Every other file on `prototype/engineer-bot`; the issue scopes this port to these two files.
