### PR TITLE
feat(web): make the chat model picker a searchable combo box (#180)

### DIFF
--- a/packages/web/src/components/chat/composer/ModelSelectorMenu.test.tsx
+++ b/packages/web/src/components/chat/composer/ModelSelectorMenu.test.tsx
@@ -1,0 +1,104 @@
+// @rstest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, rs } from "@rstest/core";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import i18n from "@/i18n";
+import { ModelSelectorMenu } from "./ModelSelectorMenu";
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+});
+
+afterEach(cleanup);
+
+function baseProps() {
+  return {
+    open: true as const,
+    onOpenChange: rs.fn(),
+    value: "auto",
+    onChange: rs.fn(),
+    disabled: false,
+  };
+}
+
+function optionLabels(): string[] {
+  return screen.getAllByRole("option").map((node) => node.textContent?.trim() ?? "");
+}
+
+describe("model selector menu", () => {
+  it("opens on the short curated list rather than every model", () => {
+    render(<ModelSelectorMenu {...baseProps()} />);
+
+    // Curated common set: Auto + one flagship per family. Uncommon rows such as
+    // Haiku stay folded away until "show all" or a search.
+    const labels = optionLabels();
+    expect(labels).toContain("Auto");
+    expect(labels).toContain("Opus 5");
+    expect(labels).toContain("Sonnet");
+    expect(labels).toContain("GPT-6 Astra");
+    expect(labels).not.toContain("Haiku");
+    expect(labels).not.toContain("GPT-5.6 Luna");
+  });
+
+  it("reveals the full family-grouped list behind show all", async () => {
+    const user = userEvent.setup();
+    render(<ModelSelectorMenu {...baseProps()} />);
+
+    await user.click(screen.getByRole("button", { name: "Show all models" }));
+
+    const labels = optionLabels();
+    expect(labels).toContain("Haiku");
+    expect(labels).toContain("Fable");
+    expect(labels).toContain("GPT-5.6 Luna");
+    // Family headings make the long list scannable (issue #180, direction 2).
+    expect(screen.getByText("Claude", { selector: "[cmdk-group-heading]" })).toBeTruthy();
+    expect(screen.getByText("GPT", { selector: "[cmdk-group-heading]" })).toBeTruthy();
+  });
+
+  it("filters across every model as the guardian types, even from the short list", async () => {
+    const user = userEvent.setup();
+    render(<ModelSelectorMenu {...baseProps()} />);
+
+    await user.type(screen.getByPlaceholderText("Search models"), "haiku");
+
+    await waitFor(() => {
+      const labels = optionLabels();
+      expect(labels).toEqual(["Haiku"]);
+    });
+    // Search already spans everything, so the show-all toggle is withheld.
+    expect(screen.queryByRole("button", { name: /Show (all|fewer) models/ })).toBeNull();
+  });
+
+  it("shows an empty message when nothing matches the query", async () => {
+    const user = userEvent.setup();
+    render(<ModelSelectorMenu {...baseProps()} />);
+
+    await user.type(screen.getByPlaceholderText("Search models"), "zzzzz");
+
+    await waitFor(() => expect(screen.queryAllByRole("option")).toHaveLength(0));
+    expect(screen.getByText(/No models match/)).toBeTruthy();
+  });
+
+  it("keeps a selected uncommon model visible on the short list", () => {
+    render(<ModelSelectorMenu {...baseProps()} value="claude-haiku" />);
+
+    // Haiku is not curated, but the current selection is always shown so its
+    // check stays visible without expanding.
+    expect(optionLabels()).toContain("Haiku");
+  });
+
+  it("reports the picked model and closes the menu", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<ModelSelectorMenu {...props} />);
+
+    await user.click(screen.getByRole("option", { name: "Opus 5" }));
+
+    expect(props.onChange).toHaveBeenCalledWith("claude-opus-5");
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/web/src/components/chat/composer/ModelSelectorMenu.tsx
+++ b/packages/web/src/components/chat/composer/ModelSelectorMenu.tsx
@@ -1,14 +1,25 @@
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, ChevronUp, ListPlus, X } from "lucide-react";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
 import { cn } from "@/lib/utils";
-import { DEFAULT_LARGE_MODEL_SELECTION, LARGE_MODEL_OPTIONS } from "@/lib/chat-constants";
+import {
+  COMMON_LARGE_MODEL_IDS,
+  DEFAULT_LARGE_MODEL_SELECTION,
+  LARGE_MODEL_FAMILY_LABEL_KEYS,
+  LARGE_MODEL_FAMILY_ORDER,
+  LARGE_MODEL_OPTIONS,
+  type LargeModelOption,
+} from "@/lib/chat-constants";
 
 export interface ModelSelectorMenuProps {
   open: boolean;
@@ -18,6 +29,10 @@ export interface ModelSelectorMenuProps {
   disabled: boolean;
 }
 
+// The picker is a combobox rather than a flat menu (issue #180): the list grows
+// with every model release, yet almost every open ends on the same two or three
+// rows. So it opens on a short curated list, folds the rest behind "show all",
+// and filters every model as the guardian types.
 export function ModelSelectorMenu({
   open,
   onOpenChange,
@@ -26,6 +41,9 @@ export function ModelSelectorMenu({
   disabled,
 }: ModelSelectorMenuProps) {
   const { t } = useTranslation("chat");
+  const [query, setQuery] = useState("");
+  const [showAll, setShowAll] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   // `auto` is a value like any other, so the trigger always has something to
   // name. The label IS the state — nothing has to encode "non-default" on top.
@@ -33,9 +51,68 @@ export function ModelSelectorMenu({
     LARGE_MODEL_OPTIONS.find((option) => option.id === value) ??
     LARGE_MODEL_OPTIONS.find((option) => option.id === DEFAULT_LARGE_MODEL_SELECTION)!;
 
+  const trimmed = query.trim().toLowerCase();
+  const searching = trimmed.length > 0;
+
+  const matches = (option: LargeModelOption) =>
+    !searching ||
+    t(option.labelKey).toLowerCase().includes(trimmed) ||
+    option.id.toLowerCase().includes(trimmed);
+
+  const autoOption = LARGE_MODEL_OPTIONS.find((option) => !option.family);
+  const familyOptions = LARGE_MODEL_OPTIONS.filter((option) => option.family);
+
+  // The collapsed short list is the curated common set plus the current
+  // selection, so a deliberately-pinned uncommon model still shows its check.
+  const shortListIds = new Set<string>([...COMMON_LARGE_MODEL_IDS, value]);
+  const shortFamilyOptions = familyOptions.filter((option) => shortListIds.has(option.id));
+
+  // Expanded and searching both render the full set grouped by family; only the
+  // former keeps every row, the latter keeps the matches.
+  const grouped = LARGE_MODEL_FAMILY_ORDER.map((family) => ({
+    family,
+    options: familyOptions.filter((option) => option.family === family && matches(option)),
+  })).filter((group) => group.options.length > 0);
+
+  const autoVisible = autoOption ? matches(autoOption) : false;
+  const resultCount =
+    (autoVisible ? 1 : 0) + grouped.reduce((total, group) => total + group.options.length, 0);
+
+  // Reset the transient view each time the menu closes so the next open starts
+  // on the short list with an empty query.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setQuery("");
+      setShowAll(false);
+    }
+    onOpenChange(next);
+  };
+
+  const pick = (id: string) => {
+    onChange(id);
+    handleOpenChange(false);
+  };
+
+  const renderRow = (option: LargeModelOption) => {
+    const isSelected = option.id === value;
+    return (
+      <CommandItem
+        key={option.id}
+        value={option.id}
+        onSelect={() => pick(option.id)}
+        className={cn(isSelected ? "text-info-fg" : "text-foreground")}
+      >
+        <span className="min-w-0 flex-1 truncate">{t(option.labelKey)}</span>
+        <span className="flex w-3.5 justify-center">
+          {isSelected ? <Check className="size-3.5 shrink-0" aria-hidden /> : null}
+        </span>
+      </CommandItem>
+    );
+  };
+
   return (
-    <DropdownMenu open={open} onOpenChange={onOpenChange}>
-      <DropdownMenuTrigger asChild>
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
         <Button
           type="button"
           variant="ghost"
@@ -48,25 +125,103 @@ export function ModelSelectorMenu({
           <span>{t(selected.labelKey)}</span>
           <ChevronDown data-icon="inline-end" aria-hidden="true" />
         </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent side="top" align="start" className="w-56 rounded-12 p-2">
-        <div className="px-2 pb-2 pt-1">
-          <p className="text-aux text-subtle-foreground">{t("modelSelector.label")}</p>
-        </div>
-        {LARGE_MODEL_OPTIONS.map((option) => (
-          <DropdownMenuItem
-            key={option.id}
-            onSelect={() => onChange(option.id)}
-            className={cn(
-              "justify-between rounded-8 px-3 py-2 text-ui",
-              value === option.id ? "text-info-fg" : "text-foreground",
-            )}
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        aria-label={t("modelSelector.label")}
+        className="w-64 gap-0 overflow-hidden rounded-12 p-0 shadow-10"
+      >
+        {/* Filtering stays ours (shouldFilter={false}): it keeps `auto` pinned
+            above the families and preserves the curated generation order, which
+            cmdk's score-based sort would scramble. */}
+        <Command
+          shouldFilter={false}
+          loop
+          // Matches ChatSearchDialog: Ctrl+K opens chat search from anywhere,
+          // and cmdk would also read it as "previous result".
+          vimBindings={false}
+          // cmdk renders this as the hidden label naming the combobox input.
+          label={t("modelSelector.searchPlaceholder")}
+          className="bg-transparent"
+        >
+          <CommandInput
+            ref={searchInputRef}
+            autoFocus
+            aria-label={t("modelSelector.searchPlaceholder")}
+            value={query}
+            onValueChange={setQuery}
+            placeholder={t("modelSelector.searchPlaceholder")}
           >
-            <span>{t(option.labelKey)}</span>
-            {value === option.id && <Check className="h-4 w-4 shrink-0" aria-hidden="true" />}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+            {query && (
+              <IconButton
+                size="sm"
+                label={t("modelSelector.clearSearch")}
+                icon={<X aria-hidden />}
+                // The button unmounts as the query empties, so focus has to be
+                // handed back or it falls to <body> and the arrow keys die.
+                onClick={() => {
+                  setQuery("");
+                  searchInputRef.current?.focus();
+                }}
+                className="text-muted-foreground hover:text-foreground"
+              />
+            )}
+          </CommandInput>
+
+          {/* Outside the listbox, whose children have to be options or groups. */}
+          {searching && resultCount === 0 ? (
+            <p className="py-6 text-center text-ui text-muted-foreground">
+              {t("modelSelector.noMatches", { query: query.trim() })}
+            </p>
+          ) : null}
+
+          {/* Kept mounted even while empty: cmdk's input always points
+              aria-controls at it, so unmounting leaves that reference dangling. */}
+          <CommandList label={t("modelSelector.label")}>
+            {autoVisible && autoOption ? (
+              <CommandGroup>{renderRow(autoOption)}</CommandGroup>
+            ) : null}
+
+            {searching || showAll ? (
+              grouped.map((group) => (
+                <CommandGroup
+                  key={group.family}
+                  heading={t(LARGE_MODEL_FAMILY_LABEL_KEYS[group.family])}
+                >
+                  {group.options.map(renderRow)}
+                </CommandGroup>
+              ))
+            ) : (
+              <CommandGroup>{shortFamilyOptions.map(renderRow)}</CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+
+        {/* The "ellipsis" affordance, outside <Command> so cmdk's root does not
+            claim the Enter/arrow keys the toggle would otherwise use. Hidden
+            while searching, since search already spans every model. */}
+        {!searching ? (
+          <div className="border-t border-border-subtle p-1">
+            <button
+              type="button"
+              onClick={() => setShowAll((previous) => !previous)}
+              aria-expanded={showAll}
+              className="flex w-full items-center gap-2 rounded-8 px-2 py-1 text-left text-ui text-muted-foreground transition hover:bg-surface-muted hover:text-foreground"
+            >
+              <span className="flex h-[22px] w-[22px] items-center justify-center">
+                {showAll ? (
+                  <ChevronUp className="size-4 shrink-0" aria-hidden />
+                ) : (
+                  <ListPlus className="size-4 shrink-0" aria-hidden />
+                )}
+              </span>
+              {showAll ? t("modelSelector.showLess") : t("modelSelector.showAll")}
+            </button>
+          </div>
+        ) : null}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -239,6 +239,15 @@
   "modelSelector": {
     "label": "Model",
     "saveFailed": "Failed to save model selection.",
+    "searchPlaceholder": "Search models",
+    "clearSearch": "Clear search",
+    "showAll": "Show all models",
+    "showLess": "Show fewer models",
+    "noMatches": "No models match “{{query}}”.",
+    "families": {
+      "claude": "Claude",
+      "gpt": "GPT"
+    },
     "options": {
       "auto": "Auto",
       "claudeOpus": "Opus",

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -239,6 +239,15 @@
   "modelSelector": {
     "label": "模型",
     "saveFailed": "保存模型选择失败。",
+    "searchPlaceholder": "搜索模型",
+    "clearSearch": "清除搜索",
+    "showAll": "显示所有模型",
+    "showLess": "收起模型列表",
+    "noMatches": "没有模型匹配“{{query}}”。",
+    "families": {
+      "claude": "Claude",
+      "gpt": "GPT"
+    },
     "options": {
       "auto": "自动",
       "claudeOpus": "Claude Opus",

--- a/packages/web/src/lib/chat-constants.ts
+++ b/packages/web/src/lib/chat-constants.ts
@@ -4,19 +4,56 @@ export const DEFAULT_PROJECT_NAME = "default";
 export const SCROLL_BOTTOM_THRESHOLD_PX = 96;
 
 export const DEFAULT_LARGE_MODEL_SELECTION = "auto";
-export const LARGE_MODEL_OPTIONS = [
+
+// Models group under a family in the picker so the full list stays scannable
+// as releases pile up (issue #180). `auto` is deliberately family-less: it is
+// the special first row, pinned above every family group and its short list.
+export type LargeModelFamily = "claude" | "gpt";
+
+export interface LargeModelOption {
+  id: string;
+  labelKey: string;
+  /** Omitted for `auto`, the pinned first row that sits above the families. */
+  family?: LargeModelFamily;
+}
+
+// Order matters twice: `auto` stays first, and within a family the newest
+// generation is listed first so it sits at the top of that family's group.
+export const LARGE_MODEL_OPTIONS: readonly LargeModelOption[] = [
   { id: "auto", labelKey: "modelSelector.options.auto" },
-  { id: "claude-opus", labelKey: "modelSelector.options.claudeOpus" },
-  { id: "claude-opus-5", labelKey: "modelSelector.options.opus5" },
-  { id: "claude-opus-4-6", labelKey: "modelSelector.options.opus46" },
-  { id: "claude-sonnet", labelKey: "modelSelector.options.sonnet" },
-  { id: "claude-haiku", labelKey: "modelSelector.options.haiku" },
-  { id: "claude-fable", labelKey: "modelSelector.options.fable" },
-  { id: "gpt-6-astra", labelKey: "modelSelector.options.gpt6Astra" },
-  { id: "gpt-5-6-sol", labelKey: "modelSelector.options.gpt56Sol" },
-  { id: "gpt-5-6-terra", labelKey: "modelSelector.options.gpt56Terra" },
-  { id: "gpt-5-6-luna", labelKey: "modelSelector.options.gpt56Luna" },
-] as const;
+  { id: "claude-opus-5", labelKey: "modelSelector.options.opus5", family: "claude" },
+  { id: "claude-opus-4-6", labelKey: "modelSelector.options.opus46", family: "claude" },
+  { id: "claude-opus", labelKey: "modelSelector.options.claudeOpus", family: "claude" },
+  { id: "claude-sonnet", labelKey: "modelSelector.options.sonnet", family: "claude" },
+  { id: "claude-haiku", labelKey: "modelSelector.options.haiku", family: "claude" },
+  { id: "claude-fable", labelKey: "modelSelector.options.fable", family: "claude" },
+  { id: "gpt-6-astra", labelKey: "modelSelector.options.gpt6Astra", family: "gpt" },
+  { id: "gpt-5-6-sol", labelKey: "modelSelector.options.gpt56Sol", family: "gpt" },
+  { id: "gpt-5-6-terra", labelKey: "modelSelector.options.gpt56Terra", family: "gpt" },
+  { id: "gpt-5-6-luna", labelKey: "modelSelector.options.gpt56Luna", family: "gpt" },
+];
+
+// Family render order + heading keys for the expanded / searched list. The
+// per-family generation order lives in LARGE_MODEL_OPTIONS above.
+export const LARGE_MODEL_FAMILY_ORDER: readonly LargeModelFamily[] = ["claude", "gpt"];
+export const LARGE_MODEL_FAMILY_LABEL_KEYS: Record<LargeModelFamily, string> = {
+  claude: "modelSelector.families.claude",
+  gpt: "modelSelector.families.gpt",
+};
+
+// The short list shown before the guardian expands ("show all") or searches.
+// Hand-curated on purpose: the client has no usage data to say which models
+// are common (issue #180), so this is an editorial default — `auto` plus one
+// current flagship per family. Revisit once real usage data exists; editing
+// this list is a one-line change and needs no other code change. Any id here
+// that is not a real option is ignored, and the currently selected model is
+// always shown even when it is absent from this list.
+export const COMMON_LARGE_MODEL_IDS: readonly string[] = [
+  "auto",
+  "claude-opus-5",
+  "claude-sonnet",
+  "gpt-6-astra",
+];
 
 export const DEFAULT_REASONING_EFFORT = "high" satisfies ReasoningEffort;
 export const REASONING_EFFORT_OPTIONS: ReadonlyArray<{


### PR DESCRIPTION
## What & why

Closes the pain in #180. The chat model picker (`ModelSelectorMenu`) was a flat dropdown listing every selectable model — 11 rows today (auto + Claude + GPT), growing with each release, with no grouping and no search. Almost every open lands on the same two or three rows, yet each open meant scanning the whole list.

The issue is a `feature-request` that deliberately proposes three directions and picks none. This PR is a concrete proposal to move that design conversation forward — **it does not close the issue; the final call is @zhangfand's.**

## Approach

Direction **1** (searchable combo box) as the core, folding in direction **2**'s family grouping for the expanded set. Direction 3 (retiring superseded generations) is deliberately avoided — no model leaves the selectable set, so a deliberately-pinned older generation is never stranded.

- **Opens short.** A hand-curated common list (`auto` + one current flagship per family) plus the current selection, so its check is always visible even when it isn't curated.
- **Show all.** A toggle folds the rest away and reveals every model grouped by family (Claude, GPT), newest generation first.
- **Type-to-filter.** Search spans every model regardless of the collapsed state, with a clear button and an empty-state message. The toggle hides while searching, since search already spans everything.

Built on the existing `cmdk` `Command` + `Popover` primitives, mirroring `project-selector.tsx`. `ModelSelectorMenu`'s props are unchanged, so `ChatComposer` needs no changes.

### The one soft spot the issue flagged

The common short list has no usage data behind it, so it's an explicit, documented constant — `COMMON_LARGE_MODEL_IDS` in `chat-constants.ts` — chosen editorially (`auto`, `claude-opus-5`, `claude-sonnet`, `gpt-6-astra`). Revising it is a one-line edit needing no other code change. Happy to adjust the default set on review.

## Changes

- `lib/chat-constants.ts` — add `family` to each model, family order + heading keys, and the curated `COMMON_LARGE_MODEL_IDS`.
- `components/chat/composer/ModelSelectorMenu.tsx` — combo box rework.
- `i18n/en,zh-CN/chat.json` — search placeholder, clear, show all/fewer, no-match, family headings.
- `ModelSelectorMenu.test.tsx` — short list, show-all grouping, type-to-filter, empty state, selected-uncommon visibility, and pick+close.

## Verification

- New test: 6/6.
- Full web suite: 164 files / 1369 tests pass.
- `tsc --noEmit` (web) clean; `biome check` clean; UI token/padding/radius/contract policy suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)