### PR TITLE
fix(web): show transient thinking progress in chat

### DIFF
--- a/packages/web/src/components/agent-trace/AgentTrace.test.tsx
+++ b/packages/web/src/components/agent-trace/AgentTrace.test.tsx
@@ -1,0 +1,84 @@
+// @rstest-environment jsdom
+import { afterEach, expect, it, rs } from "@rstest/core";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { TraceSegment, TraceSummary } from "@rome/api-types/trace-segments";
+import { CollapsedTraceButton } from "./AgentTrace";
+import "@/i18n";
+
+afterEach(cleanup);
+
+it("keeps the live transcript header as a trace entry while activity changes", () => {
+  const onClick = rs.fn();
+  const summary: TraceSummary = {
+    distinctApps: [{ id: "system", name: "System", iconUrl: "/icon.svg" }],
+    totalSteps: 1,
+    invocationCounts: { system: 1 },
+  };
+  const run: TraceSegment = {
+    kind: "run",
+    id: "run",
+    ordinal: 0,
+    app: summary.distinctApps[0],
+    count: 1,
+    blocks: [{ type: "tool_use", tool: "shell", input: {} }],
+  };
+  const { rerender } = render(<CollapsedTraceButton onClick={onClick} live compact />);
+  fireEvent.click(screen.getByRole("button", { name: "0 apps · 0 steps" }));
+  expect(onClick).toHaveBeenCalledTimes(1);
+
+  rerender(
+    <CollapsedTraceButton summary={summary} segments={[run]} onClick={onClick} live compact />,
+  );
+  const entry = screen.getByRole("button", { name: "1 app · 1 step" });
+  expect(entry.querySelector("img")).not.toBeNull();
+  expect(entry.querySelector(".shimmer")).toBeNull();
+  expect(screen.queryByText("Using System")).toBeNull();
+
+  rerender(
+    <CollapsedTraceButton
+      summary={{ ...summary, totalSteps: 2 }}
+      segments={[
+        run,
+        {
+          kind: "block",
+          id: "thinking",
+          ordinal: 1,
+          block: { type: "thinking", content: "Checking results" },
+        },
+      ]}
+      onClick={onClick}
+      live
+      compact
+    />,
+  );
+  expect(screen.getByRole("button", { name: "1 app · 2 steps" })).toBeTruthy();
+  expect(screen.queryByText("Thinking…")).toBeNull();
+});
+
+it("preserves the stopped-turn label in the compact trace entry", () => {
+  render(
+    <CollapsedTraceButton
+      summary={{ distinctApps: [], totalSteps: 0, invocationCounts: {}, stoppedByUser: true }}
+      onClick={() => {}}
+      live
+      compact
+    />,
+  );
+  expect(screen.queryByRole("button", { name: "0 apps · 0 steps" })).toBeNull();
+  expect(screen.getByRole("button").textContent).toContain("stopped");
+});
+
+it("shows duration only after the live turn settles", () => {
+  const summary: TraceSummary = {
+    distinctApps: [],
+    totalSteps: 2,
+    invocationCounts: {},
+    totalDurationMs: 40000,
+  };
+  const { rerender } = render(
+    <CollapsedTraceButton summary={summary} onClick={() => {}} live compact />,
+  );
+  expect(screen.getByRole("button").textContent).toBe("0 apps · 2 steps");
+  rerender(<CollapsedTraceButton summary={summary} onClick={() => {}} compact />);
+  expect(screen.getByRole("button").textContent).toBe("0 apps · 2 steps · 40s");
+});

--- a/packages/web/src/components/agent-trace/AgentTrace.test.tsx
+++ b/packages/web/src/components/agent-trace/AgentTrace.test.tsx
@@ -1,7 +1,7 @@
 // @rstest-environment jsdom
 import { afterEach, expect, it, rs } from "@rstest/core";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import type { TraceSegment, TraceSummary } from "@rome/api-types/trace-segments";
+import type { TraceSummary } from "@rome/api-types/trace-segments";
 import { CollapsedTraceButton } from "./AgentTrace";
 import "@/i18n";
 
@@ -14,58 +14,48 @@ it("keeps the live transcript header as a trace entry while activity changes", (
     totalSteps: 1,
     invocationCounts: { system: 1 },
   };
-  const run: TraceSegment = {
-    kind: "run",
-    id: "run",
-    ordinal: 0,
-    app: summary.distinctApps[0],
-    count: 1,
-    blocks: [{ type: "tool_use", tool: "shell", input: {} }],
-  };
   const { rerender } = render(<CollapsedTraceButton onClick={onClick} live compact />);
   fireEvent.click(screen.getByRole("button", { name: "0 apps · 0 steps" }));
   expect(onClick).toHaveBeenCalledTimes(1);
 
-  rerender(
-    <CollapsedTraceButton summary={summary} segments={[run]} onClick={onClick} live compact />,
-  );
+  rerender(<CollapsedTraceButton summary={summary} onClick={onClick} live compact />);
   const entry = screen.getByRole("button", { name: "1 app · 1 step" });
   expect(entry.querySelector("img")).not.toBeNull();
   expect(entry.querySelector(".shimmer")).toBeNull();
   expect(screen.queryByText("Using System")).toBeNull();
 
   rerender(
-    <CollapsedTraceButton
-      summary={{ ...summary, totalSteps: 2 }}
-      segments={[
-        run,
-        {
-          kind: "block",
-          id: "thinking",
-          ordinal: 1,
-          block: { type: "thinking", content: "Checking results" },
-        },
-      ]}
-      onClick={onClick}
-      live
-      compact
-    />,
+    <CollapsedTraceButton summary={{ ...summary, totalSteps: 2 }} onClick={onClick} live compact />,
   );
   expect(screen.getByRole("button", { name: "1 app · 2 steps" })).toBeTruthy();
   expect(screen.queryByText("Thinking…")).toBeNull();
 });
 
-it("preserves the stopped-turn label in the compact trace entry", () => {
-  render(
+it("keeps settled zero-tool turns readable and their trace accessible", () => {
+  const onClick = rs.fn();
+  const summary: TraceSummary = {
+    distinctApps: [],
+    totalSteps: 0,
+    invocationCounts: {},
+    totalDurationMs: 3100,
+  };
+  const { rerender } = render(
+    <CollapsedTraceButton summary={summary} onClick={onClick} live compact />,
+  );
+  expect(screen.getByRole("button").textContent).toBe("0 apps · 0 steps");
+  rerender(<CollapsedTraceButton summary={summary} onClick={onClick} compact />);
+  const entry = screen.getByRole("button", { name: "Thought for 3.1s" });
+  expect(entry.querySelector(".rounded-full")).toBeNull();
+  fireEvent.click(entry);
+  expect(onClick).toHaveBeenCalledTimes(1);
+  rerender(
     <CollapsedTraceButton
-      summary={{ distinctApps: [], totalSteps: 0, invocationCounts: {}, stoppedByUser: true }}
-      onClick={() => {}}
-      live
+      summary={{ ...summary, stoppedByUser: true }}
+      onClick={onClick}
       compact
     />,
   );
-  expect(screen.queryByRole("button", { name: "0 apps · 0 steps" })).toBeNull();
-  expect(screen.getByRole("button").textContent).toContain("stopped");
+  expect(screen.getByRole("button").textContent).toBe("Stopped by user");
 });
 
 it("shows duration only after the live turn settles", () => {

--- a/packages/web/src/components/agent-trace/AgentTrace.tsx
+++ b/packages/web/src/components/agent-trace/AgentTrace.tsx
@@ -1,6 +1,5 @@
-import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDownIcon, ChevronRightIcon } from "@radix-ui/react-icons";
+import { ChevronRightIcon } from "@radix-ui/react-icons";
 import type { TraceBlockDto, TraceSegment, TraceSummary } from "@rome/api-types/trace-segments";
 import { Button } from "@/components/ui/button";
 import { CollapsedTraceSummary, formatDuration } from "./CollapsedTraceSummary";
@@ -52,90 +51,13 @@ export function TraceBody({
   );
 }
 
-export function AgentTrace({
-  summary,
-  segments,
-  loading = false,
-  error = null,
-  onFirstOpen,
-  defaultOpen = false,
-  live = false,
-  renderInlineBlock,
-  renderRunBlocks,
-}: {
-  summary: TraceSummary;
-  segments: TraceSegment[] | null;
-  loading?: boolean;
-  error?: string | null;
-  onFirstOpen?: () => void;
-  defaultOpen?: boolean;
-  live?: boolean;
-  renderInlineBlock: (block: TraceBlockDto, key: string) => React.ReactNode;
-  renderRunBlocks: (blocks: TraceBlockDto[], live: boolean) => React.ReactNode;
-}) {
-  const [open, setOpen] = useState(defaultOpen);
-  const hasOpenedRef = useRef(defaultOpen);
-
-  // Zero-tool turns: skip the trace shell and just emit the inline blocks
-  // in stream order. Only applicable when segments are loaded.
-  if (segments && summary.totalSteps === 0) {
-    return (
-      <>
-        {segments.map((seg) =>
-          seg.kind === "block" ? (
-            <span key={seg.id}>{renderInlineBlock(seg.block, seg.id)}</span>
-          ) : null,
-        )}
-      </>
-    );
-  }
-
-  const handleToggle = () => {
-    const next = !open;
-    setOpen(next);
-    if (next && !hasOpenedRef.current) {
-      hasOpenedRef.current = true;
-      onFirstOpen?.();
-    }
-  };
-
-  return (
-    <div className={`rounded-8 ${open ? "bg-surface-muted/60 px-1 py-1" : ""}`}>
-      <button
-        type="button"
-        onClick={handleToggle}
-        className="flex w-full select-text items-center gap-2 rounded-8 px-2 py-1 text-left hover:bg-surface-muted/80"
-      >
-        <CollapsedTraceSummary summary={summary} segments={segments ?? undefined} live={live} />
-        <span className="ml-auto flex-none text-subtle-foreground">
-          {open ? <ChevronDownIcon /> : <ChevronRightIcon />}
-        </span>
-      </button>
-      {open && (
-        <div className="mt-1 px-2 pb-1">
-          <TraceBody
-            segments={segments}
-            loading={loading}
-            error={error}
-            renderInlineBlock={renderInlineBlock}
-            renderRunBlocks={renderRunBlocks}
-            live={live}
-          />
-        </div>
-      )}
-    </div>
-  );
-}
-
 export function CollapsedTraceButton({
   summary,
-  segments,
   onClick,
   live = false,
   compact = false,
 }: {
   summary?: TraceSummary;
-  segments?: TraceSegment[];
   onClick: () => void;
   live?: boolean;
   compact?: boolean;
@@ -150,7 +72,7 @@ export function CollapsedTraceButton({
         onClick={onClick}
         className="-mx-2 max-w-none select-text justify-start text-left hover:no-underline"
       >
-        <CollapsedTraceContent summary={summary} segments={segments} live={live} compact />
+        <CollapsedTraceContent summary={summary} live={live} compact />
       </Button>
     );
   }
@@ -160,7 +82,7 @@ export function CollapsedTraceButton({
       onClick={onClick}
       className="transition-all flex w-full select-text items-center gap-2 rounded-8 py-1 px-0 text-left hover:px-2 hover:bg-surface-muted/80"
     >
-      <CollapsedTraceContent summary={summary} segments={segments} live={live} />
+      <CollapsedTraceContent summary={summary} live={live} />
       <span className="ml-auto flex-none text-subtle-foreground">
         <ChevronRightIcon />
       </span>
@@ -170,12 +92,10 @@ export function CollapsedTraceButton({
 
 function CollapsedTraceContent({
   summary,
-  segments,
   live,
   compact = false,
 }: {
   summary?: TraceSummary;
-  segments?: TraceSegment[];
   live: boolean;
   compact?: boolean;
 }) {
@@ -184,7 +104,7 @@ function CollapsedTraceContent({
   if (summary?.terminalError) {
     return <TraceErrorSummary error={summary.terminalError} />;
   }
-  if (compact && (live || summary)) {
+  if (compact && live) {
     return (
       <CollapsedTraceSummary
         summary={summary ?? { distinctApps: [], totalSteps: 0, invocationCounts: {} }}
@@ -194,9 +114,7 @@ function CollapsedTraceContent({
     );
   }
   if (summary && !isEmptySummary(summary)) {
-    return (
-      <CollapsedTraceSummary summary={summary} segments={segments} live={live} compact={compact} />
-    );
+    return <CollapsedTraceSummary summary={summary} live={live} compact={compact} />;
   }
   if (summary?.stoppedByUser) {
     return <StatusPill label={t("trace.stoppedByUser")} compact={compact} />;
@@ -221,8 +139,11 @@ function StatusPill({
   pulse?: boolean;
   compact?: boolean;
 }) {
+  if (compact) {
+    return <span className="text-aux text-muted-foreground">{label}</span>;
+  }
   return (
-    <div className={compact ? "text-aux text-subtle-foreground" : "text-ui text-subtle-foreground"}>
+    <div className="text-ui text-subtle-foreground">
       <span
         className={`inline-block h-2 w-2 rounded-full bg-border-strong${pulse ? " animate-pulse" : ""}`}
       />

--- a/packages/web/src/components/agent-trace/AgentTrace.tsx
+++ b/packages/web/src/components/agent-trace/AgentTrace.tsx
@@ -145,10 +145,10 @@ export function CollapsedTraceButton({
     return (
       <Button
         type="button"
-        variant="ghost"
+        variant="link"
         size="xs"
         onClick={onClick}
-        className="-mx-2 max-w-none select-text justify-start text-left"
+        className="-mx-2 max-w-none select-text justify-start text-left hover:no-underline"
       >
         <CollapsedTraceContent summary={summary} segments={segments} live={live} compact />
       </Button>
@@ -183,6 +183,15 @@ function CollapsedTraceContent({
 
   if (summary?.terminalError) {
     return <TraceErrorSummary error={summary.terminalError} />;
+  }
+  if (compact && (live || summary)) {
+    return (
+      <CollapsedTraceSummary
+        summary={summary ?? { distinctApps: [], totalSteps: 0, invocationCounts: {} }}
+        live={live}
+        compact
+      />
+    );
   }
   if (summary && !isEmptySummary(summary)) {
     return (

--- a/packages/web/src/components/agent-trace/CollapsedTraceSummary.tsx
+++ b/packages/web/src/components/agent-trace/CollapsedTraceSummary.tsx
@@ -1,6 +1,5 @@
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
-import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { AppRefDto, TraceSegment, TraceSummary } from "@rome/api-types/trace-segments";
 
@@ -62,7 +61,7 @@ export function CollapsedTraceSummary({
   compact?: boolean;
 }) {
   if (compact) {
-    return <CompactCollapsedSummary summary={summary} segments={segments} live={live} />;
+    return <CompactCollapsedSummary summary={summary} live={live} />;
   }
   if (live) {
     return <LiveCollapsedSummary summary={summary} segments={segments} />;
@@ -72,41 +71,28 @@ export function CollapsedTraceSummary({
 
 // A single short line (tiny icons + one label), sized to sit under the agent
 // name beside the avatar. Used for both live and done traces in the transcript.
-function CompactCollapsedSummary({
-  summary,
-  segments,
-  live,
-}: {
-  summary: TraceSummary;
-  segments?: TraceSegment[];
-  live: boolean;
-}) {
+function CompactCollapsedSummary({ summary, live }: { summary: TraceSummary; live: boolean }) {
   const { t } = useTranslation("activity");
   const visible = summary.distinctApps.slice(0, MAX_ICONS);
   const appCount = summary.distinctApps.length;
   const stepCount = summary.totalSteps;
 
-  let label: string;
-  if (live) {
-    label = getLiveActivity(segments, t).label;
-  } else {
-    const appsLabel = t(
-      appCount === 1 ? "trace.summary.appsUsedSingle" : "trace.summary.appsUsedMultiple",
-      { count: appCount },
-    );
-    const stepsLabel = t(
-      stepCount === 1 ? "trace.summary.stepsSingle" : "trace.summary.stepsMultiple",
-      { count: stepCount },
-    );
-    const durationStr = formatDuration(summary.totalDurationMs);
-    label =
-      appsLabel +
-      t("trace.summary.joiner") +
-      stepsLabel +
-      (durationStr ? `${t("trace.summary.joiner")}${durationStr}` : "") +
-      (summary.stoppedByUser ? t("trace.summary.stoppedSuffix") : "") +
-      (summary.terminalError ? t("trace.summary.failedSuffix") : "");
-  }
+  const appsLabel = t(
+    appCount === 1 ? "trace.summary.liveAppsSingle" : "trace.summary.liveAppsMultiple",
+    { count: appCount },
+  );
+  const stepsLabel = t(
+    stepCount === 1 ? "trace.summary.stepsSingle" : "trace.summary.stepsMultiple",
+    { count: stepCount },
+  );
+  const durationStr = live ? null : formatDuration(summary.totalDurationMs);
+  const label =
+    appsLabel +
+    t("trace.summary.joiner") +
+    stepsLabel +
+    (durationStr ? `${t("trace.summary.joiner")}${durationStr}` : "") +
+    (summary.stoppedByUser ? t("trace.summary.stoppedSuffix") : "") +
+    (summary.terminalError ? t("trace.summary.failedSuffix") : "");
 
   return (
     <div className="flex w-max items-center gap-2 text-aux text-muted-foreground">
@@ -122,7 +108,7 @@ function CompactCollapsedSummary({
           ))}
         </div>
       )}
-      <span className={cn("whitespace-nowrap", live && "shimmer")}>{label}</span>
+      <span className="whitespace-nowrap">{label}</span>
     </div>
   );
 }

--- a/packages/web/src/components/agent-trace/CollapsedTraceSummary.tsx
+++ b/packages/web/src/components/agent-trace/CollapsedTraceSummary.tsx
@@ -1,7 +1,6 @@
-import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import type { AppRefDto, TraceSegment, TraceSummary } from "@rome/api-types/trace-segments";
+import type { AppRefDto, TraceSummary } from "@rome/api-types/trace-segments";
 
 const MAX_ICONS = 5;
 
@@ -17,54 +16,17 @@ function formatDuration(ms: number | undefined): string | null {
   return `${minutes}m ${remainder}s`;
 }
 
-interface LiveActivity {
-  label: string;
-  activeAppId: string | null;
-}
-
-function getLiveActivity(
-  segments: TraceSegment[] | undefined,
-  t: TFunction<"activity">,
-): LiveActivity {
-  const thinking = (): LiveActivity => ({
-    label: t("trace.summary.activity.thinking"),
-    activeAppId: null,
-  });
-  if (!segments || segments.length === 0) return thinking();
-  const last = segments[segments.length - 1];
-  if (last.kind === "run") {
-    const lastBlock = last.blocks[last.blocks.length - 1];
-    if (lastBlock?.type === "tool_use" || lastBlock?.type === "subagent_start") {
-      return {
-        label: t("trace.summary.activity.usingApp", { app: last.app.name }),
-        activeAppId: last.app.id,
-      };
-    }
-    return thinking();
-  }
-  const block = last.block;
-  if (block.type === "thinking") return thinking();
-  if (block.type === "text")
-    return { label: t("trace.summary.activity.responding"), activeAppId: null };
-  return thinking();
-}
-
 export function CollapsedTraceSummary({
   summary,
-  segments,
   live = false,
   compact = false,
 }: {
   summary: TraceSummary;
-  segments?: TraceSegment[];
   live?: boolean;
   compact?: boolean;
 }) {
   if (compact) {
     return <CompactCollapsedSummary summary={summary} live={live} />;
-  }
-  if (live) {
-    return <LiveCollapsedSummary summary={summary} segments={segments} />;
   }
   return <DoneCollapsedSummary summary={summary} />;
 }
@@ -158,59 +120,6 @@ function DoneCollapsedSummary({ summary }: { summary: TraceSummary }) {
   );
 }
 
-function LiveCollapsedSummary({
-  summary,
-  segments,
-}: {
-  summary: TraceSummary;
-  segments?: TraceSegment[];
-}) {
-  const { t } = useTranslation("activity");
-  const activity = getLiveActivity(segments, t);
-  const visible = summary.distinctApps.slice(0, MAX_ICONS);
-  const overflow = summary.distinctApps.length - visible.length;
-  const appCount = summary.distinctApps.length;
-  const stepCount = summary.totalSteps;
-  const appsLabel = t(
-    appCount === 1 ? "trace.summary.liveAppsSingle" : "trace.summary.liveAppsMultiple",
-    { count: appCount },
-  );
-  const stepLabel = t("trace.summary.liveStep", { count: stepCount });
-
-  return (
-    <div className="flex w-full min-w-0 items-center gap-3">
-      <div className="flex flex-none items-center -space-x-2">
-        {visible.length === 0 ? (
-          <span className="inline-block h-7 w-7 flex-none animate-pulse rounded-8 bg-surface-muted" />
-        ) : (
-          visible.map((app) => (
-            <LiveAppIconTile key={app.id} app={app} active={activity.activeAppId === app.id} />
-          ))
-        )}
-        {overflow > 0 && (
-          <span className="z-10 inline-flex h-7 min-w-[1.75rem] items-center justify-center rounded-8 bg-surface-muted px-2 text-badge text-muted-foreground ring-2 ring-surface">
-            +{overflow}
-          </span>
-        )}
-      </div>
-      <div className="flex min-w-0 flex-1 flex-col">
-        <span className="shimmer truncate text-ui">{activity.label}</span>
-        <span className="truncate text-aux text-subtle-foreground">
-          {appCount > 0 ? (
-            <>
-              {appsLabel}
-              {t("trace.summary.joiner")}
-              {stepLabel}
-            </>
-          ) : (
-            stepLabel
-          )}
-        </span>
-      </div>
-    </div>
-  );
-}
-
 function AppIconTile({ app, invocationCount }: { app: AppRefDto; invocationCount: number }) {
   return (
     <Tooltip>
@@ -222,21 +131,6 @@ function AppIconTile({ app, invocationCount }: { app: AppRefDto; invocationCount
       <TooltipContent>
         {app.name} · {invocationCount}×
       </TooltipContent>
-    </Tooltip>
-  );
-}
-
-function LiveAppIconTile({ app, active }: { app: AppRefDto; active: boolean }) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className={`inline-flex h-7 w-7 items-center justify-center rounded-8 bg-surface-muted text-foreground ring-2 ring-surface ${active ? "rome-trace-icon-ripple z-10" : "z-0"}`}
-        >
-          <img src={app.iconUrl} alt="" className="h-4 w-4" />
-        </span>
-      </TooltipTrigger>
-      <TooltipContent>{app.name}</TooltipContent>
     </Tooltip>
   );
 }

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -1707,6 +1707,7 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
                   text: liveAssistantText,
                   blockIx: floorSessionStream?.assistantBlockIx,
                   sourceText: floorSessionStream?.assistantText,
+                  textThroughOrdinal: floorSessionStream?.textThroughOrdinal,
                   identity: floorIdentity,
                 }}
                 selection={

--- a/packages/web/src/components/chat/LiveTurnActivity.test.tsx
+++ b/packages/web/src/components/chat/LiveTurnActivity.test.tsx
@@ -1,0 +1,120 @@
+// @rstest-environment jsdom
+import { afterEach, describe, expect, it } from "@rstest/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { TraceSegment, TraceSnapshot } from "@rome/api-types/trace-segments";
+import { startStream, updateAssistantText, updateSnapshot } from "@/hooks/use-streaming-sessions";
+import { LiveTurnActivity } from "./LiveTurnActivity";
+import "@/i18n";
+
+afterEach(cleanup);
+
+const thinking = (ordinal: number, content: string): TraceSegment => ({
+  kind: "block",
+  id: `thinking-${ordinal}`,
+  ordinal,
+  block: { type: "thinking", content },
+});
+const snapshot = (...segments: TraceSegment[]): TraceSnapshot => ({
+  segments,
+  summary: { distinctApps: [], totalSteps: 0, invocationCounts: {} },
+});
+
+describe("transient turn activity", () => {
+  it("replaces thinking, dismisses it on text, and does not revive it on a boundary or summary update", () => {
+    let state = startStream(new Map(), "session", "turn");
+    const view = () => {
+      const stream = state.get("session")!;
+      return <LiveTurnActivity {...stream} hasText={!!stream.assistantText} />;
+    };
+    state = updateSnapshot(
+      state,
+      "session",
+      "turn",
+      snapshot(thinking(0, "**Planning shell commands**")),
+    );
+    const { rerender } = render(view());
+    expect(screen.getByRole("status").textContent).toBe("Planning shell commands");
+
+    const next = snapshot(
+      thinking(0, "**Planning shell commands**"),
+      thinking(1, "Checking results"),
+    );
+    state = updateSnapshot(state, "session", "turn", next);
+    rerender(view());
+    expect(screen.queryByText("Planning shell commands")).toBeNull();
+    expect(screen.getAllByRole("status")).toHaveLength(1);
+    expect(screen.getByText("Checking results")).toBeTruthy();
+
+    state = updateAssistantText(state, "session", "turn", 0, "The results");
+    rerender(view());
+    expect(screen.queryByRole("status")).toBeNull();
+    state = updateAssistantText(state, "session", "turn", 1, "");
+    state = updateSnapshot(state, "session", "turn", {
+      ...next,
+      summary: { ...next.summary, totalSteps: 2 },
+    });
+    rerender(view());
+    expect(screen.queryByText("Checking results")).toBeNull();
+
+    state = updateSnapshot(
+      state,
+      "session",
+      "turn",
+      snapshot(...next.segments, thinking(2, "Verifying output")),
+    );
+    state = updateAssistantText(state, "session", "turn", 2, "");
+    rerender(view());
+    expect(screen.getByText("Verifying output")).toBeTruthy();
+  });
+
+  it("keeps parallel tools active until every paired invocation completes", () => {
+    const run: TraceSegment = {
+      kind: "run",
+      id: "run",
+      ordinal: 1,
+      count: 2,
+      app: { id: "system", name: "System", iconUrl: "/app-icon.svg" },
+      blocks: [
+        { type: "tool_use", tool: "shell", id: "a", input: {} },
+        { type: "tool_use", tool: "shell", id: "b", input: {} },
+        { type: "tool_result", tool: "shell", toolUseId: "b", output: "ok" },
+      ],
+    };
+    const { rerender } = render(<LiveTurnActivity snapshot={snapshot(run)} hasText={false} />);
+    expect(screen.getByRole("status").textContent).toContain("System");
+    const finished = {
+      ...run,
+      blocks: [
+        run.blocks[0],
+        { type: "tool_result" as const, tool: "shell", toolUseId: "a", output: "ok" },
+        ...run.blocks.slice(1),
+      ],
+    };
+    rerender(<LiveTurnActivity snapshot={snapshot(finished)} hasText={false} />);
+    expect(screen.getByRole("status").textContent).not.toContain("System");
+    const otherApp = {
+      ...finished,
+      id: "other",
+      ordinal: 2,
+      app: { ...run.app, id: "other", name: "Other app" },
+    };
+    rerender(<LiveTurnActivity snapshot={snapshot(run, otherApp)} hasText={false} />);
+    expect(screen.getByRole("status").textContent).toContain("System");
+    rerender(<LiveTurnActivity snapshot={snapshot(finished)} textThroughOrdinal={1} hasText />);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("clears progress for completed, stopped, and failed turns", () => {
+    const trace = snapshot(thinking(0, "Still working"));
+    for (const turnStatus of ["completed", "interrupted", "error"] as const) {
+      const { unmount } = render(
+        <LiveTurnActivity
+          snapshot={{ ...trace, summary: { ...trace.summary, turnStatus } }}
+          hasText={false}
+        />,
+      );
+      expect(screen.queryByRole("status")).toBeNull();
+      unmount();
+    }
+  });
+});

--- a/packages/web/src/components/chat/LiveTurnActivity.tsx
+++ b/packages/web/src/components/chat/LiveTurnActivity.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from "react-i18next";
+import type { TraceSnapshot } from "@rome/api-types/trace-segments";
+import { getThinkingBlockPreview } from "@/components/chat/blocks/ThinkingBlock";
+
+export function LiveTurnActivity({
+  snapshot,
+  textThroughOrdinal = -1,
+  hasText,
+}: {
+  snapshot: TraceSnapshot | null;
+  textThroughOrdinal?: number;
+  hasText: boolean;
+}) {
+  const { t } = useTranslation("activity");
+  if (snapshot?.summary.turnStatus || snapshot?.summary.terminalError) return null;
+
+  const latest = snapshot?.segments.at(-1);
+  let label: string | undefined;
+  if (latest && latest.ordinal > textThroughOrdinal) {
+    if (latest.kind === "block" && latest.block.type === "thinking") {
+      label = getThinkingBlockPreview(
+        latest.block.content.trim(),
+        t("trace.summary.activity.thinking"),
+      );
+    } else if (latest.kind === "run") {
+      // The trace pairs each result immediately after its invocation, even
+      // when parallel tools finish out of order.
+      label = t("trace.summary.activity.thinking");
+      for (const segment of snapshot!.segments.toReversed()) {
+        if (segment.kind !== "run" || segment.ordinal <= textThroughOrdinal) break;
+        const pending = segment.blocks.some((block, index) => {
+          const next = segment.blocks[index + 1];
+          return (
+            (block.type === "tool_use" && next?.type !== "tool_result") ||
+            (block.type === "subagent_start" && next?.type !== "subagent_result")
+          );
+        });
+        if (pending) {
+          label = t("trace.summary.activity.usingApp", { app: segment.app.name });
+          break;
+        }
+      }
+    }
+  }
+
+  if (!label && (hasText || snapshot?.summary.plan?.steps.length)) return null;
+  return (
+    <div className="text-body text-muted-foreground" role="status" aria-label="Working">
+      <span className="shimmer line-clamp-2 w-fit">
+        {label ?? t("trace.summary.activity.thinking")}
+      </span>
+    </div>
+  );
+}

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -12,6 +12,7 @@ import {
   type DelegatedSubagentNode,
 } from "@/components/chat/DelegatedSubagentGroup";
 import { MessageRow } from "@/components/chat/MessageRow";
+import { LiveTurnActivity } from "@/components/chat/LiveTurnActivity";
 import { TurnSummaryGroup } from "@/components/chat/TurnSummaryGroup";
 import { TurnBranchButton } from "@/components/chat/TurnBranchButton";
 import { TurnFeedbackButtons } from "@/components/chat/TurnFeedbackButtons";
@@ -45,6 +46,7 @@ export interface LivePreview {
   blockIx?: number;
   /** The full SSE text, which may be ahead of the typewriter preview. */
   sourceText?: string;
+  textThroughOrdinal?: number;
   identity: AgentIdentity;
 }
 
@@ -203,18 +205,6 @@ function turnCopyText(messages: ChatMessage[]): string {
   return parts.join("\n\n");
 }
 
-// The streaming-activity indicator shown when the running turn has no text tail
-// to ride on — between text blocks, during a tool call, or before the first
-// token. Mirrors the live caret's breathing dot (globals.css) as a standalone
-// element so the turn never reads as idle while Stop is still showing.
-function LiveActivityDot() {
-  return (
-    <div className="py-1" role="status" aria-label="Working">
-      <span className="rome-live-activity-dot" />
-    </div>
-  );
-}
-
 // Stable row keys preserve inline-card drafts when the live block moves on or
 // the turn ends. Memoization keeps token updates out of the historical rows.
 const RowView = memo(function RowView({
@@ -341,13 +331,13 @@ const RowView = memo(function RowView({
         <div className="rome-live-caret">
           {renderFlatBlocks([{ type: "text", content: live.text }], actions)}
         </div>
-      ) : live ? (
-        // Streaming with no text tail (tool call / block gap): keep the
-        // breathing dot alive on its own so the turn never reads as idle. A
-        // live Plan already carries its own animated state marker.
-        summary?.plan?.steps.length ? null : (
-          <LiveActivityDot />
-        )
+      ) : null}
+      {live ? (
+        <LiveTurnActivity
+          snapshot={live.snapshot}
+          textThroughOrdinal={live.textThroughOrdinal}
+          hasText={!!live.text}
+        />
       ) : null}
       {recapMessageId ? null : <TurnSummaryGroup plan={summary?.plan} live={!!live} />}
       {copyText || showFeedback ? (
@@ -421,11 +411,12 @@ function StandaloneLiveTail({
         <div className="rome-live-caret">
           {renderFlatBlocks([{ type: "text", content: live.text }], actions)}
         </div>
-      ) : live.snapshot?.summary.plan?.steps.length ? null : (
-        // No text persisted yet (turn just opened, or first phase is a tool
-        // call): the breathing dot stands in for the missing tail.
-        <LiveActivityDot />
-      )}
+      ) : null}
+      <LiveTurnActivity
+        snapshot={live.snapshot}
+        textThroughOrdinal={live.textThroughOrdinal}
+        hasText={!!live.text}
+      />
       <TurnSummaryGroup plan={live.snapshot?.summary.plan} live />
     </MessageRow>
   );

--- a/packages/web/src/components/chat/MessageList.tsx
+++ b/packages/web/src/components/chat/MessageList.tsx
@@ -253,13 +253,7 @@ const RowView = memo(function RowView({
   // Running turn: its persisted trace isn't written yet, so the live trace button
   // carries it. Settled turn: its stored trace.
   const subtitle = live ? (
-    <CollapsedTraceButton
-      summary={live.snapshot?.summary}
-      segments={live.snapshot?.segments}
-      onClick={onOpenLiveTrace}
-      live
-      compact
-    />
+    <CollapsedTraceButton summary={live.snapshot?.summary} onClick={onOpenLiveTrace} live compact />
   ) : row.trace ? (
     renderTrace(row.trace, onOpenStoredTrace)
   ) : undefined;
@@ -394,7 +388,6 @@ function StandaloneLiveTail({
       subtitle={
         <CollapsedTraceButton
           summary={live.snapshot?.summary}
-          segments={live.snapshot?.segments}
           onClick={onOpenLiveTrace}
           live
           compact

--- a/packages/web/src/globals.css
+++ b/packages/web/src/globals.css
@@ -195,25 +195,6 @@
   }
 }
 
-/* Standalone live-activity dot: the same breathing dot as the caret, but a real
-   element instead of a tail pseudo-element. Shown when the turn is streaming yet
-   has no text to ride on — between text blocks, during a tool call, or before
-   the first token — so "the turn is still working" never goes dark. */
-.rome-live-activity-dot {
-  display: inline-block;
-  width: 0.45em;
-  height: 0.45em;
-  border-radius: var(--rome-radius-full);
-  background: var(--info);
-  animation: rome-activity-breathe 1.6s ease-in-out infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .rome-live-activity-dot {
-    animation: none;
-  }
-}
-
 @keyframes rome-sheet-rise {
   from {
     transform: translateY(100%);
@@ -515,41 +496,11 @@
   }
 }
 
-@keyframes rome-trace-ripple {
-  0% {
-    transform: scale(1);
-    opacity: 0.6;
-  }
-
-  100% {
-    transform: scale(1.7);
-    opacity: 0;
-  }
-}
-
-.rome-trace-icon-ripple {
-  position: relative;
-}
-
-.rome-trace-icon-ripple::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  border: 1.5px solid var(--color-border-strong);
-  animation: rome-trace-ripple 1.6s cubic-bezier(0, 0, 0.2, 1) infinite;
-  pointer-events: none;
-}
-
 @media (prefers-reduced-motion: reduce) {
   .shimmer {
     animation: none;
     background-image: none;
     -webkit-text-fill-color: currentColor;
-  }
-
-  .rome-trace-icon-ripple::before {
-    display: none;
   }
 }
 

--- a/packages/web/src/hooks/use-streaming-sessions.ts
+++ b/packages/web/src/hooks/use-streaming-sessions.ts
@@ -12,6 +12,8 @@ export type SessionStreamState = {
   // block streams.
   assistantText: string;
   assistantBlockIx: number;
+  /** Trace activity at or before this ordinal was superseded by text. */
+  textThroughOrdinal: number;
 };
 
 export type StreamingSessionMap = ReadonlyMap<string, SessionStreamState>;
@@ -23,7 +25,13 @@ export function startStream(
 ): StreamingSessionMap {
   if (prev.get(sessionId)?.turnId === turnId) return prev;
   const next = new Map(prev);
-  next.set(sessionId, { turnId, snapshot: null, assistantText: "", assistantBlockIx: 0 });
+  next.set(sessionId, {
+    turnId,
+    snapshot: null,
+    assistantText: "",
+    assistantBlockIx: 0,
+    textThroughOrdinal: -1,
+  });
   return next;
 }
 
@@ -62,7 +70,16 @@ export function updateAssistantText(
     return prev;
   }
   const next = new Map(prev);
-  next.set(sessionId, { ...existing, assistantText, assistantBlockIx: blockIx });
+  next.set(sessionId, {
+    ...existing,
+    assistantText,
+    assistantBlockIx: blockIx,
+    // Empty block-boundary events must not erase newer thinking. Retain the
+    // watermark after text commits so summary updates cannot revive it.
+    textThroughOrdinal: assistantText.trim()
+      ? Math.max(existing.textThroughOrdinal, existing.snapshot?.segments.at(-1)?.ordinal ?? -1)
+      : existing.textThroughOrdinal,
+  });
   return next;
 }
 


### PR DESCRIPTION
## What this PR does

Long agent tasks can leave the chat transcript without a readable progress update while thinking stays inside the trace drawer.

Show one transient status below the response with the latest thinking preview or tool activity. New text replaces the status, and completed turns retain their trace entry. The status uses the body typography with muted shimmer text.

The trace header shows app and step totals instead of repeating the current activity. It adds the total duration only after the turn settles. Settled zero-tool turns show `Thought for Xs` or `Stopped by user` through the same trace entry.

Related to #261.

## Design & Invariants

- Claude and Codex use the same presentation through existing trace and text events.
- In Chat, text supersedes older trace activity within its turn. Empty block boundaries and summary updates cannot revive dismissed thinking.
- Parallel tools remain active until their paired results arrive. A completed, stopped, or failed turn clears the transient status.
- Commentary and final text remain in the transcript. Full thinking stays in the trace, following the [session transcript and trace model](https://github.com/rome-os/rome/blob/main/docs/concepts/sessions.md).

## Test plan

- [x] `pnpm typecheck`.
- [x] `pnpm test:unit:web`: 1,384 Web tests and 559 shared UI tests passed.
- [x] `pnpm test:unit`: the full suite passed.
- [x] Microsoft Edge: verified thinking replacement, text dismissal, tool activity, persistent trace access, and duration appearing only after completion through a temporary preview.
- [x] Microsoft Edge in mock mode: verified the zero-tool `Thought for 3.1s` entry has no dot and opens the trace drawer. Tool turns retain their statistics and trace access.
- [ ] Fresh branch `pnpm dev:all`: the backend health wait timed out while first-party apps installed dependencies, with npm connection resets and retries. `Rome started` was confirmed during the earlier UI development run.

Host checks used Node 24.11.1. Nix is unavailable on this machine.

## Not in this PR

- Native reasoning-delta streaming. This change displays the thinking blocks already emitted by the provider adapters.
- The Sessions detail viewer does not yet dismiss older thinking when text streams. Its separate SSE consumer needs the same text watermark in a follow-up.
- Compatibility work for older browsers is deferred. This change targets the latest browsers.

