### PR TITLE
feat(web): search the widget picker

### DIFF
--- a/packages/web/src/i18n/locales/en/common.json
+++ b/packages/web/src/i18n/locales/en/common.json
@@ -164,6 +164,8 @@
     "addApp": "App",
     "back": "Back",
     "noApps": "No apps available",
+    "searchWidgets": "Search widgets",
+    "noWidgetMatches": "No widgets match “{{query}}”.",
     "newChat": "New chat",
     "orPickSession": "or pick an existing session"
   },

--- a/packages/web/src/i18n/locales/zh-CN/common.json
+++ b/packages/web/src/i18n/locales/zh-CN/common.json
@@ -164,6 +164,8 @@
     "addApp": "应用",
     "back": "返回",
     "noApps": "暂无可用应用",
+    "searchWidgets": "搜索组件",
+    "noWidgetMatches": "没有组件匹配 “{{query}}”。",
     "newChat": "新对话",
     "orPickSession": "或选择已有对话"
   },

--- a/packages/web/src/pages/free/WidgetPicker.test.tsx
+++ b/packages/web/src/pages/free/WidgetPicker.test.tsx
@@ -1,0 +1,114 @@
+// @rstest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it, rs } from "@rstest/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import i18n from "@/i18n";
+import { WidgetPicker } from "./WidgetPicker";
+
+// Built once in the factory rather than per call, so the array identity stays
+// stable across renders and the memo downstream does not rebuild every frame.
+rs.mock("@/hooks/use-apps", () => {
+  const app = (id: string, displayName: string, hasFrontend = true) => ({
+    id,
+    displayName,
+    hasFrontend,
+    status: "active",
+    // Given so each row's text is its display name alone. Without one the row
+    // draws the initial as a letter tile, which lands in `textContent` too.
+    iconUrl: `/icons/${id}.png`,
+  });
+  const apps = [
+    app("recipe-box", "Recipe Box"),
+    app("notes", "Notes"),
+    // Filtered out before the list is built, so it must never appear.
+    app("headless", "Headless", false),
+  ];
+  return { useApps: () => ({ apps }) };
+});
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+});
+
+afterEach(cleanup);
+
+async function openPicker(onSelect = rs.fn()) {
+  const user = userEvent.setup();
+  render(
+    <WidgetPicker onSelect={onSelect}>
+      <button type="button">Add widget</button>
+    </WidgetPicker>,
+  );
+  await user.click(screen.getByRole("button", { name: "Add widget" }));
+  return { user, onSelect, search: screen.getByRole("combobox") };
+}
+
+function optionNames() {
+  return screen.queryAllByRole("option").map((option) => option.textContent);
+}
+
+describe("WidgetPicker", () => {
+  it("lists the built-in widgets and every app with a frontend", async () => {
+    await openPicker();
+
+    expect(optionNames()).toEqual(["Browser", "Projects", "Recipe Box", "Notes"]);
+  });
+
+  it("filters by substring rather than fuzzy match", async () => {
+    const { user, search } = await openPicker();
+
+    // cmdk's own matcher scores "Projects" above "Recipe Box" here, which would
+    // put the highlight — and therefore Enter — on the wrong row.
+    await user.type(search, "rec");
+
+    expect(optionNames()).toEqual(["Recipe Box"]);
+  });
+
+  it("matches a built-in on its type as well as its label", async () => {
+    const { user, search } = await openPicker();
+
+    await user.type(search, "desktop");
+
+    expect(optionNames()).toEqual(["Browser"]);
+  });
+
+  it("reports a query that matches nothing", async () => {
+    const { user, search } = await openPicker();
+
+    await user.type(search, "zzz");
+
+    expect(optionNames()).toEqual([]);
+    expect(screen.getByText("No widgets match “zzz”.")).toBeTruthy();
+  });
+
+  it("selects the app behind a searched row on Enter", async () => {
+    const { user, search, onSelect } = await openPicker();
+
+    await user.type(search, "rec");
+    await user.keyboard("{Enter}");
+
+    expect(onSelect).toHaveBeenCalledWith("app", "recipe-box");
+  });
+
+  it("selects a built-in without a target id", async () => {
+    const { user, onSelect } = await openPicker();
+
+    await user.click(screen.getByRole("option", { name: "Projects" }));
+
+    expect(onSelect).toHaveBeenCalledWith("projects", undefined);
+  });
+
+  it("drops the query when the picker closes, so the next open starts clean", async () => {
+    const { user, search } = await openPicker();
+
+    await user.type(search, "rec");
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Add widget" }));
+
+    expect(optionNames()).toEqual(["Browser", "Projects", "Recipe Box", "Notes"]);
+  });
+});

--- a/packages/web/src/pages/free/WidgetPicker.tsx
+++ b/packages/web/src/pages/free/WidgetPicker.tsx
@@ -1,13 +1,16 @@
 import { Chrome, FolderKanban } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { EmptyState, EmptyStateTitle } from "@/components/ui/empty-state";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useApps } from "@/hooks/use-apps";
 import type { WidgetType } from "./use-free-cells";
 
@@ -18,42 +21,161 @@ interface WidgetPickerProps {
 
 export function WidgetPicker({ onSelect, children }: WidgetPickerProps) {
   const { t } = useTranslation("common");
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
   const { apps: allApps } = useApps();
   const apps = useMemo(
     () => (allApps ?? []).filter((a) => a.hasFrontend && a.status === "active"),
     [allApps],
   );
 
+  // The two widgets Rome ships itself. Each carries its type as a search term
+  // alongside its label, so "desktop" finds the Browser row in any locale.
+  const builtIns: { type: WidgetType; label: string; icon: React.ReactNode }[] = [
+    {
+      type: "desktop",
+      label: t("chat.addDesktop"),
+      icon: <Chrome className="text-subtle-foreground" />,
+    },
+    {
+      type: "projects",
+      label: t("chat.addProjects"),
+      icon: <FolderKanban className="text-subtle-foreground" />,
+    },
+  ];
+
+  // Filtering stays here rather than moving to cmdk, whose matcher is fuzzy:
+  // it scores "Projects" above "Recipe Box" for the query "rec" and then
+  // highlights it, so Enter adds a widget the guardian did not search for.
+  const q = query.trim().toLowerCase();
+  const matches = (...fields: string[]) =>
+    !q || fields.some((field) => field.toLowerCase().includes(q));
+
+  const shownBuiltIns = builtIns.filter((w) => matches(w.label, w.type));
+  const shownApps = apps.filter((app) => matches(app.displayName, app.id));
+  // Only while unfiltered: under a query the absence of app rows is the
+  // query's doing, and the no-results panel below already says so.
+  const appsEmptyRow = !q && apps.length === 0;
+  const nothingToShow = shownBuiltIns.length === 0 && shownApps.length === 0 && !appsEmptyRow;
+
+  // Selecting closes the surface, so the query has to be dropped with it —
+  // otherwise the next open shows the list still filtered by the last search.
+  function pick(type: WidgetType, targetId?: string) {
+    setOpen(false);
+    setQuery("");
+    onSelect(type, targetId);
+  }
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-56">
-        <DropdownMenuItem data-coach="widget-browser" onSelect={() => onSelect("desktop")}>
-          <Chrome className="text-subtle-foreground" />
-          {t("chat.addDesktop")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => onSelect("projects")}>
-          <FolderKanban className="text-subtle-foreground" />
-          {t("chat.addProjects")}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        {apps.length === 0 ? (
-          <DropdownMenuItem disabled>{t("chat.noApps")}</DropdownMenuItem>
-        ) : (
-          apps.map((app) => (
-            <DropdownMenuItem key={app.id} onSelect={() => onSelect("app", app.id)}>
-              {app.iconUrl ? (
-                <img src={app.iconUrl} alt="" className="size-4 rounded-4" />
-              ) : (
-                <span className="flex size-4 items-center justify-center rounded-4 bg-surface-muted text-badge text-muted-foreground">
-                  {app.displayName.charAt(0).toUpperCase()}
-                </span>
-              )}
-              <span className="truncate">{app.displayName}</span>
-            </DropdownMenuItem>
-          ))
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuery("");
+      }}
+    >
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent
+        align="end"
+        aria-label={t("chat.add")}
+        className="w-72 gap-0 overflow-hidden p-0"
+      >
+        <Command
+          shouldFilter={false}
+          loop
+          // Ctrl+K opens chat search from anywhere, and cmdk would also read it
+          // as "previous result". Matches ChatSearchDialog and ProjectSelector.
+          vimBindings={false}
+          // cmdk renders this as the hidden label naming the input, and
+          // aria-labelledby beats aria-label, so this decides the combobox's
+          // accessible name. The popover keeps its own label.
+          label={t("chat.searchWidgets")}
+          className="bg-transparent"
+        >
+          <CommandInput
+            autoFocus
+            aria-label={t("chat.searchWidgets")}
+            value={query}
+            onValueChange={setQuery}
+            placeholder={t("chat.searchWidgets")}
+          />
+
+          {/* Outside the listbox, whose children have to be options or groups.
+              The list itself stays mounted even while empty: cmdk's input
+              always points `aria-controls` at it, so unmounting would leave
+              that reference dangling. */}
+          {nothingToShow ? (
+            // Shorter than the component's intrinsic height, which is sized for
+            // a page panel: the full list here is about five rows, so keeping
+            // `min-h-48` would make the no-results panel the tallest state the
+            // picker has.
+            <EmptyState className="min-h-0 py-6">
+              <EmptyStateTitle>
+                {t("chat.noWidgetMatches", { query: query.trim() })}
+              </EmptyStateTitle>
+            </EmptyState>
+          ) : null}
+
+          <CommandList className="max-h-[280px]">
+            {shownBuiltIns.length > 0 && (
+              <CommandGroup>
+                {shownBuiltIns.map((widget) => (
+                  <CommandItem
+                    key={widget.type}
+                    data-coach={widget.type === "desktop" ? "widget-browser" : undefined}
+                    value={widget.type}
+                    onSelect={() => pick(widget.type)}
+                  >
+                    {widget.icon}
+                    {widget.label}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            {shownBuiltIns.length > 0 && (shownApps.length > 0 || appsEmptyRow) && (
+              <CommandSeparator />
+            )}
+
+            {appsEmptyRow && (
+              <CommandGroup>
+                {/* A row rather than a line above the list: `CommandList` is the
+                    listbox, whose children have to be options or groups.
+                    Disabled, so the roving selection skips it. */}
+                <CommandItem disabled value="no-apps">
+                  {t("chat.noApps")}
+                </CommandItem>
+              </CommandGroup>
+            )}
+
+            {shownApps.length > 0 && (
+              <CommandGroup>
+                {shownApps.map((app) => (
+                  <CommandItem
+                    key={app.id}
+                    // cmdk keys its roving selection on `value` and folds
+                    // case, so two apps sharing a display name would register
+                    // as one option. Ids are unique, and the prefix keeps an
+                    // app whose id is "desktop" or "projects" off a built-in's
+                    // value. Nothing reads it — the filtering above is ours.
+                    value={`app:${app.id}`}
+                    onSelect={() => pick("app", app.id)}
+                  >
+                    {app.iconUrl ? (
+                      <img src={app.iconUrl} alt="" className="size-4 rounded-4" />
+                    ) : (
+                      <span className="flex size-4 items-center justify-center rounded-4 bg-surface-muted text-badge text-muted-foreground">
+                        {app.displayName.charAt(0).toUpperCase()}
+                      </span>
+                    )}
+                    <span className="truncate">{app.displayName}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/rome_apps/welcome-to-rome/src/web/lib/coach.tsx
+++ b/rome_apps/welcome-to-rome/src/web/lib/coach.tsx
@@ -31,29 +31,37 @@ export function findAddWidgetButton(): HTMLElement | null {
       document.querySelectorAll<HTMLButtonElement>("button[aria-label], button[title]"),
     ).find((b) => /widget/i.test(b.getAttribute("aria-label") || b.getAttribute("title") || ""));
   if (labelled) return labelled;
-  // 3. Cross-language fallback: the only menu-trigger button bearing a plus glyph
-  //    (the widget picker's "+"). Other menu triggers use different icons, so
-  //    scoping to a plus icon inside an `aria-haspopup="menu"` button is precise.
+  // 3. Cross-language fallback: the only popup-trigger button bearing a plus
+  //    glyph (the widget picker's "+"). Other popup triggers use different
+  //    icons, so scoping to a plus icon inside a popup trigger is precise. The
+  //    picker is a combobox, so its trigger announces `dialog`; other triggers
+  //    on the toolbar are menus.
   for (const b of Array.from(
-    document.querySelectorAll<HTMLButtonElement>('button[aria-haspopup="menu"]'),
+    document.querySelectorAll<HTMLButtonElement>(
+      'button[aria-haspopup="dialog"], button[aria-haspopup="menu"]',
+    ),
   )) {
     if (b.querySelector("svg.lucide-plus")) return b;
   }
   return null;
 }
 
-/** The coach target: while the widget menu is open, point at its "Browser" item
+/** The coach target: while the widget picker is open, point at its "Browser" row
  *  (found by its Chrome icon, so it works cross-language); otherwise point at the
- *  "Add widget" (+) trigger. */
+ *  "Add widget" (+) trigger. The picker is a combobox — a listbox inside a
+ *  popover — so its rows are options; `menu`/`menuitem` stay in the selectors
+ *  because other Rome surfaces still open the same coach on a dropdown. */
+const WIDGET_ROW = '[role="option"], [role="menuitem"]';
+
 export function findWidgetCoachTarget(): HTMLElement | null {
-  const menu = document.querySelector('[role="menu"][data-state="open"]');
-  if (menu) {
+  const popup = document.querySelector(
+    '[role="dialog"][data-state="open"], [role="menu"][data-state="open"]',
+  );
+  if (popup) {
     const item =
-      menu.querySelector<HTMLElement>('[data-coach="widget-browser"]') ??
-      menu
-        .querySelector<HTMLElement>("svg.lucide-chrome")
-        ?.closest<HTMLElement>('[role="menuitem"]') ??
-      Array.from(menu.querySelectorAll<HTMLElement>('[role="menuitem"]')).find((el) =>
+      popup.querySelector<HTMLElement>('[data-coach="widget-browser"]') ??
+      popup.querySelector<HTMLElement>("svg.lucide-chrome")?.closest<HTMLElement>(WIDGET_ROW) ??
+      Array.from(popup.querySelectorAll<HTMLElement>(WIDGET_ROW)).find((el) =>
         /browser|desktop/i.test(el.textContent || ""),
       );
     if (item) return item;


### PR DESCRIPTION
## What this PR does

The widget picker listed every built-in widget and every installed app with a frontend as one flat dropdown. That list grows with the app catalog, and a dropdown offers no way to narrow it, so finding one app meant reading the whole menu.

The picker is now a combobox: a search field over the same rows, with the built-ins and the apps kept in separate groups.


## Design & Invariants

`WidgetPicker` keeps its props, so both call sites — the chat toolbar's "Add widget" button and `FreeGrid`'s `+` — pick the new surface up unchanged.

The composition is `Popover` plus `Command`, which is what [`docs/ui/component-roles.md`](../blob/main/docs/ui/component-roles.md) prescribes for a combobox: `CommandInput` is the Control, the caller-owned `PopoverContent` is the Surface.

**Filtering is substring, not cmdk's own matcher.** cmdk scores a fuzzy match, and for the query `rec` it ranks "Projects" (p-**r**-oj-**e**-**c**-ts) above "Recipe Box", then highlights it. Enter then adds a widget nobody searched for. `ProjectSelector` already sets `shouldFilter={false}` for a related reason, so the picker follows it. A test pins the behaviour.

Each built-in row matches on its widget type as well as its label, so `desktop` finds Browser under any locale.

The rows are options in a listbox, so the no-results panel renders above `CommandList` rather than inside it, and `CommandList` stays mounted while empty — cmdk's input points `aria-controls` at it either way.

The onboarding coach in `welcome-to-rome` located the Browser row through `role="menu"` and `role="menuitem"`. A combobox is a listbox inside a popover, so that lookup would have fallen through to its "point at the + button" branch with nothing failing. It now accepts both shapes.

### Alternatives

Keeping cmdk's filter and putting every row in one group. Cross-group ranking is what surfaced the "rec" case, and one group would have fixed the ordering, but the fuzzy match itself is wrong for a five-row picker where every label is short.

## Test plan

- [x] `pnpm --filter rome-web typecheck`
- [x] `pnpm --filter rome-web test` — 1367 pass, including 7 new `WidgetPicker` tests
- [x] `biome check` on the touched files
- [x] Exercised in mock mode: opened the picker, confirmed `rec` narrows to Recipe Box alone, Enter added it, `desktop` narrows to Browser, `zzz` shows the no-results panel, the arrow keys cross the group separator, and Escape closes the picker and returns focus to the trigger
- [ ] Not run: `pnpm dev:all`. The change is frontend-only, and mock mode covers the surface

## Not in this PR

- Mock mode's dev server (`pnpm start:web:mock`) dies with `$RefreshReg$ is not defined` before the app boots, which predates this branch. Verification here went through a production-mode build of the mock config plus `rsbuild preview`
- `WidgetPicker` reads `useApps`, which also fires the Rome Cloud upgrade probe. `useAppsList` would serve it without that cost, and belongs in its own change
