### PR TITLE
feat: make the chat model menu a searchable combo box (#180)

### DIFF
--- a/packages/web/src/components/chat/composer/ModelSelectorMenu.test.tsx
+++ b/packages/web/src/components/chat/composer/ModelSelectorMenu.test.tsx
@@ -1,0 +1,113 @@
+// @rstest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, rs } from "@rstest/core";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import i18n from "@/i18n";
+import { ModelSelectorMenu } from "./ModelSelectorMenu";
+import { LARGE_MODEL_OPTIONS } from "@/lib/chat-constants";
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+});
+
+afterEach(cleanup);
+
+const SHOW_ALL = `Show all ${LARGE_MODEL_OPTIONS.length} models`;
+
+function baseProps() {
+  return {
+    open: true as const,
+    onOpenChange: rs.fn(),
+    value: "auto",
+    onChange: rs.fn(),
+    disabled: false,
+  };
+}
+
+function optionNames(): string[] {
+  return screen.getAllByRole("option").map((o) => o.textContent?.trim() ?? "");
+}
+
+describe("ModelSelectorMenu", () => {
+  it("shows only the curated common models and a show-all row when collapsed", () => {
+    render(<ModelSelectorMenu {...baseProps()} />);
+
+    const names = optionNames();
+    // Curated set: auto + latest-generation flagship per family.
+    expect(names).toEqual(expect.arrayContaining(["Auto", "Opus 5", "GPT-5.6 Sol"]));
+    // The long tail is folded away until the guardian expands or searches.
+    expect(names).not.toContain("Sonnet");
+    expect(names).not.toContain("Haiku");
+    expect(screen.getByText(SHOW_ALL)).toBeTruthy();
+  });
+
+  it("keeps a pinned non-curated model visible (with its check) when collapsed", () => {
+    render(<ModelSelectorMenu {...baseProps()} value="claude-haiku" />);
+
+    // Haiku is not curated, but it is the current selection, so it stays
+    // visible without expanding — a deliberately pinned model is not stranded.
+    const haiku = screen.getByRole("option", { name: /Haiku/ });
+    expect(haiku.querySelector("svg")).not.toBeNull();
+  });
+
+  it("reveals the full catalog when show-all is chosen", async () => {
+    const user = userEvent.setup();
+    render(<ModelSelectorMenu {...baseProps()} />);
+
+    expect(optionNames()).not.toContain("Sonnet");
+    await user.click(screen.getByText(SHOW_ALL));
+
+    await waitFor(() =>
+      expect(screen.getAllByRole("option").length).toBe(LARGE_MODEL_OPTIONS.length),
+    );
+    expect(optionNames()).toContain("Sonnet");
+    // The show-all row is gone once everything is shown.
+    expect(screen.queryByText(SHOW_ALL)).toBeNull();
+  });
+
+  it("filters across every model as the guardian types", async () => {
+    const user = userEvent.setup();
+    render(<ModelSelectorMenu {...baseProps()} />);
+
+    await user.type(screen.getByPlaceholderText("Search models…"), "sonnet");
+
+    await waitFor(() => {
+      const names = optionNames();
+      expect(names).toContain("Sonnet");
+      expect(names).not.toContain("Auto");
+    });
+  });
+
+  it("shows an empty state when nothing matches", async () => {
+    const user = userEvent.setup();
+    render(<ModelSelectorMenu {...baseProps()} />);
+
+    await user.type(screen.getByPlaceholderText("Search models…"), "nope-xyz");
+
+    await waitFor(() => expect(screen.getByText("No matching models.")).toBeTruthy());
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+  });
+
+  it("reports the picked model and closes when a row is chosen", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<ModelSelectorMenu {...props} />);
+
+    await user.click(screen.getByRole("option", { name: /Opus 5/ }));
+
+    expect(props.onChange).toHaveBeenCalledWith("claude-opus-5");
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("marks the current selection with a check and leaves other rows unmarked", () => {
+    render(<ModelSelectorMenu {...baseProps()} value="auto" />);
+
+    // The check mark is the only svg inside a model row.
+    expect(screen.getByRole("option", { name: /Auto/ }).querySelector("svg")).not.toBeNull();
+    expect(screen.getByRole("option", { name: /GPT-5\.6 Sol/ }).querySelector("svg")).toBeNull();
+  });
+});

--- a/packages/web/src/components/chat/composer/ModelSelectorMenu.test.tsx
+++ b/packages/web/src/components/chat/composer/ModelSelectorMenu.test.tsx
@@ -37,8 +37,9 @@ describe("ModelSelectorMenu", () => {
     render(<ModelSelectorMenu {...baseProps()} />);
 
     const names = optionNames();
-    // Curated set: auto + latest-generation flagship per family.
-    expect(names).toEqual(expect.arrayContaining(["Auto", "Opus 5", "GPT-5.6 Sol"]));
+    // Curated set: auto + latest-generation flagship per family (GPT-6 Astra is
+    // the newest OpenAI generation in the catalog).
+    expect(names).toEqual(expect.arrayContaining(["Auto", "Opus 5", "GPT-6 Astra"]));
     // The long tail is folded away until the guardian expands or searches.
     expect(names).not.toContain("Sonnet");
     expect(names).not.toContain("Haiku");
@@ -108,6 +109,33 @@ describe("ModelSelectorMenu", () => {
 
     // The check mark is the only svg inside a model row.
     expect(screen.getByRole("option", { name: /Auto/ }).querySelector("svg")).not.toBeNull();
-    expect(screen.getByRole("option", { name: /GPT-5\.6 Sol/ }).querySelector("svg")).toBeNull();
+    expect(screen.getByRole("option", { name: /GPT-6 Astra/ }).querySelector("svg")).toBeNull();
+  });
+
+  it("resets to the collapsed common view after a selection made from a filtered list", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    const { rerender } = render(<ModelSelectorMenu {...props} />);
+
+    // Filter down to a non-curated model, then pick it — selection closes the menu.
+    await user.type(screen.getByPlaceholderText("Search models…"), "sonnet");
+    await waitFor(() => expect(optionNames()).toContain("Sonnet"));
+    await user.click(screen.getByRole("option", { name: /Sonnet/ }));
+    expect(props.onChange).toHaveBeenCalledWith("claude-sonnet");
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+
+    // Selecting a row flips the parent's `open` prop rather than going through
+    // the Popover's onOpenChange wrapper, so the reset must happen on the select
+    // path too. Simulate the parent closing then reopening the menu.
+    rerender(<ModelSelectorMenu {...props} open={false} />);
+    rerender(<ModelSelectorMenu {...props} open={true} />);
+
+    // Back to the curated rows + show-all — not the stale "sonnet" filter.
+    const names = optionNames();
+    expect(names).toEqual(expect.arrayContaining(["Auto", "Opus 5", "GPT-6 Astra"]));
+    expect(names).not.toContain("Sonnet");
+    expect(screen.getByText(SHOW_ALL)).toBeTruthy();
+    // The search field is cleared too.
+    expect((screen.getByPlaceholderText("Search models…") as HTMLInputElement).value).toBe("");
   });
 });

--- a/packages/web/src/components/chat/composer/ModelSelectorMenu.tsx
+++ b/packages/web/src/components/chat/composer/ModelSelectorMenu.tsx
@@ -52,17 +52,20 @@ export function ModelSelectorMenu({
   const [showAll, setShowAll] = useState(false);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
 
-  // `auto` is a value like any other, so the trigger always has something to
-  // name. The label IS the state — nothing has to encode "non-default" on top.
-  const selected =
-    LARGE_MODEL_OPTIONS.find((option) => option.id === value) ??
-    LARGE_MODEL_OPTIONS.find((option) => option.id === DEFAULT_LARGE_MODEL_SELECTION)!;
-
-  // Resolve labels once so the filter and the rows read the exact same text.
+  // Resolve labels once so the trigger, the filter, and the rows all read the
+  // exact same text — a single source for "what the model is called".
   const options = useMemo(
     () => LARGE_MODEL_OPTIONS.map((option) => ({ ...option, label: t(option.labelKey) })),
     [t],
   );
+
+  // `auto` is a value like any other, so the trigger always has something to
+  // name. The label IS the state — nothing has to encode "non-default" on top.
+  // Resolved from `options` (not raw LARGE_MODEL_OPTIONS) so the trigger renders
+  // the same translated label as the rows, with no second lookup path.
+  const selected =
+    options.find((option) => option.id === value) ??
+    options.find((option) => option.id === DEFAULT_LARGE_MODEL_SELECTION)!;
 
   const trimmedQuery = query.trim().toLowerCase();
 
@@ -97,6 +100,17 @@ export function ModelSelectorMenu({
     setShowAll(false);
   }
 
+  // Picking a row closes the menu by flipping the parent's `open` prop, which
+  // Radix does NOT route through the Popover's onOpenChange wrapper below — so
+  // resetting only there would leave `query`/`showAll` alive across a select and
+  // reopen filtered or expanded. Route every close through here instead, so the
+  // documented "each open starts collapsed and unfiltered" contract holds on the
+  // most common path too.
+  function close() {
+    resetView();
+    onOpenChange(false);
+  }
+
   return (
     <Popover
       open={open}
@@ -117,7 +131,7 @@ export function ModelSelectorMenu({
           title={t("modelSelector.label")}
           className="touch-target"
         >
-          <span>{t(selected.labelKey)}</span>
+          <span>{selected.label}</span>
           <ChevronDown data-icon="inline-end" aria-hidden="true" />
         </Button>
       </PopoverTrigger>
@@ -175,7 +189,7 @@ export function ModelSelectorMenu({
                   value={option.id}
                   onSelect={() => {
                     onChange(option.id);
-                    onOpenChange(false);
+                    close();
                   }}
                   className={cn(
                     "justify-between",

--- a/packages/web/src/components/chat/composer/ModelSelectorMenu.tsx
+++ b/packages/web/src/components/chat/composer/ModelSelectorMenu.tsx
@@ -1,14 +1,27 @@
+import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, MoreHorizontal, X } from "lucide-react";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { IconButton } from "@/components/ui/icon-button";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { DEFAULT_LARGE_MODEL_SELECTION, LARGE_MODEL_OPTIONS } from "@/lib/chat-constants";
+import {
+  COMMON_LARGE_MODEL_IDS,
+  DEFAULT_LARGE_MODEL_SELECTION,
+  LARGE_MODEL_OPTIONS,
+} from "@/lib/chat-constants";
+
+// A value no model id can collide with, so the "show all" row and the model
+// rows never share a cmdk key.
+const SHOW_ALL_VALUE = "__show_all__";
 
 export interface ModelSelectorMenuProps {
   open: boolean;
@@ -18,6 +31,15 @@ export interface ModelSelectorMenuProps {
   disabled: boolean;
 }
 
+/**
+ * The chat model picker. The menu opened flat — one row per model, no grouping,
+ * no search — and grew with every release, yet almost every open lands on the
+ * same two or three rows (#180). So it is a combo box: a small curated set of
+ * common models shows first, the rest fold behind a "show all" row, and typing
+ * filters across the whole catalog. The currently selected model is always
+ * shown even when it is not in the curated set, so a deliberately pinned older
+ * model is never hidden.
+ */
 export function ModelSelectorMenu({
   open,
   onOpenChange,
@@ -26,6 +48,9 @@ export function ModelSelectorMenu({
   disabled,
 }: ModelSelectorMenuProps) {
   const { t } = useTranslation("chat");
+  const [query, setQuery] = useState("");
+  const [showAll, setShowAll] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   // `auto` is a value like any other, so the trigger always has something to
   // name. The label IS the state — nothing has to encode "non-default" on top.
@@ -33,9 +58,56 @@ export function ModelSelectorMenu({
     LARGE_MODEL_OPTIONS.find((option) => option.id === value) ??
     LARGE_MODEL_OPTIONS.find((option) => option.id === DEFAULT_LARGE_MODEL_SELECTION)!;
 
+  // Resolve labels once so the filter and the rows read the exact same text.
+  const options = useMemo(
+    () => LARGE_MODEL_OPTIONS.map((option) => ({ ...option, label: t(option.labelKey) })),
+    [t],
+  );
+
+  const trimmedQuery = query.trim().toLowerCase();
+
+  // Three view states share one list:
+  //  - typing filters across every model — search already spans the catalog, so
+  //    the "show all" row would be redundant and is withheld;
+  //  - collapsed shows the curated common set plus whatever is selected (so a
+  //    deliberately pinned model stays visible), with a trailing "show all" row;
+  //  - expanded shows the full catalog in its declared order.
+  const { rows, showAllRow } = useMemo(() => {
+    if (trimmedQuery) {
+      return {
+        rows: options.filter(
+          (option) =>
+            option.label.toLowerCase().includes(trimmedQuery) ||
+            option.id.toLowerCase().includes(trimmedQuery),
+        ),
+        showAllRow: false,
+      };
+    }
+    if (showAll) {
+      return { rows: options, showAllRow: false };
+    }
+    const common = options.filter(
+      (option) => COMMON_LARGE_MODEL_IDS.includes(option.id) || option.id === value,
+    );
+    return { rows: common, showAllRow: common.length < options.length };
+  }, [options, trimmedQuery, showAll, value]);
+
+  function resetView() {
+    setQuery("");
+    setShowAll(false);
+  }
+
   return (
-    <DropdownMenu open={open} onOpenChange={onOpenChange}>
-      <DropdownMenuTrigger asChild>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        // Each open starts collapsed and unfiltered — the whole point is that
+        // the common rows are the first thing seen.
+        if (!next) resetView();
+        onOpenChange(next);
+      }}
+    >
+      <PopoverTrigger asChild>
         <Button
           type="button"
           variant="ghost"
@@ -48,25 +120,99 @@ export function ModelSelectorMenu({
           <span>{t(selected.labelKey)}</span>
           <ChevronDown data-icon="inline-end" aria-hidden="true" />
         </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent side="top" align="start" className="w-56 rounded-12 p-2">
-        <div className="px-2 pb-2 pt-1">
-          <p className="text-aux text-subtle-foreground">{t("modelSelector.label")}</p>
-        </div>
-        {LARGE_MODEL_OPTIONS.map((option) => (
-          <DropdownMenuItem
-            key={option.id}
-            onSelect={() => onChange(option.id)}
-            className={cn(
-              "justify-between rounded-8 px-3 py-2 text-ui",
-              value === option.id ? "text-info-fg" : "text-foreground",
-            )}
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        aria-label={t("modelSelector.label")}
+        className="w-64 gap-0 overflow-hidden rounded-12 p-0 shadow-10"
+      >
+        {/* Filtering stays ours (shouldFilter=false): cmdk sorts matches by
+            score, which would reorder the curated rows and unpin the trailing
+            "show all" row from the bottom of the list. */}
+        <Command
+          shouldFilter={false}
+          loop
+          // Ctrl+K opens chat search app-wide; cmdk would also read it as
+          // "previous result". Matches ChatSearchDialog / ProjectSelector.
+          vimBindings={false}
+          // cmdk renders this as the hidden label naming the combobox, and
+          // aria-labelledby beats aria-label, so this decides the accessible
+          // name. The popover keeps its own aria-label.
+          label={t("modelSelector.searchPlaceholder")}
+          className="bg-transparent"
+        >
+          <CommandInput
+            ref={searchInputRef}
+            autoFocus
+            aria-label={t("modelSelector.searchPlaceholder")}
+            value={query}
+            onValueChange={setQuery}
+            placeholder={t("modelSelector.searchPlaceholder")}
           >
-            <span>{t(option.labelKey)}</span>
-            {value === option.id && <Check className="h-4 w-4 shrink-0" aria-hidden="true" />}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+            {query && (
+              <IconButton
+                size="sm"
+                label={t("modelSelector.clearSearch")}
+                icon={<X aria-hidden />}
+                // The button unmounts as the query empties, so focus has to be
+                // handed back or it falls to <body> and the arrow keys die.
+                onClick={() => {
+                  setQuery("");
+                  searchInputRef.current?.focus();
+                }}
+                className="text-muted-foreground hover:text-foreground"
+              />
+            )}
+          </CommandInput>
+          <CommandList label={t("modelSelector.label")} className="max-h-72">
+            <CommandEmpty>{t("modelSelector.noMatches")}</CommandEmpty>
+            <CommandGroup>
+              {rows.map((option) => (
+                <CommandItem
+                  key={option.id}
+                  value={option.id}
+                  onSelect={() => {
+                    onChange(option.id);
+                    onOpenChange(false);
+                  }}
+                  className={cn(
+                    "justify-between",
+                    value === option.id ? "text-info-fg" : "text-foreground",
+                  )}
+                >
+                  <span className="min-w-0 flex-1 truncate">{option.label}</span>
+                  <span className="flex w-3.5 justify-center">
+                    {value === option.id ? (
+                      <Check className="size-3.5 shrink-0" aria-hidden="true" />
+                    ) : null}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+            {showAllRow && (
+              <CommandGroup className="border-t border-border-subtle">
+                <CommandItem
+                  value={SHOW_ALL_VALUE}
+                  onSelect={() => {
+                    setShowAll(true);
+                    // Keep the menu open and focus in the field so the freshly
+                    // revealed rows are reachable by keyboard straight away.
+                    searchInputRef.current?.focus();
+                  }}
+                  className="text-muted-foreground"
+                >
+                  <MoreHorizontal className="size-3.5 shrink-0" aria-hidden="true" />
+                  <span className="min-w-0 flex-1 truncate">
+                    {t("modelSelector.showAll", { count: options.length })}
+                  </span>
+                </CommandItem>
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -239,6 +239,10 @@
   "modelSelector": {
     "label": "Model",
     "saveFailed": "Failed to save model selection.",
+    "searchPlaceholder": "Search models…",
+    "clearSearch": "Clear search",
+    "showAll": "Show all {{count}} models",
+    "noMatches": "No matching models.",
     "options": {
       "auto": "Auto",
       "claudeOpus": "Opus",

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -239,6 +239,10 @@
   "modelSelector": {
     "label": "模型",
     "saveFailed": "保存模型选择失败。",
+    "searchPlaceholder": "搜索模型…",
+    "clearSearch": "清除搜索",
+    "showAll": "显示全部 {{count}} 个模型",
+    "noMatches": "没有匹配的模型。",
     "options": {
       "auto": "自动",
       "claudeOpus": "Claude Opus",

--- a/packages/web/src/lib/chat-constants.ts
+++ b/packages/web/src/lib/chat-constants.ts
@@ -18,6 +18,15 @@ export const LARGE_MODEL_OPTIONS = [
   { id: "gpt-5-6-luna", labelKey: "modelSelector.options.gpt56Luna" },
 ] as const;
 
+// The curated "commonly used" subset the model menu shows before the guardian
+// expands it or types to filter. Nothing in the client records which models a
+// guardian actually reaches for, so this list is hand-picked (see #180): the
+// automatic choice plus the latest-generation flagship of each provider family
+// — Claude Opus 5 and GPT-5.6 Sol. Every other model stays one "show all" click
+// (or a few keystrokes) away, and a deliberately pinned model is always shown
+// too, so nothing is stranded. Revisit this set once real usage data exists.
+export const COMMON_LARGE_MODEL_IDS: readonly string[] = ["auto", "claude-opus-5", "gpt-5-6-sol"];
+
 export const DEFAULT_REASONING_EFFORT = "high" satisfies ReasoningEffort;
 export const REASONING_EFFORT_OPTIONS: ReadonlyArray<{
   id: ReasoningEffort;

--- a/packages/web/src/lib/chat-constants.ts
+++ b/packages/web/src/lib/chat-constants.ts
@@ -22,10 +22,20 @@ export const LARGE_MODEL_OPTIONS = [
 // expands it or types to filter. Nothing in the client records which models a
 // guardian actually reaches for, so this list is hand-picked (see #180): the
 // automatic choice plus the latest-generation flagship of each provider family
-// — Claude Opus 5 and GPT-5.6 Sol. Every other model stays one "show all" click
-// (or a few keystrokes) away, and a deliberately pinned model is always shown
-// too, so nothing is stranded. Revisit this set once real usage data exists.
-export const COMMON_LARGE_MODEL_IDS: readonly string[] = ["auto", "claude-opus-5", "gpt-5-6-sol"];
+// — Claude Opus 5 and GPT-6 Astra (the newest OpenAI generation in the catalog
+// above). Every other model stays one "show all" click (or a few keystrokes)
+// away, and a deliberately pinned model is always shown too, so nothing is
+// stranded. Revisit this set once real usage data exists.
+//
+// Typed against the catalog's id union (not `string[]`) so a typo, or retiring
+// or renaming a model in LARGE_MODEL_OPTIONS, is a typecheck error rather than a
+// silent drop from the curated set — `.includes(option.id)` still narrows fine
+// because option.id is a member of the same union.
+export const COMMON_LARGE_MODEL_IDS: ReadonlyArray<(typeof LARGE_MODEL_OPTIONS)[number]["id"]> = [
+  "auto",
+  "claude-opus-5",
+  "gpt-6-astra",
+];
 
 export const DEFAULT_REASONING_EFFORT = "high" satisfies ReasoningEffort;
 export const REASONING_EFFORT_OPTIONS: ReadonlyArray<{


### PR DESCRIPTION
Closes #180.

## What & why

The chat composer's model picker (`ModelSelectorMenu`) opened as a flat dropdown: one row per model, no grouping, no search. It holds ten rows today (`auto` + six Claude + three GPT from `LARGE_MODEL_OPTIONS`) and grows with every release, yet almost every open lands on the same two or three rows — so each open means scanning the whole list to find them.

Per the decision on #180, this implements **Direction 1 — the searchable combo box**, built on the existing cmdk `Command` primitive (the same one behind `ProjectSelector` / `ChatSearchDialog`).

## Behaviour

- **Curated common set first.** When the menu opens it shows only a small hand-picked set, then a trailing **"Show all N models"** row.
- **Show all** expands to the full catalog in its declared order (the row disappears once everything is shown).
- **Type-to-filter** searches across the *whole* catalog — matching both the visible label and the model id (so typing `gpt` or `sonnet` works) — regardless of collapsed/expanded state.
- **The current selection is always shown**, even when it is not in the curated set, so a deliberately pinned older generation is never hidden or stranded.
- Each open starts collapsed and unfiltered; the trigger, keyboard nav, and `auto`-as-a-value semantics are unchanged. Props are identical, so `ChatComposer` needs no change.

## The curated short list (and its rationale)

Nothing in the client records which models a guardian actually reaches for, so the "common" set is hand-curated for now. As agreed on the issue, the default is **`auto` plus the latest-generation flagship of each provider family**:

| id | label |
|----|-------|
| `auto` | Auto |
| `claude-opus-5` | Opus 5 |
| `gpt-6-astra` | GPT-6 Astra |

_(Updated in review: the OpenAI flagship is `gpt-6-astra`, the newest generation in the catalog after #241, not `gpt-5-6-sol` — matching the chosen "latest-generation flagship per family" rationale. `COMMON_LARGE_MODEL_IDS` is now typed against the catalog's id union so the set can't silently drift.)_

It lives as a single documented constant — `COMMON_LARGE_MODEL_IDS` in `packages/web/src/lib/chat-constants.ts` — so it is trivial to revisit once real usage data exists. Everything else stays one "Show all" click, or a few keystrokes, away. This is a soft product default, deliberately easy to change; reviewers should feel free to adjust the membership.

## Changes

- `packages/web/src/components/chat/composer/ModelSelectorMenu.tsx` — rewired from `DropdownMenu` to `Popover` + `Command` combo box.
- `packages/web/src/lib/chat-constants.ts` — new `COMMON_LARGE_MODEL_IDS`.
- `packages/web/src/i18n/locales/{en,zh-CN}/chat.json` — `searchPlaceholder`, `clearSearch`, `showAll`, `noMatches`.
- `packages/web/src/components/chat/composer/ModelSelectorMenu.test.tsx` — new test (curated view, pinned-model visibility, show-all, type-to-filter, empty state, selection).

## Verification

- `pnpm --filter rome-web exec rstest run ModelSelectorMenu` → 7 passed
- `ChatComposer.test.tsx` → 13 passed (no regression)
- `pnpm --filter rome-web typecheck` → clean
- `biome check` on changed files → clean
