### PR TITLE
refactor(api-types): give a message its own name and its own home (#165)

### DIFF
--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -20,6 +20,7 @@
     "./apps-runtime": "./src/apps-runtime.ts",
     "./discord-broker": "./src/discord-broker.ts",
     "./favors": "./src/favors.ts",
+    "./message": "./src/message.ts",
     "./people": "./src/people.ts",
     "./persons": "./src/persons.ts"
   },

--- a/packages/api-types/src/message.ts
+++ b/packages/api-types/src/message.ts
@@ -1,0 +1,120 @@
+// The one thing Rome renders whenever it shows what was said: a line, which way
+// it went, when it was said, and a stable id for it. That is a message
+// (docs/concepts/messaging.md#message).
+//
+// It lives on its own, not inside any one surface's contract, because more than
+// one surface reads it. A person's timeline pages messages, and a conversation
+// on a channel answers what it holds with the same shape — and a conversation
+// is not a person's timeline. The shape, the order it is read in, and the
+// cursor that names a position in it are stated once, here, so no reader has to
+// import a surface it has nothing to do with to say "message".
+
+/**
+ * One message: a line, whichever surface produced it.
+ *
+ * Deliberately generic: `source` names the producer, `ref` is that producer's
+ * own id for the message, and `body` is the line to render. A Rome App that
+ * starts contributing messages fills the same five fields instead of extending
+ * this shape.
+ *
+ * `ref` must be unique across everything one `source` can put on one timeline,
+ * not merely within the conversation it came from. A person holds several
+ * accounts, and a producer whose ids are per-conversation (WhatsApp message ids
+ * are unique within a chat, not within an account) has to qualify them —
+ * `<chat>:<messageId>` — before writing them here. {@link compareMessages}
+ * settles ties on `(source, ref)`, so two messages sharing one within the same
+ * second compare equal, serialize to the same cursor, and lose one of the pair
+ * on resume.
+ */
+export interface Message {
+  source: string;
+  /** Epoch seconds. */
+  timestamp: number;
+  body: string | null;
+  direction: "inbound" | "outbound";
+  ref: string;
+}
+
+/**
+ * Compare two strings by code point, returning zero only for exact equality.
+ *
+ * `localeCompare` answers zero for strings that are canonically equivalent but
+ * distinct — "é" and "é" — and its result depends on the running
+ * locale, so a server and a client can disagree on the same pair. Neither is
+ * acceptable where an order has to be total and has to mean the same thing on
+ * both ends of a cursor.
+ *
+ * It lives here because the message order is the leaf both a store and a
+ * person's timeline read through. The People contract re-exports it for the
+ * account and display-name orders, which settle their own ties the same way, so
+ * "how two strings order for a cursor" has one definition rather than two that
+ * can drift.
+ */
+export function compareCodePoints(a: string, b: string): number {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+/**
+ * A message order: newest first, and total.
+ *
+ * Producers share no key but the timestamp, and timestamps collide — whole
+ * seconds from two stores, and a reply Rome sent recorded against the message
+ * it answers. So the order is settled past the timestamp: a reply sits above
+ * the line it answers, and `source`/`ref` break what remains. Totality is not
+ * cosmetic — it is what lets a cursor name a position and resume there without
+ * repeating or skipping a message.
+ *
+ * The `source`/`ref` ties break through {@link compareCodePoints} — the same
+ * total string order the account and display-name orders use — so a cursor
+ * written on one end resumes at the same position on the other.
+ */
+export function compareMessages(a: Message, b: Message): number {
+  if (a.timestamp !== b.timestamp) return b.timestamp - a.timestamp;
+  if (a.direction !== b.direction) return a.direction === "outbound" ? -1 : 1;
+  if (a.source !== b.source) return compareCodePoints(a.source, b.source);
+  return compareCodePoints(a.ref, b.ref);
+}
+
+/**
+ * A cursor naming the exact message a page ended on.
+ *
+ * Encoded rather than a bare timestamp: the timestamp alone cannot say *which*
+ * of a second's messages was the last one sent, so resuming from it drops the
+ * rest of that second.
+ *
+ * Every part is escaped. `source` is whatever a producer calls itself and a
+ * Rome App names its own, so neither it nor `ref` can be trusted to leave the
+ * separator alone — an unescaped one shifts the split and resumes the page at
+ * a position no message occupies.
+ */
+export function messageCursor(message: Message): string {
+  return [message.timestamp, message.direction, message.source, message.ref]
+    .map((part) => encodeURIComponent(String(part)))
+    .join("|");
+}
+
+/** Decode a {@link messageCursor}, or null when it is not one. */
+export function parseMessageCursor(raw: string | undefined | null): Message | null {
+  if (!raw) return null;
+  const parts = raw.split("|");
+  if (parts.length !== 4) return null;
+  let decoded: string[];
+  try {
+    decoded = parts.map(decodeURIComponent);
+  } catch {
+    return null;
+  }
+  const [rawTimestamp, direction, source, ref] = decoded;
+  const timestamp = Number(rawTimestamp);
+  if (rawTimestamp === "" || !Number.isFinite(timestamp)) return null;
+  if (direction !== "inbound" && direction !== "outbound") return null;
+  if (!ref) return null;
+  return { timestamp, direction, source, ref, body: null };
+}
+
+/** Whether a message falls after a cursor in {@link compareMessages} order —
+ *  i.e. belongs on a later page than the one that cursor ended. */
+export function isAfterMessageCursor(message: Message, cursor: Message): boolean {
+  return compareMessages(cursor, message) < 0;
+}

--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -28,12 +28,16 @@
 // Rome contributes is which person it belongs to. So the writes here move a
 // link between people; none of them creates or destroys the account under it.
 //
-// The bond ladder, the merged timeline and the activity order both the person
-// listing and the account stream run on live here too. They are the pieces both
-// nouns share: a row's `latest` is the head of the timeline the same row opens,
-// and a cursor written against one activity listing has to name a position in
-// the other. A second definition of any of them is a page boundary the two ends
-// disagree about, so they are stated once, here.
+// The bond ladder, the activity order both the person listing and the account
+// stream run on, and a person's timeline paging (`TimelinePage`,
+// `latestDynamic`) live here. What that timeline holds — the message shape, its
+// order and its cursor — is the message module's (`./message.ts`), which this
+// file imports. They are the pieces the two nouns share: a row's `latest` is
+// the head of the timeline the same row opens, and a cursor written against one
+// activity listing has to name a position in the other. A second definition of
+// any of them is a page boundary the two ends disagree about, so each is stated
+// once — the activity order here, the message shape and its order in
+// `./message.ts`.
 //
 // The account read is two reads, because two surfaces ask two questions. The
 // directory is a contacts list: every account, ordered by name, carrying
@@ -43,6 +47,7 @@
 // on. Each has its own row shape and its own cursor, so neither pays for the
 // other's fields and neither order can be resumed with the other's position.
 
+import { compareCodePoints, type Message } from "./message.js";
 import { STRANGER_PERSON_ID } from "./persons.js";
 
 // ---------------------------------------------------------------------------
@@ -103,18 +108,12 @@ export function normalizeBondLevel(raw: string): PlacedBondLevel {
 // ---------------------------------------------------------------------------
 
 /**
- * Compare two strings by code point, returning zero only for exact equality.
- *
- * `localeCompare` answers zero for strings that are canonically equivalent but
- * distinct — "\u00e9" and "e\u0301" — and its result depends on the running
- * locale, so a server and a client can disagree on the same pair. Neither is
- * acceptable where an order has to be total and has to mean the same thing on
- * both ends of a cursor.
+ * The total string order the account and display-name orders settle their ties
+ * with. Re-exported from the message module ({@link compareCodePoints}), which
+ * owns it because the message cursor is written against it, so "how two strings
+ * order for a cursor" has one definition here rather than a second that drifts.
  */
-export function compareCodePoints(a: string, b: string): number {
-  if (a === b) return 0;
-  return a < b ? -1 : 1;
-}
+export { compareCodePoints };
 
 /**
  * Order two display names the same way in every runtime.
@@ -184,39 +183,18 @@ export function isChannelIdentifier(channel: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// The merged timeline, and the cursor that resumes it
+// A person's merged timeline
 // ---------------------------------------------------------------------------
-
-/**
- * One entry on a person's merged timeline, whichever surface produced it.
- *
- * Deliberately generic: `source` names the producer, `ref` is that producer's
- * own id for the entry, and `body` is the line to render. A Rome App that
- * starts contributing dynamics fills the same five fields instead of
- * extending this shape.
- *
- * `ref` must be unique across everything one `source` can put on one person's
- * timeline, not merely within the conversation it came from. A person holds
- * several accounts, and a producer whose ids are per-conversation (WhatsApp
- * message ids are unique within a chat, not within an account) has to qualify
- * them — `<chat>:<messageId>` — before writing them here.
- * {@link compareTimelineEntries} settles ties on `(source, ref)`, so two
- * entries sharing one within the same second compare equal, serialize to the
- * same cursor, and lose one of the pair on resume.
- */
-export interface TimelineEntry {
-  source: string;
-  /** Epoch seconds. */
-  timestamp: number;
-  body: string | null;
-  direction: "inbound" | "outbound";
-  ref: string;
-}
+//
+// What the timeline holds is a {@link Message}, and the order it is read in and
+// the cursor that resumes it are the message module's ({@link compareMessages},
+// {@link messageCursor}). A person's timeline is still a timeline; its rows are
+// messages, and its paging is the People surface's own — stated below.
 
 /** One page of a person's timeline, newest first. `nextCursor` is opaque and
- *  null once the oldest entry has been sent. */
+ *  null once the oldest message has been sent. */
 export interface TimelinePage {
-  entries: TimelineEntry[];
+  entries: Message[];
   nextCursor: string | null;
 }
 
@@ -224,24 +202,7 @@ export const TIMELINE_PAGE_DEFAULT_LIMIT = 100;
 export const TIMELINE_PAGE_MAX_LIMIT = 300;
 
 /**
- * The timeline's order: newest first, and total.
- *
- * Producers share no key but the timestamp, and timestamps collide — whole
- * seconds from two stores, and a reply Rome sent recorded against the message
- * it answers. So the order is settled past the timestamp: a reply sits above
- * the line it answers, and `source`/`ref` break what remains. Totality is not
- * cosmetic — it is what lets a cursor name a position and resume there without
- * repeating or skipping an entry.
- */
-export function compareTimelineEntries(a: TimelineEntry, b: TimelineEntry): number {
-  if (a.timestamp !== b.timestamp) return b.timestamp - a.timestamp;
-  if (a.direction !== b.direction) return a.direction === "outbound" ? -1 : 1;
-  const bySource = compareCodePoints(a.source, b.source);
-  return bySource !== 0 ? bySource : compareCodePoints(a.ref, b.ref);
-}
-
-/**
- * The dynamic a row reports as `latest`: the newest entry of that row's own
+ * The dynamic a row reports as `latest`: the newest message of that row's own
  * timeline, projected.
  *
  * One definition rather than two. A separate "newest dynamic" comparison
@@ -250,56 +211,13 @@ export function compareTimelineEntries(a: TimelineEntry, b: TimelineEntry): numb
  * another, and neither would be wrong. Deriving the preview from the ordering
  * makes that disagreement unrepresentable.
  *
- * `entries` must already be in {@link compareTimelineEntries} order.
+ * `entries` must already be in {@link compareMessages} order.
  */
-export function latestDynamic(entries: readonly TimelineEntry[]): AccountDynamic | null {
+export function latestDynamic(entries: readonly Message[]): AccountDynamic | null {
   const newest = entries[0];
   return newest
     ? { source: newest.source, timestamp: newest.timestamp, preview: newest.body }
     : null;
-}
-
-/**
- * A cursor naming the exact entry a page ended on.
- *
- * Encoded rather than a bare timestamp: the timestamp alone cannot say *which*
- * of a second's entries was the last one sent, so resuming from it drops the
- * rest of that second.
- *
- * Every part is escaped. `source` is whatever a producer calls itself and a
- * Rome App names its own, so neither it nor `ref` can be trusted to leave the
- * separator alone — an unescaped one shifts the split and resumes the page at
- * a position no entry occupies.
- */
-export function timelineCursor(entry: TimelineEntry): string {
-  return [entry.timestamp, entry.direction, entry.source, entry.ref]
-    .map((part) => encodeURIComponent(String(part)))
-    .join("|");
-}
-
-/** Decode a {@link timelineCursor}, or null when it is not one. */
-export function parseTimelineCursor(raw: string | undefined | null): TimelineEntry | null {
-  if (!raw) return null;
-  const parts = raw.split("|");
-  if (parts.length !== 4) return null;
-  let decoded: string[];
-  try {
-    decoded = parts.map(decodeURIComponent);
-  } catch {
-    return null;
-  }
-  const [rawTimestamp, direction, source, ref] = decoded;
-  const timestamp = Number(rawTimestamp);
-  if (rawTimestamp === "" || !Number.isFinite(timestamp)) return null;
-  if (direction !== "inbound" && direction !== "outbound") return null;
-  if (!ref) return null;
-  return { timestamp, direction, source, ref, body: null };
-}
-
-/** Whether an entry falls after a cursor in {@link compareTimelineEntries}
- *  order — i.e. belongs on a later page than the one that cursor ended. */
-export function isAfterTimelineCursor(entry: TimelineEntry, cursor: TimelineEntry): boolean {
-  return compareTimelineEntries(cursor, entry) < 0;
 }
 
 /**
@@ -900,7 +818,7 @@ export function defaultSendAccount(accounts: readonly LinkedAccount[]): LinkedAc
  * it and `messageCount` is how many entries it holds, so the line a row
  * previews is the line its dossier opens on, and the number beside it counts
  * what the dossier will show. A group conversation contributes to neither: a
- * timeline entry names no sender, so nothing said in a room of ten people is
+ * message names no sender, so nothing said in a room of ten people is
  * attributable to one of them.
  *
  * `memoryPath` is the profile Rome has written about them, as a path under the
@@ -1295,7 +1213,7 @@ export function whatsAppDisplayName(contact: {
  * The account is named, always. There is no shape of this request that omits
  * it and no rule anywhere that fills it in, because every rule that could is a
  * rule that decides who receives a message on evidence too thin to carry it:
- * a timeline entry names its channel and not its address, so "reply where they
+ * a message names its channel and not its address, so "reply where they
  * last wrote" cannot separate two numbers on one channel, and "use another
  * channel when this one is down" silently sends somewhere nobody chose.
  * {@link defaultSendAccount} exists for surfaces that want a preselected
@@ -1347,11 +1265,11 @@ export type OutboxState = "sending" | "unconfirmed" | "failed";
 /**
  * One message Rome is still trying to deliver.
  *
- * Deliberately not a {@link TimelineEntry} with a status on it. A timeline
- * entry is a message that happened; these have not, and some never will. Two
- * nouns keep the timeline's contract — its `ref` uniqueness and the ordering
- * its cursor is written against — free of rows that may yet be withdrawn, and
- * keep each account owned by exactly one store.
+ * Deliberately not a {@link Message} with a status on it. A message is
+ * something that happened; these have not, and some never will. Two nouns keep
+ * the message contract — its `ref` uniqueness and the ordering its cursor is
+ * written against — free of rows that may yet be withdrawn, and keep each
+ * account owned by exactly one store.
  *
  * `ref` is the entry this message would become at the address it was sent to.
  * It is a hint and not a key: a channel that folds several addresses onto one

--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -8,7 +8,6 @@ import {
   parseMergeRequest,
   parsePersonFilterLevel,
   parseSendMessageRequest,
-  parseTimelineCursor,
   parseUpdatePersonRequest,
   personMatchesLevel,
   personMatchesQuery,
@@ -18,6 +17,7 @@ import {
   type PeopleList,
   type SendRefusal,
 } from "@rome/api-types/people";
+import { parseMessageCursor } from "@rome/api-types/message";
 import { createPerson } from "../../people/create.js";
 import { mergePeople } from "../../people/merge.js";
 import { discardSend, readOutbox, retrySend, sendToAccount } from "../../people/outbox.js";
@@ -238,7 +238,7 @@ export function peopleRoutes(deps: ApiDeps): Hono {
     if (!person) return c.json({ error: "Unknown person" }, 404);
 
     const rawCursor = c.req.query("cursor");
-    const cursor = parseTimelineCursor(rawCursor);
+    const cursor = parseMessageCursor(rawCursor);
     if (rawCursor != null && rawCursor !== "" && cursor === null) {
       return c.json({ error: "cursor is not a timeline cursor" }, 400);
     }

--- a/packages/core/src/channels/messages-contract.ts
+++ b/packages/core/src/channels/messages-contract.ts
@@ -5,11 +5,11 @@
 
 import { describe, expect, it } from "@rstest/core";
 import {
-  compareTimelineEntries,
-  isAfterTimelineCursor,
-  timelineCursor,
-  type TimelineEntry,
-} from "@rome/api-types/people";
+  compareMessages,
+  isAfterMessageCursor,
+  messageCursor,
+  type Message,
+} from "@rome/api-types/message";
 import type { MessageAccount, MessageConversation, Messages } from "./messages.js";
 
 /** A limit large enough to hold any history a store can answer — what
@@ -83,7 +83,7 @@ export function testMessagesContract(
       const store = await subject();
       const page = await store.messages.read({ accounts: store.accounts, limit: PAGE });
       expect(page.length).toBeLessThanOrEqual(PAGE);
-      expect(page).toEqual([...page].sort(compareTimelineEntries));
+      expect(page).toEqual([...page].sort(compareMessages));
     });
 
     it("answers only messages strictly after the cursor", async () => {
@@ -96,19 +96,19 @@ export function testMessagesContract(
         after: cursor,
         limit: WHOLE_HISTORY,
       });
-      expect(next.every((entry) => isAfterTimelineCursor(entry, cursor))).toBe(true);
+      expect(next.every((entry) => isAfterMessageCursor(entry, cursor))).toBe(true);
     });
 
     it("pages to exhaustion over exactly the full read", async () => {
       const store = await subject();
       const full = await fullRead(store);
 
-      const walked: TimelineEntry[] = [];
-      let after: TimelineEntry | null = null;
+      const walked: Message[] = [];
+      let after: Message | null = null;
       // Bounded rather than `while (true)`: a store that answers the same page
       // forever fails as a wrong page count instead of hanging the suite.
       for (let page = 0; page <= Math.ceil(full.length / PAGE); page++) {
-        const entries: TimelineEntry[] = await store.messages.read({
+        const entries: Message[] = await store.messages.read({
           accounts: store.accounts,
           after,
           limit: PAGE,
@@ -139,7 +139,7 @@ export function testMessagesContract(
       const full = await fullRead(store);
       // Two entries that compare equal serialize to one cursor, so resuming
       // from it drops one of the pair — the pages above would never show it.
-      expect(new Set(full.map(timelineCursor)).size).toBe(full.length);
+      expect(new Set(full.map(messageCursor)).size).toBe(full.length);
     });
 
     it("holds nothing for a silent account", async () => {
@@ -174,7 +174,7 @@ export function testMessagesContract(
         limit: PAGE,
       });
       expect(page.length).toBeLessThanOrEqual(PAGE);
-      expect(page).toEqual([...page].sort(compareTimelineEntries));
+      expect(page).toEqual([...page].sort(compareMessages));
     });
 
     it("answers only messages of a conversation strictly after the cursor", async () => {
@@ -190,17 +190,17 @@ export function testMessagesContract(
         after: cursor,
         limit: WHOLE_HISTORY,
       });
-      expect(next.every((entry) => isAfterTimelineCursor(entry, cursor))).toBe(true);
+      expect(next.every((entry) => isAfterMessageCursor(entry, cursor))).toBe(true);
     });
 
     it("pages a conversation to exhaustion over exactly its full read", async () => {
       const store = await subject();
       const full = await fullConversation(store);
 
-      const walked: TimelineEntry[] = [];
-      let after: TimelineEntry | null = null;
+      const walked: Message[] = [];
+      let after: Message | null = null;
       for (let page = 0; page <= Math.ceil(full.length / PAGE); page++) {
-        const entries: TimelineEntry[] = await store.messages.readConversation({
+        const entries: Message[] = await store.messages.readConversation({
           conversation: store.conversation,
           after,
           limit: PAGE,
@@ -216,7 +216,7 @@ export function testMessagesContract(
     it("gives every message of a conversation its own cursor position", async () => {
       const store = await subject();
       const full = await fullConversation(store);
-      expect(new Set(full.map(timelineCursor)).size).toBe(full.length);
+      expect(new Set(full.map(messageCursor)).size).toBe(full.length);
     });
 
     // An empty page rather than a failure or a null: a conversation the store

--- a/packages/core/src/channels/messages-memory.test.ts
+++ b/packages/core/src/channels/messages-memory.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@rstest/core";
-import type { TimelineEntry } from "@rome/api-types/people";
+import type { Message } from "@rome/api-types/message";
 import { memoryMessages, type HeldMessage } from "./messages-memory.js";
 import { testMessagesContract, WHOLE_HISTORY } from "./messages-contract.js";
 
@@ -28,7 +28,7 @@ const entry = (
   timestamp: number,
   ref: string,
   direction: "inbound" | "outbound" = "inbound",
-): TimelineEntry => ({ source, timestamp, ref, direction, body: `${ref}@${timestamp}` });
+): Message => ({ source, timestamp, ref, direction, body: `${ref}@${timestamp}` });
 
 const held: HeldMessage[] = [
   { channel: "whatsapp", address: PHONE, entry: entry("whatsapp", 100, "wa:a") },

--- a/packages/core/src/channels/messages-memory.ts
+++ b/packages/core/src/channels/messages-memory.ts
@@ -2,11 +2,7 @@
 // proved against, and a store any test can state whole. The obligations it
 // meets are messages.ts's.
 
-import {
-  compareTimelineEntries,
-  isAfterTimelineCursor,
-  type TimelineEntry,
-} from "@rome/api-types/people";
+import { compareMessages, isAfterMessageCursor, type Message } from "@rome/api-types/message";
 import type { ConversationRead, MessageAccount, MessageRead, Messages } from "./messages.js";
 
 /** One message the store holds, at the address it arrived on and in the
@@ -28,7 +24,7 @@ export interface HeldMessage {
    * subtracting anything — which is the guarantee messages.ts states.
    */
   conversation?: string;
-  entry: TimelineEntry;
+  entry: Message;
 }
 
 /**
@@ -42,13 +38,13 @@ export interface HeldMessage {
  * address.
  */
 export function memoryMessages(held: readonly HeldMessage[]): Messages {
-  const ranked = (holds: (message: HeldMessage) => boolean): TimelineEntry[] =>
+  const ranked = (holds: (message: HeldMessage) => boolean): Message[] =>
     held
       .filter(holds)
       .map((message) => message.entry)
-      .sort(compareTimelineEntries);
+      .sort(compareMessages);
 
-  const full = (accounts: readonly MessageAccount[]): TimelineEntry[] => {
+  const full = (accounts: readonly MessageAccount[]): Message[] => {
     const scope = new Set(
       accounts.flatMap((account) =>
         account.addresses.map((address) => pair(account.channel, address)),
@@ -59,13 +55,9 @@ export function memoryMessages(held: readonly HeldMessage[]): Messages {
 
   /** One page off a ranking: what every read here answers, and the only place
    *  the cursor and the limit are applied. */
-  const page = (
-    entries: TimelineEntry[],
-    after: TimelineEntry | null,
-    limit: number,
-  ): TimelineEntry[] =>
+  const page = (entries: Message[], after: Message | null, limit: number): Message[] =>
     entries
-      .filter((entry) => after === null || isAfterTimelineCursor(entry, after))
+      .filter((entry) => after === null || isAfterMessageCursor(entry, after))
       .slice(0, Math.max(1, Math.floor(limit)));
 
   return {

--- a/packages/core/src/channels/messages-sql.ts
+++ b/packages/core/src/channels/messages-sql.ts
@@ -10,7 +10,7 @@
 // answers concurrent `resolve` calls from a single shared load.
 
 import { sql, type SQL } from "drizzle-orm";
-import type { TimelineEntry } from "@rome/api-types/people";
+import type { Message } from "@rome/api-types/message";
 import type { DrizzleDb } from "../db/index.js";
 import type {
   ConversationRead,
@@ -119,7 +119,7 @@ export function sqlMessages(options: SqlMessagesOptions): Messages {
   const byAccount = batched<Job, JobResult>((jobs) => runBatch(options, "account", jobs));
   const byConversation = batched<Job, JobResult>((jobs) => runBatch(options, "conversation", jobs));
 
-  const job = (accounts: readonly MessageAccount[], after: TimelineEntry | null, limit: number) =>
+  const job = (accounts: readonly MessageAccount[], after: Message | null, limit: number) =>
     byAccount({ keys: accountKeys(accounts, options.channel), after, limit });
 
   return {
@@ -192,12 +192,12 @@ export function keysIn(scope: readonly MessageScopeKey[]): string[] {
  *  wants the length of a history and none of it. */
 interface Job {
   keys: readonly MessageScopeKey[];
-  after: TimelineEntry | null;
+  after: Message | null;
   limit: number;
 }
 
 interface JobResult {
-  entries: TimelineEntry[];
+  entries: Message[];
   /** The length of the job's whole history — meaningful for a job with no
    *  cursor, which is every job `count` raises. */
   total: number;
@@ -325,7 +325,7 @@ function askRow(index: number, job: Job): SQL {
 
 /**
  * The rows that fall strictly after a job's cursor, in the order the window's
- * ORDER BY imposes — which is `compareTimelineEntries` read as SQL.
+ * ORDER BY imposes — which is `compareMessages` read as SQL.
  *
  * The whole tuple, not `at < c_at`: a second holds more than one entry, and
  * resuming from the bare timestamp drops the rest of that second.
@@ -346,7 +346,7 @@ const AFTER_CURSOR = sql`
 function toEntry(
   row: Record<string, unknown>,
   body?: (raw: string | null) => string | null,
-): TimelineEntry {
+): Message {
   const raw = (row.body as string | null) ?? null;
   return {
     source: String(row.source),

--- a/packages/core/src/channels/messages.ts
+++ b/packages/core/src/channels/messages.ts
@@ -2,16 +2,15 @@
  * What was said to a channel's accounts, as one store holds it. `Accounts` (accounts.ts) answers who a channel can reach, and this
  * answers what passed between Rome and them.
  *
- * A message is a {@link TimelineEntry}, however the store was asked for it. A
+ * A message is a {@link Message}, however the store was asked for it. A
  * store holds one history and ranks it one way, and every read below cuts that
- * one ranking. The shape, the ordering and the cursor are written down in the
- * People contract (`@rome/api-types/people`) because a person's timeline was
- * the first surface to page them, not because it is the only one: a second
- * shape here would be a second ranking of the same rows, which is a page
- * boundary the two ends disagree about.
+ * one ranking. The shape, the ordering and the cursor are the message module's
+ * (`@rome/api-types/message`), stated once there so a store and a person's
+ * timeline cut the same ranking: a second shape here would be a second ranking
+ * of the same rows, which is a page boundary the two ends disagree about.
  */
 
-import type { TimelineEntry } from "@rome/api-types/people";
+import type { Message } from "@rome/api-types/message";
 
 /**
  * One account a store reads for, named by every address it answers to —
@@ -54,14 +53,14 @@ export interface MessageConversation {
 export interface MessageRead {
   accounts: readonly MessageAccount[];
   /** The entry the previous page ended on. Null or absent for the first page. */
-  after?: TimelineEntry | null;
+  after?: Message | null;
   limit: number;
 }
 
 export interface ConversationRead {
   conversation: MessageConversation;
   /** The entry the previous page ended on. Null or absent for the first page. */
-  after?: TimelineEntry | null;
+  after?: Message | null;
   limit: number;
 }
 
@@ -96,7 +95,7 @@ export interface ConversationRead {
 export interface Messages {
   /**
    * The store's newest messages for `accounts`, at most `limit` of them, every
-   * one strictly after `after`, in `compareTimelineEntries` order — newest
+   * one strictly after `after`, in `compareMessages` order — newest
    * first, and total.
    *
    * "Strictly after `after`" is the store's own obligation and not the
@@ -105,7 +104,7 @@ export interface Messages {
    * already seen, and the ones it dropped to make room are the ones no page
    * ever shows.
    */
-  read(request: MessageRead): Promise<TimelineEntry[]>;
+  read(request: MessageRead): Promise<Message[]>;
 
   /** How many messages the full read of `accounts` answers. */
   count(accounts: readonly MessageAccount[]): Promise<number>;
@@ -117,7 +116,7 @@ export interface Messages {
    * `read` with a limit of one, declared as its own verb so a store can answer
    * it in one pass over a whole directory rather than one page per row.
    */
-  latest(accounts: readonly MessageAccount[]): Promise<TimelineEntry | null>;
+  latest(accounts: readonly MessageAccount[]): Promise<Message | null>;
 
   /**
    * The store's newest messages in `conversation`, on `read`'s terms exactly:
@@ -140,5 +139,5 @@ export interface Messages {
    * them apart, and a store that failed the first would refuse a conversation
    * that exists on the channel and has simply not been mirrored yet.
    */
-  readConversation(request: ConversationRead): Promise<TimelineEntry[]>;
+  readConversation(request: ConversationRead): Promise<Message[]>;
 }

--- a/packages/core/src/db/schema/system.ts
+++ b/packages/core/src/db/schema/system.ts
@@ -149,7 +149,7 @@ export const waContacts = sqliteTable("wa_contacts", {
  *
  * Not a message store, and deliberately not part of the timeline. A row here
  * is a send that has not happened yet and may never; a timeline entry is one
- * that did. Keeping them apart is what lets `TimelineEntry`'s `ref` stay unique
+ * that did. Keeping them apart is what lets `Message`'s `ref` stay unique
  * and its ordering stay total — a cursor cannot be written across rows that may
  * still be withdrawn — and what keeps each account owned by exactly one message
  * store rather than two that disagree.

--- a/packages/core/src/people/account-directory.ts
+++ b/packages/core/src/people/account-directory.ts
@@ -18,8 +18,8 @@ import {
   latestDynamic,
   type DirectoryAccount,
   type StreamAccount,
-  type TimelineEntry,
 } from "@rome/api-types/people";
+import type { Message } from "@rome/api-types/message";
 import { STRANGER_PERSON_ID } from "../constants.js";
 import type { AccountNames } from "../channels/account-names.js";
 import { foldAccounts } from "../channels/account-fold.js";
@@ -93,7 +93,7 @@ export async function readAccountStream(deps: AccountDirectoryDeps): Promise<Str
   const accounts = await observeAccounts(deps);
   const stores = personMessageStores(deps);
 
-  const heads = new Map<DirectoryAccount, TimelineEntry>();
+  const heads = new Map<DirectoryAccount, Message>();
   for (const round of rounds(accounts)) {
     for (const [account, owned] of await assignAccountHeads(stores, round)) {
       heads.set(account, owned.head);

--- a/packages/core/src/people/activity.ts
+++ b/packages/core/src/people/activity.ts
@@ -8,12 +8,8 @@
 // preview is the store's `latest`, which `Messages` binds to the head of the
 // history its `read` pages, and the number beside it is that history's `count`.
 
-import {
-  compareTimelineEntries,
-  latestDynamic,
-  type AccountDynamic,
-  type TimelineEntry,
-} from "@rome/api-types/people";
+import { latestDynamic, type AccountDynamic } from "@rome/api-types/people";
+import { compareMessages, type Message } from "@rome/api-types/message";
 import type { MessageAccount, Messages } from "../channels/messages.js";
 import { assignAccountHeads } from "./timeline.js";
 
@@ -43,7 +39,7 @@ export interface PeopleActivity {
   /** Each account's own newest entry, keyed by the account object passed in —
    *  the idiom `assignAccountHeads` uses, so a caller reads its answer back off
    *  the values it gave. Absent for an account no store holds. */
-  perAccount: Map<MessageAccount, TimelineEntry>;
+  perAccount: Map<MessageAccount, Message>;
 }
 
 /**
@@ -66,7 +62,7 @@ export async function readActivity(
 ): Promise<PeopleActivity> {
   const owned = await assignAccountHeads(stores, accountsByPerson.flat());
   const owner = new Map<MessageAccount, Messages>();
-  const perAccount = new Map<MessageAccount, TimelineEntry>();
+  const perAccount = new Map<MessageAccount, Message>();
   for (const [account, { store, head }] of owned) {
     owner.set(account, store);
     perAccount.set(account, head);
@@ -96,7 +92,7 @@ export async function readActivity(
     Promise.all(summaries.map((summary) => summary.store.latest(summary.accounts))),
   ]);
 
-  const activity = accountsByPerson.map(() => ({ heads: [] as TimelineEntry[], messageCount: 0 }));
+  const activity = accountsByPerson.map(() => ({ heads: [] as Message[], messageCount: 0 }));
   summaries.forEach((summary, index) => {
     const person = activity[summary.person];
     if (!person) return;
@@ -111,7 +107,7 @@ export async function readActivity(
       // order, so a person whose two accounts last spoke in the same second
       // previews the entry their merged timeline opens on rather than whichever
       // store the fold reached first.
-      latest: latestDynamic(person.heads.sort(compareTimelineEntries)),
+      latest: latestDynamic(person.heads.sort(compareMessages)),
       messageCount: person.messageCount,
     })),
     perAccount,

--- a/packages/core/src/people/resource.ts
+++ b/packages/core/src/people/resource.ts
@@ -10,7 +10,8 @@
 // once, so no route can serve it by forgetting to.
 
 import { readdir } from "node:fs/promises";
-import type { AccountSendState, PersonResource, TimelineEntry } from "@rome/api-types/people";
+import type { AccountSendState, PersonResource } from "@rome/api-types/people";
+import type { Message } from "@rome/api-types/message";
 import { STRANGER_PERSON_ID } from "../constants.js";
 import { getRelationshipDir, personProfileFileName, RELATIONSHIP_DIR } from "../profile-memory.js";
 import type { AccountNames } from "../channels/account-names.js";
@@ -150,7 +151,7 @@ async function memoryProfilePaths(persons: readonly PersonRow[]): Promise<(strin
  * is the same rule `timelineAccounts` grouped by.
  */
 function latestAtOf(
-  heads: Map<MessageAccount, TimelineEntry>,
+  heads: Map<MessageAccount, Message>,
   accounts: readonly MessageAccount[] | undefined,
   mapping: { channel: string; channelUserId: string },
 ): number | null {

--- a/packages/core/src/people/timeline.test.ts
+++ b/packages/core/src/people/timeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "@rstest/core";
-import { latestDynamic, parseTimelineCursor, type TimelineEntry } from "@rome/api-types/people";
+import { latestDynamic } from "@rome/api-types/people";
+import { parseMessageCursor, type Message } from "@rome/api-types/message";
 import { memoryMessages } from "../channels/messages-memory.js";
 import type { MessageAccount, Messages } from "../channels/messages.js";
 import { readPersonTimeline } from "./timeline.js";
@@ -20,7 +21,7 @@ const entry = (
   timestamp: number,
   ref: string,
   direction: "inbound" | "outbound" = "inbound",
-): TimelineEntry => ({ source, timestamp, ref, direction, body: `${ref}@${timestamp}` });
+): Message => ({ source, timestamp, ref, direction, body: `${ref}@${timestamp}` });
 
 /**
  * A store holding `held`, keyed by the address each entry arrived at — the
@@ -30,7 +31,7 @@ const entry = (
  * An entry's `source` is the channel it belongs to, so an address on one
  * channel never answers for an account on another.
  */
-function store(held: Record<string, TimelineEntry[]>): Messages {
+function store(held: Record<string, Message[]>): Messages {
   return memoryMessages(
     Object.entries(held).flatMap(([address, entries]) =>
       entries.map((held) => ({ channel: held.source, address, entry: held })),
@@ -74,13 +75,13 @@ describe("readPersonTimeline", () => {
   it("pages by nextCursor with no duplicate and no missing entry", async () => {
     const whole = (await readPersonTimeline([whatsapp, telegram], accounts, { limit: 10 })).entries;
 
-    const walked: TimelineEntry[] = [];
-    let cursor: TimelineEntry | null = null;
+    const walked: Message[] = [];
+    let cursor: Message | null = null;
     for (let page = 0; page < 10; page += 1) {
       const next = await readPersonTimeline([whatsapp, telegram], accounts, { cursor, limit: 1 });
       walked.push(...next.entries);
       if (next.nextCursor === null) break;
-      cursor = parseTimelineCursor(next.nextCursor);
+      cursor = parseMessageCursor(next.nextCursor);
       expect(cursor).not.toBeNull();
     }
     expect(walked).toEqual(whole);
@@ -100,7 +101,7 @@ describe("readPersonTimeline", () => {
     const one = [account("whatsapp", "c-1")];
     const first = await readPersonTimeline([crowded], one, { limit: 2 });
     const rest = await readPersonTimeline([crowded], one, {
-      cursor: parseTimelineCursor(first.nextCursor),
+      cursor: parseMessageCursor(first.nextCursor),
       limit: 10,
     });
     expect([...first.entries, ...rest.entries].map((e) => e.ref)).toEqual(["b", "a", "c", "d"]);

--- a/packages/core/src/people/timeline.ts
+++ b/packages/core/src/people/timeline.ts
@@ -1,15 +1,16 @@
 // A person's history, merged across every account they are linked to. The
-// entry shape, the ordering and the cursor are the contract's
-// (@rome/api-types/people); a store is the channel's (`Messages`, in
+// message shape, the ordering and the cursor are the message module's
+// (@rome/api-types/message), and the page that wraps them is the People
+// contract's (@rome/api-types/people); a store is the channel's (`Messages`, in
 // channels/messages.js); this module is only the merge above them.
 
+import { type TimelinePage } from "@rome/api-types/people";
 import {
-  compareTimelineEntries,
-  isAfterTimelineCursor,
-  timelineCursor,
-  type TimelineEntry,
-  type TimelinePage,
-} from "@rome/api-types/people";
+  compareMessages,
+  isAfterMessageCursor,
+  messageCursor,
+  type Message,
+} from "@rome/api-types/message";
 import type { MessageAccount, Messages } from "../channels/messages.js";
 
 /**
@@ -24,7 +25,7 @@ import type { MessageAccount, Messages } from "../channels/messages.js";
 export async function readPersonTimeline(
   stores: readonly Messages[],
   accounts: readonly MessageAccount[],
-  options: { cursor?: TimelineEntry | null; limit: number },
+  options: { cursor?: Message | null; limit: number },
 ): Promise<TimelinePage> {
   const cursor = options.cursor ?? null;
   const limit = Math.max(1, Math.floor(options.limit));
@@ -43,13 +44,13 @@ export async function readPersonTimeline(
   // newest `limit` that a store could contribute is among the entries it sent.
   const merged = pages
     .flat()
-    .filter((entry) => cursor === null || isAfterTimelineCursor(entry, cursor))
-    .sort(compareTimelineEntries);
+    .filter((entry) => cursor === null || isAfterMessageCursor(entry, cursor))
+    .sort(compareMessages);
   const entries = merged.slice(0, limit);
   const oldest = entries.at(-1);
   return {
     entries,
-    nextCursor: merged.length > entries.length && oldest ? timelineCursor(oldest) : null,
+    nextCursor: merged.length > entries.length && oldest ? messageCursor(oldest) : null,
   };
 }
 
@@ -113,8 +114,8 @@ export async function assignAccounts<Account extends MessageAccount>(
 export async function assignAccountHeads<Account extends MessageAccount>(
   stores: readonly Messages[],
   accounts: readonly Account[],
-): Promise<Map<Account, { store: Messages; head: TimelineEntry }>> {
-  const owned = new Map<Account, { store: Messages; head: TimelineEntry }>();
+): Promise<Map<Account, { store: Messages; head: Message }>> {
+  const owned = new Map<Account, { store: Messages; head: Message }>();
   let unclaimed = [...accounts];
   for (const store of stores) {
     if (unclaimed.length === 0) break;

--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -4,7 +4,6 @@ import {
   accountPresentation,
   comparePeople,
   countPeople,
-  isAfterTimelineCursor,
   isAssignableBondLevel,
   latestDynamic,
   parseAccountCursor,
@@ -13,13 +12,11 @@ import {
   parseMergeRequest,
   parsePersonFilterLevel,
   parseSendMessageRequest,
-  parseTimelineCursor,
   parseUpdatePersonRequest,
   personMatchesLevel,
   personMatchesQuery,
   sliceAccountDirectory,
   sliceAccountStream,
-  timelineCursor,
   timelinePageLimit,
   type CreatePersonRequest,
   type DirectoryAccount,
@@ -33,9 +30,14 @@ import {
   type PersonResource,
   type SendRefusal,
   type StreamAccount,
-  type TimelineEntry,
   type TimelinePage,
 } from "@rome/api-types/people";
+import {
+  isAfterMessageCursor,
+  messageCursor,
+  parseMessageCursor,
+  type Message,
+} from "@rome/api-types/message";
 import { talkConnections } from "./connections-store";
 import { memoryProfilePath } from "./memory-files";
 import {
@@ -586,19 +588,19 @@ export const peopleHandlers = [
       (entry) => !channel || entry.source === channel,
     );
     const rawCursor = search.get("cursor");
-    const cursor = parseTimelineCursor(rawCursor);
+    const cursor = parseMessageCursor(rawCursor);
     if (rawCursor != null && rawCursor !== "" && cursor === null) {
       return HttpResponse.json({ error: "cursor is not a timeline cursor" }, { status: 400 });
     }
     const limit = timelinePageLimit(search.get("limit"));
-    const remaining: TimelineEntry[] = cursor
-      ? all.filter((entry) => isAfterTimelineCursor(entry, cursor))
+    const remaining: Message[] = cursor
+      ? all.filter((entry) => isAfterMessageCursor(entry, cursor))
       : all;
     const page = remaining.slice(0, limit);
     const oldest = page.at(-1);
     return HttpResponse.json({
       entries: page,
-      nextCursor: remaining.length > page.length && oldest ? timelineCursor(oldest) : null,
+      nextCursor: remaining.length > page.length && oldest ? messageCursor(oldest) : null,
     } satisfies TimelinePage);
   }),
 

--- a/packages/web/mock/handlers/people.ts
+++ b/packages/web/mock/handlers/people.ts
@@ -6,11 +6,8 @@ import {
   STRANGER_PERSON_DISPLAY_NAME,
   STRANGER_PERSON_ID,
 } from "@rome/api-types/persons";
-import {
-  compareTimelineEntries,
-  whatsAppDisplayName,
-  type TimelineEntry,
-} from "@rome/api-types/people";
+import { whatsAppDisplayName } from "@rome/api-types/people";
+import { compareMessages, type Message } from "@rome/api-types/message";
 
 /**
  * The People tab's in-memory store: the curated people, the sentinel log, and
@@ -670,14 +667,14 @@ export interface AccountRef {
  * single line the sentinel recorded. Entries are generic — source, time, body,
  * direction, ref — so nothing here knows it is looking at WhatsApp.
  */
-export function personTimeline(personId: string): TimelineEntry[] | null {
+export function personTimeline(personId: string): Message[] | null {
   const channels = persons.find((person) => person.id === personId)?.channelMappings;
   return channels ? timelineForChannels(channels) : null;
 }
 
 /** One account's dynamics, newest first. Always an answer: an account Rome has
  *  never heard from has an empty history, not a missing one. */
-export function accountTimeline(ref: AccountRef): TimelineEntry[] {
+export function accountTimeline(ref: AccountRef): Message[] {
   return timelineForChannels([ref]);
 }
 
@@ -691,13 +688,13 @@ export function accountTimeline(ref: AccountRef): TimelineEntry[] {
  * to look the message up here and find it — the same comparison the route runs,
  * rather than a delivery bit someone remembered to set.
  */
-const deliveredEntries: (TimelineEntry & { channelUserId: string })[] = [];
+const deliveredEntries: (Message & { channelUserId: string })[] = [];
 
 /** Put a sent message where the timeline will find it. The `ref` is the one the
  *  outbox row is waiting on, which is what clears the row. */
 export function recordDelivered(
   account: AccountRef,
-  entry: Omit<TimelineEntry, "source" | "direction">,
+  entry: Omit<Message, "source" | "direction">,
 ): void {
   deliveredEntries.push({
     ...entry,
@@ -709,8 +706,8 @@ export function recordDelivered(
 
 /** One channel set's dynamics, newest first. The row's `latest` is this
  *  sequence's head, so the two cannot disagree about what happened last. */
-function timelineForChannels(channels: AccountRef[]): TimelineEntry[] {
-  const entries: TimelineEntry[] = [];
+function timelineForChannels(channels: AccountRef[]): Message[] {
+  const entries: Message[] = [];
   for (const mapping of channels) {
     for (const sent of deliveredEntries) {
       if (sent.source !== mapping.channel || sent.channelUserId !== mapping.channelUserId) continue;
@@ -750,12 +747,12 @@ function timelineForChannels(channels: AccountRef[]): TimelineEntry[] {
     }
     entries.push(...sentinelEntriesFor(mapping));
   }
-  return entries.sort(compareTimelineEntries);
+  return entries.sort(compareMessages);
 }
 
 /** Every sentinel log row for one account, as timeline entries. */
-function sentinelEntriesFor(mapping: AccountRef): TimelineEntry[] {
-  const entries: TimelineEntry[] = [];
+function sentinelEntriesFor(mapping: AccountRef): Message[] {
+  const entries: Message[] = [];
   for (const sender of sentinelSenders) {
     if (sender.channel !== mapping.channel || sender.channelUserId !== mapping.channelUserId) {
       continue;

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -4,7 +4,8 @@ import { act, cleanup, render, screen, waitFor, within } from "@testing-library/
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { OutboxMessage, TimelineEntry } from "@rome/api-types/people";
+import type { OutboxMessage } from "@rome/api-types/people";
+import type { Message } from "@rome/api-types/message";
 import {
   countPeople,
   linkConflict,
@@ -90,7 +91,7 @@ const READ_ONLY_PERSON: PersonResource = {
   memoryPath: null,
 };
 
-const ENTRIES: TimelineEntry[] = [
+const ENTRIES: Message[] = [
   {
     source: "whatsapp",
     timestamp: NOW - 300,
@@ -165,9 +166,9 @@ interface FetchCall {
 function mockApi(
   options: {
     person?: PersonResource | "missing" | "fail";
-    entries?: TimelineEntry[] | "fail";
+    entries?: Message[] | "fail";
     nextCursor?: string | null;
-    older?: TimelineEntry[];
+    older?: Message[];
     people?: PersonResource[];
     accounts?: DirectoryAccount[];
     writes?: "fail";
@@ -197,7 +198,7 @@ function mockApi(
   // outbox, never both and never neither. Nothing here marks a row delivered —
   // it moves between the stores, and the reads report where it is.
   const outbox: OutboxMessage[] = [...(options.outbox ?? [])];
-  const delivered: TimelineEntry[] = [];
+  const delivered: Message[] = [];
   /** The channel took it and its mirror now holds it — which is what puts it on
    *  the timeline, and therefore what takes it out of the outbox. */
   const accept = (row: OutboxMessage) =>
@@ -485,14 +486,14 @@ describe("PersonDetailPage", () => {
     // entries would render twice, under keys React would then see twice.
     // Paging belongs to the query rather than to state kept here, so there is
     // no cursor to snap back — this is that, pinned.
-    const older: TimelineEntry = {
+    const older: Message = {
       source: "telegram",
       timestamp: NOW - 400_000,
       body: "first hello",
       direction: "inbound",
       ref: "sentinel:1",
     };
-    const arrival: TimelineEntry = {
+    const arrival: Message = {
       source: "whatsapp",
       timestamp: NOW - 5,
       body: "one more thing",

--- a/packages/web/src/pages/people/conversation.tsx
+++ b/packages/web/src/pages/people/conversation.tsx
@@ -5,8 +5,8 @@ import {
   defaultSendAccount,
   type LinkedAccount,
   type PersonResource,
-  type TimelineEntry,
 } from "@rome/api-types/people";
+import type { Message } from "@rome/api-types/message";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { SegmentedControl } from "@/components/ui/segmented-control";
@@ -180,12 +180,12 @@ function sameAccount(a: LinkedAccount, b: LinkedAccount): boolean {
 
 interface TimelineDay {
   dayStart: number;
-  entries: TimelineEntry[];
+  entries: Message[];
 }
 
 /** Entries arrive newest first and stay that way inside each day, so the page
  *  reads top-down as "most recent first" at both levels. */
-function groupByDay(entries: readonly TimelineEntry[]): TimelineDay[] {
+function groupByDay(entries: readonly Message[]): TimelineDay[] {
   const days: TimelineDay[] = [];
   for (const entry of entries) {
     const dayStart = startOfDay(entry.timestamp);

--- a/packages/web/src/pages/people/people-contract.test.ts
+++ b/packages/web/src/pages/people/people-contract.test.ts
@@ -3,20 +3,22 @@ import {
   accountMatchesQuery,
   compareCodePoints,
   compareDisplayNames,
-  compareTimelineEntries,
   comparePeople,
   encodeStreamCursor,
   latestDynamic,
   normalizeBondLevel,
   parseStreamCursor,
-  parseTimelineCursor,
   personMatchesQuery,
-  timelineCursor,
   type StreamCursor,
   type DirectoryAccount,
   type PersonResource,
-  type TimelineEntry,
 } from "@rome/api-types/people";
+import {
+  compareMessages,
+  messageCursor,
+  parseMessageCursor,
+  type Message,
+} from "@rome/api-types/message";
 import { protectedPersonReason, STRANGER_PERSON_ID } from "@rome/api-types/persons";
 
 // The rules `@rome/api-types/people` holds that both ends have to agree on,
@@ -31,7 +33,7 @@ import { protectedPersonReason, STRANGER_PERSON_ID } from "@rome/api-types/perso
 // those show up as a failure in the surface that calls them, only as a wrong
 // answer.
 
-const entry = (over: Partial<TimelineEntry> = {}): TimelineEntry => ({
+const entry = (over: Partial<Message> = {}): Message => ({
   source: "whatsapp",
   timestamp: 100,
   body: null,
@@ -63,29 +65,29 @@ const account = (
 describe("timeline cursor", () => {
   it("round-trips a source and a ref carrying the separator", () => {
     const tricky = entry({ source: "app|notes", ref: "chat|1:msg|2" });
-    const parsed = parseTimelineCursor(timelineCursor(tricky));
+    const parsed = parseMessageCursor(messageCursor(tricky));
 
     expect(parsed?.source).toBe("app|notes");
     expect(parsed?.ref).toBe("chat|1:msg|2");
     // The decoded position has to compare equal to the entry it names, or the
     // next page resumes somewhere no entry sits.
-    expect(compareTimelineEntries(parsed as TimelineEntry, tricky)).toBe(0);
+    expect(compareMessages(parsed as Message, tricky)).toBe(0);
   });
 
   it("keeps two entries whose separators would otherwise collide apart", () => {
     const a = entry({ source: "a|b", ref: "r" });
     const b = entry({ source: "a", ref: "b|r" });
 
-    expect(timelineCursor(a)).not.toBe(timelineCursor(b));
-    expect(compareTimelineEntries(a, b)).not.toBe(0);
+    expect(messageCursor(a)).not.toBe(messageCursor(b));
+    expect(compareMessages(a, b)).not.toBe(0);
   });
 
   it("rejects a value that is not a cursor", () => {
-    expect(parseTimelineCursor("100|inbound|whatsapp")).toBeNull();
-    expect(parseTimelineCursor("100|sideways|whatsapp|r1")).toBeNull();
-    expect(parseTimelineCursor("|inbound|whatsapp|r1")).toBeNull();
-    expect(parseTimelineCursor("100|inbound|whatsapp|")).toBeNull();
-    expect(parseTimelineCursor("%E0%A4%A|inbound|whatsapp|r1")).toBeNull();
+    expect(parseMessageCursor("100|inbound|whatsapp")).toBeNull();
+    expect(parseMessageCursor("100|sideways|whatsapp|r1")).toBeNull();
+    expect(parseMessageCursor("|inbound|whatsapp|r1")).toBeNull();
+    expect(parseMessageCursor("100|inbound|whatsapp|")).toBeNull();
+    expect(parseMessageCursor("%E0%A4%A|inbound|whatsapp|r1")).toBeNull();
   });
 });
 
@@ -125,7 +127,7 @@ describe("orderings are total", () => {
     expect("é".localeCompare("e\u0301")).toBe(0);
     expect(compareCodePoints("é", "e\u0301")).not.toBe(0);
 
-    expect(compareTimelineEntries(entry({ ref: "é" }), entry({ ref: "e\u0301" }))).not.toBe(0);
+    expect(compareMessages(entry({ ref: "é" }), entry({ ref: "e\u0301" }))).not.toBe(0);
   });
 
   it("separates two people whose names differ only by normalization", () => {
@@ -140,7 +142,7 @@ describe("orderings are total", () => {
     const inbound = entry({ direction: "inbound", ref: "msg" });
     const reply = entry({ direction: "outbound", ref: "msg:reply" });
 
-    expect(compareTimelineEntries(reply, inbound)).toBeLessThan(0);
+    expect(compareMessages(reply, inbound)).toBeLessThan(0);
   });
 });
 
@@ -197,7 +199,7 @@ describe("what a search matches", () => {
 });
 
 describe("latestDynamic", () => {
-  const said = (over: Partial<TimelineEntry> = {}) => entry({ body: "hello", ...over });
+  const said = (over: Partial<Message> = {}) => entry({ body: "hello", ...over });
 
   it("projects the head of the ordering, whatever it is", () => {
     // One definition of "newest". A second comparison would settle a same-second
@@ -205,7 +207,7 @@ describe("latestDynamic", () => {
     // opened on another.
     const inbound = said({ source: "telegram", direction: "inbound", ref: "a" });
     const outbound = said({ source: "whatsapp", direction: "outbound", ref: "b" });
-    const ordered = [inbound, outbound].sort(compareTimelineEntries);
+    const ordered = [inbound, outbound].sort(compareMessages);
 
     expect(latestDynamic(ordered)).toEqual({
       source: ordered[0].source,

--- a/packages/web/src/pages/people/send-model.test.ts
+++ b/packages/web/src/pages/people/send-model.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@rstest/core";
-import { defaultSendAccount, type LinkedAccount, type TimelineEntry } from "@rome/api-types/people";
+import { defaultSendAccount, type LinkedAccount } from "@rome/api-types/people";
+import type { Message } from "@rome/api-types/message";
 import {
   ALL_ACCOUNTS,
   isDismissable,
@@ -91,7 +92,7 @@ describe("segmentAccount", () => {
 });
 
 describe("segmentEntries", () => {
-  const entries: TimelineEntry[] = [
+  const entries: Message[] = [
     { source: "whatsapp", timestamp: 20, body: "wa", direction: "inbound", ref: "a" },
     { source: "telegram", timestamp: 10, body: "tg", direction: "inbound", ref: "b" },
   ];

--- a/packages/web/src/pages/people/send-model.ts
+++ b/packages/web/src/pages/people/send-model.ts
@@ -3,8 +3,8 @@ import {
   formatWhatsAppPhone,
   type LinkedAccount,
   type OutboxMessage,
-  type TimelineEntry,
 } from "@rome/api-types/people";
+import type { Message } from "@rome/api-types/message";
 
 // The shape of the person page's two views, with no React in it: which segments
 // the switcher offers, and what each one scopes.
@@ -85,9 +85,9 @@ export function segmentAccount(
  * refuses to make.
  */
 export function segmentEntries(
-  entries: readonly TimelineEntry[],
+  entries: readonly Message[],
   account: LinkedAccount | null,
-): TimelineEntry[] {
+): Message[] {
   return account ? entries.filter((entry) => entry.source === account.channel) : [...entries];
 }
 


### PR DESCRIPTION
Closes #165. Follows #162.

## What

Move the message shape — the one thing Rome renders whenever it shows what was said (a line, its direction, when it was said, and a stable id) — out of the People contract into its own module, and rename it so the naming is not half-done. A channel now answers what a conversation holds with the same shape, and a conversation is not a person's timeline, so the shape no longer belongs to the People surface alone.

New leaf module `packages/api-types/src/message.ts` (exported as `@rome/api-types/message`) now owns the shape, its order, and its cursor:

| before | after |
| --- | --- |
| `TimelineEntry` | `Message` |
| `compareTimelineEntries` | `compareMessages` |
| `timelineCursor` | `messageCursor` |
| `parseTimelineCursor` | `parseMessageCursor` |
| `isAfterTimelineCursor` | `isAfterMessageCursor` |

- The module imports **nothing**, so a reader that only needs "message" (the channels stores, a conversation) no longer drags in the People page boundary. It also **owns `compareCodePoints`** — the total string order the `source`/`ref` tiebreak uses — and `people.ts` re-exports it for the account and display-name orders, so "how two strings order for a cursor" has one definition rather than two. The dependency points `people.ts` → `message.ts` only; no cycle.
- **`people.ts` keeps its own paging and row** (`TimelinePage`, `TIMELINE_PAGE_*`, `timelinePageLimit`, `latestDynamic`, `AccountDynamic`) and imports `Message` (and `compareCodePoints`) from the new module. A person's timeline is still a timeline; what it holds is a message.
- Every reader is swept — backend, dashboard pages, mock handlers, and the channels stores (~150 references); each mixed import is split so moved symbols come from `/message` and People symbols stay on `/people`. The unrelated iOS WidgetKit `WidgetTimelineEntry` is deliberately left alone.

## Out of scope

The wire format: no field moves and the cursor string is unchanged, so the People routes serve byte-identical JSON — the route tests pass unedited, which is what proves it.

## Verification

- `pnpm typecheck` clean for `api-types`, `core`, `web`, `mobile`.
- Grep for the five renamed symbols returns nothing (whole-word) outside git history.
- `pnpm test:unit`: message/timeline tests pass with no expectation edited (core 4354 pass; web people/detail/contract suites pass). Remaining failures are pre-existing/environmental (`pty.node` native module missing; a flaky `channels-settings-page` test that fails on base too) and reference none of the renamed symbols.
- People route tests (`people.test.ts`, `people-send.test.ts`) pass unedited.
- `biome format` reports no changes on the touched files.
- `pnpm start:web:mock`: server boots, `/` and `/people` and the compiled bundle serve 200, the new subpath resolves, and a person's message history pages.

## Base

Rebased onto current `main`; the PR is exactly one commit (the #165 refactor). Earlier it was cut from an in-flight lineage and carried three unrelated commits (a Cache-Control change from #271 and two UI fixes) — those are gone from the diff now that `main` has advanced to include the messaging surface this refactor sweeps.

## Review rounds

**Round 1** (both bots requested changes):
- **Rebased onto `main`** so only the #165 change lands.
- Fixed two stale headers (`channels/messages.ts`, `people/timeline.ts`) still attributing the shape/order/cursor to the People contract.
- Ran `biome format` on `channels/messages-memory.ts` so the required lint check is green.

**Round 2** (`zoolsher` approved; three follow-up notes):
- **Moved `compareCodePoints` into `message.ts`** and re-exported it from `people.ts`, so the string tiebreak has a single authoritative definition instead of an inlined copy — resolving the SSOT/naming-drift note the cycle-free way (people already depends on message).
- Fixed the `people.ts` top-of-file header that still claimed the timeline order/cursor were "stated once, here".
- The `messages-sql.ts` collation comment naming `compareCodePoints` is accurate again on its own after the move; left unchanged.
