### PR TITLE
feat(core): read a session's latest turn outcome and transcript tail

### DIFF
--- a/packages/core/src/db/repositories/webchat.test.ts
+++ b/packages/core/src/db/repositories/webchat.test.ts
@@ -1468,6 +1468,176 @@ describe("WebChatRepository", () => {
     });
   });
 
+  describe("detached child status reads", () => {
+    // Mirrors what AgentTraceRecorder writes for one child turn: a user row, a
+    // trace whose blocks bracket the turn, and (when the turn produced one) an
+    // assistant row.
+    async function recordTurn(
+      sessionId: string,
+      turnId: string,
+      options: {
+        at: string;
+        prompt: string;
+        reply?: string;
+        turnEnd?: "completed" | "error" | "interrupted";
+        error?: string;
+      },
+    ) {
+      rs.setSystemTime(new Date(options.at));
+      const blocks: unknown[] = [{ type: "turn_start", turnId, userPrompt: options.prompt }];
+      if (options.reply !== undefined) blocks.push({ type: "result", content: options.reply });
+      if (options.error !== undefined) blocks.push({ type: "error", error: options.error });
+      if (options.turnEnd) blocks.push({ type: "turn_end", turnId, status: options.turnEnd });
+      await repo.appendTraceBlocks({
+        messageId: `trace:${sessionId}:${turnId}`,
+        sessionId,
+        turnId,
+        startSeq: 0,
+        blocks,
+        transcriptMessages: [
+          {
+            id: `transcript:${sessionId}:${turnId}:user`,
+            sessionId,
+            role: "user",
+            content: JSON.stringify([{ type: "text", content: options.prompt }]),
+            turnId,
+          },
+          ...(options.reply !== undefined
+            ? [
+                {
+                  id: `transcript:${sessionId}:${turnId}:assistant`,
+                  sessionId,
+                  role: "assistant" as const,
+                  content: JSON.stringify([{ type: "text", content: options.reply }]),
+                  turnId,
+                },
+              ]
+            : []),
+        ],
+      });
+    }
+
+    beforeEach(() => {
+      rs.useFakeTimers();
+    });
+
+    it("reports the newest turn's outcome, not the first one's", async () => {
+      await repo.createSession("child-many", "Child");
+      await recordTurn("child-many", "turn-1", {
+        at: "2030-01-01T00:00:00.000Z",
+        prompt: "first",
+        reply: "first answer",
+        turnEnd: "completed",
+      });
+      await recordTurn("child-many", "turn-2", {
+        at: "2030-01-01T01:00:00.000Z",
+        prompt: "second",
+        reply: "second answer",
+        turnEnd: "completed",
+      });
+
+      await expect(repo.getLatestTurnOutcome("child-many")).resolves.toEqual({
+        turnId: "turn-2",
+        turnEndStatus: "completed",
+        error: null,
+        reply: "second answer",
+      });
+    });
+
+    it("reports the last-written turn when two land in the same second", async () => {
+      // createdAt stores whole seconds, so back-to-back turns tie on it. The
+      // ids are uuids, which makes an id tiebreak a coin flip.
+      await repo.createSession("child-fast", "Child");
+      await recordTurn("child-fast", "turn-1", {
+        at: "2030-01-01T00:00:00.000Z",
+        prompt: "first",
+        reply: "first answer",
+        turnEnd: "completed",
+      });
+      await recordTurn("child-fast", "turn-2", {
+        at: "2030-01-01T00:00:00.900Z",
+        prompt: "second",
+        reply: "second answer",
+        turnEnd: "error",
+        error: "model refused",
+      });
+
+      await expect(repo.getLatestTurnOutcome("child-fast")).resolves.toEqual({
+        turnId: "turn-2",
+        turnEndStatus: "error",
+        error: "model refused",
+        reply: "second answer",
+      });
+      await expect(repo.getRecentTranscript("child-fast", 2)).resolves.toEqual([
+        { role: "user", turnId: "turn-2", text: "second", createdAt: expect.any(Date) },
+        { role: "assistant", turnId: "turn-2", text: "second answer", createdAt: expect.any(Date) },
+      ]);
+    });
+
+    it("carries the terminal error text of a failed turn", async () => {
+      await repo.createSession("child-failed", "Child");
+      await recordTurn("child-failed", "turn-1", {
+        at: "2030-01-01T00:00:00.000Z",
+        prompt: "go",
+        turnEnd: "error",
+        error: "model refused",
+      });
+
+      await expect(repo.getLatestTurnOutcome("child-failed")).resolves.toEqual({
+        turnId: "turn-1",
+        turnEndStatus: "error",
+        error: "model refused",
+        reply: null,
+      });
+    });
+
+    it("leaves turnEndStatus null for a turn that never closed", async () => {
+      await repo.createSession("child-cut", "Child");
+      await recordTurn("child-cut", "turn-1", {
+        at: "2030-01-01T00:00:00.000Z",
+        prompt: "go",
+      });
+
+      await expect(repo.getLatestTurnOutcome("child-cut")).resolves.toEqual({
+        turnId: "turn-1",
+        turnEndStatus: null,
+        error: null,
+        reply: null,
+      });
+    });
+
+    it("returns null for a session that has recorded no turn", async () => {
+      await repo.createSession("child-empty", "Child");
+      await expect(repo.getLatestTurnOutcome("child-empty")).resolves.toBeNull();
+      await expect(repo.getLatestTurnOutcome("no-such-session")).resolves.toBeNull();
+    });
+
+    it("returns the last N chat rows oldest-first and never a trace row", async () => {
+      await repo.createSession("child-tail", "Child");
+      await recordTurn("child-tail", "turn-1", {
+        at: "2030-01-01T00:00:00.000Z",
+        prompt: "one",
+        reply: "answer one",
+        turnEnd: "completed",
+      });
+      await recordTurn("child-tail", "turn-2", {
+        at: "2030-01-01T01:00:00.000Z",
+        prompt: "two",
+        reply: "answer two",
+        turnEnd: "completed",
+      });
+
+      await expect(repo.getRecentTranscript("child-tail", 3)).resolves.toEqual([
+        { role: "assistant", turnId: "turn-1", text: "answer one", createdAt: expect.any(Date) },
+        { role: "user", turnId: "turn-2", text: "two", createdAt: expect.any(Date) },
+        { role: "assistant", turnId: "turn-2", text: "answer two", createdAt: expect.any(Date) },
+      ]);
+      await expect(repo.getRecentTranscript("child-tail", 100)).resolves.toHaveLength(4);
+      await expect(repo.getRecentTranscript("child-tail", 0)).resolves.toEqual([]);
+      await expect(repo.getRecentTranscript("child-tail", -1)).resolves.toEqual([]);
+    });
+  });
+
   it("groups messages by turnId so concurrent turns render in turn order", async () => {
     // Reproduces the user-A / user-B / reply-A / reply-B insertion pattern
     // that happens when two POSTs race on the same session. With turnId

--- a/packages/core/src/db/repositories/webchat.test.ts
+++ b/packages/core/src/db/repositories/webchat.test.ts
@@ -1562,11 +1562,14 @@ describe("WebChatRepository", () => {
         error: "model refused",
       });
 
+      // turn-2's last terminal block is the error, so `reply` is null even
+      // though a result block preceded it — outcome reads the terminal block,
+      // not the assistant chat row that getRecentTranscript still surfaces.
       await expect(repo.getLatestTurnOutcome("child-fast")).resolves.toEqual({
         turnId: "turn-2",
         turnEndStatus: "error",
         error: "model refused",
-        reply: "second answer",
+        reply: null,
       });
       await expect(repo.getRecentTranscript("child-fast", 2)).resolves.toEqual([
         { role: "user", turnId: "turn-2", text: "second", createdAt: expect.any(Date) },
@@ -1634,6 +1637,35 @@ describe("WebChatRepository", () => {
       });
     });
 
+    it("reads the terminal result, not a later commentary or recap chat row", async () => {
+      // A webchat session appends extra role='assistant' rows on the same
+      // turnId after the reply: in-turn commentary, and a turn recap whose part
+      // carries no text. A last-by-rowid chat read would return the commentary,
+      // or the recap's empty text; the terminal-block read must return neither.
+      await repo.createSession("child-recap", "Child");
+      await recordTurn("child-recap", "turn-1", {
+        at: "2030-01-01T00:00:00.000Z",
+        prompt: "go",
+        reply: "the real answer",
+        turnEnd: "completed",
+      });
+      await repo.addBackendMessage("child-recap", "turn-1", [
+        { type: "text", content: "just some commentary" },
+      ]);
+      await repo.addTurnRecapMessage({
+        sessionId: "child-recap",
+        turnId: "turn-1",
+        content: "recap summary",
+      });
+
+      await expect(repo.getLatestTurnOutcome("child-recap")).resolves.toEqual({
+        turnId: "turn-1",
+        turnEndStatus: "completed",
+        error: null,
+        reply: "the real answer",
+      });
+    });
+
     it("leaves turnEndStatus null for a turn that never closed", async () => {
       await repo.createSession("child-cut", "Child");
       await recordTurn("child-cut", "turn-1", {
@@ -1678,6 +1710,10 @@ describe("WebChatRepository", () => {
       await expect(repo.getRecentTranscript("child-tail", 100)).resolves.toHaveLength(4);
       await expect(repo.getRecentTranscript("child-tail", 0)).resolves.toEqual([]);
       await expect(repo.getRecentTranscript("child-tail", -1)).resolves.toEqual([]);
+      // A fractional or NaN limit would reach SQLite's LIMIT and throw; the
+      // guard turns both into an empty result instead.
+      await expect(repo.getRecentTranscript("child-tail", 2.5)).resolves.toEqual([]);
+      await expect(repo.getRecentTranscript("child-tail", Number.NaN)).resolves.toEqual([]);
     });
 
     it("reads a turn recorded across multiple trace-block batches", async () => {

--- a/packages/core/src/db/repositories/webchat.test.ts
+++ b/packages/core/src/db/repositories/webchat.test.ts
@@ -1591,6 +1591,49 @@ describe("WebChatRepository", () => {
       });
     });
 
+    it("ignores a relayed subagent error when the owner's turn completed", async () => {
+      // A trace can hold a child's terminal error ahead of the owner's own
+      // result + turn_end{completed}. The turn's error must stay null: the
+      // failure belongs to the subagent, not this turn.
+      await repo.createSession("child-relayed", "Child");
+      rs.setSystemTime(new Date("2030-01-01T00:00:00.000Z"));
+      await repo.appendTraceBlocks({
+        messageId: "trace:child-relayed:turn-1",
+        sessionId: "child-relayed",
+        turnId: "turn-1",
+        startSeq: 0,
+        blocks: [
+          { type: "turn_start", turnId: "turn-1", userPrompt: "go" },
+          { type: "error", agent: "child", error: "subagent blew up" },
+          { type: "result", agent: "main", content: "recovered answer" },
+          { type: "turn_end", turnId: "turn-1", status: "completed" },
+        ],
+        transcriptMessages: [
+          {
+            id: "transcript:child-relayed:turn-1:user",
+            sessionId: "child-relayed",
+            role: "user",
+            content: JSON.stringify([{ type: "text", content: "go" }]),
+            turnId: "turn-1",
+          },
+          {
+            id: "transcript:child-relayed:turn-1:assistant",
+            sessionId: "child-relayed",
+            role: "assistant",
+            content: JSON.stringify([{ type: "text", content: "recovered answer" }]),
+            turnId: "turn-1",
+          },
+        ],
+      });
+
+      await expect(repo.getLatestTurnOutcome("child-relayed")).resolves.toEqual({
+        turnId: "turn-1",
+        turnEndStatus: "completed",
+        error: null,
+        reply: "recovered answer",
+      });
+    });
+
     it("leaves turnEndStatus null for a turn that never closed", async () => {
       await repo.createSession("child-cut", "Child");
       await recordTurn("child-cut", "turn-1", {

--- a/packages/core/src/db/repositories/webchat.test.ts
+++ b/packages/core/src/db/repositories/webchat.test.ts
@@ -1679,6 +1679,125 @@ describe("WebChatRepository", () => {
       await expect(repo.getRecentTranscript("child-tail", 0)).resolves.toEqual([]);
       await expect(repo.getRecentTranscript("child-tail", -1)).resolves.toEqual([]);
     });
+
+    it("reads a turn recorded across multiple trace-block batches", async () => {
+      // The recorder appends per event, not once per turn, so seq climbs across
+      // separate appendTraceBlocks calls and the terminal read must span them.
+      // Here a relayed subagent error (batch 2) precedes the owner's result
+      // (batch 3): keying on the last terminal block by seq must still pick the
+      // owner's result and leave the turn's error null.
+      await repo.createSession("child-batched", "Child");
+      const messageId = "trace:child-batched:turn-1";
+      rs.setSystemTime(new Date("2030-01-01T00:00:00.000Z"));
+      await repo.appendTraceBlocks({
+        messageId,
+        sessionId: "child-batched",
+        turnId: "turn-1",
+        startSeq: 0,
+        blocks: [{ type: "turn_start", turnId: "turn-1", userPrompt: "go" }],
+        transcriptMessages: [
+          {
+            id: "transcript:child-batched:turn-1:user",
+            sessionId: "child-batched",
+            role: "user",
+            content: JSON.stringify([{ type: "text", content: "go" }]),
+            turnId: "turn-1",
+          },
+        ],
+      });
+      await repo.appendTraceBlocks({
+        messageId,
+        sessionId: "child-batched",
+        turnId: "turn-1",
+        startSeq: 1,
+        blocks: [{ type: "error", agent: "child", error: "subagent blew up" }],
+      });
+      await repo.appendTraceBlocks({
+        messageId,
+        sessionId: "child-batched",
+        turnId: "turn-1",
+        startSeq: 2,
+        blocks: [
+          { type: "result", agent: "main", content: "recovered answer" },
+          { type: "turn_end", turnId: "turn-1", status: "completed" },
+        ],
+        transcriptMessages: [
+          {
+            id: "transcript:child-batched:turn-1:assistant",
+            sessionId: "child-batched",
+            role: "assistant",
+            content: JSON.stringify([{ type: "text", content: "recovered answer" }]),
+            turnId: "turn-1",
+          },
+        ],
+      });
+
+      await expect(repo.getLatestTurnOutcome("child-batched")).resolves.toEqual({
+        turnId: "turn-1",
+        turnEndStatus: "completed",
+        error: null,
+        reply: "recovered answer",
+      });
+    });
+
+    it("keeps each turn's rows together when turns interleave across batches", async () => {
+      // Both turns open before either replies, so the assistant row of the
+      // earlier turn is inserted after the user row of the later turn. The
+      // partition-by-turn ordering must still keep each turn's rows adjacent.
+      await repo.createSession("child-interleaved", "Child");
+      const openTurn = async (turnId: string, prompt: string) => {
+        await repo.appendTraceBlocks({
+          messageId: `trace:child-interleaved:${turnId}`,
+          sessionId: "child-interleaved",
+          turnId,
+          startSeq: 0,
+          blocks: [{ type: "turn_start", turnId, userPrompt: prompt }],
+          transcriptMessages: [
+            {
+              id: `transcript:child-interleaved:${turnId}:user`,
+              sessionId: "child-interleaved",
+              role: "user",
+              content: JSON.stringify([{ type: "text", content: prompt }]),
+              turnId,
+            },
+          ],
+        });
+      };
+      const closeTurn = async (turnId: string, reply: string) => {
+        await repo.appendTraceBlocks({
+          messageId: `trace:child-interleaved:${turnId}`,
+          sessionId: "child-interleaved",
+          turnId,
+          startSeq: 1,
+          blocks: [
+            { type: "result", content: reply },
+            { type: "turn_end", turnId, status: "completed" },
+          ],
+          transcriptMessages: [
+            {
+              id: `transcript:child-interleaved:${turnId}:assistant`,
+              sessionId: "child-interleaved",
+              role: "assistant",
+              content: JSON.stringify([{ type: "text", content: reply }]),
+              turnId,
+            },
+          ],
+        });
+      };
+
+      rs.setSystemTime(new Date("2030-01-01T00:00:00.000Z"));
+      await openTurn("turn-1", "one");
+      await openTurn("turn-2", "two");
+      await closeTurn("turn-1", "answer one");
+      await closeTurn("turn-2", "answer two");
+
+      await expect(repo.getRecentTranscript("child-interleaved", 4)).resolves.toEqual([
+        { role: "user", turnId: "turn-1", text: "one", createdAt: expect.any(Date) },
+        { role: "assistant", turnId: "turn-1", text: "answer one", createdAt: expect.any(Date) },
+        { role: "user", turnId: "turn-2", text: "two", createdAt: expect.any(Date) },
+        { role: "assistant", turnId: "turn-2", text: "answer two", createdAt: expect.any(Date) },
+      ]);
+    });
   });
 
   it("groups messages by turnId so concurrent turns render in turn order", async () => {

--- a/packages/core/src/db/repositories/webchat.ts
+++ b/packages/core/src/db/repositories/webchat.ts
@@ -266,6 +266,42 @@ function extractTranscriptText(content: string): string {
   return texts.join("\n").replace(/\s+/g, " ").trim();
 }
 
+/** The text a stored message row reads as: its `text` parts joined by newline,
+ * whitespace untouched. Empty string when the row holds no text part or does
+ * not parse. Unlike extractTranscriptText this preserves the original layout,
+ * so a caller can hand the result back verbatim. */
+function messagePartsToText(content: string): string {
+  let blocks: unknown;
+  try {
+    blocks = JSON.parse(content);
+  } catch {
+    return "";
+  }
+  if (!Array.isArray(blocks)) return "";
+  const texts: string[] = [];
+  for (const block of blocks) {
+    if (!block || typeof block !== "object") continue;
+    if ((block as { type?: unknown }).type !== "text") continue;
+    const text = (block as { content?: unknown }).content;
+    if (typeof text === "string") texts.push(text);
+  }
+  return texts.join("\n");
+}
+
+/** Reads one string field off a stored JSON trace block. Null when the block
+ * does not parse or the field is absent or not a string. */
+function readJsonStringField(content: string | undefined, field: string): string | null {
+  if (content === undefined) return null;
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (!parsed || typeof parsed !== "object") return null;
+    const value = (parsed as Record<string, unknown>)[field];
+    return typeof value === "string" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Confirms every lowercased `term` occurs in `text` (case-insensitive) and
  * returns a single-line snippet cut around the earliest hit, ellipsized on
@@ -2253,6 +2289,120 @@ export class WebChatRepository {
       id: stub.id,
       content: mergeTraceContent(stub.content, await this.getTraceBlockContents(stub.id)),
     };
+  }
+
+  /**
+   * The session's newest recorded turn and how it ended, or null when the
+   * session has recorded none. Newest means last written, not largest
+   * createdAt: createdAt stores whole seconds, so back-to-back turns tie. `turnEndStatus` is `'completed' | 'error' |
+   * 'interrupted'` when the turn wrote its closing bracket, and null when it
+   * never did — a turn cut short by a process exit leaves it null forever.
+   * `error` carries the text of the turn's last terminal error block, `reply`
+   * the text of its assistant transcript row; both are null when absent.
+   */
+  async getLatestTurnOutcome(sessionId: string): Promise<{
+    turnId: string;
+    turnEndStatus: string | null;
+    error: string | null;
+    reply: string | null;
+  } | null> {
+    const traceRows = await this.db
+      .select({ id: romeAgentMessages.id, turnId: romeAgentMessages.turnId })
+      .from(romeAgentMessages)
+      .where(
+        and(
+          eq(romeAgentMessages.sessionId, sessionId),
+          eq(romeAgentMessages.role, "trace"),
+          isNotNull(romeAgentMessages.turnId),
+        ),
+      )
+      .orderBy(sql`rowid DESC`)
+      .limit(1);
+    const trace = traceRows[0];
+    if (!trace?.turnId) return null;
+
+    const [turnEndRows, errorRows, replyRows] = await Promise.all([
+      this.db
+        .select({ content: romeAgentTraceBlocks.content })
+        .from(romeAgentTraceBlocks)
+        .where(
+          and(
+            eq(romeAgentTraceBlocks.messageId, trace.id),
+            sql`json_extract(${romeAgentTraceBlocks.content}, '$.type') = 'turn_end'`,
+          ),
+        )
+        .orderBy(desc(romeAgentTraceBlocks.seq))
+        .limit(1),
+      this.db
+        .select({ content: romeAgentTraceBlocks.content })
+        .from(romeAgentTraceBlocks)
+        .where(
+          and(
+            eq(romeAgentTraceBlocks.messageId, trace.id),
+            sql`json_extract(${romeAgentTraceBlocks.content}, '$.type') = 'error'`,
+          ),
+        )
+        .orderBy(desc(romeAgentTraceBlocks.seq))
+        .limit(1),
+      this.db
+        .select({ content: romeAgentMessages.content })
+        .from(romeAgentMessages)
+        .where(
+          and(
+            eq(romeAgentMessages.sessionId, sessionId),
+            eq(romeAgentMessages.turnId, trace.turnId),
+            eq(romeAgentMessages.role, "assistant"),
+          ),
+        )
+        .orderBy(sql`rowid DESC`)
+        .limit(1),
+    ]);
+
+    return {
+      turnId: trace.turnId,
+      turnEndStatus: readJsonStringField(turnEndRows[0]?.content, "status"),
+      error: readJsonStringField(errorRows[0]?.content, "error"),
+      reply: replyRows[0] ? messagePartsToText(replyRows[0].content) : null,
+    };
+  }
+
+  /** The session's last `limit` visible chat rows (user prompts + assistant
+   * replies, no trace), oldest-first. Empty for `limit <= 0`.
+   *
+   * Ordering mirrors getHistoryMessages, inverted so the tail can be taken with
+   * a LIMIT: turns sort by their earliest row, and rows sort within a turn by
+   * insertion. It keys on rowid rather than createdAt because createdAt stores
+   * whole seconds, and a whole turn regularly lands inside one. */
+  async getRecentTranscript(
+    sessionId: string,
+    limit: number,
+  ): Promise<Array<{ role: string; turnId: string | null; text: string; createdAt: Date }>> {
+    if (limit <= 0) return [];
+    const rows = await this.db
+      .select({
+        role: romeAgentMessages.role,
+        turnId: romeAgentMessages.turnId,
+        content: romeAgentMessages.content,
+        createdAt: romeAgentMessages.createdAt,
+      })
+      .from(romeAgentMessages)
+      .where(
+        and(
+          eq(romeAgentMessages.sessionId, sessionId),
+          inArray(romeAgentMessages.role, ["user", "assistant"]),
+        ),
+      )
+      .orderBy(
+        sql`MIN(rowid) OVER (PARTITION BY COALESCE(${romeAgentMessages.turnId}, ${romeAgentMessages.id})) DESC`,
+        sql`rowid DESC`,
+      )
+      .limit(limit);
+    return rows.reverse().map((row) => ({
+      role: row.role,
+      turnId: row.turnId,
+      text: messagePartsToText(row.content),
+      createdAt: row.createdAt,
+    }));
   }
 
   async getMessageContent(id: string) {

--- a/packages/core/src/db/repositories/webchat.ts
+++ b/packages/core/src/db/repositories/webchat.ts
@@ -2299,22 +2299,28 @@ export class WebChatRepository {
 
   /**
    * The session's newest recorded turn and how it ended, or null when the
-   * session has recorded none. Newest means last written, not largest
-   * createdAt: createdAt stores whole seconds, so back-to-back turns tie.
+   * session has recorded none. "Newest" is the last turn to start — the
+   * highest-rowid `trace` row, whose stub is written at turn start — not the
+   * largest createdAt, which stores whole seconds and ties back-to-back turns.
+   * For the sequential detached-child sessions this serves, the last turn to
+   * start is also the last to finish; under interleaved turns it would return
+   * the last-started, not the last-completed, turn.
+   *
    * `turnEndStatus` is `'completed' | 'error' | 'interrupted'` when the turn
    * wrote its closing bracket, and null when it never did — a turn cut short by
    * a process exit leaves it null forever.
    *
-   * `error` is the text of the turn's own terminal error, populated only when
-   * the turn's last terminal block (`result` or `error`) is an `error` and the
-   * turn closed with status `'error'`. A trace can hold a relayed subagent's
-   * terminal error ahead of the owner's own `result` + `turn_end{completed}`,
-   * so keying on the last terminal block keeps a child's failure from surfacing
-   * as the parent turn's error. `reply` is the text of the turn's assistant
-   * transcript row; both are null when absent. A turn records one assistant
-   * transcript row (the recorder writes a single reply per turn), so `reply`
-   * takes the last such row by rowid — if that invariant ever breaks, earlier
-   * assistant text is dropped rather than concatenated.
+   * `error` and `reply` both read from the turn's last terminal block (`result`
+   * or `error`): `error` is the block's error text when it is an `error` and
+   * the turn closed with status `'error'`, and `reply` is the block's result
+   * text when it is a `result`; each is null otherwise. A trace can hold a
+   * relayed subagent's terminal error ahead of the owner's own `result` +
+   * `turn_end{completed}`, so keying on the last terminal block keeps a child's
+   * failure from surfacing as the parent turn's error. Reading `reply` from the
+   * terminal block, not an assistant chat row, sidesteps the commentary and
+   * turn-recap rows a webchat session can insert on the same turnId — a
+   * last-by-rowid chat read would return commentary, or a recap's empty text,
+   * in place of the real answer.
    */
   async getLatestTurnOutcome(sessionId: string): Promise<{
     turnId: string;
@@ -2337,7 +2343,7 @@ export class WebChatRepository {
     const trace = traceRows[0];
     if (!trace?.turnId) return null;
 
-    const [turnEndRows, terminalRows, replyRows] = await Promise.all([
+    const [turnEndRows, terminalRows] = await Promise.all([
       this.db
         .select({ content: romeAgentTraceBlocks.content })
         .from(romeAgentTraceBlocks)
@@ -2349,8 +2355,9 @@ export class WebChatRepository {
         )
         .orderBy(desc(romeAgentTraceBlocks.seq))
         .limit(1),
-      // The turn's last terminal block. Filtering on `result`/`error` matches
-      // the idx_rome_agent_trace_blocks_terminal_message partial index, and the
+      // The turn's last terminal block, source of both `error` and `reply`.
+      // Filtering on `result`/`error` matches the
+      // idx_rome_agent_trace_blocks_terminal_message partial index, and the
       // owner's terminal always follows any relayed subagent one.
       this.db
         .select({ content: romeAgentTraceBlocks.content })
@@ -2363,39 +2370,30 @@ export class WebChatRepository {
         )
         .orderBy(desc(romeAgentTraceBlocks.seq))
         .limit(1),
-      // The turn's assistant reply. One per turn by the recorder's contract;
-      // the last-by-rowid read is defensive against a hypothetical second row.
-      this.db
-        .select({ content: romeAgentMessages.content })
-        .from(romeAgentMessages)
-        .where(
-          and(
-            eq(romeAgentMessages.sessionId, sessionId),
-            eq(romeAgentMessages.turnId, trace.turnId),
-            eq(romeAgentMessages.role, "assistant"),
-          ),
-        )
-        .orderBy(sql`rowid DESC`)
-        .limit(1),
     ]);
 
     const turnEndStatus = readTurnEndStatus(turnEndRows[0]?.content);
     const terminalContent = terminalRows[0]?.content;
+    const terminalType = readJsonStringField(terminalContent, "type");
     const error =
-      turnEndStatus === "error" && readJsonStringField(terminalContent, "type") === "error"
+      turnEndStatus === "error" && terminalType === "error"
         ? readJsonStringField(terminalContent, "error")
         : null;
+    const reply =
+      terminalType === "result" ? readJsonStringField(terminalContent, "content") : null;
 
     return {
       turnId: trace.turnId,
       turnEndStatus,
       error,
-      reply: replyRows[0] ? messagePartsToText(replyRows[0].content) : null,
+      reply,
     };
   }
 
   /** The session's last `limit` visible chat rows (user prompts + assistant
-   * replies, no trace), oldest-first. Empty for `limit <= 0`.
+   * replies, no trace), oldest-first. Empty for a non-positive or non-integer
+   * `limit` — a fractional or NaN value would otherwise reach SQLite's `LIMIT`,
+   * which throws on a value it can't losslessly narrow to an integer.
    *
    * Ordering relies on insertion order (rowid) reproducing the user→assistant
    * sequence within a turn, then groups turns by their earliest row. It is
@@ -2414,7 +2412,7 @@ export class WebChatRepository {
   ): Promise<
     Array<{ role: "user" | "assistant"; turnId: string | null; text: string; createdAt: Date }>
   > {
-    if (limit <= 0) return [];
+    if (!Number.isInteger(limit) || limit <= 0) return [];
     const rows = await this.db
       .select({
         role: romeAgentMessages.role,

--- a/packages/core/src/db/repositories/webchat.ts
+++ b/packages/core/src/db/repositories/webchat.ts
@@ -25,7 +25,7 @@ import {
 } from "../schema.js";
 import type { DrizzleDb } from "../index.js";
 import { DEFAULT_WEBCHAT_PROJECT_NAME } from "../../webchat/constants.js";
-import type { TurnFeedbackRating } from "@rome/api-types/trace-segments";
+import type { TurnEndBlock, TurnFeedbackRating } from "@rome/api-types/trace-segments";
 import type { RomeSessionType } from "@rome-os/app-runtime";
 import type { MessagePart } from "../../types.js";
 import { isCoreMainAgentId } from "../../apps/artifact-id.js";
@@ -242,42 +242,18 @@ function escapeSqlLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, (character) => `${SQL_LIKE_ESCAPE}${character}`);
 }
 
-/**
- * Flattens a stored message's JSON block array into the transcript text a
- * guardian actually sees: `text` block contents joined, whitespace collapsed.
- * Non-text blocks (tool calls, attachments, …) never contribute, so JSON keys
- * and tool payloads can't produce phantom search hits.
- */
-function extractTranscriptText(content: string): string {
+/** The `text` block contents of a stored message's JSON block array, in order.
+ * Empty array when the content does not parse or holds no text part. Non-text
+ * blocks (tool calls, attachments, …) never contribute, so JSON keys and tool
+ * payloads can't leak into a caller's view. */
+function collectTextParts(content: string): string[] {
   let blocks: unknown;
   try {
     blocks = JSON.parse(content);
   } catch {
-    return "";
+    return [];
   }
-  if (!Array.isArray(blocks)) return "";
-  const texts: string[] = [];
-  for (const block of blocks) {
-    if (!block || typeof block !== "object") continue;
-    const type = (block as { type?: unknown }).type;
-    const text = (block as { content?: unknown }).content;
-    if (type === "text" && typeof text === "string" && text.trim()) texts.push(text);
-  }
-  return texts.join("\n").replace(/\s+/g, " ").trim();
-}
-
-/** The text a stored message row reads as: its `text` parts joined by newline,
- * whitespace untouched. Empty string when the row holds no text part or does
- * not parse. Unlike extractTranscriptText this preserves the original layout,
- * so a caller can hand the result back verbatim. */
-function messagePartsToText(content: string): string {
-  let blocks: unknown;
-  try {
-    blocks = JSON.parse(content);
-  } catch {
-    return "";
-  }
-  if (!Array.isArray(blocks)) return "";
+  if (!Array.isArray(blocks)) return [];
   const texts: string[] = [];
   for (const block of blocks) {
     if (!block || typeof block !== "object") continue;
@@ -285,7 +261,25 @@ function messagePartsToText(content: string): string {
     const text = (block as { content?: unknown }).content;
     if (typeof text === "string") texts.push(text);
   }
-  return texts.join("\n");
+  return texts;
+}
+
+/**
+ * Flattens a stored message's JSON block array into the transcript text a
+ * guardian actually sees: `text` block contents joined, whitespace collapsed.
+ * Non-text blocks (tool calls, attachments, …) never contribute, so JSON keys
+ * and tool payloads can't produce phantom search hits.
+ */
+function extractTranscriptText(content: string): string {
+  return collectTextParts(content).join("\n").replace(/\s+/g, " ").trim();
+}
+
+/** The text a stored message row reads as: its `text` parts joined by newline,
+ * whitespace untouched. Empty string when the row holds no text part or does
+ * not parse. Unlike extractTranscriptText this preserves the original layout,
+ * so a caller can hand the result back verbatim. */
+function messagePartsToText(content: string): string {
+  return collectTextParts(content).join("\n");
 }
 
 /** Reads one string field off a stored JSON trace block. Null when the block
@@ -300,6 +294,18 @@ function readJsonStringField(content: string | undefined, field: string): string
   } catch {
     return null;
   }
+}
+
+const TURN_END_STATUSES: readonly TurnEndBlock["status"][] = ["completed", "error", "interrupted"];
+
+/** The `status` of a stored `turn_end` block, narrowed to the wire union. Null
+ * when the block is absent, unparseable, or carries a status outside the union
+ * (a future writer's value the caller cannot interpret). */
+function readTurnEndStatus(content: string | undefined): TurnEndBlock["status"] | null {
+  const raw = readJsonStringField(content, "status");
+  return raw !== null && (TURN_END_STATUSES as readonly string[]).includes(raw)
+    ? (raw as TurnEndBlock["status"])
+    : null;
 }
 
 /**
@@ -2294,15 +2300,22 @@ export class WebChatRepository {
   /**
    * The session's newest recorded turn and how it ended, or null when the
    * session has recorded none. Newest means last written, not largest
-   * createdAt: createdAt stores whole seconds, so back-to-back turns tie. `turnEndStatus` is `'completed' | 'error' |
-   * 'interrupted'` when the turn wrote its closing bracket, and null when it
-   * never did — a turn cut short by a process exit leaves it null forever.
-   * `error` carries the text of the turn's last terminal error block, `reply`
-   * the text of its assistant transcript row; both are null when absent.
+   * createdAt: createdAt stores whole seconds, so back-to-back turns tie.
+   * `turnEndStatus` is `'completed' | 'error' | 'interrupted'` when the turn
+   * wrote its closing bracket, and null when it never did — a turn cut short by
+   * a process exit leaves it null forever.
+   *
+   * `error` is the text of the turn's own terminal error, populated only when
+   * the turn's last terminal block (`result` or `error`) is an `error` and the
+   * turn closed with status `'error'`. A trace can hold a relayed subagent's
+   * terminal error ahead of the owner's own `result` + `turn_end{completed}`,
+   * so keying on the last terminal block keeps a child's failure from surfacing
+   * as the parent turn's error. `reply` is the text of the turn's assistant
+   * transcript row; both are null when absent.
    */
   async getLatestTurnOutcome(sessionId: string): Promise<{
     turnId: string;
-    turnEndStatus: string | null;
+    turnEndStatus: TurnEndBlock["status"] | null;
     error: string | null;
     reply: string | null;
   } | null> {
@@ -2321,7 +2334,7 @@ export class WebChatRepository {
     const trace = traceRows[0];
     if (!trace?.turnId) return null;
 
-    const [turnEndRows, errorRows, replyRows] = await Promise.all([
+    const [turnEndRows, terminalRows, replyRows] = await Promise.all([
       this.db
         .select({ content: romeAgentTraceBlocks.content })
         .from(romeAgentTraceBlocks)
@@ -2333,13 +2346,16 @@ export class WebChatRepository {
         )
         .orderBy(desc(romeAgentTraceBlocks.seq))
         .limit(1),
+      // The turn's last terminal block. Filtering on `result`/`error` matches
+      // the idx_rome_agent_trace_blocks_terminal_message partial index, and the
+      // owner's terminal always follows any relayed subagent one.
       this.db
         .select({ content: romeAgentTraceBlocks.content })
         .from(romeAgentTraceBlocks)
         .where(
           and(
             eq(romeAgentTraceBlocks.messageId, trace.id),
-            sql`json_extract(${romeAgentTraceBlocks.content}, '$.type') = 'error'`,
+            sql`json_extract(${romeAgentTraceBlocks.content}, '$.type') IN ('result', 'error')`,
           ),
         )
         .orderBy(desc(romeAgentTraceBlocks.seq))
@@ -2358,10 +2374,17 @@ export class WebChatRepository {
         .limit(1),
     ]);
 
+    const turnEndStatus = readTurnEndStatus(turnEndRows[0]?.content);
+    const terminalContent = terminalRows[0]?.content;
+    const error =
+      turnEndStatus === "error" && readJsonStringField(terminalContent, "type") === "error"
+        ? readJsonStringField(terminalContent, "error")
+        : null;
+
     return {
       turnId: trace.turnId,
-      turnEndStatus: readJsonStringField(turnEndRows[0]?.content, "status"),
-      error: readJsonStringField(errorRows[0]?.content, "error"),
+      turnEndStatus,
+      error,
       reply: replyRows[0] ? messagePartsToText(replyRows[0].content) : null,
     };
   }
@@ -2369,14 +2392,18 @@ export class WebChatRepository {
   /** The session's last `limit` visible chat rows (user prompts + assistant
    * replies, no trace), oldest-first. Empty for `limit <= 0`.
    *
-   * Ordering mirrors getHistoryMessages, inverted so the tail can be taken with
-   * a LIMIT: turns sort by their earliest row, and rows sort within a turn by
-   * insertion. It keys on rowid rather than createdAt because createdAt stores
-   * whole seconds, and a whole turn regularly lands inside one. */
+   * Ordering relies on insertion order (rowid) reproducing the user→assistant
+   * sequence within a turn, then groups turns by their earliest row. It is
+   * inverted so the tail can be taken with a LIMIT and reversed back. rowid,
+   * not createdAt, is the key because createdAt stores whole seconds and a
+   * whole turn regularly lands inside one. This is a like-spirited but distinct
+   * ordering from getHistoryMessages, which groups by role rather than rowid. */
   async getRecentTranscript(
     sessionId: string,
     limit: number,
-  ): Promise<Array<{ role: string; turnId: string | null; text: string; createdAt: Date }>> {
+  ): Promise<
+    Array<{ role: "user" | "assistant"; turnId: string | null; text: string; createdAt: Date }>
+  > {
     if (limit <= 0) return [];
     const rows = await this.db
       .select({
@@ -2398,7 +2425,8 @@ export class WebChatRepository {
       )
       .limit(limit);
     return rows.reverse().map((row) => ({
-      role: row.role,
+      // The WHERE clause admits only these two roles.
+      role: row.role as "user" | "assistant",
       turnId: row.turnId,
       text: messagePartsToText(row.content),
       createdAt: row.createdAt,

--- a/packages/core/src/db/repositories/webchat.ts
+++ b/packages/core/src/db/repositories/webchat.ts
@@ -2311,7 +2311,10 @@ export class WebChatRepository {
    * terminal error ahead of the owner's own `result` + `turn_end{completed}`,
    * so keying on the last terminal block keeps a child's failure from surfacing
    * as the parent turn's error. `reply` is the text of the turn's assistant
-   * transcript row; both are null when absent.
+   * transcript row; both are null when absent. A turn records one assistant
+   * transcript row (the recorder writes a single reply per turn), so `reply`
+   * takes the last such row by rowid — if that invariant ever breaks, earlier
+   * assistant text is dropped rather than concatenated.
    */
   async getLatestTurnOutcome(sessionId: string): Promise<{
     turnId: string;
@@ -2360,6 +2363,8 @@ export class WebChatRepository {
         )
         .orderBy(desc(romeAgentTraceBlocks.seq))
         .limit(1),
+      // The turn's assistant reply. One per turn by the recorder's contract;
+      // the last-by-rowid read is defensive against a hypothetical second row.
       this.db
         .select({ content: romeAgentMessages.content })
         .from(romeAgentMessages)
@@ -2397,7 +2402,12 @@ export class WebChatRepository {
    * inverted so the tail can be taken with a LIMIT and reversed back. rowid,
    * not createdAt, is the key because createdAt stores whole seconds and a
    * whole turn regularly lands inside one. This is a like-spirited but distinct
-   * ordering from getHistoryMessages, which groups by role rather than rowid. */
+   * ordering from getHistoryMessages, which groups by role rather than rowid.
+   *
+   * The LIMIT is applied over rows, not turns, so a `limit` that lands
+   * mid-turn splits it: the tail can begin with an assistant reply whose
+   * preceding user prompt fell outside the window. Callers that need whole
+   * turns should overshoot `limit` and trim on `turnId` themselves. */
   async getRecentTranscript(
     sessionId: string,
     limit: number,


### PR DESCRIPTION
## What this PR does

A caller outside a session had no way to read the outcome of that session's newest turn or the tail of its transcript. The detached subagent work that follows needs both to observe a child session it does not itself drive.

This adds two methods to `WebChatRepository`:

- `getLatestTurnOutcome(sessionId)` — returns the session's newest recorded turn as `{ turnId, turnEndStatus, error, reply }`, or `null` when the session has recorded none. `turnEndStatus` is `'completed' | 'error' | 'interrupted'` when the turn wrote its closing bracket and `null` when it never did (a turn cut short by a process exit stays `null` forever). `error` carries the text of the turn's last terminal error block and `reply` the text of its assistant transcript row; both are `null` when absent.
- `getRecentTranscript(sessionId, limit)` — returns the session's last `limit` visible chat rows (user prompts + assistant replies, no trace), oldest-first. Empty for `limit <= 0`.

Two private helpers back them: `messagePartsToText`, which joins a stored message row's `text` parts verbatim (unlike `extractTranscriptText`, it preserves layout so the result can be handed back as-is), and `readJsonStringField`, which reads one string field off a stored JSON trace block.

## Design & Invariants

- **Newest means last written, not largest `createdAt`.** `createdAt` stores whole seconds, so back-to-back turns tie on it and a whole turn regularly lands inside one second. Both methods key on `rowid` instead: `getLatestTurnOutcome` takes the last trace row by `rowid DESC`, and `getRecentTranscript` orders turns by their earliest row and rows within a turn by insertion, then takes the tail with a `LIMIT`.
- **Transcript ordering mirrors `getHistoryMessages`, inverted.** Turns sort by their earliest row and rows sort within a turn by insertion, so the inversion lets the tail be taken with a `LIMIT` and reversed back to oldest-first.
- **Trace rows never appear in a transcript.** `getRecentTranscript` restricts to the `user` and `assistant` roles.
- **Absent fields read as `null`, never throw.** Unparseable or missing trace/message content yields `null` (or `""` for text), so a turn still in flight or cut short reads cleanly.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` (372 test files, 4366 tests passed)
- [x] New `WebChatRepository > detached child status reads` cases cover: newest-turn selection, the same-second tiebreak, terminal error text, an unclosed turn's `null` status, a session with no turn, and the oldest-first transcript tail with its `limit` bounds.

## Not in this PR

- The detached subagent work that consumes these reads; this PR adds only the two repository methods and their tests.

Closes #245