### PR TITLE
feat: isolate webchat workspaces and unify sidebar conversations

### DIFF
--- a/docs/concepts/data.md
+++ b/docs/concepts/data.md
@@ -18,11 +18,12 @@ The memory system provides persistent, git-tracked knowledge that survives acros
 
 ## Projects
 
-Projects are working directories where the agent does its work — writing code, creating files, running commands. A default project directory serves when no specific project context applies.
+Projects are execution workspaces rooted at local directories. Agents write files and run commands inside them.
 
 **Contracts:**
 
 - A project can have a memory summary. The first paragraph of the summary always loads into agent context as a brief description. The rest is available for deeper reference (repo structure, commands, conventions).
+- A standalone WebChat session gets its own implicit project. Selecting an existing project starts a chat that intentionally shares that workspace.
 
 **Not to be confused with:**
 

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -10,7 +10,8 @@ A Rome session is the durable product boundary around one continuous body of age
 - Only an explicit product boundary — New Chat, or entering another platform-native thread — creates another conversation. An ordinary reply never does.
 - Provider compaction manages the live context window without deleting Rome's durable transcript.
 - Usage belongs to the session that executed it: a first-class child subagent session owns its own [runs](#agent-run) and accounting, and the parent session does not duplicate that usage. Parent/child sessions are linked and appear as session lineage.
-- Project attribution matches the session's project directory (exact path or child path). A project's display name is metadata, not an attribution fallback. Forks and subagents inherit the parent's project. Sessions created without project context stay unattributed.
+- Project attribution matches the session's project directory (exact path or child path). A project's display name is metadata, not an attribution fallback.
+- A new WebChat session without a project selection gets an isolated implicit project. Forks and subagents inherit the parent's project. Other sessions without project context stay unattributed.
 
 **Not to be confused with:**
 

--- a/packages/core/src/api/routes/projects-files.test.ts
+++ b/packages/core/src/api/routes/projects-files.test.ts
@@ -1371,6 +1371,42 @@ describe("Projects files API", () => {
       expect(existsSync(join(projectsRoot, "demo"))).toBe(false);
     });
 
+    it("does not delete the shared standalone chats workspace root", async () => {
+      const sessionId = "4e4c34b7-4c2a-4563-a3e8-709154afbdff";
+      const projectPath = `chats/${sessionId}`;
+      mkdirSync(join(projectsRoot, projectPath), { recursive: true });
+      await webchatRepo.createSession(
+        sessionId,
+        "Standalone",
+        undefined,
+        sessionId,
+        null,
+        projectPath,
+      );
+
+      const res = await buildApp().request("/projects/file?path=projects/chats", {
+        method: "DELETE",
+      });
+
+      expect(res.status).toBe(400);
+      expect(existsSync(join(projectsRoot, projectPath))).toBe(true);
+      await expect(webchatRepo.getSession(sessionId)).resolves.toMatchObject({ id: sessionId });
+
+      const rootTree = (await (
+        await buildApp().request("/projects/tree?path=projects")
+      ).json()) as Array<{ name: string }>;
+      expect(rootTree.some((entry) => entry.name === "chats")).toBe(false);
+
+      const workspaceTree = await buildApp().request(`/projects/tree?path=projects/${projectPath}`);
+      expect(workspaceTree.status).toBe(200);
+
+      const dashboard = (await (
+        await buildApp().request("/projects/dashboard?path=projects")
+      ).json()) as { availableProjectPaths: string[] };
+      expect(dashboard.availableProjectPaths).not.toContain("chats");
+      expect(dashboard.availableProjectPaths).not.toContain(projectPath);
+    });
+
     it("removes deleted project folder metadata after cleanup", async () => {
       mkdirSync(join(projectsRoot, "demo", "nested"), { recursive: true });
       mkdirSync(join(projectsRoot, "demo-other"), { recursive: true });

--- a/packages/core/src/api/routes/projects-files.ts
+++ b/packages/core/src/api/routes/projects-files.ts
@@ -29,6 +29,8 @@ import { ensureProjectsRootInitialized } from "../../paths.js";
 import { parseTimeZone } from "../../lib/timezone.js";
 import { resolveWebchatLargeModelSelection } from "../../core/model-selector.js";
 import type { ApiDeps } from "../deps.js";
+import { STANDALONE_WEBCHAT_PROJECT_PREFIX } from "../../webchat/constants.js";
+import { isReservedWebchatProjectPath } from "../../webchat/projects.js";
 
 const PROJECTS_IGNORED_NAMES = [".next", ".turbo", "build", "coverage", "dist", "node_modules"];
 const PROJECT_DASHBOARD_DAYS = 14;
@@ -258,12 +260,13 @@ async function listAvailableProjectPaths(
   const projectPaths = new Set<string>();
 
   for (const projectPath of listTopLevelShadowProjectPaths(rootDir)) {
+    if (isReservedWebchatProjectPath(projectPath)) continue;
     projectPaths.add(projectPath);
   }
 
   for (const projectPath of await webchatRepo.listProjectPaths()) {
     const normalizedProjectPath = normalizeProjectCandidatePath(projectPath);
-    if (!normalizedProjectPath) continue;
+    if (!normalizedProjectPath || isReservedWebchatProjectPath(normalizedProjectPath)) continue;
 
     const resolvedProjectPath = resolve(rootDir, normalizedProjectPath);
     if (isWithinDirectory(resolvedProjectPath, rootDir)) {
@@ -704,6 +707,10 @@ export function projectsFilesRoutes(deps: ProjectsRouteDeps): Hono {
     logicalRoot: "projects",
     rootDir: projectsRoot,
   };
+  const treeScope: FileBrowserScope = {
+    ...baseScope,
+    ignoredNames: [...PROJECTS_IGNORED_NAMES, STANDALONE_WEBCHAT_PROJECT_PREFIX],
+  };
 
   const fileScope: FileBrowserScope = {
     ...baseScope,
@@ -729,13 +736,20 @@ export function projectsFilesRoutes(deps: ProjectsRouteDeps): Hono {
   };
 
   app.get("/projects/events", createFileWatchEventsHandler(baseScope));
-  app.get("/projects/tree", createTreeHandler(baseScope));
+  app.get("/projects/tree", createTreeHandler(treeScope));
   app.get("/projects/resolve", createResolveHandler(baseScope));
   app.get("/projects/file", createFileGetHandler(fileScope));
   app.post("/projects/file", createFilePostHandler(fileScope));
   app.put("/projects/file", createFilePutHandler(fileScope));
   app.patch("/projects/file", createFileRenameHandler(fileScope));
-  app.delete("/projects/file", createFileDeleteHandler(fileScope));
+  const deleteProjectFile = createFileDeleteHandler(fileScope);
+  app.delete("/projects/file", (c) => {
+    const projectPath = normalizeProjectCandidatePath(c.req.query("path") ?? "");
+    if (projectPath === STANDALONE_WEBCHAT_PROJECT_PREFIX) {
+      return c.json({ error: "Cannot delete the standalone chats workspace root" }, 400);
+    }
+    return deleteProjectFile(c);
+  });
   app.get("/projects/asset", createAssetHandler(baseScope));
   app.get("/projects/asset/:fileName", createAssetHandler(baseScope));
   app.get("/projects/download", createDownloadHandler(baseScope));

--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { context as otelContext } from "@opentelemetry/api";
@@ -27,6 +27,7 @@ import { ModelResolutionError } from "../../core/model-resolver.js";
 import { webchatProjects } from "../../db/schema.js";
 import { TURN_BRANCH_PROMPT_MAX_LENGTH } from "@rome/api-types/trace-segments";
 import type { TraceSnapshot } from "@rome/api-types/trace-segments";
+import { resolveWebchatContinuationWorkingDir } from "../../webchat/projects.js";
 
 describe("Webchat API", () => {
   const originalProjectsRoot = process.env.ROME_PROJECTS_ROOT;
@@ -629,6 +630,106 @@ describe("Webchat API", () => {
       });
     });
 
+    it("creates and binds an implicit project before returning a standalone session", async () => {
+      const app = createWebchatRuntime(deps).routes;
+
+      const res = await app.request("/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Standalone" }),
+      });
+
+      expect(res.status).toBe(200);
+      const session = (await res.json()) as { id: string; projectPath: string };
+      expect(session.projectPath).toBe(`chats/${session.id}`);
+      await expect(deps.webchatRepo.getProjectByPath(session.projectPath)).resolves.toMatchObject({
+        path: session.projectPath,
+      });
+      expect(existsSync(join(projectsRoot, session.projectPath))).toBe(true);
+
+      const catalog = (await (await app.request("/chat/projects")).json()) as {
+        projects: Array<{ name: string }>;
+      };
+      expect(catalog.projects.map((project) => project.name)).toEqual(["default"]);
+    });
+
+    it("isolates the cwd and relative files of two standalone sessions", async () => {
+      const app = createWebchatRuntime(deps).routes;
+      const createStandalone = async (name: string) => {
+        const response = await app.request("/chat/sessions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name }),
+        });
+        return (await response.json()) as { id: string; projectPath: string };
+      };
+
+      const first = await createStandalone("First");
+      const second = await createStandalone("Second");
+      const firstCwd = await resolveWebchatContinuationWorkingDir(
+        "webchat",
+        first.id,
+        deps.webchatRepo,
+        projectsRoot,
+      );
+      const secondCwd = await resolveWebchatContinuationWorkingDir(
+        "webchat",
+        second.id,
+        deps.webchatRepo,
+        projectsRoot,
+      );
+
+      expect(first.projectPath).not.toBe(second.projectPath);
+      expect(firstCwd).not.toBe(secondCwd);
+      writeFileSync(join(firstCwd as string, "result.txt"), "first");
+      writeFileSync(join(secondCwd as string, "result.txt"), "second");
+      expect(readFileSync(join(firstCwd as string, "result.txt"), "utf8")).toBe("first");
+      expect(readFileSync(join(secondCwd as string, "result.txt"), "utf8")).toBe("second");
+    });
+
+    it("reuses the exact selected project for an explicit project session", async () => {
+      const app = createWebchatRuntime(deps).routes;
+      await deps.webchatRepo.createProject("Alpha", "alpha");
+      mkdirSync(join(projectsRoot, "alpha"));
+
+      const res = await app.request("/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Explicit", projectPath: "alpha" }),
+      });
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        projectName: "Alpha",
+        projectPath: "alpha",
+      });
+    });
+
+    it("reloads and continues a standalone session in its stored workspace", async () => {
+      const app = createWebchatRuntime(deps).routes;
+      const created = (await (
+        await app.request("/chat/sessions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: "Persistent" }),
+        })
+      ).json()) as { id: string; projectPath: string };
+
+      const reloadedApp = createWebchatRuntime(deps).routes;
+      const reloaded = (await (
+        await reloadedApp.request(`/chat/sessions/${created.id}`)
+      ).json()) as { projectPath: string };
+      const continuationCwd = await resolveWebchatContinuationWorkingDir(
+        "webchat",
+        created.id,
+        deps.webchatRepo,
+        projectsRoot,
+      );
+
+      expect(reloaded.projectPath).toBe(created.projectPath);
+      expect(continuationCwd).toBe(join(projectsRoot, created.projectPath));
+    });
+
     it("does not list or materialize archived projects", async () => {
       await deps.webchatRepo.createProject("alpha", "alpha");
       await deps.webchatRepo.archiveProjectsByPathPrefix("alpha");
@@ -919,7 +1020,7 @@ describe("Webchat API", () => {
           "rome.log.source": "rome",
           sessionId: created.id,
           agentName: "main",
-          projectPath: "default",
+          projectPath: `chats/${created.id}`,
         },
       });
       expect(creationRecords[0].attributes).not.toHaveProperty("name");

--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -630,6 +630,58 @@ describe("Webchat API", () => {
       });
     });
 
+    it("rejects explicit projects in the standalone workspace namespace", async () => {
+      const app = createWebchatRuntime(deps).routes;
+      const path = "chats/4e4c34b7-4c2a-4563-a3e8-709154afbdff";
+
+      for (const request of [
+        app.request("/chat/projects", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: path }),
+        }),
+        app.request("/chat/sessions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: "Explicit", projectPath: path }),
+        }),
+      ]) {
+        const response = await request;
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+          error: `Project "${path}" is reserved`,
+        });
+      }
+
+      await expect(deps.webchatRepo.getProjectByPath(path)).resolves.toBeNull();
+      expect(existsSync(join(projectsRoot, path))).toBe(false);
+
+      await deps.webchatRepo.createProject("chats", "chats");
+      const catalog = (await (await app.request("/chat/projects")).json()) as {
+        projects: Array<{ name: string }>;
+      };
+      expect(catalog.projects.map((project) => project.name)).not.toContain("chats");
+    });
+
+    it("validates the requested agent before creating a standalone workspace", async () => {
+      const app = createWebchatRuntime(deps).routes;
+      const projectPathsBefore = (await deps.webchatRepo.listProjects()).map(
+        (project) => project.path,
+      );
+
+      const response = await app.request("/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentName: "missing:agent" }),
+      });
+
+      expect(response.status).toBe(400);
+      expect((await deps.webchatRepo.listProjects()).map((project) => project.path)).toEqual(
+        projectPathsBefore,
+      );
+      expect(existsSync(join(projectsRoot, "chats"))).toBe(false);
+    });
+
     it("creates and binds an implicit project before returning a standalone session", async () => {
       const app = createWebchatRuntime(deps).routes;
 

--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -682,6 +682,20 @@ describe("Webchat API", () => {
       expect(existsSync(join(projectsRoot, "chats"))).toBe(false);
     });
 
+    it("rejects a non-string project path instead of creating a standalone session", async () => {
+      const app = createWebchatRuntime(deps).routes;
+
+      const response = await app.request("/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectPath: 42 }),
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "Project path must be a string" });
+      expect(existsSync(join(projectsRoot, "chats"))).toBe(false);
+    });
+
     it("creates and binds an implicit project before returning a standalone session", async () => {
       const app = createWebchatRuntime(deps).routes;
 
@@ -924,6 +938,29 @@ describe("Webchat API", () => {
       await expect(deps.webchatRepo.getProjectByPath("default/test")).resolves.toMatchObject({
         name: "test",
         path: "default/test",
+      });
+    });
+
+    it("rejects an empty project update without rebinding a standalone session", async () => {
+      const app = createWebchatRuntime(deps).routes;
+      const created = (await (
+        await app.request("/chat/sessions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: "Draft" }),
+        })
+      ).json()) as { id: string; projectPath: string };
+
+      const response = await app.request(`/chat/sessions/${created.id}/project`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "Project path is required" });
+      await expect(deps.webchatRepo.getSession(created.id)).resolves.toMatchObject({
+        projectPath: created.projectPath,
       });
     });
 

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -32,8 +32,10 @@ import type { ChatShareSnapshot, ChatShareMessage } from "../share-snapshot.js";
 import { createRegistryAppResolver } from "../registry-app-resolver.js";
 import {
   ensureWebchatProjectWorkspace,
+  getStandaloneWebchatProjectPath,
   getWebchatProjectDisplayName,
   getWebchatProjectsRoot,
+  isStandaloneWebchatProjectPath,
   normalizeWebchatProjectPath,
   normalizeSelectedWebchatProjectPath,
   resolveWebchatProjectPath,
@@ -1964,7 +1966,9 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
         id: DEFAULT_WEBCHAT_PROJECT_NAME,
       },
     );
-    const projects = await deps.webchatRepo.listProjects();
+    const projects = (await deps.webchatRepo.listProjects()).filter(
+      (project) => !isStandaloneWebchatProjectPath(project.path),
+    );
     await Promise.all(
       projects.map((project) => ensureWebchatProjectWorkspace(project.path, rootPath)),
     );
@@ -2025,8 +2029,11 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     const name = body.name || "New Chat";
     let project;
     try {
+      const selectedProjectPath = body.projectPath ?? body.projectName;
       project = await ensureStoredProjectSelection(
-        normalizeSelectedWebchatProjectPath(body.projectPath ?? body.projectName),
+        selectedProjectPath?.trim()
+          ? normalizeSelectedWebchatProjectPath(selectedProjectPath)
+          : getStandaloneWebchatProjectPath(id),
       );
     } catch (err) {
       const message = err instanceof Error ? err.message : "Internal error";

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -35,7 +35,7 @@ import {
   getStandaloneWebchatProjectPath,
   getWebchatProjectDisplayName,
   getWebchatProjectsRoot,
-  isStandaloneWebchatProjectPath,
+  isReservedWebchatProjectPath,
   normalizeWebchatProjectPath,
   normalizeSelectedWebchatProjectPath,
   resolveWebchatProjectPath,
@@ -1967,7 +1967,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       },
     );
     const projects = (await deps.webchatRepo.listProjects()).filter(
-      (project) => !isStandaloneWebchatProjectPath(project.path),
+      (project) => !isReservedWebchatProjectPath(project.path),
     );
     await Promise.all(
       projects.map((project) => ensureWebchatProjectWorkspace(project.path, rootPath)),
@@ -1980,8 +1980,11 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     const body = await c.req.json<{ name?: string }>().catch(() => ({}) as { name?: string });
     try {
       const projectPath = normalizeWebchatProjectPath(body.name ?? "");
-      if (projectPath === DEFAULT_WEBCHAT_PROJECT_NAME) {
-        throw new Error(`Project "${DEFAULT_WEBCHAT_PROJECT_NAME}" is reserved`);
+      if (
+        projectPath === DEFAULT_WEBCHAT_PROJECT_NAME ||
+        isReservedWebchatProjectPath(projectPath)
+      ) {
+        throw new Error(`Project "${projectPath}" is reserved`);
       }
       const projectName = getWebchatProjectDisplayName(projectPath);
       const existingProject = await deps.webchatRepo.getProjectRecordByPath(projectPath);
@@ -2027,18 +2030,6 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       );
     const id = randomUUID();
     const name = body.name || "New Chat";
-    let project;
-    try {
-      const selectedProjectPath = body.projectPath ?? body.projectName;
-      project = await ensureStoredProjectSelection(
-        selectedProjectPath?.trim()
-          ? normalizeSelectedWebchatProjectPath(selectedProjectPath)
-          : getStandaloneWebchatProjectPath(id),
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Internal error";
-      return c.json({ error: message }, getWebchatProjectErrorStatus(message));
-    }
     const modelSelection = await resolveRequestedInitialModelSelection(body.largeModelSelection);
     const personaId = await resolveRequestedPersonaId(body.personaId);
 
@@ -2055,6 +2046,24 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       requestedAgentName && !isCoreMainAgentId(requestedAgentName)
         ? deps.agentLoader.getCanonicalName(requestedAgentName)
         : null;
+
+    let project;
+    try {
+      const selectedProjectPath = body.projectPath ?? body.projectName;
+      const explicitProjectPath =
+        typeof selectedProjectPath === "string" && selectedProjectPath.trim()
+          ? normalizeSelectedWebchatProjectPath(selectedProjectPath)
+          : null;
+      if (explicitProjectPath && isReservedWebchatProjectPath(explicitProjectPath)) {
+        throw new Error(`Project "${explicitProjectPath}" is reserved`);
+      }
+      project = await ensureStoredProjectSelection(
+        explicitProjectPath ?? getStandaloneWebchatProjectPath(id),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Internal error";
+      return c.json({ error: message }, getWebchatProjectErrorStatus(message));
+    }
 
     await deps.webchatRepo.createSession(
       id,
@@ -2099,6 +2108,9 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       const requestedProjectPath = normalizeSelectedWebchatProjectPath(
         body.projectPath ?? body.projectName,
       );
+      if (isReservedWebchatProjectPath(requestedProjectPath)) {
+        throw new Error(`Project "${requestedProjectPath}" is reserved`);
+      }
       const currentProjectPath = normalizeSelectedWebchatProjectPath(
         session.projectPath ?? session.projectName,
       );

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -50,7 +50,7 @@ import {
   isTurnFeedbackRating,
 } from "@rome/api-types/trace-segments";
 import type { TurnFeedback } from "@rome/api-types/trace-segments";
-import type { StoredTurnFeedback } from "../../db/repositories/webchat.js";
+import type { StoredTurnFeedback, StoredWebchatProject } from "../../db/repositories/webchat.js";
 import type { AgentMessage, MessagePart } from "../../types.js";
 import type { AgentTurnHandle } from "../../core/agent-session.js";
 import type { RomeSessionType, StreamAgentMessage } from "@rome-os/app-runtime";
@@ -556,11 +556,17 @@ async function findOpenSuspensions(
 }
 
 function getWebchatProjectErrorStatus(message: string): 400 | 500 {
-  return /already exists|required|invalid|relative folder path|empty|current|parent|unsupported|reserved|unavailable/.test(
+  return /already exists|required|must be a string|invalid|relative folder path|empty|current|parent|unsupported|reserved|unavailable/.test(
     message,
   )
     ? 400
     : 500;
+}
+
+function parseOptionalWebchatProjectPath(value: unknown): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string") throw new Error("Project path must be a string");
+  return value.trim() ? normalizeSelectedWebchatProjectPath(value) : null;
 }
 
 interface WebchatSseEvent {
@@ -1966,9 +1972,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
         id: DEFAULT_WEBCHAT_PROJECT_NAME,
       },
     );
-    const projects = (await deps.webchatRepo.listProjects()).filter(
-      (project) => !isReservedWebchatProjectPath(project.path),
-    );
+    const projects = await deps.webchatRepo.listProjects();
     await Promise.all(
       projects.map((project) => ensureWebchatProjectWorkspace(project.path, rootPath)),
     );
@@ -2010,8 +2014,8 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       .json<{
         name?: string;
         personaId?: string;
-        projectName?: string | null;
-        projectPath?: string | null;
+        projectName?: unknown;
+        projectPath?: unknown;
         largeModelSelection?: string;
         reasoningEffort?: string;
         agentName?: string | null;
@@ -2021,8 +2025,8 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
           ({}) as {
             name?: string;
             personaId?: string;
-            projectName?: string | null;
-            projectPath?: string | null;
+            projectName?: unknown;
+            projectPath?: unknown;
             largeModelSelection?: string;
             reasoningEffort?: string;
             agentName?: string | null;
@@ -2047,13 +2051,10 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
         ? deps.agentLoader.getCanonicalName(requestedAgentName)
         : null;
 
-    let project;
+    let project: StoredWebchatProject;
     try {
       const selectedProjectPath = body.projectPath ?? body.projectName;
-      const explicitProjectPath =
-        typeof selectedProjectPath === "string" && selectedProjectPath.trim()
-          ? normalizeSelectedWebchatProjectPath(selectedProjectPath)
-          : null;
+      const explicitProjectPath = parseOptionalWebchatProjectPath(selectedProjectPath);
       if (explicitProjectPath && isReservedWebchatProjectPath(explicitProjectPath)) {
         throw new Error(`Project "${explicitProjectPath}" is reserved`);
       }
@@ -2085,7 +2086,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     log.info("webchat_session_created", {
       sessionId: id,
       agentName: storedAgentName ?? "main",
-      projectPath: project.path ?? project.name,
+      projectPath: project.path,
       largeModelSelection: modelSelection?.id ?? null,
       ...(await sessionActorLogAttributes()),
     });
@@ -2095,19 +2096,20 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
   app.patch("/chat/sessions/:id/project", async (c) => {
     const sessionId = c.req.param("id");
     const body = await c.req
-      .json<{ projectName?: string | null; projectPath?: string | null }>()
-      .catch(() => ({}) as { projectName?: string | null; projectPath?: string | null });
+      .json<{ projectName?: unknown; projectPath?: unknown }>()
+      .catch(() => ({}) as { projectName?: unknown; projectPath?: unknown });
     const lookup = await getTopLevelWebchatSession(c, sessionId);
     if ("response" in lookup) return lookup.response;
     const { session } = lookup;
 
     const messageCount = await deps.webchatRepo.getMessageCount(sessionId);
-    let project;
+    let project: StoredWebchatProject;
 
     try {
-      const requestedProjectPath = normalizeSelectedWebchatProjectPath(
+      const requestedProjectPath = parseOptionalWebchatProjectPath(
         body.projectPath ?? body.projectName,
       );
+      if (!requestedProjectPath) throw new Error("Project path is required");
       if (isReservedWebchatProjectPath(requestedProjectPath)) {
         throw new Error(`Project "${requestedProjectPath}" is reserved`);
       }
@@ -2967,7 +2969,7 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
       session.projectPath ?? session.projectName,
     );
     const projectsRoot = getWebchatProjectsRoot();
-    let storedProject: Awaited<ReturnType<typeof ensureStoredProjectSelection>>;
+    let storedProject: StoredWebchatProject;
     try {
       storedProject = await ensureStoredProjectSelection(sessionProjectPath);
     } catch (err) {

--- a/packages/core/src/db/repositories/webchat.test.ts
+++ b/packages/core/src/db/repositories/webchat.test.ts
@@ -645,6 +645,14 @@ describe("WebChatRepository", () => {
       "alpha/nested",
     );
     await repo.createSession("sess-alpha-2", "Chat Alpha 2", undefined, "alpha", null, "alpha");
+    await repo.createSession(
+      "sess-standalone",
+      "Standalone",
+      undefined,
+      "Standalone",
+      null,
+      "chats/standalone",
+    );
     await repo.createSession("sess-legacy", "Chat Legacy", undefined, "legacy", null, null);
 
     await expect(repo.listProjectPaths()).resolves.toEqual(["default", "alpha", "alpha/nested"]);

--- a/packages/core/src/db/repositories/webchat.ts
+++ b/packages/core/src/db/repositories/webchat.ts
@@ -11,6 +11,8 @@ import {
   isNotNull,
   isNull,
   like,
+  ne,
+  not,
   or,
   sql,
 } from "drizzle-orm";
@@ -24,7 +26,10 @@ import {
   webchatWorkspaceLayouts,
 } from "../schema.js";
 import type { DrizzleDb } from "../index.js";
-import { DEFAULT_WEBCHAT_PROJECT_NAME } from "../../webchat/constants.js";
+import {
+  DEFAULT_WEBCHAT_PROJECT_NAME,
+  STANDALONE_WEBCHAT_PROJECT_PREFIX,
+} from "../../webchat/constants.js";
 import type { TurnFeedbackRating } from "@rome/api-types/trace-segments";
 import type { RomeSessionType } from "@rome-os/app-runtime";
 import type { MessagePart } from "../../types.js";
@@ -721,7 +726,13 @@ export class WebChatRepository {
     return this.db
       .select()
       .from(webchatProjects)
-      .where(isNull(webchatProjects.archivedAt))
+      .where(
+        and(
+          isNull(webchatProjects.archivedAt),
+          ne(webchatProjects.path, STANDALONE_WEBCHAT_PROJECT_PREFIX),
+          not(sql`${webchatProjects.path} GLOB ${`${STANDALONE_WEBCHAT_PROJECT_PREFIX}/*`}`),
+        ),
+      )
       .orderBy(
         sql`CASE WHEN ${webchatProjects.path} = ${DEFAULT_WEBCHAT_PROJECT_NAME} THEN 0 ELSE 1 END`,
         asc(webchatProjects.path),

--- a/packages/core/src/webchat/constants.ts
+++ b/packages/core/src/webchat/constants.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_WEBCHAT_PROJECT_NAME = "default";
+export const STANDALONE_WEBCHAT_PROJECT_PREFIX = "chats";

--- a/packages/core/src/webchat/projects.test.ts
+++ b/packages/core/src/webchat/projects.test.ts
@@ -9,6 +9,7 @@ import {
   ensureWebchatProjectExists,
   getStandaloneWebchatProjectPath,
   getWebchatProjectDisplayName,
+  isReservedWebchatProjectPath,
   isStandaloneWebchatProjectPath,
   listWebchatProjects,
   normalizeSelectedWebchatProjectPath,
@@ -96,6 +97,9 @@ describe("webchat project helpers", () => {
     const sessionId = "4e4c34b7-4c2a-4563-a3e8-709154afbdff";
 
     expect(getStandaloneWebchatProjectPath(sessionId)).toBe(`chats/${sessionId}`);
+    expect(isReservedWebchatProjectPath("chats")).toBe(true);
+    expect(isReservedWebchatProjectPath(`chats/${sessionId}`)).toBe(true);
+    expect(isReservedWebchatProjectPath("chat-showcase")).toBe(false);
     expect(isStandaloneWebchatProjectPath(`chats/${sessionId}`)).toBe(true);
     expect(isStandaloneWebchatProjectPath("chats/not-a-session-id")).toBe(false);
   });

--- a/packages/core/src/webchat/projects.test.ts
+++ b/packages/core/src/webchat/projects.test.ts
@@ -7,7 +7,9 @@ import { tmpdir } from "node:os";
 import {
   createWebchatProject,
   ensureWebchatProjectExists,
+  getStandaloneWebchatProjectPath,
   getWebchatProjectDisplayName,
+  isStandaloneWebchatProjectPath,
   listWebchatProjects,
   normalizeSelectedWebchatProjectPath,
   normalizeWebchatProjectPath,
@@ -88,6 +90,14 @@ describe("webchat project helpers", () => {
     expect(normalizeSelectedWebchatProjectPath(" landingpage/content ")).toBe(
       "landingpage/content",
     );
+  });
+
+  it("derives the standalone project path from the session id", () => {
+    const sessionId = "4e4c34b7-4c2a-4563-a3e8-709154afbdff";
+
+    expect(getStandaloneWebchatProjectPath(sessionId)).toBe(`chats/${sessionId}`);
+    expect(isStandaloneWebchatProjectPath(`chats/${sessionId}`)).toBe(true);
+    expect(isStandaloneWebchatProjectPath("chats/not-a-session-id")).toBe(false);
   });
 
   it("rejects creating the default project because it already exists", async () => {

--- a/packages/core/src/webchat/projects.ts
+++ b/packages/core/src/webchat/projects.ts
@@ -1,7 +1,7 @@
 import { mkdir, readdir, stat } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { getProjectsRoot } from "../paths.js";
-import { DEFAULT_WEBCHAT_PROJECT_NAME } from "./constants.js";
+import { DEFAULT_WEBCHAT_PROJECT_NAME, STANDALONE_WEBCHAT_PROJECT_PREFIX } from "./constants.js";
 
 export interface WebchatProjectOption {
   archivedAt?: string | null;
@@ -133,6 +133,16 @@ export function getWebchatProjectPath(
 export function normalizeSelectedWebchatProjectPath(projectPath?: string | null): string {
   const trimmed = typeof projectPath === "string" ? projectPath.trim() : "";
   return trimmed ? normalizeWebchatProjectPath(trimmed) : DEFAULT_WEBCHAT_PROJECT_NAME;
+}
+
+export function getStandaloneWebchatProjectPath(sessionId: string): string {
+  return `${STANDALONE_WEBCHAT_PROJECT_PREFIX}/${sessionId}`;
+}
+
+export function isStandaloneWebchatProjectPath(projectPath: string): boolean {
+  return /^chats\/[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    projectPath,
+  );
 }
 
 export async function listWebchatProjects(

--- a/packages/core/src/webchat/projects.ts
+++ b/packages/core/src/webchat/projects.ts
@@ -139,6 +139,14 @@ export function getStandaloneWebchatProjectPath(sessionId: string): string {
   return `${STANDALONE_WEBCHAT_PROJECT_PREFIX}/${sessionId}`;
 }
 
+export function isReservedWebchatProjectPath(projectPath: string): boolean {
+  const normalizedPath = normalizeWebchatProjectPath(projectPath);
+  return (
+    normalizedPath === STANDALONE_WEBCHAT_PROJECT_PREFIX ||
+    normalizedPath.startsWith(`${STANDALONE_WEBCHAT_PROJECT_PREFIX}/`)
+  );
+}
+
 export function isStandaloneWebchatProjectPath(projectPath: string): boolean {
   return /^chats\/[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
     projectPath,

--- a/packages/web/src/components/chat/ChatComponent.test.tsx
+++ b/packages/web/src/components/chat/ChatComponent.test.tsx
@@ -77,6 +77,9 @@ function renderChatComponent(
       });
     }
     if (url === "/api/chat/sessions") {
+      if (init?.method === "POST") {
+        return Response.json({ id: "new-session" });
+      }
       return Response.json(homeData?.sessions ?? []);
     }
     if (url === "/api/chat/projects") {
@@ -96,6 +99,9 @@ function renderChatComponent(
       const target = homeData?.sessions.find((session) => session.id === id);
       if (target) target.pinnedAt = null;
       return Response.json(target ?? {});
+    }
+    if (/\/api\/chat\/sessions\/[^/]+\/turns$/.test(url) && init?.method === "POST") {
+      return Response.json({ turnId: "turn-1" });
     }
     return Response.json({}, { status: 404 });
   }) as typeof fetch);
@@ -135,6 +141,65 @@ describe("ChatComponent draft file drops", () => {
     fireEvent.drop(container.firstElementChild as Element, { dataTransfer });
 
     expect(await screen.findByText("note.txt")).toBeTruthy();
+  });
+});
+
+describe("ChatComponent draft project selection", () => {
+  it("omits projectPath when starting a standalone chat", async () => {
+    const user = userEvent.setup();
+    const { fetchSpy } = renderChatComponent({}, { sessions: [], projects: [] });
+
+    await user.type(screen.getByRole("textbox"), "Start isolated work");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() =>
+      expect(
+        fetchSpy.mock.calls.some(
+          ([input, init]) => String(input) === "/api/chat/sessions" && init?.method === "POST",
+        ),
+      ).toBe(true),
+    );
+    const createCall = fetchSpy.mock.calls.find(
+      ([input, init]) => String(input) === "/api/chat/sessions" && init?.method === "POST",
+    );
+    const body = JSON.parse(String(createCall?.[1]?.body)) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("projectPath");
+  });
+
+  it("sends projectPath only after the guardian selects a project", async () => {
+    const user = userEvent.setup();
+    const { fetchSpy } = renderChatComponent(
+      {},
+      {
+        sessions: [],
+        projects: [
+          {
+            name: "alpha",
+            displayName: "Alpha project",
+            projectPath: "alpha",
+            path: "/projects/alpha",
+          },
+        ],
+      },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Project" }));
+    await user.click(await screen.findByRole("option", { name: "Alpha project" }));
+    await user.type(screen.getByRole("textbox"), "Reuse shared work");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() =>
+      expect(
+        fetchSpy.mock.calls.some(
+          ([input, init]) => String(input) === "/api/chat/sessions" && init?.method === "POST",
+        ),
+      ).toBe(true),
+    );
+    const createCall = fetchSpy.mock.calls.find(
+      ([input, init]) => String(input) === "/api/chat/sessions" && init?.method === "POST",
+    );
+    const body = JSON.parse(String(createCall?.[1]?.body)) as Record<string, unknown>;
+    expect(body.projectPath).toBe("alpha");
   });
 });
 

--- a/packages/web/src/components/chat/ChatComponent.tsx
+++ b/packages/web/src/components/chat/ChatComponent.tsx
@@ -77,7 +77,7 @@ export function ChatComponent({
   const [isDraggingDraftFiles, setIsDraggingDraftFiles] = useState(false);
   const pendingDraftRef = useRef<{
     sessionId: string;
-    projectPath: string;
+    projectPath?: string;
     largeModelSelection?: string;
     agentName?: string;
   } | null>(null);

--- a/packages/web/src/components/chat/ChatComposer.tsx
+++ b/packages/web/src/components/chat/ChatComposer.tsx
@@ -27,7 +27,6 @@ import { usePeople } from "@/hooks/use-people";
 import { useCoarsePointer } from "@/hooks/use-coarse-pointer";
 import {
   DEFAULT_LARGE_MODEL_SELECTION,
-  DEFAULT_PROJECT_NAME,
   DEFAULT_REASONING_EFFORT,
   LARGE_MODEL_OPTIONS,
 } from "@/lib/chat-constants";
@@ -58,7 +57,7 @@ export interface ChatComposerSnapshot {
   personaId?: string;
   largeModelSelection?: string;
   reasoningEffort: ReasoningEffort;
-  projectPath: string;
+  projectPath?: string;
   // Set only in draft mode when the user picked an `@app/agent` from the
   // mention menu. Active sessions inherit their agent from `pinnedAgentMention`
   // instead — `onSend` for those should ignore this field.
@@ -256,9 +255,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
   const [modelMenuOpen, setModelMenuOpen] = useState(false);
   const [reasoningMenuOpen, setReasoningMenuOpen] = useState(false);
 
-  const [draftProjectName, setDraftProjectName] = useState(
-    initialProjectName?.trim() || DEFAULT_PROJECT_NAME,
-  );
+  const [draftProjectName, setDraftProjectName] = useState(initialProjectName?.trim() || "");
   const [projectCatalog, setProjectCatalog] = useState<ProjectCatalog | null>(null);
   const [projectsLoading, setProjectsLoading] = useState(false);
   const [projectsError, setProjectsError] = useState<string | null>(null);
@@ -297,12 +294,12 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
   //      project the user explicitly picked from the menu.
   const initialProjectNameRef = useRef(initialProjectName);
   useEffect(() => {
-    const next = initialProjectName?.trim() || DEFAULT_PROJECT_NAME;
+    const next = initialProjectName?.trim() || "";
     if (next === draftProjectName) {
       initialProjectNameRef.current = initialProjectName;
       return;
     }
-    if (draftProjectName === (initialProjectNameRef.current?.trim() || DEFAULT_PROJECT_NAME)) {
+    if (draftProjectName === (initialProjectNameRef.current?.trim() || "")) {
       setDraftProjectName(next);
     }
     initialProjectNameRef.current = initialProjectName;
@@ -438,7 +435,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
           largeModelSelection:
             showModelSelector && modelSelectorEnabled ? largeModelSelection : undefined,
           reasoningEffort,
-          projectPath: draftProjectName,
+          projectPath: draftProjectName || undefined,
           agentMention: draftAgentMention ?? undefined,
           skillName,
         };
@@ -507,7 +504,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
       largeModelSelection:
         showModelSelector && modelSelectorEnabled ? largeModelSelection : undefined,
       reasoningEffort,
-      projectPath: draftProjectName,
+      projectPath: draftProjectName || undefined,
       // Pinned sessions ignore this; draft hosts read it to lock the new
       // session to the picked agent.
       agentMention: draftAgentMention ?? undefined,
@@ -797,7 +794,9 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
   const draftProject = projectCatalog?.projects.find((p) => p.name === draftProjectName);
   const draftProjectLabel = draftProject
     ? (draftProject.displayName ?? formatProjectLabel(draftProject.name))
-    : formatProjectLabel(draftProjectName);
+    : draftProjectName
+      ? formatProjectLabel(draftProjectName)
+      : t("project.noProjectSelected");
 
   // Live handoff (not the approve moment, which keeps its own banner). When set,
   // it's the active chip in the row and supersedes the @agent chip — both would
@@ -951,7 +950,6 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
               projectsError={projectsError}
               draftProjectName={draftProjectName}
               draftProjectLabel={draftProjectLabel}
-              defaultProjectName={DEFAULT_PROJECT_NAME}
               menuOpen={draftProjectMenuOpen}
               searchQuery={projectSearchQuery}
               setSearchQuery={setProjectSearchQuery}

--- a/packages/web/src/components/project-selector.test.tsx
+++ b/packages/web/src/components/project-selector.test.tsx
@@ -24,7 +24,6 @@ function renderCreateForm() {
       projectsError={null}
       draftProjectName="general"
       draftProjectLabel="general"
-      defaultProjectName="general"
       menuOpen
       searchQuery=""
       setSearchQuery={rs.fn()}
@@ -61,7 +60,6 @@ function baseProps() {
     projectsError: null,
     draftProjectName: "general",
     draftProjectLabel: "general",
-    defaultProjectName: "general",
     menuOpen: true as const,
     searchQuery: "",
     setSearchQuery: rs.fn(),
@@ -160,10 +158,10 @@ describe("project selector list", () => {
 
     // `loop` wraps upward from the first project straight onto the reset row.
     await user.keyboard("{ArrowUp}");
-    await waitFor(() => expect(selectedOption()).toContain("general"));
+    await waitFor(() => expect(selectedOption()).toContain("no project selected"));
 
     await user.keyboard("{Enter}");
-    expect(props.onPickProject).toHaveBeenCalledWith("general");
+    expect(props.onPickProject).toHaveBeenCalledWith("");
   });
 });
 

--- a/packages/web/src/components/project-selector.tsx
+++ b/packages/web/src/components/project-selector.tsx
@@ -38,7 +38,6 @@ interface ProjectSelectorProps {
   projectsError: string | null;
   draftProjectName: string;
   draftProjectLabel: string;
-  defaultProjectName: string;
   menuOpen: boolean;
   searchQuery: string;
   setSearchQuery: (value: string) => void;
@@ -67,7 +66,6 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
     projectsError,
     draftProjectName,
     draftProjectLabel,
-    defaultProjectName,
     menuOpen,
     searchQuery,
     setSearchQuery,
@@ -85,7 +83,7 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
   ref: Ref<HTMLDivElement>,
 ) {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
-  const isDefault = draftProjectName === defaultProjectName;
+  const hasNoSelection = !draftProjectName;
   const projects = projectCatalog?.projects ?? [];
 
   const filtered = useMemo(() => {
@@ -96,17 +94,12 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
     );
   }, [projects, searchQuery]);
 
-  const namedProjects = filtered.filter((p) => p.name !== defaultProjectName);
-  const defaultProject =
-    filtered.find((p) => p.name === defaultProjectName) ??
-    (searchQuery.trim() ? null : { name: defaultProjectName, path: "" });
-
   // Rendered above the list rather than inside it: cmdk gives CommandList
   // role="listbox", whose children have to be options or groups. Non-null
   // exactly when there are no project rows to show.
   const status = projectsLoading
     ? { text: t("project.loading"), loading: true }
-    : namedProjects.length > 0
+    : filtered.length > 0
       ? null
       : projects.length > 0 && filtered.length === 0
         ? {
@@ -118,7 +111,7 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
             loading: false,
           };
 
-  const resetRowVisible = Boolean(!projectsLoading && defaultProject);
+  const resetRowVisible = !projectsLoading;
 
   return (
     <div ref={ref} className="shrink-0">
@@ -131,18 +124,20 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
         <PopoverTrigger asChild>
           <Button
             type="button"
-            // The fill is the variant's job: transparent while the default
-            // project is in play, filled once a real one is, and each variant
+            // The fill is the variant's job: transparent while no project is
+            // selected, filled once a real one is, and each variant
             // carries its own open-state fill through `aria-expanded`. `ghost`
             // sets no resting colour, so the label takes one or it reads as the
             // loudest thing in a row of muted chrome.
-            variant={isDefault ? "ghost" : "secondary"}
+            variant={hasNoSelection ? "ghost" : "secondary"}
             size="sm"
-            className={cn("max-w-[200px] touch-target", isDefault && "text-muted-foreground")}
-            title={isDefault ? t("project.buttonLabel") : draftProjectLabel}
+            className={cn("max-w-[200px] touch-target", hasNoSelection && "text-muted-foreground")}
+            title={hasNoSelection ? t("project.noProjectSelected") : draftProjectLabel}
             aria-label={t("project.buttonLabel")}
           >
-            <span className="truncate">{isDefault ? defaultProjectName : draftProjectLabel}</span>
+            <span className="truncate">
+              {hasNoSelection ? t("project.buttonLabel") : draftProjectLabel}
+            </span>
             <ChevronDown data-icon="inline-end" aria-hidden="true" />
           </Button>
         </PopoverTrigger>
@@ -228,7 +223,7 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
             >
               {status ? null : (
                 <CommandGroup>
-                  {namedProjects.map((project, index) => {
+                  {filtered.map((project, index) => {
                     const isSelected = project.name === draftProjectName;
                     return (
                       <CommandItem
@@ -259,7 +254,7 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
                   that selection once the projects arrive — leaving the
                   highlight on the trailing reset row instead of the first
                   project, which is then what Enter picks. */}
-              {!projectsLoading && defaultProject && (
+              {!projectsLoading && (
                 // Sticky so it stays visible once the projects overflow the
                 // list's own scroll box — before the migration it sat in a
                 // footer outside that box. Opaque, or the rows scroll under it.
@@ -270,18 +265,15 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
                 // The failure is visual only, so no test will catch it.
                 <CommandGroup className="sticky bottom-0 border-t border-border-subtle bg-popover">
                   <CommandItem
-                    value={defaultProject.name}
-                    onSelect={() => onPickProject(defaultProject.name)}
+                    value="standalone-chat"
+                    onSelect={() => onPickProject("")}
                     className="text-muted-foreground"
                   >
                     <span className="min-w-0 flex-1 truncate">
-                      {defaultProject.name}
-                      <span className="ml-2 text-aux text-subtle-foreground">
-                        {t("project.noProjectSelected")}
-                      </span>
+                      {t("project.noProjectSelected")}
                     </span>
                     <span className="flex w-3.5 justify-center text-foreground">
-                      {isDefault ? <Check className="size-3.5 shrink-0" aria-hidden /> : null}
+                      {hasNoSelection ? <Check className="size-3.5 shrink-0" aria-hidden /> : null}
                     </span>
                   </CommandItem>
                 </CommandGroup>

--- a/packages/web/src/i18n/locales/en/common.json
+++ b/packages/web/src/i18n/locales/en/common.json
@@ -29,7 +29,9 @@
     "add": "Add",
     "newApps": "New apps available",
     "new": "New",
-    "appDisabled": "Disabled"
+    "appDisabled": "Disabled",
+    "search": "Search",
+    "searchShortcut": "Search ({{shortcut}})"
   },
   "recentChats": {
     "title": "Chats",
@@ -69,7 +71,6 @@
     "searchCloseHint": "Close",
     "projectActions": "Project actions",
     "pinned": "Pinned",
-    "sectionProjects": "Projects",
     "pin": "Pin",
     "unpin": "Unpin",
     "pinChat": "Pin chat",

--- a/packages/web/src/i18n/locales/zh-CN/common.json
+++ b/packages/web/src/i18n/locales/zh-CN/common.json
@@ -29,10 +29,12 @@
     "add": "添加",
     "newApps": "有新应用可用",
     "new": "新",
-    "appDisabled": "已停用"
+    "appDisabled": "已停用",
+    "search": "搜索",
+    "searchShortcut": "搜索 ({{shortcut}})"
   },
   "recentChats": {
-    "title": "最近对话",
+    "title": "对话",
     "newChat": "新对话",
     "empty": "还没有对话",
     "unread": "未读",
@@ -69,7 +71,6 @@
     "searchCloseHint": "关闭",
     "projectActions": "项目操作",
     "pinned": "已置顶",
-    "sectionProjects": "项目",
     "pin": "置顶",
     "unpin": "取消置顶",
     "pinChat": "置顶对话",

--- a/packages/web/src/lib/chat-api.ts
+++ b/packages/web/src/lib/chat-api.ts
@@ -271,7 +271,7 @@ export async function listRomeSessionMessages(sessionId: string): Promise<ChatMe
 export interface CreateSessionInput {
   name: string;
   personaId?: string;
-  projectPath: string;
+  projectPath?: string;
   largeModelSelection?: string;
   reasoningEffort: ReasoningEffort;
   agentName?: string;

--- a/packages/web/src/shell/RecentChats.test.tsx
+++ b/packages/web/src/shell/RecentChats.test.tsx
@@ -90,10 +90,10 @@ function mockSessions(sessions: MockSession[]) {
   return spy;
 }
 
-function renderRecentChats(initialEntry = "/chat", onSearch = () => {}) {
+function renderRecentChats(initialEntry = "/chat") {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
-      <RecentChats onSearch={onSearch} />
+      <RecentChats />
       <LocationProbe />
     </MemoryRouter>,
   );
@@ -109,21 +109,16 @@ function textIndex(container: HTMLElement, text: string): number {
 }
 
 describe("RecentChats", () => {
-  it("keeps search and list settings visible together", async () => {
+  it("keeps list settings on the Chats section", async () => {
     mockSessions([]);
-    const onSearch = rs.fn();
-    const user = userEvent.setup();
-
-    renderRecentChats("/chat", onSearch);
+    renderRecentChats();
 
     await screen.findByText("No chats yet");
-    const searchButton = screen.getByRole("button", { name: "Search chats" });
-    expect(searchButton).toBeTruthy();
-    expect(searchButton.getAttribute("title")).toMatch(/^Search chats \((⌘K|Ctrl K)\)$/);
     expect(screen.getByRole("button", { name: "List settings" })).toBeTruthy();
-
-    await user.click(searchButton);
-    expect(onSearch).toHaveBeenCalledOnce();
+    const chatsToggle = screen.getByRole("button", { name: "Chats" });
+    await userEvent.click(chatsToggle);
+    expect(screen.queryByText("No chats yet")).toBeNull();
+    expect(chatsToggle.getAttribute("aria-expanded")).toBe("false");
   });
 
   it("offers a retry instead of claiming the guardian has no chats when the fetch fails", async () => {
@@ -230,7 +225,7 @@ describe("RecentChats", () => {
     expect(container.querySelectorAll(".bg-info")).toHaveLength(1);
   });
 
-  it("hides the Projects heading when nothing is pinned", async () => {
+  it("keeps project groups inside the Chats section", async () => {
     mockSessions([
       {
         id: "regular-chat",
@@ -246,9 +241,9 @@ describe("RecentChats", () => {
 
     renderRecentChats();
 
-    const projectsSection = await screen.findByRole("region", { name: "Projects" });
-    expect(screen.queryByRole("heading", { name: "Projects" })).toBeNull();
-    expect(within(projectsSection).getByRole("link", { name: "Regular chat" })).toBeTruthy();
+    const chatsSection = await screen.findByRole("region", { name: "Chats" });
+    expect(screen.getByRole("heading", { name: "Chats" })).toBeTruthy();
+    expect(within(chatsSection).getByRole("link", { name: "Regular chat" })).toBeTruthy();
   });
 
   it("groups by date using activity time instead of created time", async () => {
@@ -273,8 +268,15 @@ describe("RecentChats", () => {
     await act(async () => {
       await rs.advanceTimersByTimeAsync(0);
     });
-    expect(screen.getByText("Today")).toBeTruthy();
+    const dateHeading = screen.getByRole("button", { name: "Today" });
+    expect(dateHeading?.classList.contains("text-ui")).toBe(true);
+    expect(dateHeading?.classList.contains("text-aux")).toBe(false);
+    expect(dateHeading.querySelector("svg")?.classList.contains("opacity-0")).toBe(true);
     expect(screen.getByText("Today activity")).toBeTruthy();
+    act(() => dateHeading.click());
+    expect(screen.queryByText("Today activity")).toBeNull();
+    expect(dateHeading.getAttribute("aria-expanded")).toBe("false");
+    expect(dateHeading.querySelector("svg")?.classList.contains("opacity-0")).toBe(false);
   });
 
   it("shows pinned projects in a shared Pinned section without pin status icons", async () => {
@@ -307,7 +309,7 @@ describe("RecentChats", () => {
     await user.click(unpinItem);
     await waitFor(() => expect(screen.queryByRole("region", { name: "Pinned" })).toBeNull());
     expect(
-      within(screen.getByRole("region", { name: "Projects" })).getByRole("link", {
+      within(screen.getByRole("region", { name: "Chats" })).getByRole("link", {
         name: "Project chat",
       }),
     ).toBeTruthy();
@@ -317,14 +319,14 @@ describe("RecentChats", () => {
     localStorage.setItem("rome-recent-chats-pinned-projects", JSON.stringify(["alpha"]));
     mockSessions([
       {
-        id: "pinned-chat",
+        id: "6f8c5f4e-6b2f-4f8e-9b55-63f3283e138e",
         name: "Pinned standalone chat",
         createdAt: "2026-07-04T00:00:00.000Z",
         activityAt: "2026-07-09T12:00:00.000Z",
         lastSeenActivityAt: null,
         unread: false,
-        projectName: "default",
-        projectPath: "default",
+        projectName: "6f8c5f4e-6b2f-4f8e-9b55-63f3283e138e",
+        projectPath: "chats/6f8c5f4e-6b2f-4f8e-9b55-63f3283e138e",
         pinnedAt: "2026-07-09T13:00:00.000Z",
       },
       {
@@ -336,6 +338,17 @@ describe("RecentChats", () => {
         unread: false,
         projectName: "Alpha project",
         projectPath: "alpha",
+      },
+      {
+        id: "pinned-child-chat",
+        name: "Pinned child chat",
+        createdAt: "2026-07-03T00:00:00.000Z",
+        activityAt: "2026-07-09T10:30:00.000Z",
+        lastSeenActivityAt: null,
+        unread: false,
+        projectName: "Beta project",
+        projectPath: "beta",
+        pinnedAt: "2026-07-09T14:00:00.000Z",
       },
       {
         id: "standalone-chat",
@@ -363,7 +376,12 @@ describe("RecentChats", () => {
     renderRecentChats();
 
     const pinnedSection = await screen.findByRole("region", { name: "Pinned" });
-    const projectsSection = screen.getByRole("region", { name: "Projects" });
+    const chatsSection = screen.getByRole("region", { name: "Chats" });
+    const pinnedHeading = within(pinnedSection).getByRole("heading", { name: "Pinned" });
+    const chatsHeading = screen.getByRole("heading", { name: "Chats" });
+    expect(pinnedHeading.parentElement?.className).toBe(chatsHeading.parentElement?.className);
+    expect(within(pinnedHeading).getByRole("button", { name: "Pinned" })).toBeTruthy();
+    expect(within(chatsHeading).getByRole("button", { name: "Chats" })).toBeTruthy();
 
     expect(
       within(pinnedSection).getByRole("link", { name: "Pinned standalone chat" }),
@@ -375,21 +393,30 @@ describe("RecentChats", () => {
     const pinnedProjectChat = within(pinnedSection).getByRole("link", {
       name: "Pinned project child",
     });
-    expect(pinnedProjectChat.classList.contains("pl-4")).toBe(true);
+    expect(pinnedProjectChat.classList.contains("pl-8")).toBe(true);
     expect(pinnedProjectChat.classList.contains("pl-12")).toBe(false);
+    expect(textIndex(pinnedSection, "Pinned standalone chat")).toBeLessThan(
+      textIndex(pinnedSection, "Alpha project"),
+    );
+    expect(textIndex(pinnedSection, "Alpha project")).toBeLessThan(
+      textIndex(pinnedSection, "Pinned child chat"),
+    );
+    expect(textIndex(document.body, "Pinned")).toBeLessThan(textIndex(document.body, "Chats"));
     expect(
       within(pinnedSection).getByRole("button", { name: "New chat in this project" }),
     ).toBeTruthy();
-    expect(screen.queryByRole("region", { name: "Chats" })).toBeNull();
-    const defaultProjectButton = within(projectsSection).getByRole("button", {
+    const defaultProjectButton = within(chatsSection).getByRole("button", {
       name: "default",
     });
     expect(defaultProjectButton.querySelector(".lucide-folder-open")).toBeTruthy();
-    expect(within(projectsSection).getByRole("link", { name: "Standalone chat" })).toBeTruthy();
-    expect(within(projectsSection).getByRole("button", { name: "Beta project" })).toBeTruthy();
     expect(
-      within(projectsSection).getByRole("link", { name: "Regular project child" }),
-    ).toBeTruthy();
+      defaultProjectButton
+        .querySelector(".lucide-folder-open")
+        ?.classList.contains("text-subtle-foreground"),
+    ).toBe(false);
+    expect(within(chatsSection).getByRole("link", { name: "Standalone chat" })).toBeTruthy();
+    expect(within(chatsSection).getByRole("button", { name: "Beta project" })).toBeTruthy();
+    expect(within(chatsSection).getByRole("link", { name: "Regular project child" })).toBeTruthy();
     expect(screen.getAllByText("Alpha project")).toHaveLength(1);
 
     await user.click(pinnedProjectButton);
@@ -401,12 +428,14 @@ describe("RecentChats", () => {
     expect(within(pinnedSection).getByText("Pinned project child")).toBeTruthy();
     expect(pinnedProjectButton.querySelector(".lucide-folder-open")).toBeTruthy();
 
-    await user.click(within(pinnedSection).getByRole("button", { name: "Pinned" }));
+    const pinnedToggle = within(pinnedSection).getByRole("button", { name: "Pinned" });
+    await user.click(pinnedToggle);
     expect(within(pinnedSection).queryByText("Pinned standalone chat")).toBeNull();
     expect(within(pinnedSection).queryByText("Pinned project child")).toBeNull();
+    expect(pinnedToggle.getAttribute("aria-expanded")).toBe("false");
   });
 
-  it("keeps implicit standalone chats navigable outside project groups", async () => {
+  it("mixes implicit standalone chats with project groups by activity", async () => {
     const id = "4e4c34b7-4c2a-4563-a3e8-709154afbdff";
     mockSessions([
       {
@@ -431,13 +460,19 @@ describe("RecentChats", () => {
       },
     ]);
 
-    renderRecentChats();
+    const { container } = renderRecentChats();
 
     const chatsSection = await screen.findByRole("region", { name: "Chats" });
-    expect(within(chatsSection).getByRole("link", { name: "Isolated chat" })).toBeTruthy();
-    const projectsSection = screen.getByRole("region", { name: "Projects" });
-    expect(within(projectsSection).getByRole("button", { name: "Alpha" })).toBeTruthy();
-    expect(within(projectsSection).queryByText("Isolated chat")).toBeNull();
+    const chatLink = within(chatsSection).getByRole("link", { name: "Isolated chat" });
+    const projectButton = within(chatsSection).getByRole("button", { name: "Alpha" });
+    expect(textIndex(container, "Isolated chat")).toBeLessThan(textIndex(container, "Alpha"));
+    expect(projectButton.parentElement?.classList.contains("text-ui")).toBe(true);
+    expect(projectButton.parentElement?.classList.contains("text-foreground")).toBe(true);
+    expect(chatLink.closest("[data-chat-row]")?.classList.contains("text-ui")).toBe(true);
+    const nestedChatLink = within(chatsSection).getByRole("link", { name: "Shared chat" });
+    expect(nestedChatLink.classList.contains("pl-8")).toBe(true);
+
+    expect(screen.getAllByRole("button", { name: "List settings" })).toHaveLength(1);
   });
 
   it("does not render unread dots for the active session", async () => {
@@ -702,7 +737,7 @@ describe("RecentChats", () => {
     );
   });
 
-  it("grays out archived chat rows", async () => {
+  it("keeps archived chat labels at the same emphasis as active chats", async () => {
     localStorage.setItem("rome-recent-chats-status-filter", "all");
     mockSessions([activeSession(), archivedSession()]);
 
@@ -710,8 +745,7 @@ describe("RecentChats", () => {
 
     const archivedRow = (await screen.findByText("Archived chat")).closest("[data-chat-row]");
     const activeRow = screen.getByText("Active chat").closest("[data-chat-row]");
-    expect(archivedRow?.classList.contains("text-subtle-foreground")).toBe(true);
-    expect(archivedRow?.classList.contains("text-foreground")).toBe(false);
+    expect(archivedRow?.classList.contains("text-foreground")).toBe(true);
     expect(activeRow?.classList.contains("text-foreground")).toBe(true);
   });
 

--- a/packages/web/src/shell/RecentChats.test.tsx
+++ b/packages/web/src/shell/RecentChats.test.tsx
@@ -406,6 +406,40 @@ describe("RecentChats", () => {
     expect(within(pinnedSection).queryByText("Pinned project child")).toBeNull();
   });
 
+  it("keeps implicit standalone chats navigable outside project groups", async () => {
+    const id = "4e4c34b7-4c2a-4563-a3e8-709154afbdff";
+    mockSessions([
+      {
+        id,
+        name: "Isolated chat",
+        createdAt: "2026-07-02T00:00:00.000Z",
+        activityAt: "2026-07-09T10:00:00.000Z",
+        lastSeenActivityAt: null,
+        unread: false,
+        projectName: id,
+        projectPath: `chats/${id}`,
+      },
+      {
+        id: "shared-chat",
+        name: "Shared chat",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        activityAt: "2026-07-09T09:00:00.000Z",
+        lastSeenActivityAt: null,
+        unread: false,
+        projectName: "Alpha",
+        projectPath: "alpha",
+      },
+    ]);
+
+    renderRecentChats();
+
+    const chatsSection = await screen.findByRole("region", { name: "Chats" });
+    expect(within(chatsSection).getByRole("link", { name: "Isolated chat" })).toBeTruthy();
+    const projectsSection = screen.getByRole("region", { name: "Projects" });
+    expect(within(projectsSection).getByRole("button", { name: "Alpha" })).toBeTruthy();
+    expect(within(projectsSection).queryByText("Isolated chat")).toBeNull();
+  });
+
   it("does not render unread dots for the active session", async () => {
     mockSessions([
       {

--- a/packages/web/src/shell/RecentChats.tsx
+++ b/packages/web/src/shell/RecentChats.tsx
@@ -9,10 +9,9 @@ import {
   Pencil,
   Pin,
   PinOff,
-  Search,
   Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
@@ -36,7 +35,6 @@ import {
   usePinSession,
   useSessionsChanged,
 } from "@/lib/session-events";
-import { chatSearchShortcutForPlatform } from "./ChatSearchDialog";
 
 interface ChatSession {
   id: string;
@@ -62,6 +60,86 @@ interface SessionGroup {
   items: ChatSession[];
   latest: number;
   projectPath: string;
+}
+
+type ConversationCollectionItem =
+  | { kind: "chat"; item: ChatSession; latest: number }
+  | { kind: "project"; item: SessionGroup; latest: number; pinned: boolean };
+
+function ConversationCollection({
+  items,
+  renderChat,
+  renderProject,
+}: {
+  items: ConversationCollectionItem[];
+  renderChat: (session: ChatSession) => ReactNode;
+  renderProject: (group: SessionGroup, pinned: boolean) => ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      {items.map((entry) =>
+        entry.kind === "chat" ? renderChat(entry.item) : renderProject(entry.item, entry.pinned),
+      )}
+    </div>
+  );
+}
+
+function ConversationCollectionToggle({
+  title,
+  collapsed,
+  onToggle,
+  className = "",
+}: {
+  title: ReactNode;
+  collapsed: boolean;
+  onToggle: () => void;
+  className?: string;
+}) {
+  const chevronClassName = collapsed
+    ? "h-3.5 w-3.5"
+    : "touch-show h-3.5 w-3.5 opacity-0 transition-opacity group-hover/collection-toggle:opacity-100 group-focus-within/collection-toggle:opacity-100 motion-reduce:transition-none";
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={!collapsed}
+      className={`flex items-center gap-2 rounded-4 border border-transparent text-ui text-subtle-foreground transition outline-none hover:text-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring ${className}`}
+    >
+      <span>{title}</span>
+      {collapsed ? (
+        <ChevronRightIcon className={chevronClassName} aria-hidden />
+      ) : (
+        <ChevronDownIcon className={chevronClassName} aria-hidden />
+      )}
+    </button>
+  );
+}
+
+function ConversationCollectionHeader({
+  id,
+  title,
+  controls,
+  collapsed,
+  onToggle,
+}: {
+  id: string;
+  title: ReactNode;
+  controls?: ReactNode;
+  collapsed: boolean;
+  onToggle: () => void;
+}) {
+  const controlsClassName =
+    "touch-show flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 has-[[data-state=open]]:opacity-100 motion-reduce:transition-none";
+
+  return (
+    <div className="group group/collection-toggle flex items-center justify-between px-5 pt-4">
+      <h2 id={id}>
+        <ConversationCollectionToggle title={title} collapsed={collapsed} onToggle={onToggle} />
+      </h2>
+      {controls ? <div className={controlsClassName}>{controls}</div> : null}
+    </div>
+  );
 }
 
 const GROUP_MODE_STORAGE_KEY = "rome-recent-chats-group-mode";
@@ -187,7 +265,7 @@ function ChatRowLink({ id, name, nested }: { id: string; name: string; nested: b
           onPointerEnter={syncNameClipped}
           onFocus={syncNameClipped}
           className={`flex h-full min-w-0 flex-1 items-center rounded-8 border border-transparent pr-1 outline-none focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring ${
-            nested ? "pl-4" : "pl-2"
+            nested ? "pl-8" : "pl-2"
           }`}
         >
           <span ref={nameRef} className="truncate">
@@ -202,11 +280,7 @@ function ChatRowLink({ id, name, nested }: { id: string; name: string; nested: b
   );
 }
 
-export interface RecentChatsProps {
-  onSearch: () => void;
-}
-
-export function RecentChats({ onSearch }: RecentChatsProps) {
+export function RecentChats() {
   const { t } = useTranslation("common");
   const navigate = useNavigate();
   const location = useLocation();
@@ -226,7 +300,6 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   const renamingRef = useRef(false);
   const activeSessionId = activeSessionFromPath(location.pathname);
-  const searchShortcut = chatSearchShortcutForPlatform();
 
   const loadSessions = useCallback(async () => {
     try {
@@ -301,6 +374,29 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
     }));
   }, [pinnedProjectPaths, sessions]);
 
+  const pinnedItems: ConversationCollectionItem[] = [
+    ...pinnedChats.map((item) => ({
+      kind: "chat" as const,
+      item,
+      latest: sessionActivityTime(item),
+    })),
+    ...pinnedProjects.map(({ projectPath, name, items }) => {
+      const latest = items[0] ? sessionActivityTime(items[0]) : 0;
+      return {
+        kind: "project" as const,
+        item: {
+          key: `pinned-project:${projectPath}`,
+          label: name,
+          items,
+          latest,
+          projectPath,
+        },
+        latest,
+        pinned: true,
+      };
+    }),
+  ].sort((a, b) => b.latest - a.latest);
+
   const regularSessions = useMemo(
     () =>
       sessions
@@ -345,6 +441,20 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
       }))
       .sort((a, b) => b.latest - a.latest);
   }, [regularSessions]);
+
+  const projectModeItems: ConversationCollectionItem[] = [
+    ...standaloneSessions.map((item) => ({
+      kind: "chat" as const,
+      item,
+      latest: sessionActivityTime(item),
+    })),
+    ...projectGroups.map((item) => ({
+      kind: "project" as const,
+      item,
+      latest: item.latest,
+      pinned: false,
+    })),
+  ].sort((a, b) => b.latest - a.latest);
 
   const dateGroups = useMemo<SessionGroup[]>(() => {
     const now = Date.now();
@@ -523,9 +633,7 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
       <div
         key={session.id}
         data-chat-row
-        className={`group flex h-8 items-center gap-1 rounded-8 text-ui transition ${
-          session.archived ? "text-subtle-foreground" : "text-foreground"
-        } ${
+        className={`group flex h-8 items-center gap-1 rounded-8 text-ui text-foreground transition ${
           isActive
             ? "bg-surface shadow-1 dark:bg-surface-hover"
             : "hover:bg-surface-hover dark:hover:bg-surface"
@@ -550,7 +658,7 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
               }
             }}
             className={`my-1 h-[var(--control-h-sm)] min-w-0 flex-1 rounded-4 border border-foreground/20 bg-background px-1 py-1 text-ui text-foreground outline-none focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring ${
-              nested ? "ml-4" : "ml-2"
+              nested ? "ml-8" : "ml-2"
             }`}
           />
         ) : (
@@ -669,9 +777,9 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
     const projectLabel = (
       <>
         {collapsed ? (
-          <Folder className="h-4 w-4 shrink-0 text-subtle-foreground" aria-hidden />
+          <Folder className="h-4 w-4 shrink-0" aria-hidden />
         ) : (
-          <FolderOpen className="h-4 w-4 shrink-0 text-subtle-foreground" aria-hidden />
+          <FolderOpen className="h-4 w-4 shrink-0" aria-hidden />
         )}
         <span className="truncate">{label}</span>
       </>
@@ -748,8 +856,77 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
     );
   };
 
+  const renderProjectListItem = (group: SessionGroup, pinned: boolean) =>
+    renderProjectGroup({
+      key: group.key,
+      label: group.label,
+      items: group.items,
+      projectPath: group.projectPath,
+      pinned,
+    });
+
   const hasPinned = pinnedChats.length > 0 || pinnedProjects.length > 0;
   const pinnedCollapsed = collapsedGroups.has("section:pinned");
+  const chatsCollapsed = collapsedGroups.has("section:chats");
+  const renderListMenu = () => (
+    <div className="flex items-center gap-1">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <IconButton
+            size="sm"
+            label={t("recentChats.settings")}
+            icon={<Ellipsis aria-hidden />}
+            className="touch-target text-subtle-foreground hover:text-foreground"
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="bottom" align="end" className="min-w-[180px]">
+          <div className="px-2 pb-1 pt-1 text-aux text-subtle-foreground">
+            {t("recentChats.groupBy")}
+          </div>
+          {[
+            { mode: "date" as const, label: t("recentChats.groupByDate") },
+            { mode: "project" as const, label: t("recentChats.groupByProjects") },
+          ].map(({ mode, label }) => {
+            const selected = groupMode === mode;
+            return (
+              <DropdownMenuItem
+                key={mode}
+                onSelect={() => setGroupMode(mode)}
+                className={selected ? "text-ui text-foreground" : "text-ui text-foreground/85"}
+              >
+                <span>{label}</span>
+                {selected ? (
+                  <Check className="ml-auto h-3.5 w-3.5 text-subtle-foreground" aria-hidden />
+                ) : null}
+              </DropdownMenuItem>
+            );
+          })}
+          <div className="px-2 pb-1 pt-2 text-aux text-subtle-foreground">
+            {t("recentChats.status")}
+          </div>
+          {[
+            { value: "all" as const, label: t("recentChats.statusAll") },
+            { value: "active" as const, label: t("recentChats.statusActive") },
+            { value: "archived" as const, label: t("recentChats.statusArchived") },
+          ].map(({ value, label }) => {
+            const selected = statusFilter === value;
+            return (
+              <DropdownMenuItem
+                key={value}
+                onSelect={() => setStatusFilter(value)}
+                className={selected ? "text-ui text-foreground" : "text-ui text-foreground/85"}
+              >
+                <span>{label}</span>
+                {selected ? (
+                  <Check className="ml-auto h-3.5 w-3.5 text-subtle-foreground" aria-hidden />
+                ) : null}
+              </DropdownMenuItem>
+            );
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
 
   return (
     // skipDelayDuration 0 makes every row wait out the delay on its own:
@@ -757,214 +934,95 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
     // once one has opened, strobing the list as the pointer runs down it.
     <TooltipProvider delayDuration={300} skipDelayDuration={0}>
       <div className="flex flex-col">
-        <div className="flex items-center justify-between px-5 pt-4">
-          <span className="text-body text-foreground">{t("recentChats.title")}</span>
-          <div className="flex items-center gap-1">
-            <IconButton
-              size="sm"
-              label={t("recentChats.search")}
-              title={t("recentChats.searchShortcut", { shortcut: searchShortcut })}
-              onClick={onSearch}
-              icon={<Search aria-hidden />}
-              className="text-subtle-foreground hover:text-foreground"
+        {hasPinned ? (
+          <section aria-labelledby="recent-chats-pinned-heading" data-pinned-section>
+            <ConversationCollectionHeader
+              id="recent-chats-pinned-heading"
+              title={t("recentChats.pinned")}
+              collapsed={pinnedCollapsed}
+              onToggle={() => toggleGroup("section:pinned")}
             />
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <IconButton
-                  size="sm"
-                  label={t("recentChats.settings")}
-                  icon={<Ellipsis aria-hidden />}
-                  className="text-subtle-foreground hover:text-foreground"
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent side="bottom" align="end" className="min-w-[180px]">
-                <div className="px-2 pb-1 pt-1 text-aux text-subtle-foreground">
-                  {t("recentChats.groupBy")}
-                </div>
-                {[
-                  { mode: "date" as const, label: t("recentChats.groupByDate") },
-                  { mode: "project" as const, label: t("recentChats.groupByProjects") },
-                ].map(({ mode, label }) => {
-                  const selected = groupMode === mode;
-                  return (
-                    <DropdownMenuItem
-                      key={mode}
-                      onSelect={() => setGroupMode(mode)}
-                      className={
-                        selected ? "text-ui text-foreground" : "text-ui text-foreground/85"
-                      }
-                    >
-                      <span>{label}</span>
-                      {selected ? (
-                        <Check className="ml-auto h-3.5 w-3.5 text-subtle-foreground" aria-hidden />
-                      ) : null}
-                    </DropdownMenuItem>
-                  );
-                })}
-                <div className="px-2 pb-1 pt-2 text-aux text-subtle-foreground">
-                  {t("recentChats.status")}
-                </div>
-                {[
-                  { value: "all" as const, label: t("recentChats.statusAll") },
-                  { value: "active" as const, label: t("recentChats.statusActive") },
-                  { value: "archived" as const, label: t("recentChats.statusArchived") },
-                ].map(({ value, label }) => {
-                  const selected = statusFilter === value;
-                  return (
-                    <DropdownMenuItem
-                      key={value}
-                      onSelect={() => setStatusFilter(value)}
-                      className={
-                        selected ? "text-ui text-foreground" : "text-ui text-foreground/85"
-                      }
-                    >
-                      <span>{label}</span>
-                      {selected ? (
-                        <Check className="ml-auto h-3.5 w-3.5 text-subtle-foreground" aria-hidden />
-                      ) : null}
-                    </DropdownMenuItem>
-                  );
-                })}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </div>
-        <div className="px-3 pt-2 pb-3">
-          {hasPinned ? (
-            <section
-              aria-labelledby="recent-chats-pinned-heading"
-              className="mb-4"
-              data-pinned-section
-            >
-              <button
-                type="button"
-                id="recent-chats-pinned-heading"
-                onClick={() => toggleGroup("section:pinned")}
-                aria-expanded={!pinnedCollapsed}
-                className="flex items-center gap-2 rounded-4 border border-transparent px-2 pb-1 pt-3 text-aux text-subtle-foreground transition outline-none hover:text-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring"
-              >
-                {t("recentChats.pinned")}
-                {pinnedCollapsed ? (
-                  <ChevronRightIcon className="h-3.5 w-3.5" aria-hidden />
-                ) : (
-                  <ChevronDownIcon className="h-3.5 w-3.5" aria-hidden />
-                )}
-              </button>
+            <div className="px-3 pt-2">
               {pinnedCollapsed ? null : (
-                <div className="space-y-1">
-                  {pinnedChats.map((session) => renderChatRow(session))}
-                  {pinnedProjects.map(({ projectPath, name, items }) =>
-                    renderProjectGroup({
-                      key: `pinned-project:${projectPath}`,
-                      label: name,
-                      items,
-                      projectPath,
-                      pinned: true,
-                    }),
-                  )}
-                </div>
+                <ConversationCollection
+                  items={pinnedItems}
+                  renderChat={renderChatRow}
+                  renderProject={renderProjectListItem}
+                />
               )}
-            </section>
-          ) : null}
-          {phase === "loading" ? (
-            <div className="space-y-1 px-2 py-2" aria-hidden>
-              <Skeleton className="h-8 w-full" />
-              <Skeleton className="h-8 w-4/5" />
-              <Skeleton className="h-8 w-3/5" />
             </div>
-          ) : !hasPinned && regularSessions.length === 0 ? (
-            // Only reachable with nothing to show: a refetch that fails while the
-            // list already has rows keeps the rows rather than blanking them.
-            phase === "error" ? (
-              <div className="px-3 py-8 text-center" role="alert">
-                <p className="text-aux text-subtle-foreground">
-                  {t("recentChats.searchLoadError")}
-                </p>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="mt-3"
-                  onClick={() => void loadSessions()}
-                >
-                  {t("recentChats.searchRetry")}
-                </Button>
+          </section>
+        ) : null}
+        <ConversationCollectionHeader
+          id="recent-chats-heading"
+          title={t("recentChats.title")}
+          controls={renderListMenu()}
+          collapsed={chatsCollapsed}
+          onToggle={() => toggleGroup("section:chats")}
+        />
+        {chatsCollapsed ? null : (
+          <div className="px-3 pt-2 pb-3">
+            {phase === "loading" ? (
+              <div className="space-y-1 px-2 py-2" aria-hidden>
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-4/5" />
+                <Skeleton className="h-8 w-3/5" />
               </div>
-            ) : (
-              <div className="px-3 py-8 text-center text-aux text-subtle-foreground">
-                {t("recentChats.empty")}
-              </div>
-            )
-          ) : groupMode === "project" ? (
-            <>
-              {standaloneSessions.length > 0 ? (
-                <section aria-label={t("recentChats.title")} className="space-y-1">
-                  {standaloneSessions.map((session) => renderChatRow(session))}
-                </section>
-              ) : null}
-              {projectGroups.length > 0 ? (
-                <section
-                  aria-label={
-                    hasPinned || standaloneSessions.length > 0
-                      ? undefined
-                      : t("recentChats.sectionProjects")
-                  }
-                  aria-labelledby={
-                    hasPinned || standaloneSessions.length > 0
-                      ? "recent-chats-projects-heading"
-                      : undefined
-                  }
-                >
-                  {hasPinned || standaloneSessions.length > 0 ? (
-                    <h2
-                      id="recent-chats-projects-heading"
-                      className="px-2 pb-1 pt-3 text-aux text-subtle-foreground"
-                    >
-                      {t("recentChats.sectionProjects")}
-                    </h2>
-                  ) : null}
-                  <div className="space-y-1">
-                    {projectGroups.map(({ key, label, items, projectPath }) =>
-                      renderProjectGroup({
-                        key,
-                        label,
-                        items,
-                        projectPath,
-                        pinned: false,
-                      }),
-                    )}
-                  </div>
-                </section>
-              ) : null}
-            </>
-          ) : (
-            dateGroups.map(({ key, label, items }) => {
-              const collapsed = collapsedGroups.has(key);
-              return (
-                <section key={key} className="mb-4 last:mb-0">
-                  <button
+            ) : !hasPinned && regularSessions.length === 0 ? (
+              // Only reachable with nothing to show: a refetch that fails while the
+              // list already has rows keeps the rows rather than blanking them.
+              phase === "error" ? (
+                <div className="px-3 py-8 text-center" role="alert">
+                  <p className="text-aux text-subtle-foreground">
+                    {t("recentChats.searchLoadError")}
+                  </p>
+                  <Button
                     type="button"
-                    onClick={() => toggleGroup(key)}
-                    aria-expanded={!collapsed}
-                    className="flex items-center gap-2 rounded-4 border border-transparent px-2 pb-1 pt-3 text-aux text-subtle-foreground transition outline-none hover:text-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring"
+                    variant="outline"
+                    size="sm"
+                    className="mt-3"
+                    onClick={() => void loadSessions()}
                   >
-                    <span>{label}</span>
-                    {collapsed ? (
-                      <ChevronRightIcon className="h-3.5 w-3.5" aria-hidden />
-                    ) : (
-                      <ChevronDownIcon className="h-3.5 w-3.5" aria-hidden />
+                    {t("recentChats.searchRetry")}
+                  </Button>
+                </div>
+              ) : (
+                <div className="px-3 py-8 text-center text-aux text-subtle-foreground">
+                  {t("recentChats.empty")}
+                </div>
+              )
+            ) : groupMode === "project" ? (
+              <section aria-labelledby="recent-chats-heading">
+                <ConversationCollection
+                  items={projectModeItems}
+                  renderChat={renderChatRow}
+                  renderProject={renderProjectListItem}
+                />
+              </section>
+            ) : (
+              dateGroups.map(({ key, label, items }) => {
+                const collapsed = collapsedGroups.has(key);
+                return (
+                  <section key={key} className="group/collection-toggle mb-4 last:mb-0">
+                    <h3>
+                      <ConversationCollectionToggle
+                        title={label}
+                        collapsed={collapsed}
+                        onToggle={() => toggleGroup(key)}
+                        className="px-2 pb-1 pt-3"
+                      />
+                    </h3>
+                    {collapsed ? null : (
+                      <div className="space-y-1">
+                        {items.map((session) => renderChatRow(session))}
+                      </div>
                     )}
-                  </button>
-                  {collapsed ? null : (
-                    <div className="space-y-1">
-                      {items.map((session) => renderChatRow(session))}
-                    </div>
-                  )}
-                </section>
-              );
-            })
-          )}
-        </div>
+                  </section>
+                );
+              })
+            )}
+          </div>
+        )}
         <RomeConfirmDialog
           open={pendingDeleteId !== null}
           destructive

--- a/packages/web/src/shell/RecentChats.tsx
+++ b/packages/web/src/shell/RecentChats.tsx
@@ -133,6 +133,12 @@ function projectNameFromPath(projectPath: string): string {
   return projectPath.split(/[\\/]/).filter(Boolean).at(-1) ?? projectPath;
 }
 
+function isStandaloneProjectPath(projectPath: string): boolean {
+  return /^chats\/[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    projectPath,
+  );
+}
+
 function isDefaultProjectChat(session: ChatSession): boolean {
   return (
     session.projectPath === DEFAULT_PROJECT_NAME ||
@@ -305,9 +311,18 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
     [pinnedProjectPaths, sessions],
   );
 
+  const standaloneSessions = useMemo(
+    () =>
+      regularSessions.filter(
+        (session) => !!session.projectPath && isStandaloneProjectPath(session.projectPath),
+      ),
+    [regularSessions],
+  );
+
   const projectGroups = useMemo<SessionGroup[]>(() => {
     const buckets = new Map<string, { label: string; items: ChatSession[]; projectPath: string }>();
     for (const session of regularSessions) {
+      if (session.projectPath && isStandaloneProjectPath(session.projectPath)) continue;
       const projectPath = projectPathForSession(session);
       const rawKey = projectPath || session.projectName || "";
       if (!rawKey) continue;
@@ -881,32 +896,47 @@ export function RecentChats({ onSearch }: RecentChatsProps) {
               </div>
             )
           ) : groupMode === "project" ? (
-            projectGroups.length > 0 ? (
-              <section
-                aria-label={hasPinned ? undefined : t("recentChats.sectionProjects")}
-                aria-labelledby={hasPinned ? "recent-chats-projects-heading" : undefined}
-              >
-                {hasPinned ? (
-                  <h2
-                    id="recent-chats-projects-heading"
-                    className="px-2 pb-1 pt-3 text-aux text-subtle-foreground"
-                  >
-                    {t("recentChats.sectionProjects")}
-                  </h2>
-                ) : null}
-                <div className="space-y-1">
-                  {projectGroups.map(({ key, label, items, projectPath }) =>
-                    renderProjectGroup({
-                      key,
-                      label,
-                      items,
-                      projectPath,
-                      pinned: false,
-                    }),
-                  )}
-                </div>
-              </section>
-            ) : null
+            <>
+              {standaloneSessions.length > 0 ? (
+                <section aria-label={t("recentChats.title")} className="space-y-1">
+                  {standaloneSessions.map((session) => renderChatRow(session))}
+                </section>
+              ) : null}
+              {projectGroups.length > 0 ? (
+                <section
+                  aria-label={
+                    hasPinned || standaloneSessions.length > 0
+                      ? undefined
+                      : t("recentChats.sectionProjects")
+                  }
+                  aria-labelledby={
+                    hasPinned || standaloneSessions.length > 0
+                      ? "recent-chats-projects-heading"
+                      : undefined
+                  }
+                >
+                  {hasPinned || standaloneSessions.length > 0 ? (
+                    <h2
+                      id="recent-chats-projects-heading"
+                      className="px-2 pb-1 pt-3 text-aux text-subtle-foreground"
+                    >
+                      {t("recentChats.sectionProjects")}
+                    </h2>
+                  ) : null}
+                  <div className="space-y-1">
+                    {projectGroups.map(({ key, label, items, projectPath }) =>
+                      renderProjectGroup({
+                        key,
+                        label,
+                        items,
+                        projectPath,
+                        pinned: false,
+                      }),
+                    )}
+                  </div>
+                </section>
+              ) : null}
+            </>
           ) : (
             dateGroups.map(({ key, label, items }) => {
               const collapsed = collapsedGroups.has(key);

--- a/packages/web/src/shell/RomeShellLayout.tsx
+++ b/packages/web/src/shell/RomeShellLayout.tsx
@@ -1,5 +1,5 @@
 import { Cross1Icon, HamburgerMenuIcon } from "@radix-ui/react-icons";
-import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { PanelLeftClose, PanelLeftOpen, Search } from "lucide-react";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
@@ -8,7 +8,7 @@ import { IconButton } from "../components/ui/icon-button";
 import { MobileBackdrop } from "../components/ui/mobile-backdrop";
 import { SlotOutlet } from "../components/slot";
 import { AppGrid } from "./AppGrid";
-import { ChatSearchDialog } from "./ChatSearchDialog";
+import { ChatSearchDialog, chatSearchShortcutForPlatform } from "./ChatSearchDialog";
 import { ProfileMenu } from "./ProfileMenu";
 import { RecentChats } from "./RecentChats";
 import { SUPPORTED_LANGUAGES } from "@/i18n";
@@ -187,6 +187,16 @@ export function RomeShellLayout() {
                   <div ref={setAppGridControlsHost} />
                   <IconButton
                     size="md"
+                    label={t("sidebar.search")}
+                    title={t("sidebar.searchShortcut", {
+                      shortcut: chatSearchShortcutForPlatform(),
+                    })}
+                    icon={<Search aria-hidden />}
+                    onClick={() => setChatSearchOpen(true)}
+                    className="text-subtle-foreground hover:text-foreground"
+                  />
+                  <IconButton
+                    size="md"
                     label={t("nav.collapseSidebar")}
                     title={t("nav.collapseSidebarShortcut", { shortcut: sidebarShortcut })}
                     icon={<PanelLeftClose aria-hidden />}
@@ -209,7 +219,7 @@ export function RomeShellLayout() {
               ) : (
                 <>
                   <AppGrid headerControlsHost={appGridControlsHost} />
-                  <RecentChats onSearch={() => setChatSearchOpen(true)} />
+                  <RecentChats />
                 </>
               )}
             </div>


### PR DESCRIPTION
## What this PR does

Standalone WebChat sessions created without a project selection reused the default project workspace, while the sidebar represented projects and standalone chats as separate collections with inconsistent controls. This made no-project sessions look like projects and made pinning, grouping, and rediscovery harder to reason about.

This PR gives every implicit WebChat session its own `chats/<session UUID>` workspace, keeps explicit project selection intact, and presents pinned projects/chats plus remaining projects/standalone chats through shared sidebar collection components.

## Design & Invariants

- An explicitly selected project keeps its project workspace.
- An implicit WebChat session gets an isolated workspace and is not materialized as a first-class project.
- Pinned projects and chats share one activity-ordered collection.
- Remaining project groups and standalone chats share one activity-ordered Chats collection.
- Collection and date-group headers reuse the same control behavior: expanded chevrons appear on hover, while collapsed chevrons remain visible.

## Test plan

- [x] `nix develop -c pnpm typecheck`
- [x] Focused core workspace tests: 122 passed.
- [x] Focused web workspace tests: 60 passed.
- [x] Focused `RecentChats` tests: 29 passed.
- [x] Full web assertions: 1,362 passed. The local runner then hit an existing React cleanup worker exit.
- [x] `pnpm dev:all`; the container reached `Rome started` and the dashboard returned HTTP 200.
- [x] Browser acceptance: created two no-project chats and one explicit `default` project chat; verified isolation, rediscovery, mixed project/chat ordering, pinning, grouping, and collapse controls.
- [ ] CI unit and layout jobs are running.

## Not in this PR

- Session API cache policy is tracked separately in #257.

The isolated dev instance had no AI model provider configured, so browser turns showed the expected provider configuration error; session creation, persistence, filesystem isolation, and navigation were verified independently.

Refs #244