### PR TITLE
feat(webchat): show the resolved session model

### DIFF
--- a/packages/core/src/api/routes/webchat.test.ts
+++ b/packages/core/src/api/routes/webchat.test.ts
@@ -1387,6 +1387,41 @@ describe("Webchat API", () => {
     });
   });
 
+  describe("session model", () => {
+    it("returns the stored model pin for the selected agent and model key", async () => {
+      const app = createWebchatRuntime(deps).routes;
+      const response = await app.request("/chat/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Model identity" }),
+      });
+      const session = (await response.json()) as { id: string };
+      const read = async () => (await app.request(`/chat/sessions/${session.id}`)).json();
+      expect(await read()).toMatchObject({ model: null });
+
+      const runtimeId = await deps.sessionsRepo.create({
+        agentName: "main",
+        channelThreadKey: `webchat:${session.id}`,
+      });
+      await deps.sessionsRepo.setProviderInfo(runtimeId, "codex", "thread-1", "gpt-5.5");
+      const otherAgentId = await deps.sessionsRepo.create({
+        agentName: "other-agent",
+        channelThreadKey: `webchat:${session.id}`,
+      });
+      await deps.sessionsRepo.setProviderInfo(otherAgentId, "claude", "thread-2", "other-model");
+      expect(await read()).toMatchObject({ model: "gpt-5.5" });
+
+      await deps.webchatRepo.updateSessionLargeModelSelection(session.id, "gpt-5-6-sol");
+      expect(await read()).toMatchObject({ model: null });
+      const selectedRuntimeId = await deps.sessionsRepo.create({
+        agentName: "main",
+        channelThreadKey: `webchat:${session.id}:large-model:gpt-5-6-sol`,
+      });
+      await deps.sessionsRepo.setProviderInfo(selectedRuntimeId, "codex", "thread-3", "gpt-6");
+      expect(await read()).toMatchObject({ model: "gpt-6" });
+    });
+  });
+
   describe("rename route", () => {
     const createSession = async (
       app: ReturnType<typeof createWebchatRuntime>["routes"],

--- a/packages/core/src/api/routes/webchat.ts
+++ b/packages/core/src/api/routes/webchat.ts
@@ -2134,7 +2134,17 @@ export function createWebchatRuntime(deps: ApiDeps): { routes: Hono; runtime: We
     if ("response" in lookup) return lookup.response;
     const { session } = lookup;
     const messageCount = await deps.webchatRepo.getMessageCount(sessionId);
-    return c.json(toWebchatSessionResponse(session, messageCount));
+    const runtimeSession = await deps.sessionManager.findReusableSession(
+      buildWebchatChannelThreadKey(
+        sessionId,
+        resolveStoredModelSelection(session.largeModelSelection),
+      ),
+      session.agentName ?? "main",
+    );
+    return c.json({
+      ...toWebchatSessionResponse(session, messageCount),
+      model: runtimeSession?.model ?? null,
+    });
   });
 
   app.delete("/chat/sessions/:id", async (c) => {

--- a/packages/web/src/components/chat/Chat.test.tsx
+++ b/packages/web/src/components/chat/Chat.test.tsx
@@ -191,6 +191,22 @@ afterEach(() => {
 });
 
 describe("Chat agent identity", () => {
+  it("shows the session model in the chat header", () => {
+    mockUseSessionIdentity.mockReturnValue({
+      sessionName: "A conversation",
+      model: "gpt-5.5",
+      pinnedAgentMention: null,
+      archivedAt: null,
+    });
+    renderChat(<Chat sessionId="session-1" />);
+    expect(screen.getByLabelText("navbar.sessionModel").textContent).toBe("gpt-5.5");
+  });
+
+  it("does not invent a model for a session without a pin", () => {
+    renderChat(<Chat sessionId="session-1" />);
+    expect(screen.queryByLabelText("navbar.sessionModel")).toBeNull();
+  });
+
   it("uses the guardian-chosen name for the default main agent", () => {
     renderChat(<Chat sessionId="session-1" mainAgentDisplayName="  Atlas  " />);
 

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -40,6 +40,7 @@ import {
   type TraceDrawerTarget,
 } from "@/components/agent-trace/TraceDrawer";
 import { AgentAvatar } from "@/components/chat/AgentAvatar";
+import { SessionModelLabel } from "@/components/chat/SessionModelLabel";
 import { useSessionIdentity } from "@/components/chat/use-session-identity";
 import { prettyAgentName } from "@/lib/agent-name";
 import { artifactLocalName } from "@/lib/artifact-name";
@@ -322,7 +323,7 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
   // The session's bound agent (`null` ⇒ default "main") and display name. The
   // composer renders the agent as a non-removable chip and the navbar shows the
   // name as the title; the mobile header bar (FreeGrid) reuses the same hook.
-  const { sessionName, pinnedAgentMention, archivedAt, pinnedAt } =
+  const { sessionName, model, pinnedAgentMention, archivedAt, pinnedAt } =
     useSessionIdentity(mainSessionId);
   // Local override so archive/unarchive from the navbar flips the read-only
   // composer immediately; `undefined` defers to the session read (`archivedAt`).
@@ -1618,6 +1619,7 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
               <span className="truncate text-ui text-foreground">
                 {sessionName?.trim() || pinnedAgentMention?.appLabel || t("sidebar.newChat")}
               </span>
+              <SessionModelLabel model={model} />
               {sessionName?.trim() && pinnedAgentMention && (
                 <span className="shrink-0 truncate text-aux text-muted-foreground">
                   {pinnedAgentMention.appLabel}

--- a/packages/web/src/components/chat/SessionModelLabel.tsx
+++ b/packages/web/src/components/chat/SessionModelLabel.tsx
@@ -1,0 +1,16 @@
+import { useTranslation } from "react-i18next";
+
+export function SessionModelLabel({ model }: { model: string | null | undefined }) {
+  const { t } = useTranslation("chat");
+  if (!model) return null;
+
+  return (
+    <span
+      className="min-w-0 max-w-full shrink-0 truncate text-aux text-muted-foreground md:max-w-48"
+      title={t("navbar.sessionModel", { model })}
+      aria-label={t("navbar.sessionModel", { model })}
+    >
+      {model}
+    </span>
+  );
+}

--- a/packages/web/src/components/chat/use-session-identity.test.tsx
+++ b/packages/web/src/components/chat/use-session-identity.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, rs } from "@rstest/core";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { AgentCatalogGroup, ChatSession } from "@/lib/chat-types";
+import { emitSessionsChanged } from "@/lib/session-events";
 import { setPresentationMode } from "@/lib/presentation-mode";
 import { useSessionIdentity } from "./use-session-identity";
 
@@ -73,4 +74,53 @@ describe("useSessionIdentity presentation mode", () => {
     await waitFor(() => expect(result.current.sessionName).toBe("Planning the launch"));
     expect(result.current.pinnedAgentMention).toBeNull();
   });
+});
+
+describe("useSessionIdentity model", () => {
+  it("shows the actual model rather than the requested selection and refreshes it", async () => {
+    rs.mocked(getSession).mockResolvedValue({
+      ...session,
+      largeModelSelection: "auto",
+      model: "gpt-5.5",
+    });
+    rs.mocked(listChatAgents).mockResolvedValue(groups);
+    const { result } = renderHook(() => useSessionIdentity("s1"));
+    await waitFor(() => expect(result.current.model).toBe("gpt-5.5"));
+    rs.mocked(getSession).mockResolvedValue({ ...session, model: "claude-opus-4-6" });
+    act(() => emitSessionsChanged());
+    await waitFor(() => expect(result.current.model).toBe("claude-opus-4-6"));
+  });
+
+  it("clears the model when navigating to a session without a pin", async () => {
+    rs.mocked(getSession).mockResolvedValue({ ...session, model: "gpt-5.5" });
+    rs.mocked(listChatAgents).mockResolvedValue(groups);
+    const { result, rerender } = renderHook(({ id }) => useSessionIdentity(id), {
+      initialProps: { id: "s1" },
+    });
+    await waitFor(() => expect(result.current.model).toBe("gpt-5.5"));
+    rs.mocked(getSession).mockResolvedValue({ ...session, id: "s2" });
+    rerender({ id: "s2" });
+    await waitFor(() => expect(result.current.model).toBeNull());
+  });
+});
+
+it("ignores an old session's pending model refresh after navigation", async () => {
+  rs.mocked(getSession).mockResolvedValue({ ...session, model: "gpt-5.5" });
+  rs.mocked(listChatAgents).mockResolvedValue(groups);
+  const { result, rerender } = renderHook(({ id }) => useSessionIdentity(id), {
+    initialProps: { id: "s1" },
+  });
+  await waitFor(() => expect(result.current.model).toBe("gpt-5.5"));
+  let finishRefresh!: (session: ChatSession) => void;
+  rs.mocked(getSession).mockReturnValueOnce(
+    new Promise((resolve) => {
+      finishRefresh = resolve;
+    }),
+  );
+  act(() => emitSessionsChanged());
+  rs.mocked(getSession).mockResolvedValue({ ...session, id: "s2", model: "claude-opus-4-6" });
+  rerender({ id: "s2" });
+  await waitFor(() => expect(result.current.model).toBe("claude-opus-4-6"));
+  await act(async () => finishRefresh({ ...session, model: "gpt-5.5" }));
+  expect(result.current.model).toBe("claude-opus-4-6");
 });

--- a/packages/web/src/components/chat/use-session-identity.ts
+++ b/packages/web/src/components/chat/use-session-identity.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { AgentMention } from "@/lib/chat-types";
 import { getSession, listChatAgents } from "@/lib/chat-api";
 import { artifactOwnerId } from "@/lib/artifact-name";
@@ -9,6 +9,7 @@ import { useSessionsChanged } from "@/lib/session-events";
 export interface SessionIdentity {
   /** The session's display name, or null while loading / unnamed. */
   sessionName: string | null;
+  model: string | null;
   /** The session's locked agent, resolved to its owning app's label + icon. */
   pinnedAgentMention: AgentMention | null;
   /** ISO timestamp when the session was archived, or null when not archived. */
@@ -31,19 +32,24 @@ export interface SessionIdentity {
  */
 export function useSessionIdentity(sessionId: string | null | undefined): SessionIdentity {
   const presentationMode = usePresentationMode();
+  const sessionGeneration = useRef(0);
+  const [model, setModel] = useState<string | null>(null);
   const [sessionName, setSessionName] = useState<string | null>(null);
   const [pinnedAgentMention, setPinnedAgentMention] = useState<AgentMention | null>(null);
   const [archivedAt, setArchivedAt] = useState<string | null>(null);
   const [pinnedAt, setPinnedAt] = useState<string | null>(null);
 
   useEffect(() => {
+    sessionGeneration.current += 1;
     if (!sessionId) {
       setPinnedAgentMention(null);
+      setModel(null);
       setSessionName(null);
       setArchivedAt(null);
       setPinnedAt(null);
       return;
     }
+    setModel(null);
     let cancelled = false;
     (async () => {
       try {
@@ -53,6 +59,7 @@ export function useSessionIdentity(sessionId: string | null | undefined): Sessio
         ]);
         if (cancelled) return;
         setSessionName(session?.name ?? null);
+        setModel(session?.model ?? null);
         setArchivedAt(session?.archivedAt ?? null);
         setPinnedAt(session?.pinnedAt ?? null);
         const agentName = session?.agentName ?? null;
@@ -74,6 +81,7 @@ export function useSessionIdentity(sessionId: string | null | undefined): Sessio
         }
       } catch {
         if (!cancelled) {
+          setModel(null);
           setSessionName(null);
           setPinnedAgentMention(null);
           setArchivedAt(null);
@@ -83,6 +91,7 @@ export function useSessionIdentity(sessionId: string | null | undefined): Sessio
     })();
     return () => {
       cancelled = true;
+      sessionGeneration.current += 1;
     };
   }, [sessionId]);
 
@@ -94,10 +103,13 @@ export function useSessionIdentity(sessionId: string | null | undefined): Sessio
   // which don't change on archive) to keep the listener cheap.
   useSessionsChanged(() => {
     if (!sessionId) return;
+    const generation = sessionGeneration.current;
     void (async () => {
       try {
         const session = await getSession(sessionId);
+        if (generation !== sessionGeneration.current) return;
         setSessionName(session?.name ?? null);
+        setModel(session?.model ?? null);
         setArchivedAt(session?.archivedAt ?? null);
         setPinnedAt(session?.pinnedAt ?? null);
       } catch {
@@ -108,6 +120,7 @@ export function useSessionIdentity(sessionId: string | null | undefined): Sessio
 
   return {
     sessionName,
+    model,
     pinnedAgentMention: presentationMode ? null : pinnedAgentMention,
     archivedAt,
     pinnedAt,

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -15,6 +15,7 @@
     "openSidebar": "Open sidebar"
   },
   "navbar": {
+    "sessionModel": "Session model: {{model}}",
     "add": "Add widget",
     "addShort": "Add widget",
     "more": "More actions",

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -15,6 +15,7 @@
     "openSidebar": "打开侧边栏"
   },
   "navbar": {
+    "sessionModel": "会话模型：{{model}}",
     "add": "添加小组件",
     "addShort": "加组件",
     "more": "更多操作",

--- a/packages/web/src/lib/chat-types.ts
+++ b/packages/web/src/lib/chat-types.ts
@@ -26,6 +26,8 @@ export interface ChatSession {
   name: string;
   personaId: string | null;
   largeModelSelection?: string | null;
+  /** Concrete model pinned by the session’s last successful turn, when known. */
+  model?: string | null;
   projectName: string;
   projectPath?: string | null;
   agentName?: string | null;

--- a/packages/web/src/pages/free/FreeGrid.tsx
+++ b/packages/web/src/pages/free/FreeGrid.tsx
@@ -35,6 +35,7 @@ import { resolveAppToOpen } from "@/lib/chat-helpers";
 import { deleteSession } from "@/lib/chat-api";
 import { AgentAvatar } from "@/components/chat/AgentAvatar";
 import { useApps } from "@/hooks/use-apps";
+import { SessionModelLabel } from "@/components/chat/SessionModelLabel";
 import { useSessionIdentity } from "@/components/chat/use-session-identity";
 import { SlotContent } from "@/components/slot";
 import {
@@ -457,7 +458,7 @@ export function FreeGrid() {
   // Session identity for the mobile header bar (the desktop chat navbar resolves
   // its own copy inside Chat). Both read the same hook; see its note on the
   // intentional double-fetch.
-  const { sessionName, pinnedAgentMention, pinnedAt } = useSessionIdentity(chatSessionId);
+  const { sessionName, model, pinnedAgentMention, pinnedAt } = useSessionIdentity(chatSessionId);
   const setPinned = usePinSession();
 
   // Delete the active chat from the mobile header's "⋯" menu, mirroring the
@@ -631,14 +632,21 @@ export function FreeGrid() {
                   size="sm"
                   className="shrink-0"
                 />
-                <span className="truncate text-ui text-foreground">
-                  {sessionName?.trim() || pinnedAgentMention?.appLabel || t("recentChats.newChat")}
-                </span>
-                {sessionName?.trim() && pinnedAgentMention && (
-                  <span className="shrink-0 truncate text-aux text-muted-foreground">
-                    {pinnedAgentMention.appLabel}
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-ui text-foreground">
+                    {sessionName?.trim() ||
+                      pinnedAgentMention?.appLabel ||
+                      t("recentChats.newChat")}
                   </span>
-                )}
+                  <div className="flex min-w-0 items-center gap-2">
+                    <SessionModelLabel model={model} />
+                    {sessionName?.trim() && pinnedAgentMention && (
+                      <span className="truncate text-aux text-muted-foreground">
+                        {pinnedAgentMention.appLabel}
+                      </span>
+                    )}
+                  </div>
+                </div>
               </div>
             )}
             <WidgetPicker


### PR DESCRIPTION
## What this PR does

Webchat does not show which concrete model produced a session. The model selection can say “Auto”, which does not identify the model that ran.

Show the recorded model beside the desktop chat title and beneath the mobile title. Include English and Chinese accessible labels.

## Design & Invariants

- Read the concrete [session model pin](https://github.com/rome-os/rome/blob/main/docs/concepts/sessions.md#model-pin), not the requested model selection or a tier.
- Scope the lookup to the session's agent and selected model key. A different agent's pin must not appear.
- Hide the label until a concrete model is recorded. Refresh it with session metadata, and ignore refresh responses from a session the guardian has left.
- Keep model selection and routing unchanged. This PR contains only the requested display, API field, and regression tests.

## Test plan

- [x] `pnpm --filter rome-web test src/components/chat/Chat.test.tsx src/components/chat/use-session-identity.test.tsx` — 19 tests pass on this branch.
- [x] `pnpm --filter @rome/core test:unit src/api/routes/webchat.test.ts` — 105 tests pass on this branch.
- [x] Desktop and 390px mobile browser checks during implementation, using a test-only model pin in the mock session response.
- [x] `pnpm --filter rome-web typecheck` on this branch.
- [ ] `pnpm --filter @rome/core typecheck`: the isolated worktree cannot resolve app runtime SDK dependencies in the system app.
- [x] `git diff --check` and `scripts/check-pr-title.sh`.
- [ ] Full-project validation: earlier attempts hit an unresolved example-app SDK import, missing Electron/node-pty binaries, and unavailable Docker/Nix. No unrelated environment changes are included.