### PR TITLE
refactor(core): consolidate the turn-outcome rule and turn-end status list into @rome/api-types

### DIFF
--- a/packages/api-types/src/sessions.ts
+++ b/packages/api-types/src/sessions.ts
@@ -1,9 +1,11 @@
 import type { RomeSessionType } from "@rome-os/app-runtime";
+import type { TurnEndStatus } from "./trace-segments.js";
 
 export type SessionsRange = "24h" | "7d" | "30d" | "all";
 export type SessionsMetric = "runs" | "tokens" | "cost" | "errors";
 export type SessionsSort = "activity" | SessionsMetric;
-export type RunOutcome = "completed" | "interrupted" | "error" | "unknown";
+/** A run's turn-end status, plus `unknown` for runs with no/other status. */
+export type RunOutcome = TurnEndStatus | "unknown";
 export type SessionMetricsDimension = "app" | "type" | "source" | "agent" | "model" | "project";
 export type SessionMetricsInterval = "none" | "hour" | "day" | "week" | "auto";
 

--- a/packages/api-types/src/trace-segments.ts
+++ b/packages/api-types/src/trace-segments.ts
@@ -42,13 +42,21 @@ export interface TurnStartBlock extends TraceBlockBase {
   userPrompt: string;
 }
 
+/** The closed set of `turn_end` outcomes. Single source of truth for the
+ *  status list; every consumer (trace summary, session query, webchat) reads
+ *  it from here rather than re-spelling the union. */
+export const TURN_END_STATUSES = ["completed", "error", "interrupted"] as const;
+
+/** A turn's authoritative outcome, carried on its `turn_end` block. */
+export type TurnEndStatus = (typeof TURN_END_STATUSES)[number];
+
 /** Follows the terminal result or error and closes its turn. */
 export interface TurnEndBlock extends TraceBlockBase {
   type: "turn_end";
   turnId: string;
   /** Turn outcome. `interrupted` means the user stopped the turn mid-flight;
    *  it takes precedence over `error`. */
-  status: "completed" | "interrupted" | "error";
+  status: TurnEndStatus;
   /** Turn wall-clock measured by the AgentSession. Distinct from
    *  `accounting.durationMs` on the terminal block, which is the provider's
    *  self-reported per-call duration. */
@@ -208,6 +216,26 @@ export type TraceBlockDto =
   | ErrorBlock
   | StructuredOutputBlock
   | PlanUpdateBlock;
+
+/** A turn's terminal block: the `result` or `error` that a `turn_end` brackets. */
+export type TerminalTraceBlock = ResultBlock | ErrorBlock;
+
+/** The turn-outcome rule, applied in one place.
+ *
+ *  A turn's error text is reportable only when the turn closed with an `error`
+ *  status *and* its last terminal block is itself an `error`. `turn_end.status`
+ *  is authoritative for the outcome; the terminal block only supplies the
+ *  message. Anything else — a `completed`/`interrupted` turn, or an `error`
+ *  status whose last terminal is a `result` (e.g. a relayed subagent error
+ *  landing ahead of the owner's completed result) — reports no error.
+ *
+ *  @returns the terminal error message, or `null` when no error should show. */
+export function turnTerminalError(
+  lastTerminal: TerminalTraceBlock | null | undefined,
+  status: TurnEndStatus | undefined,
+): string | null {
+  return status === "error" && lastTerminal?.type === "error" ? lastTerminal.error : null;
+}
 
 export interface TraceRunSegment {
   kind: "run";

--- a/packages/api-types/src/trace-segments.ts
+++ b/packages/api-types/src/trace-segments.ts
@@ -42,9 +42,14 @@ export interface TurnStartBlock extends TraceBlockBase {
   userPrompt: string;
 }
 
-/** The closed set of `turn_end` outcomes. Single source of truth for the
- *  status list; every consumer (trace summary, session query, webchat) reads
- *  it from here rather than re-spelling the union. */
+/** The closed set of `turn_end` outcomes, and the single source every consumer
+ *  at or below `@rome/api-types` derives from: `TurnEndStatus`,
+ *  `TurnEndBlock.status`, `RunOutcome`, the session-query status list, the
+ *  session-route `outcomeSchema`, and the webchat `turnStatus` validator. The
+ *  upstream `@rome-os/app-runtime` `TurnEndMessage.status` is still declared on
+ *  its own — `@rome/api-types` depends on app-runtime, not the reverse, so it
+ *  cannot import this without inverting the dependency; aligning it is tracked
+ *  in #274. */
 export const TURN_END_STATUSES = ["completed", "error", "interrupted"] as const;
 
 /** A turn's authoritative outcome, carried on its `turn_end` block. */
@@ -228,6 +233,11 @@ export type TerminalTraceBlock = ResultBlock | ErrorBlock;
  *  message. Anything else — a `completed`/`interrupted` turn, or an `error`
  *  status whose last terminal is a `result` (e.g. a relayed subagent error
  *  landing ahead of the owner's completed result) — reports no error.
+ *
+ *  Returns `null` (not `undefined`) on purpose: issue #254 specifies "null
+ *  otherwise", and the external webchat consumer models absence as `null`.
+ *  In-repo callers that prefer the optional-field style coerce with
+ *  `?? undefined`.
  *
  *  @returns the terminal error message, or `null` when no error should show. */
 export function turnTerminalError(

--- a/packages/core/src/api/routes/sessions.ts
+++ b/packages/core/src/api/routes/sessions.ts
@@ -7,6 +7,7 @@ import type {
   SessionMetricsResponse,
   SessionQueryRequest,
 } from "@rome/api-types/sessions";
+import { TURN_END_STATUSES } from "@rome/api-types/trace-segments";
 
 export interface SessionQueries {
   querySessions(request: SessionQueryRequest): Promise<RomeSessionsPageResult>;
@@ -22,7 +23,7 @@ const sessionTypeSchema = z.enum([
   "fork",
   "subagent",
 ]);
-const outcomeSchema = z.enum(["completed", "interrupted", "error", "unknown"]);
+const outcomeSchema = z.enum([...TURN_END_STATUSES, "unknown"]);
 const metricSchema = z.enum(["runs", "tokens", "cost", "errors"]);
 const dimensionSchema = z.enum(["app", "type", "source", "agent", "model", "project"]);
 const intervalSchema = z.enum(["none", "hour", "day", "week", "auto"]);

--- a/packages/core/src/api/trace-segments.ts
+++ b/packages/core/src/api/trace-segments.ts
@@ -10,6 +10,7 @@ import type {
   TraceSnapshot,
   TraceSummary,
 } from "@rome/api-types/trace-segments";
+import { turnTerminalError } from "@rome/api-types/trace-segments";
 import { toTraceBlock, type TraceableAgentMessage } from "./helpers.js";
 import { isTerminalBlock } from "../core/agent-message.js";
 
@@ -209,10 +210,7 @@ export function createSegmentBuilder(args: SegmentBuilderArgs): SegmentBuilder {
         // interrupted turn doesn't leave `stoppedByUser` sticky for the turns
         // that follow it.
         stoppedByUser = block.status === "interrupted";
-        terminalError =
-          block.status === "error" && lastTerminal?.type === "error"
-            ? lastTerminal.error
-            : undefined;
+        terminalError = turnTerminalError(lastTerminal, block.status) ?? undefined;
         lastTerminal = undefined;
         return changed;
       }

--- a/packages/core/src/api/trace-segments.ts
+++ b/packages/core/src/api/trace-segments.ts
@@ -4,6 +4,7 @@ import type {
   SubagentStartBlock,
   ToolUseBlock,
   ToolResultBlock,
+  TerminalTraceBlock,
   TraceBlockDto,
   TraceRunSegment,
   TraceSegment,
@@ -121,7 +122,7 @@ export function createSegmentBuilder(args: SegmentBuilderArgs): SegmentBuilder {
   let latestPlan: TraceSummary["plan"];
   /** Most recent result/error block; the turn's own `turn_end` reads it to
    *  derive the summary (stop/error state). */
-  let lastTerminal: (TraceBlockDto & { type: "result" | "error" }) | undefined;
+  let lastTerminal: TerminalTraceBlock | undefined;
 
   const observeApp = (app: AppRefDto) => {
     if (!seenAppIds.has(app.id)) {

--- a/packages/core/src/api/turn-terminal-error.test.ts
+++ b/packages/core/src/api/turn-terminal-error.test.ts
@@ -1,3 +1,5 @@
+// Exercises exports owned by `@rome/api-types`, which has no rstest setup of
+// its own; it is hosted here (core depends on api-types) rather than orphaned.
 import { describe, it, expect } from "@rstest/core";
 import {
   TURN_END_STATUSES,

--- a/packages/core/src/api/turn-terminal-error.test.ts
+++ b/packages/core/src/api/turn-terminal-error.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "@rstest/core";
+import {
+  TURN_END_STATUSES,
+  turnTerminalError,
+  type ErrorBlock,
+  type ResultBlock,
+} from "@rome/api-types/trace-segments";
+
+const errorBlock = (error: string): ErrorBlock => ({ type: "error", error });
+const resultBlock = (content = "done"): ResultBlock => ({ type: "result", content });
+
+describe("TURN_END_STATUSES", () => {
+  it("is the closed turn-end status set", () => {
+    expect([...TURN_END_STATUSES].sort()).toEqual(["completed", "error", "interrupted"]);
+  });
+});
+
+describe("turnTerminalError", () => {
+  it("returns the message only when the turn errored and its last terminal is an error", () => {
+    expect(turnTerminalError(errorBlock("Access token expired"), "error")).toBe(
+      "Access token expired",
+    );
+  });
+
+  it("returns null when the error status closes over a non-error terminal", () => {
+    // A relayed subagent error can land ahead of the owner's completed result;
+    // the last terminal is that result, so the turn reports no error.
+    expect(turnTerminalError(resultBlock(), "error")).toBeNull();
+  });
+
+  it("returns null when the turn completed even if the last terminal is an error", () => {
+    expect(turnTerminalError(errorBlock("boom"), "completed")).toBeNull();
+  });
+
+  it("returns null when the turn was interrupted over an error terminal", () => {
+    expect(turnTerminalError(errorBlock("Request was aborted"), "interrupted")).toBeNull();
+  });
+
+  it("returns null when there is no terminal block or no status", () => {
+    expect(turnTerminalError(undefined, "error")).toBeNull();
+    expect(turnTerminalError(null, "error")).toBeNull();
+    expect(turnTerminalError(errorBlock("boom"), undefined)).toBeNull();
+  });
+});

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -8,6 +8,7 @@ import {
   type SubmitInputOptions,
 } from "./agent-input-queue.js";
 import { v4 as uuidv4 } from "uuid";
+import type { TurnEndStatus } from "@rome/api-types/trace-segments";
 import type { AgentLoader } from "./agent-loader.js";
 import type { AppCatalog } from "../apps/catalog.js";
 import type { SessionManager } from "./session-manager.js";
@@ -2665,7 +2666,7 @@ class AgentSessionImpl implements AgentSession {
     // synthesizing the error terminal here.
     let forkSession: ModelSession | undefined;
     let disposeForkResources: (() => Promise<void>) | undefined;
-    let status: "completed" | "interrupted" | "error" = "completed";
+    let status: TurnEndStatus = "completed";
     let terminalSeen = false;
     let outputSchemaSuspended = false;
     // Assigned inside the mutex below, after ensureModelSessionForTurn() may

--- a/packages/core/src/db/repositories/session-query.ts
+++ b/packages/core/src/db/repositories/session-query.ts
@@ -17,6 +17,7 @@ import {
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/sqlite-core";
 import type { RunOutcome, SessionsSort } from "@rome/api-types/sessions";
+import { TURN_END_STATUSES } from "@rome/api-types/trace-segments";
 import type { DrizzleDb } from "../index.js";
 import { romeAgentMessages, romeAgentTraceBlocks, romeSessions } from "../schema.js";
 
@@ -33,6 +34,12 @@ const modelName = sql<
 const turnEndBlockType = sql<string>`json_extract(${turnEndTraceBlocks.content}, '$.type')`;
 const turnEndBlockCondition = sql`${turnEndBlockType} = 'turn_end'`;
 const runStatus = sql<string | null>`json_extract(${turnEndTraceBlocks.content}, '$.status')`;
+/** The known turn-end statuses as a SQL value list, derived from the single
+ *  source in `@rome/api-types`. `unknown` is any `runStatus` outside this set. */
+const knownTurnStatusesSql = sql.join(
+  TURN_END_STATUSES.map((status) => sql`${status}`),
+  sql`, `,
+);
 const normalizedAgentName = sql<string>`coalesce(${romeSessions.agentName}, 'main')`;
 const SQL_LIKE_ESCAPE = "\\";
 
@@ -200,7 +207,7 @@ function runPredicates(scope: SessionQueryStorageScope): SQL[] {
   if (scope.outcomes) {
     const outcomes = scope.outcomes.map((outcome): SQL => {
       if (outcome === "unknown") {
-        return sql`${runStatus} is null or ${runStatus} not in ('completed', 'interrupted', 'error')`;
+        return sql`${runStatus} is null or ${runStatus} not in (${knownTurnStatusesSql})`;
       }
       return eq(runStatus, outcome);
     });
@@ -260,7 +267,7 @@ export class SessionQueryRepository {
           .mapWith(Number)
           .as("error_count"),
         unknown:
-          sql<number>`sum(case when ${runStatus} is null or ${runStatus} not in ('completed', 'interrupted', 'error') then 1 else 0 end)`
+          sql<number>`sum(case when ${runStatus} is null or ${runStatus} not in (${knownTurnStatusesSql}) then 1 else 0 end)`
             .mapWith(Number)
             .as("unknown_count"),
       })
@@ -386,7 +393,7 @@ export class SessionQueryRepository {
           ),
         error: sql<number>`sum(case when ${runStatus} = 'error' then 1 else 0 end)`.mapWith(Number),
         unknown:
-          sql<number>`sum(case when ${runStatus} is null or ${runStatus} not in ('completed', 'interrupted', 'error') then 1 else 0 end)`.mapWith(
+          sql<number>`sum(case when ${runStatus} is null or ${runStatus} not in (${knownTurnStatusesSql}) then 1 else 0 end)`.mapWith(
             Number,
           ),
         modelProvider,

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -53,6 +53,7 @@ import { ShareBar } from "@/components/chat/ShareBar";
 import { WidgetPicker } from "@/pages/free/WidgetPicker";
 import { useWorkspaceEventBus } from "@/pages/free/workspace-event-bus";
 import { useFreeCells, type WidgetType } from "@/pages/free/use-free-cells";
+import { TURN_END_STATUSES } from "@rome/api-types/trace-segments";
 import type { TraceSegment, TraceSnapshot, TraceSummary } from "@rome/api-types/trace-segments";
 import { useSmoothText } from "@/hooks/use-smooth-text";
 import { useStickToBottom } from "@/hooks/use-stick-to-bottom";
@@ -164,7 +165,7 @@ const traceSummarySchema: z.ZodType<TraceSummary> = z.lazy(() =>
       )
       .optional(),
     totalDurationMs: z.number().optional(),
-    turnStatus: z.enum(["completed", "interrupted", "error"]).optional(),
+    turnStatus: z.enum(TURN_END_STATUSES).optional(),
     invocationCounts: z.record(z.string(), z.number()),
     stoppedByUser: z.boolean().optional(),
     terminalError: z.string().optional(),


### PR DESCRIPTION
Closes #254.

## What & why

Rome decided one thing — how a turn ended and whether its own error should be reported — in separate, drifting copies. This gives it a single home in `@rome/api-types`, a de-duplication with **no behavior change**.

### New single sources of truth (`@rome/api-types/trace-segments`)
- `TURN_END_STATUSES = ["completed", "error", "interrupted"]` — the closed turn-end status set. `TurnEndStatus` is derived from it, and `TurnEndBlock.status` is now that type rather than a re-spelled union.
- `turnTerminalError(lastTerminal, status)` — the pure turn-outcome rule: returns the terminal error text only when the turn closed with an `error` status **and** its last terminal block is itself an `error`; `null` otherwise (including a relayed subagent error landing ahead of the owner's completed `result`). Returns `null` (not `undefined`) by the issue's acceptance wording; in-repo callers coerce with `?? undefined`. Plus a `TerminalTraceBlock` alias.

### Consumers derived from it
Everything at or below `@rome/api-types` now derives from the constant rather than re-spelling the union:
- `buildTraceSnapshot` / the segment builder (`packages/core/src/api/trace-segments.ts`) calls `turnTerminalError(...)` and types `lastTerminal` as `TerminalTraceBlock`.
- `session-query.ts` derives its three `not in (...)` status lists from `TURN_END_STATUSES`.
- `RunOutcome` (`api-types/sessions.ts`) = `TurnEndStatus | "unknown"`.
- The session-route `outcomeSchema` = `z.enum([...TURN_END_STATUSES, "unknown"])`.
- The web `turnStatus` validator = `z.enum(TURN_END_STATUSES)`.
- The fork producer's `status` (`agent-session.ts`) is typed `TurnEndStatus`.

### Test
- `packages/core/src/api/turn-terminal-error.test.ts` covers the helper (error text only when the last terminal is an `error` and the status is `error`; `null` for completed/interrupted, for an `error` status over a non-error terminal, and for a missing terminal/status). A header note records why an `@rome/api-types` test is hosted in core (api-types has no rstest setup).

## Verification
- `pnpm --filter @rome/api-types typecheck`, `@rome/core`, and `rome-web` typecheck pass.
- Unit tests pass: `turn-terminal-error` (6), `trace-segments` (31), `session-query` (2), `query-service` (5), `routes/sessions` (4), web `MessageList` (26).
- Biome lint clean on the changed files.

## Not in this PR
- The **upstream** `@rome-os/app-runtime` `TurnEndMessage.status` stays an independent union: `@rome/api-types` depends on `@rome-os/app-runtime`, not the reverse, so app-runtime cannot import `TURN_END_STATUSES` without inverting the dependency. Moving the source into the SDK's public contract is an architectural change beyond #254's "de-duplication only" scope — tracked in #274.
- The webchat repository's `getLatestTurnOutcome` does not exist anywhere in this monorepo (checked working tree, all refs, and history); this PR exports what such a consumer would import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
