### PR TITLE
fix(core): refuse to resume a session that has a live turn

### DIFF
--- a/packages/core/src/core/agent-runner.test.ts
+++ b/packages/core/src/core/agent-runner.test.ts
@@ -1546,6 +1546,7 @@ describe("AgentRunner", () => {
       skillCatalog: new SkillCatalog(),
       lifecycleDispatcher: lifecycleDispatcher ?? createAgentLifecycleDispatcher(),
       activeSubagentRegistry,
+      turnStreams,
       subagentExecutionService: createSubagentExecutionService({
         webchatRepo: new WebChatRepository(testDb.db),
         activeRegistry: activeSubagentRegistry,
@@ -2147,6 +2148,33 @@ describe("AgentRunner", () => {
         // resumed into whichever provider happens to resolve now.
         isNewSession: true,
       });
+
+      await manager.shutdown();
+    });
+
+    it("refuses to resume a session that already has a turn running", async () => {
+      // Two managers hold separate session maps, so resuming by id mid-turn
+      // would put a second AgentSessionImpl on the same provider thread. A
+      // detached child is exactly that case: it runs under its own manager.
+      const repo = new SessionsRepository(testDb.db);
+      await repo.create({
+        id: "sess-live",
+        agentName: "test-main",
+        channelThreadKey: "telegram:t-live",
+        status: "active",
+      });
+      const modelResolver = createTestModelResolver({ providers: [new MockModelProvider()] });
+      const deps = managerDeps(modelResolver);
+      const manager = createAgentSessionManager(deps, { keepAliveAcrossTurns: true });
+      deps.turnStreams.register({
+        sessionId: "sess-live",
+        turnId: "turn-live",
+        agentName: "test-main",
+      });
+
+      await expect(manager.acquireBySessionId!("sess-live", "test-main")).rejects.toThrow(
+        /has a turn running/,
+      );
 
       await manager.shutdown();
     });

--- a/packages/core/src/core/agent-runner.test.ts
+++ b/packages/core/src/core/agent-runner.test.ts
@@ -2178,6 +2178,83 @@ describe("AgentRunner", () => {
 
       await manager.shutdown();
     });
+
+    it("resumes a session whose live turn this manager owns (reuse, not refuse)", async () => {
+      // The guard must not fire for a session's own in-flight turn: a
+      // continuation (resume_session/defer/timer) or approval re-enters through
+      // the same manager, and acquire reuses that impl and FIFO-queues the new
+      // turn behind the running one. Refusing here would have broken those paths.
+      const repo = new SessionsRepository(testDb.db);
+      await repo.create({
+        id: "sess-own",
+        agentName: "test-main",
+        channelThreadKey: "telegram:t-own",
+        status: "active",
+      });
+      // A provider whose turn parks until the session closes, so the impl stays
+      // genuinely mid-turn (status "running", turn mutex held) during the resume.
+      const provider: ModelProvider = {
+        id: "mock",
+        displayName: "mock-parking-session",
+        builtinTools: new Set<string>(),
+        openSession: async (params) => createClosableModelSession(params),
+      };
+      const modelResolver = createTestModelResolver({ providers: [provider] });
+      const deps = managerDeps(modelResolver);
+      const manager = createAgentSessionManager(deps, { keepAliveAcrossTurns: true });
+
+      const live = await manager.acquireBySessionId!("sess-own", "test-main");
+      const turn = live.sendTurn({ prompt: "park" });
+      // Let the turn take the mutex and enter "running" before the resume.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      // Mirror production: the bridge registers the live turn on turn_start.
+      deps.turnStreams.register({
+        sessionId: live.sessionId,
+        turnId: turn.turnId,
+        agentName: "test-main",
+      });
+
+      const again = await manager.acquireBySessionId!("sess-own", "test-main");
+      expect(again).toBe(live);
+
+      await manager.shutdown();
+      await collectMessages(turn.events);
+    });
+
+    it("refuses a cross-manager resume while another manager runs the session's turn", async () => {
+      // The #246 scenario: a detached child runs under its own manager but shares
+      // the process-wide turn registry with the parent. The child holds the id,
+      // the parent's turn is live — the child must refuse rather than open a
+      // second AgentSessionImpl over the same provider thread.
+      const repo = new SessionsRepository(testDb.db);
+      await repo.create({
+        id: "sess-shared",
+        agentName: "test-main",
+        channelThreadKey: "telegram:t-shared",
+        status: "active",
+      });
+      const modelResolver = createTestModelResolver({ providers: [new MockModelProvider()] });
+      const parentDeps = managerDeps(modelResolver);
+      const parentManager = createAgentSessionManager(parentDeps, { keepAliveAcrossTurns: true });
+      const childManager = createAgentSessionManager(
+        { ...managerDeps(modelResolver), turnStreams: parentDeps.turnStreams },
+        { keepAliveAcrossTurns: true, isSubagent: true },
+      );
+
+      const parentSession = await parentManager.acquireBySessionId!("sess-shared", "test-main");
+      parentDeps.turnStreams.register({
+        sessionId: parentSession.sessionId,
+        turnId: "turn-shared",
+        agentName: "test-main",
+      });
+
+      await expect(childManager.acquireBySessionId!("sess-shared", "test-main")).rejects.toThrow(
+        /has a turn running/,
+      );
+
+      await parentManager.shutdown();
+      await childManager.shutdown();
+    });
   });
 
   describe("message yielding", () => {

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -622,11 +622,20 @@ export function createAgentSessionManager(
     if (!row) {
       throw new Error(`Agent session "${sessionId}" was not found or cannot be resumed`);
     }
-    // Two managers hold separate session maps, so resuming by id while a turn
-    // is running would hand out a second AgentSessionImpl over the same
-    // provider thread — two writers, one history. The turn registry is shared
-    // across managers, which makes it the one place that sees both.
-    if (deps.turnStreams && deps.turnStreams.listBySession(sessionId).length > 0) {
+    // Resuming by id while a turn is running would hand out a second
+    // AgentSessionImpl over the same provider thread — two writers, one history.
+    // But only when the turn runs under a *different* manager. When this
+    // manager already owns the session for that id, `acquire` below reuses that
+    // impl and FIFO-queues the new turn behind the running one on its turn
+    // mutex; refusing here would break the session's own continuations
+    // (resume_session/defer/timer) and approvals, which re-enter through their
+    // own in-flight turn. So skip the refusal for a turn owned here, and let the
+    // process-wide registry — the one place that sees another manager's turn —
+    // guard the cross-manager case.
+    const ownKey = canonicalizeKey({ agentName, channelThreadKey: row.channelThreadKey });
+    const own = sessions.get(keyOf(ownKey));
+    const ownedHere = own !== undefined && own.status !== "closed" && own.sessionId === sessionId;
+    if (!ownedHere && deps.turnStreams && deps.turnStreams.listBySession(sessionId).length > 0) {
       throw new Error(
         `Agent session "${sessionId}" has a turn running and cannot be resumed until it ends`,
       );

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -360,8 +360,22 @@ interface ManagerDeps {
   webchatRepo?: WebChatRepository;
   subagentExecutionService?: SubagentExecutionService;
   activeSubagentRegistry?: ActiveSubagentRegistry;
-  /** Process-wide record of turns that are running right now. Read by
-   * `acquireBySessionId` to refuse resuming a session that already has one. */
+  /**
+   * Process-wide record of turns that are running right now. Read by
+   * `acquireBySessionId` to refuse resuming a session that already has one.
+   *
+   * Advisory, not authoritative. This registry was built as best-effort
+   * observability: producers catch-and-log if `register` throws, and some
+   * turn owners (`AgentRunner.run`, in-main webchat) never register at all.
+   * The resume guard rides on it as a cheap backstop for the cross-manager
+   * collision in #246 — it narrows the window, it does not close it. It reads
+   * "a turn is live", not "an impl is live", so two managers can each hold an
+   * idle keep-alive impl for one session and both later start a turn; and the
+   * check is not atomic with the acquire that follows. A hard guarantee needs
+   * a process-wide live-impl claim keyed by provider thread (openSession /
+   * onClosed), which is deliberately out of scope here — see the note on the
+   * guard in `acquireBySessionId`.
+   */
   turnStreams?: AgentTurnStreamRegistry;
   /** Turn-middleware onion. Optional — when absent, every turn runs the
    *  model terminal directly (behavior identical to a chain of size 0). */
@@ -632,6 +646,14 @@ export function createAgentSessionManager(
     // own in-flight turn. So skip the refusal for a turn owned here, and let the
     // process-wide registry — the one place that sees another manager's turn —
     // guard the cross-manager case.
+    //
+    // This guard is advisory (see the `turnStreams` note on ManagerDeps). The
+    // registry is best-effort: `register` can be skipped or swallowed, and this
+    // check is not atomic with the `acquire` below, so a cross-manager
+    // registration can still land in the gap. It also gates on a live *turn*,
+    // not a live *impl*, so it does not stop two managers from each parking an
+    // idle keep-alive impl on one session. It narrows the #246 window rather
+    // than closing it; the airtight fix is a live-impl claim, left to follow-up.
     const ownKey = canonicalizeKey({ agentName, channelThreadKey: row.channelThreadKey });
     const own = sessions.get(keyOf(ownKey));
     const ownedHere = own !== undefined && own.status !== "closed" && own.sessionId === sessionId;

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -86,6 +86,7 @@ import {
 } from "@opentelemetry/api";
 import { isTerminalBlock } from "./agent-message.js";
 import type { ActiveSubagentRegistry, ParentSubagentRef } from "./active-subagent-registry.js";
+import type { AgentTurnStreamRegistry } from "./agent-turn-stream-registry.js";
 import type {
   ExecuteSubagentInput,
   SubagentExecution,
@@ -359,6 +360,9 @@ interface ManagerDeps {
   webchatRepo?: WebChatRepository;
   subagentExecutionService?: SubagentExecutionService;
   activeSubagentRegistry?: ActiveSubagentRegistry;
+  /** Process-wide record of turns that are running right now. Read by
+   * `acquireBySessionId` to refuse resuming a session that already has one. */
+  turnStreams?: AgentTurnStreamRegistry;
   /** Turn-middleware onion. Optional — when absent, every turn runs the
    *  model terminal directly (behavior identical to a chain of size 0). */
   turnMiddleware?: TurnMiddlewareChain;
@@ -617,6 +621,15 @@ export function createAgentSessionManager(
     const row = await deps.sessionManager.findResumableSessionById(sessionId, agentName);
     if (!row) {
       throw new Error(`Agent session "${sessionId}" was not found or cannot be resumed`);
+    }
+    // Two managers hold separate session maps, so resuming by id while a turn
+    // is running would hand out a second AgentSessionImpl over the same
+    // provider thread — two writers, one history. The turn registry is shared
+    // across managers, which makes it the one place that sees both.
+    if (deps.turnStreams && deps.turnStreams.listBySession(sessionId).length > 0) {
+      throw new Error(
+        `Agent session "${sessionId}" has a turn running and cannot be resumed until it ends`,
+      );
     }
     return acquire(
       { agentName, channelThreadKey: row.channelThreadKey },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -654,6 +654,7 @@ async function main() {
       webchatRepo,
       subagentExecutionService,
       activeSubagentRegistry,
+      turnStreams: agentTurnStreamRegistry,
       turnMiddleware: turnMiddlewareChain,
       resolveProviderSessionReset: async (ref) =>
         (await conversationSettings.get(ref)).effective.session.reset,

--- a/packages/core/src/test/helpers.ts
+++ b/packages/core/src/test/helpers.ts
@@ -549,6 +549,10 @@ export async function buildTestDeps(
     lifecycleDispatcher: createAgentLifecycleDispatcher(),
     subagentExecutionService,
     activeSubagentRegistry,
+    // Match production wiring so resume-by-id paths (approvals, defer/timer
+    // continuations, subagent resume) exercise the live-turn guard rather than
+    // running with it disabled.
+    turnStreams: agentTurnStreamRegistry,
   });
   const agentRunner = new AgentRunner(agentSessionManager, agentLoader);
   const backendTurnRunner = createBackendTurnRunner({

--- a/packages/core/src/test/kit/test-rome.ts
+++ b/packages/core/src/test/kit/test-rome.ts
@@ -28,6 +28,7 @@ import { SessionManager } from "../../core/session-manager.js";
 import { PromptBuilder } from "../../core/prompt-builder.js";
 import { createModelResolver } from "../../core/model-resolver.js";
 import { createAgentSessionManager } from "../../core/agent-session.js";
+import { createAgentTurnStreamRegistry } from "../../core/agent-turn-stream-registry.js";
 import { createAgentLifecycleDispatcher } from "../../core/agent-lifecycle.js";
 import { CapabilityDiscovery } from "../../core/capability-discovery.js";
 import { SkillCatalog } from "../../core/skill-catalog.js";
@@ -257,6 +258,7 @@ async function buildHarness(
 
   const sessionManager = new SessionManager(repos.sessions);
   const promptBuilder = new PromptBuilder();
+  const agentTurnStreamRegistry = createAgentTurnStreamRegistry();
   const agentSessionManager = createAgentSessionManager(
     {
       agentLoader,
@@ -270,6 +272,8 @@ async function buildHarness(
       capabilityDiscovery: new CapabilityDiscovery(),
       skillCatalog: new SkillCatalog(),
       lifecycleDispatcher: createAgentLifecycleDispatcher(),
+      // Match production wiring so resume-by-id paths hit the live-turn guard.
+      turnStreams: agentTurnStreamRegistry,
     },
     { keepAliveAcrossTurns: options.keepAliveAcrossTurns ?? false },
   );


### PR DESCRIPTION
## What this PR does

Resuming a session by id only checked that the session was active and belonged to the same agent. A caller holding the id of a session whose turn is still running could open a second in-memory session on the same provider thread — two `AgentSessionImpl`s writing one history. Nothing rejected the resume while work was already in flight.

This guards `acquireBySessionId` against the shared turn stream registry: if a live turn is recorded for that session **under a different manager**, the resume is refused until the turn ends. A resume of the session's own in-flight turn under the same manager is still allowed — `acquire` reuses that impl and FIFO-queues the new turn behind the running one.

## Design & Invariants

- Invariant: at most one `AgentSessionImpl` is live over a given provider thread at a time. A resume must not hand out a *second* writer while a turn is running under a different manager.
- Same-manager resume is not a second writer. Each manager keeps its own in-memory session map; when this manager already holds a non-closed impl for the requested id (`own.sessionId === sessionId`), `acquire` reuses it and queues the new turn on the impl's turn mutex. The session's own continuations (`resume_session`/`defer`/timer) and approvals re-enter exactly this way, so the guard must let them through — refusing there would break turn queueing and make the approval path mark an already-run action as failed. The guard therefore fires only when `!ownedHere`.
- Cross-manager is the case worth refusing: a detached child runs under its own manager and cannot see the parent's turn in its local map. The `AgentTurnStreamRegistry` is process-wide and observed by every manager, so it is the one place that sees the other manager's turn. `index.ts` passes the existing `agentTurnStreamRegistry` (already shared with the subagent execution service) into the session manager deps.
- The `turnStreams` dependency is optional. When absent, behavior is unchanged; the guard only fires when a registry is wired in and reports a live turn via `listBySession`.

## Test plan

- [x] `pnpm typecheck` — passes (all packages, including `@rome/core`).
- [x] `pnpm test:unit` — passes.
- [x] `src/core/agent-runner.test.ts` standalone — 112/112 pass. Covers:
  - refuses a resume when the registry reports a live turn this manager does not own;
  - **same-manager resume mid-turn reuses the impl** (parks a real turn via a non-completing model session, registers it, asserts `acquireBySessionId` returns the same instance rather than throwing — would have caught the over-refusal);
  - **cross-manager resume** — a second manager sharing the process-wide registry refuses while the first manager runs the session's turn.

## Not in this PR

- A process-wide owner claim taken in `openSession`/released on close. The guard reads a best-effort observability registry: in-main webchat turns and `AgentRunner.run` never register, and there is a narrow TOCTOU window between the check and turn_start registration. Closing those needs an ownership primitive that outgrows this narrowly-scoped fix; deferred to a follow-up. This PR closes the reported cross-manager gap for registered turns.
- A typed/tagged error for the refusal. After the ownership scoping, the only throw is a genuine cross-manager collision, and it sits beside the existing plain-`Error` "cannot be resumed" throw; a retry taxonomy for scheduled-continuation callers is follow-up work.

Closes #246
