### PR TITLE
fix(ui): key SegmentedControl selection on aria-checked (#264)

### DIFF
--- a/packages/ui/src/segmented-control.test.tsx
+++ b/packages/ui/src/segmented-control.test.tsx
@@ -238,6 +238,48 @@ describe("SegmentedControl", () => {
     expect(onValueChange).toHaveBeenCalledWith("open");
   });
 
+  it("lifts the selected segment onto the canvas surface", () => {
+    render(
+      <SegmentedControl
+        aria-label="Sessions view"
+        options={OPTIONS}
+        value="sessions"
+        onValueChange={() => {}}
+      />,
+    );
+
+    // The active segment reads as an elevated surface — `bg-background` +
+    // `shadow-1` — while the others stay flat on the muted track.
+    const selected = screen.getByRole("radio", { name: "Sessions" });
+    expect(selected.className).toContain("aria-checked:bg-background");
+    expect(selected.className).toContain("aria-checked:shadow-1");
+  });
+
+  it("keeps the selected surface on a segment carrying a title (#264)", () => {
+    render(
+      <SegmentedControl
+        aria-label="Epic filter"
+        options={[
+          { value: "all", label: "All", title: "Everything" },
+          { value: "open", label: "Open", title: "Only projects with unfinished work" },
+        ]}
+        value="all"
+        onValueChange={() => {}}
+      />,
+    );
+
+    // A `title` wraps the item in a Radix TooltipTrigger, whose merged
+    // `data-state` used to clobber Radix's `checked`. Keying the selected
+    // styles on `aria-checked` — which the tooltip never touches — keeps the
+    // active segment lit regardless of the tooltip's state.
+    const selected = screen.getByRole("radio", { name: "All" });
+    expect(selected.getAttribute("aria-checked")).toBe("true");
+    expect(selected.className).toContain("aria-checked:bg-background");
+    expect(selected.className).toContain("aria-checked:shadow-1");
+    // The old, broken keying must be gone so the tooltip's data-state can't win.
+    expect(selected.className).not.toContain("data-[state=checked]");
+  });
+
   it("hands the caller its own value union back, not a bare string", () => {
     type EpicFilter = "all" | "open" | "archived";
     const epicOptions: SegmentedControlOption<EpicFilter>[] = [

--- a/packages/ui/src/segmented-control.tsx
+++ b/packages/ui/src/segmented-control.tsx
@@ -107,7 +107,13 @@ export function SegmentedControl<T extends string = string>({
               disabled={option.disabled}
               aria-describedby={option.title ? optionDescriptionId : undefined}
               className={cn(
-                "inline-flex h-full items-center justify-center rounded-[var(--control-r-sm)] border border-transparent text-ui whitespace-nowrap text-foreground/60 transition-colors outline-none hover:text-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 data-[state=checked]:bg-background data-[state=checked]:text-foreground data-[state=checked]:shadow-1 dark:text-muted-foreground dark:hover:text-foreground dark:data-[state=checked]:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
+                // Selected styles key on `aria-checked`, not Radix's
+                // `data-state`: when an option carries a `title` the item is a
+                // `TooltipTrigger asChild`, and the tooltip's own `data-state`
+                // (`closed`/`open`) is merged onto the radio *after* Radix's
+                // `checked`/`unchecked`, clobbering it. `aria-checked` is the
+                // one selection signal the tooltip never touches. (#264)
+                "inline-flex h-full items-center justify-center rounded-[var(--control-r-sm)] border border-transparent text-ui whitespace-nowrap text-foreground/60 transition-colors outline-none hover:text-foreground focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 aria-checked:bg-background aria-checked:text-foreground aria-checked:shadow-1 dark:text-muted-foreground dark:hover:text-foreground dark:aria-checked:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
                 s.segment,
               )}
             >


### PR DESCRIPTION
Closes #264.

## Problem

`SegmentedControl` lost its selected-segment surface (`bg-background` + `shadow-1`) whenever an option carried a `title`. Options without a `title` rendered correctly.

A `title` wraps the radio item in a Radix `TooltipTrigger asChild`. The trigger sets its own `data-state` (`closed` / `delayed-open` / `instant-open`), and with `asChild` that prop is merged onto the `RadioGroupPrimitive.Item` *after* Radix's own `data-state={checked ? "checked" : "unchecked"}` — so the tooltip's value wins. The selected styles were keyed entirely on `data-[state=checked]:…`, so they never matched on a titled, checked segment (`aria-checked="true"` but `data-state="closed"`).

## Fix

Re-key the selected styles on `aria-checked`, which Radix's tooltip never touches (Tailwind v4 ships the `aria-checked:` variant):

```
aria-checked:bg-background aria-checked:text-foreground aria-checked:shadow-1
dark:aria-checked:text-foreground
```

This is the smaller change the issue recommends over introducing a separate `<span>` trigger (which would move the hover/focus target).

## Tests

Added two regression tests to `segmented-control.test.tsx`:
- the selected segment carries the elevated-surface classes, and
- a segment carrying a `title` keeps that surface (and no longer keys on `data-[state=checked]`).

`pnpm test segmented-control` (15 passed) and `pnpm typecheck` both pass in `packages/ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)