### PR TITLE
feat(manager): add a long-running agent whose loop is code

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1149,6 +1149,22 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.15)
 
+  rome_apps/manager:
+    dependencies:
+      '@rome-os/app-runtime':
+        specifier: ^0.6.0
+        version: link:../../packages/app-runtime-sdk
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.1(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(better-sqlite3@12.6.2)(pg@8.18.0)
+    devDependencies:
+      drizzle-kit:
+        specifier: ^0.31.9
+        version: 0.31.9(supports-color@8.1.1)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   rome_apps/recap:
     dependencies:
       '@rome-os/app-runtime':

--- a/rome_apps/manager/README.md
+++ b/rome_apps/manager/README.md
@@ -1,0 +1,159 @@
+# Manager
+
+A long-running agent: it keeps working on your tasks across sessions, and its
+correctness never depends on a session continuing.
+
+Tell it what you want in chat. It records the task in an append-only ledger,
+puts a coding session on it, retries what fails, asks you when it is stuck, and
+reports when there is something to look at. Only you close a task.
+
+This is a prototype of the "long-running agent, revision 3" model. Almost all of
+it is plain TypeScript; a model runs at exactly two points.
+
+## The two model call sites
+
+**The language boundary.** You chat with the `manager` agent
+(`src/agents/manager.yaml`). Its only ledger-writing tools are `manager:create`,
+`manager:reply`, `manager:complete`, and `manager:cancel`, plus the read-only
+`manager:snapshot`. The agent picks which task your words are about and how to
+word the fact; the app stamps who said it and cites the message. When the words
+map to none of those, the agent answers in chat and writes nothing. Its system
+prompt carries no scheduling logic — no caps, no retries, no age.
+
+**The judge.** `src/lib/judge.ts` answers one question: is the task done, given
+what the worker returned. The default answer needs no model — done when the
+reply is not empty and no line opens with `BLOCKED:`. The worker's brief states
+that contract, so a worker that hits a wall says so in a form a plain function
+can read. Swapping in a model-graded judge is a change to that one file.
+
+Everything else — when to take a task, when to start a worker, how many at once,
+when to retry, when to ask, when to stop — is `src/lib/reconcile.ts`, a pure
+function from a ledger snapshot to a list of writes.
+
+## The ledger
+
+One table, `manager__facts`, append-only. Nothing updates or deletes a fact.
+A task's state and position are folded from its facts every time they are
+needed, so a pass can die between any two writes without corrupting anything.
+
+Facts are named by one rule: a participle is something that happened, a noun is
+something somebody said.
+
+| Kind | Written by | Payload |
+| --- | --- | --- |
+| `Created` | a person | `brief` |
+| `Taken` | the runtime | — |
+| `Completed` | a person | `reason?` |
+| `Cancelled` | a person | `reason?` |
+| `Started` | the runtime | `workerId`, `prompt` |
+| `Returned` | the worker | `workerId`, `reply` |
+| `Failed` | the worker | `workerId`, `error` |
+| `Lost` | the runtime | `workerId`, `why` |
+| `Question` | the runtime | `why` |
+| `Report` | the runtime | `what`, `evidence` |
+| `Reply` | a person | `text` |
+
+Every fact a person writes carries `by` (who) and `source` (their words or the
+action, verbatim).
+
+**States** are about ownership: Created, Taken, Completed, Cancelled. Only a
+person ends a task, from Created or Taken. **Positions** live inside Taken and
+are never stored: `working` (the runtime's last word is a Started),
+`stuck` (a Question), `reported` (a Report). The runtime never leaves Taken on
+its own.
+
+## Setting it up
+
+```jsonc
+// manager:setup — the only required field is the directory workers work in.
+{
+  "workingDir": "/absolute/path/to/your/project",
+  "workerAgent": "coding:coding",  // default
+  "startCap": 2,                   // starts per task since the last person fact
+  "maxWorkers": 3,                 // workers running at once, across tasks
+  "ageCapHours": 3,                // silence before a worker is declared lost
+  "intervalMinutes": 5             // how often reconcile runs
+}
+```
+
+`setup` stores the config and registers one routine, `Manager: reconcile`,
+deduplicated on its routine key. Rome's scheduler accepts `FREQ=MINUTELY` down
+to one minute, so five minutes is a choice rather than a floor; the app snaps an
+arbitrary interval to a cadence the RRULE-to-cron conversion reproduces exactly.
+
+Then talk to the `manager` agent, or call `manager:create` directly:
+
+```jsonc
+{ "brief": "add rate limiting to the upload endpoint", "source": "<the person's message>" }
+```
+
+`manager:reconcile` also runs at the end of every person-fact action and at the
+end of every worker, so a new fact is acted on immediately rather than at the
+next tick.
+
+## Known gaps
+
+These are limits of what Rome exposes to an app today, not choices.
+
+- **No detached agent run.** `system:summon` runs an agent to completion and
+  returns its reply; it has no detached mode. The app gets detachment one level
+  up: the runtime dispatches `manager:run_worker` with `{ detached: true }`, and
+  that action holds the blocking summon. The worker is a Rome execution the
+  runtime does not wait for, which is what the model needs — but Rome sees an
+  action, not a session it can report on.
+- **No way to stop a worker.** Nothing in `@rome-os/app-runtime` cancels a
+  detached execution or an agent session. `ActionEngine.cancel(rootExecutionId)`
+  exists in core and takes exactly the id `runAction` hands back, but no
+  `system:*` action and no `RomeAppContext` method reaches it. So a stop is
+  recorded as `Lost(why="stopped by runtime")` and the runtime stops reading
+  that worker; the worker itself runs to the end. A late reply from a stopped
+  worker is dropped, because the Lost already closed it. Closing this gap needs
+  a `system:cancel_execution` action or a `cancel(executionId)` on
+  `RomeAppContext`.
+- **No working directory on summon.** `RunParams.workingDir` exists on the agent
+  runner, but `system:summon` does not pass it through, and an app must go
+  through summon to run another app's agent. So the configured `workingDir` is
+  stated in the worker's brief instead of being enforced by the platform.
+- **No boot-time restart detection.** An app cannot ask whether an execution it
+  launched is still alive, so the runtime cannot write `Lost(why="host restart")`
+  on boot. The age cap covers the same case: a worker silent past `ageCapHours`
+  gets `Lost(why="silent past cap")` and is retried. The cost is latency, up to
+  the cap, on a restart.
+- **No person id in an action.** `getCurrentActionContext()` gives the calling
+  session, agent, and channel thread, but core deliberately drops the resolved
+  `SessionActor` before the context reaches app code. So a fact from a chat is
+  stamped `by="guardian"` unless the channel names its sender, and the agent is
+  required to pass the person's message verbatim as `source`. A guardian id
+  would need `SessionActor` threaded through the projection in
+  `packages/core/src/actions/context.ts`.
+- **No web UI.** `manager:snapshot` is the only view.
+
+## Layout
+
+```
+src/
+├── agents/manager.yaml        the language boundary, one of two model call sites
+├── lib/
+│   ├── facts.ts               the ledger's vocabulary
+│   ├── fold.ts                facts -> states and positions
+│   ├── reconcile.ts           snapshot -> the list of writes and launches
+│   ├── judge.ts               the other model call site
+│   ├── prompt.ts              the worker's brief
+│   ├── config.ts              settings and the routine's trigger
+│   ├── identity.ts            who a person's fact is stamped with
+│   └── person-fact.ts         stamp, append, reconcile
+├── db/
+│   ├── schema.ts              facts, config, locks
+│   └── repositories/          the only way into those tables
+└── actions/
+    ├── setup                  config + the reconcile routine
+    ├── reconcile              the runtime loop; applies reconcile's list
+    ├── run-worker             one worker, dispatched detached
+    ├── create reply complete cancel   the person's four verbs
+    └── snapshot               read-only
+```
+
+The pure logic is unit-tested next to it — `fold.test.ts`, `reconcile.test.ts`,
+`judge.test.ts`, `config.test.ts`. None of them touches a database: `reconcile`
+takes a snapshot value and returns actions, and the action layer applies them.
+Run them with `pnpm --filter @rome/core test:unit`.

--- a/rome_apps/manager/app.yaml
+++ b/rome_apps/manager/app.yaml
@@ -1,0 +1,29 @@
+formatVersion: 2
+id: manager
+name: Manager
+icon: assets/icon.svg
+version: 0.1.0
+description: >-
+  A long-running agent that keeps working on your tasks across sessions. Tell it
+  what you want in chat; it records the task in an append-only ledger, puts a
+  coding session on it, retries what fails, asks you when it is stuck, and
+  reports when there is something to look at. Only you close a task.
+appRoot: dist
+includeSource: true
+
+db:
+  migrations: db/migrations
+  tablePrefix: manager
+
+agents:
+  - agents/manager.yaml
+
+actions:
+  - actions/setup
+  - actions/reconcile
+  - actions/run-worker
+  - actions/create
+  - actions/reply
+  - actions/complete
+  - actions/cancel
+  - actions/snapshot

--- a/rome_apps/manager/docs/2026-09-08-first-cut.md
+++ b/rome_apps/manager/docs/2026-09-08-first-cut.md
@@ -1,0 +1,58 @@
+# 2026-09-08 — first cut
+
+The revision 3 long-running agent, as a Rome app.
+
+## What landed
+
+- `src/lib/` holds the whole loop as pure functions: `fold` (facts to states and
+  positions), `reconcile` (snapshot to a list of writes, launches, and stops),
+  `judge`, `prompt`, `config`. 42 unit tests, none of which touch a database.
+- `src/db/` is one append-only `facts` table plus a config row and a leased lock
+  row, reached only through repositories.
+- `src/actions/` is the thin layer that applies what `reconcile` decided and the
+  four verbs the manager agent may call.
+- `src/agents/manager.yaml` is the language boundary. Its prompt names four
+  verbs and no scheduling rule.
+
+## Decisions
+
+**The worker is a detached action, not a detached session.** `system:summon` on
+main is blocking and takes no `workingDir`. Rather than reach past the app
+boundary into `agentRunner.run`, `manager:run_worker` holds the blocking summon
+and the *runtime* dispatches that action with `{ detached: true }`. The working
+directory is stated in the worker's brief instead of enforced by the platform.
+
+**A stop is a `Lost` fact.** Nothing in `@rome-os/app-runtime` cancels an
+execution, so `reconcile` still emits a `stop` action — the model needs it and
+the tests assert it — and the applier records it as
+`Lost(why="stopped by runtime")`. `LedgerRepository.appendWorkerOutcome` then
+drops the stopped worker's late reply, so a steered task does not get moved by
+the worker it replaced.
+
+**Host-restart detection is the age cap.** An app cannot ask whether an
+execution it launched is alive, so there is no boot-time `Lost(why="host
+restart")`. A worker silent past `ageCapHours` gets
+`Lost(why="silent past cap")` and is retried; the cost is latency on a restart.
+
+**`by` is `guardian`.** Core drops the resolved `SessionActor` before an action
+sees its context, so the runtime has no person id to stamp. The four person
+actions therefore require `source` and the agent's prompt says to pass the
+message verbatim.
+
+## Validation
+
+`pnpm typecheck` at the root, the 42 unit tests through `pnpm test:unit`,
+`pnpm build:apps` (packs `manager@0.1.0`), and a live run on `pnpm dev:all`:
+setup registered the minutely routine, `manager:create` opened a task, reconcile
+wrote Taken and Started and launched a worker, the worker failed (no model
+provider in this container), reconcile retried under the cap, asked over it, a
+Reply reset the cap and reached the next worker's brief, and a Cancel left every
+later pass with nothing to do.
+
+## Follow-ups
+
+- A `system:cancel_execution` action, or `cancel(executionId)` on
+  `RomeAppContext`, would make a stop real.
+- `workingDir` on `system:summon` would let the platform enforce where a worker
+  works.
+- A model-backed judge is one file, `src/lib/judge.ts`, and no other change.

--- a/rome_apps/manager/drizzle.config.ts
+++ b/rome_apps/manager/drizzle.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./src/db/schema.ts",
+  out: "./src/db/migrations",
+  dialect: "sqlite",
+  migrations: { table: "__drizzle_migrations_app_manager" },
+  tablesFilter: ["manager\\__*"],
+});

--- a/rome_apps/manager/package.json
+++ b/rome_apps/manager/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@rome/app-manager",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-artifacts.mjs",
+    "typecheck": "tsc --noEmit",
+    "db:generate": "drizzle-kit generate"
+  },
+  "dependencies": {
+    "@rome-os/app-runtime": "^0.6.0",
+    "drizzle-orm": "^0.45.1"
+  },
+  "devDependencies": {
+    "drizzle-kit": "^0.31.9",
+    "typescript": "^5.9.3"
+  }
+}

--- a/rome_apps/manager/scripts/copy-artifacts.mjs
+++ b/rome_apps/manager/scripts/copy-artifacts.mjs
@@ -1,0 +1,18 @@
+// Build step 2 of 2. `tsc` emits only JavaScript, so the YAML, SQL, and JSON the
+// manifest points at (agent definitions, `action.yaml`, the Drizzle migrations)
+// would never reach `dist/` — and install validation fails on a missing
+// artifact file.
+
+import { cpSync, statSync } from "node:fs";
+import { dirname, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const COPIED_EXTENSIONS = new Set([".yaml", ".yml", ".md", ".json", ".sql", ".svg"]);
+
+cpSync(join(appDir, "src"), join(appDir, "dist"), {
+  recursive: true,
+  // The filter runs on directories too, and returning false for one prunes the
+  // whole subtree — so every directory passes and only files are tested.
+  filter: (source) => statSync(source).isDirectory() || COPIED_EXTENSIONS.has(extname(source)),
+});

--- a/rome_apps/manager/src/actions/cancel/action.yaml
+++ b/rome_apps/manager/src/actions/cancel/action.yaml
@@ -1,0 +1,10 @@
+name: cancel
+type: custom
+description: >-
+  Close a task as not wanted, on a person's say-so. Use it when their words drop
+  the work rather than approve it. `source` is their message, verbatim.
+entry: ./index.ts
+complexity: simple
+speed: fast
+reliability: high
+sideEffects: write

--- a/rome_apps/manager/src/actions/cancel/index.ts
+++ b/rome_apps/manager/src/actions/cancel/index.ts
@@ -1,0 +1,51 @@
+import type {
+  Action,
+  ActionConfig,
+  ActionResult,
+  AppActionRuntimeDeps,
+} from "@rome-os/app-runtime";
+import { loadTask, rejectIfClosed, writePersonFact } from "../../lib/person-fact.js";
+
+/** A person closes the task as not wanted. Terminal, like complete. */
+export function createAction(config: ActionConfig, deps: AppActionRuntimeDeps): Action {
+  const { appContext } = deps;
+
+  return {
+    config,
+    inputSchema: {
+      type: "object",
+      properties: {
+        taskId: { type: "string", description: "Task to drop. Read it from manager:snapshot." },
+        reason: { type: "string", description: "Why it is dropped, if the person said." },
+        source: {
+          type: "string",
+          description: "The person's message, verbatim. Recorded as the fact's citation.",
+        },
+      },
+      required: ["taskId", "source"],
+      additionalProperties: false,
+    },
+
+    async execute(args): Promise<ActionResult> {
+      const taskId = String(args.taskId ?? "").trim();
+      const source = String(args.source ?? "").trim();
+      const reason = typeof args.reason === "string" ? args.reason.trim() : undefined;
+      if (!taskId) return { status: "error", error: "taskId is required" };
+      if (!source) {
+        return { status: "error", error: "source is required: pass the person's message verbatim" };
+      }
+
+      const found = loadTask(appContext, taskId);
+      if (!found.ok) return { status: "error", error: found.error };
+      const closed = rejectIfClosed(found.task);
+      if (closed) return { status: "error", error: closed };
+
+      return await writePersonFact(appContext, {
+        taskId,
+        kind: "Cancelled",
+        source,
+        payload: reason ? { reason } : {},
+      });
+    },
+  };
+}

--- a/rome_apps/manager/src/actions/complete/action.yaml
+++ b/rome_apps/manager/src/actions/complete/action.yaml
@@ -1,0 +1,11 @@
+name: complete
+type: custom
+description: >-
+  Close a task as done, on a person's say-so. Only a person ends a task, so call
+  this only when their words approve the result — never on your own reading of
+  what a worker returned. `source` is their message, verbatim.
+entry: ./index.ts
+complexity: simple
+speed: fast
+reliability: high
+sideEffects: write

--- a/rome_apps/manager/src/actions/complete/index.ts
+++ b/rome_apps/manager/src/actions/complete/index.ts
@@ -1,0 +1,55 @@
+import type {
+  Action,
+  ActionConfig,
+  ActionResult,
+  AppActionRuntimeDeps,
+} from "@rome-os/app-runtime";
+import { loadTask, rejectIfClosed, writePersonFact } from "../../lib/person-fact.js";
+
+/**
+ * A person closes the task as done. This action exists only in a turn a person
+ * triggered, and the runtime stamps who called it, so the app has no path to
+ * Completed on its own judgement.
+ */
+export function createAction(config: ActionConfig, deps: AppActionRuntimeDeps): Action {
+  const { appContext } = deps;
+
+  return {
+    config,
+    inputSchema: {
+      type: "object",
+      properties: {
+        taskId: { type: "string", description: "Task to close. Read it from manager:snapshot." },
+        reason: { type: "string", description: "Why it is done, if the person said." },
+        source: {
+          type: "string",
+          description: "The person's message, verbatim. Recorded as the fact's citation.",
+        },
+      },
+      required: ["taskId", "source"],
+      additionalProperties: false,
+    },
+
+    async execute(args): Promise<ActionResult> {
+      const taskId = String(args.taskId ?? "").trim();
+      const source = String(args.source ?? "").trim();
+      const reason = typeof args.reason === "string" ? args.reason.trim() : undefined;
+      if (!taskId) return { status: "error", error: "taskId is required" };
+      if (!source) {
+        return { status: "error", error: "source is required: pass the person's message verbatim" };
+      }
+
+      const found = loadTask(appContext, taskId);
+      if (!found.ok) return { status: "error", error: found.error };
+      const closed = rejectIfClosed(found.task);
+      if (closed) return { status: "error", error: closed };
+
+      return await writePersonFact(appContext, {
+        taskId,
+        kind: "Completed",
+        source,
+        payload: reason ? { reason } : {},
+      });
+    },
+  };
+}

--- a/rome_apps/manager/src/actions/create/action.yaml
+++ b/rome_apps/manager/src/actions/create/action.yaml
@@ -1,0 +1,11 @@
+name: create
+type: custom
+description: >-
+  Record a new task the person just asked for. `brief` is what to do, in your
+  words; `source` is the person's own message, verbatim. Use this when their
+  words describe work that is not already a task.
+entry: ./index.ts
+complexity: simple
+speed: fast
+reliability: high
+sideEffects: write

--- a/rome_apps/manager/src/actions/create/index.ts
+++ b/rome_apps/manager/src/actions/create/index.ts
@@ -1,0 +1,51 @@
+import type {
+  Action,
+  ActionConfig,
+  ActionResult,
+  AppActionRuntimeDeps,
+} from "@rome-os/app-runtime";
+import { writePersonFact } from "../../lib/person-fact.js";
+
+/** Opens a task with a Created fact. The only way a task comes into being. */
+export function createAction(config: ActionConfig, deps: AppActionRuntimeDeps): Action {
+  const { appContext } = deps;
+
+  return {
+    config,
+    inputSchema: {
+      type: "object",
+      properties: {
+        brief: {
+          type: "string",
+          description: "What the task is, in a sentence or two. This becomes the worker's brief.",
+        },
+        source: {
+          type: "string",
+          description: "The person's message, verbatim. Recorded as the fact's citation.",
+        },
+      },
+      required: ["brief", "source"],
+      additionalProperties: false,
+    },
+
+    async execute(args): Promise<ActionResult> {
+      const brief = String(args.brief ?? "").trim();
+      const source = String(args.source ?? "").trim();
+      if (!brief) return { status: "error", error: "brief is required" };
+      if (!source) {
+        return {
+          status: "error",
+          error: "source is required: pass the person's message verbatim",
+        };
+      }
+
+      const taskId = `t-${crypto.randomUUID().slice(0, 8)}`;
+      return await writePersonFact(appContext, {
+        taskId,
+        kind: "Created",
+        source,
+        payload: { brief },
+      });
+    },
+  };
+}

--- a/rome_apps/manager/src/actions/reconcile/action.yaml
+++ b/rome_apps/manager/src/actions/reconcile/action.yaml
@@ -1,0 +1,12 @@
+name: reconcile
+type: custom
+description: >-
+  Run one reconciliation pass over the ledger. Folds every task, writes the next
+  fact each one calls for, and launches or stops workers. Fires on a schedule and
+  again after every fact, so it is safe to call at any time; it is not something
+  an agent needs to reason about.
+entry: ./index.ts
+complexity: moderate
+speed: fast
+reliability: high
+sideEffects: write

--- a/rome_apps/manager/src/actions/reconcile/index.ts
+++ b/rome_apps/manager/src/actions/reconcile/index.ts
@@ -1,0 +1,121 @@
+import {
+  createAppLogger,
+  type Action,
+  type ActionConfig,
+  type ActionResult,
+  type AppActionRuntimeDeps,
+} from "@rome-os/app-runtime";
+import { createLedgerRepository, type LedgerRepository } from "../../db/repositories/ledger.js";
+import { createLockRepository, RECONCILE_LOCK } from "../../db/repositories/lock.js";
+import { createSettingsRepository } from "../../db/repositories/settings.js";
+import { RUNTIME } from "../../lib/facts.js";
+import { fold } from "../../lib/fold.js";
+import { judge } from "../../lib/judge.js";
+import { LOST_STOPPED, reconcile, type ReconcileAction } from "../../lib/reconcile.js";
+
+const log = createAppLogger("manager:reconcile");
+
+/**
+ * How long a pass may hold the lock. Long enough that a slow pass is never cut
+ * off mid-list, short enough that a killed process does not stall the loop for
+ * more than a couple of scheduled ticks.
+ */
+const LOCK_LEASE_MS = 5 * 60_000;
+
+export function createAction(config: ActionConfig, deps: AppActionRuntimeDeps): Action {
+  const { appContext } = deps;
+
+  return {
+    config,
+    inputSchema: { type: "object", properties: {}, additionalProperties: true },
+
+    async execute(): Promise<ActionResult> {
+      const settings = createSettingsRepository(appContext.db);
+      const ledger = createLedgerRepository(appContext.db);
+      const locks = createLockRepository(appContext.db);
+
+      // No ledger, no pass. Nothing is written and nothing is inferred from
+      // anywhere else; the next tick tries again.
+      if (!ledger.reachable()) {
+        log.warn("ledger unreachable; skipping");
+        return { status: "ok", data: { skipped: "ledger unreachable" } };
+      }
+
+      const managerConfig = settings.get();
+      if (!managerConfig) {
+        return { status: "error", error: "manager is not configured. Run manager:setup first." };
+      }
+
+      // A second pass arriving while one runs returns immediately; the pass
+      // that holds the lock, or the next tick, sees whatever it missed.
+      if (!locks.tryAcquire(RECONCILE_LOCK, LOCK_LEASE_MS)) {
+        return { status: "ok", data: { skipped: "another reconcile is running" } };
+      }
+
+      try {
+        const snapshot = fold(new Date(), ledger.all());
+        const actions = reconcile({
+          snapshot,
+          config: managerConfig,
+          judge,
+          newWorkerId: () => `w-${crypto.randomUUID().slice(0, 8)}`,
+        });
+
+        const applied: string[] = [];
+        for (const action of actions) {
+          applied.push(await apply(action, ledger, appContext));
+        }
+
+        log.info("reconcile finished", { tasks: snapshot.tasks.length, applied: applied.length });
+        return { status: "ok", data: { tasks: snapshot.tasks.length, applied } };
+      } finally {
+        locks.release(RECONCILE_LOCK);
+      }
+    },
+  };
+}
+
+/**
+ * Carry out one item from reconcile's list. The order matters: a Started is
+ * appended before its worker is launched, so a pass that dies in between leaves
+ * a worker the next pass can see rather than one it cannot.
+ */
+async function apply(
+  action: ReconcileAction,
+  ledger: LedgerRepository,
+  appContext: AppActionRuntimeDeps["appContext"],
+): Promise<string> {
+  switch (action.type) {
+    case "append": {
+      const fact = ledger.append(action.fact);
+      return `${fact.kind}(${fact.taskId})`;
+    }
+
+    case "launch": {
+      // Detached, so the worker's run is a root execution with its own
+      // lifetime: this pass returns as soon as main accepts it.
+      const receipt = await appContext.runAction(
+        "manager:run_worker",
+        { taskId: action.taskId, workerId: action.workerId },
+        { detached: true },
+      );
+      log.info("worker launched", { ...action, executionId: receipt.executionId });
+      return `launch(${action.workerId})`;
+    }
+
+    case "stop": {
+      // Rome has no app-facing way to cancel a detached execution or an agent
+      // session, so the runtime records the stop it intended and stops reading
+      // that worker. The worker itself runs on; `appendWorkerOutcome` drops its
+      // late reply because this Lost already closed it.
+      ledger.append({
+        taskId: action.taskId,
+        kind: "Lost",
+        by: RUNTIME,
+        payload: { workerId: action.workerId, why: action.why },
+      });
+      log.warn("worker stop recorded as Lost", { ...action, gap: LOST_STOPPED });
+      return `stop(${action.workerId})`;
+    }
+  }
+}

--- a/rome_apps/manager/src/actions/reply/action.yaml
+++ b/rome_apps/manager/src/actions/reply/action.yaml
@@ -1,0 +1,11 @@
+name: reply
+type: custom
+description: >-
+  Record what a person said about a task that is already running. Use it to
+  answer a question the task is stuck on, or to steer work in progress. `text` is
+  what the worker should know; `source` is the person's message, verbatim.
+entry: ./index.ts
+complexity: simple
+speed: fast
+reliability: high
+sideEffects: write

--- a/rome_apps/manager/src/actions/reply/index.ts
+++ b/rome_apps/manager/src/actions/reply/index.ts
@@ -1,0 +1,62 @@
+import type {
+  Action,
+  ActionConfig,
+  ActionResult,
+  AppActionRuntimeDeps,
+} from "@rome-os/app-runtime";
+import { loadTask, rejectIfClosed, writePersonFact } from "../../lib/person-fact.js";
+
+/**
+ * A person's words on an open task. The runtime treats a Reply as the signal to
+ * put a worker back on the task, stopping the one already running if there is
+ * one — none of which this action decides.
+ */
+export function createAction(config: ActionConfig, deps: AppActionRuntimeDeps): Action {
+  const { appContext } = deps;
+
+  return {
+    config,
+    inputSchema: {
+      type: "object",
+      properties: {
+        taskId: {
+          type: "string",
+          description: "Task this answers. Read it from manager:snapshot.",
+        },
+        text: {
+          type: "string",
+          description: "What the worker should know, in a sentence or two.",
+        },
+        source: {
+          type: "string",
+          description: "The person's message, verbatim. Recorded as the fact's citation.",
+        },
+      },
+      required: ["taskId", "text", "source"],
+      additionalProperties: false,
+    },
+
+    async execute(args): Promise<ActionResult> {
+      const taskId = String(args.taskId ?? "").trim();
+      const text = String(args.text ?? "").trim();
+      const source = String(args.source ?? "").trim();
+      if (!taskId) return { status: "error", error: "taskId is required" };
+      if (!text) return { status: "error", error: "text is required" };
+      if (!source) {
+        return { status: "error", error: "source is required: pass the person's message verbatim" };
+      }
+
+      const found = loadTask(appContext, taskId);
+      if (!found.ok) return { status: "error", error: found.error };
+      const closed = rejectIfClosed(found.task);
+      if (closed) return { status: "error", error: closed };
+
+      return await writePersonFact(appContext, {
+        taskId,
+        kind: "Reply",
+        source,
+        payload: { text },
+      });
+    },
+  };
+}

--- a/rome_apps/manager/src/actions/run-worker/action.yaml
+++ b/rome_apps/manager/src/actions/run-worker/action.yaml
@@ -1,0 +1,11 @@
+name: run_worker
+type: custom
+description: >-
+  Internal. Runs the coding session named by a Started fact and writes what came
+  back — Returned or Failed — to the ledger on the worker's behalf, then triggers
+  a reconcile. The runtime dispatches this detached; nothing else should call it.
+entry: ./index.ts
+complexity: complex
+speed: slow
+reliability: medium
+sideEffects: write

--- a/rome_apps/manager/src/actions/run-worker/index.ts
+++ b/rome_apps/manager/src/actions/run-worker/index.ts
@@ -1,0 +1,130 @@
+import {
+  createAppLogger,
+  type Action,
+  type ActionConfig,
+  type ActionResult,
+  type AppActionRuntimeDeps,
+} from "@rome-os/app-runtime";
+import { createLedgerRepository } from "../../db/repositories/ledger.js";
+import { createSettingsRepository } from "../../db/repositories/settings.js";
+
+const log = createAppLogger("manager:run_worker");
+
+/**
+ * A worker, as this app can build one on today's platform.
+ *
+ * `system:summon` runs an agent to completion and returns its reply — there is
+ * no detached mode and no way to stop a run. So the detachment lives one level
+ * up: the runtime dispatches *this action* detached, and the action holds the
+ * blocking summon for as long as it takes. The worker is a Rome execution the
+ * runtime does not wait for, which is what the model asks for, even though the
+ * summon inside it is ordinary and synchronous.
+ *
+ * The action writes the worker's own fact — Returned or Failed — because the
+ * coding agent has no tools on this ledger and should not need any.
+ */
+export function createAction(config: ActionConfig, deps: AppActionRuntimeDeps): Action {
+  const { appContext } = deps;
+
+  return {
+    config,
+    inputSchema: {
+      type: "object",
+      properties: {
+        taskId: { type: "string", description: "Task the worker is working on." },
+        workerId: { type: "string", description: "Worker id from the task's Started fact." },
+      },
+      required: ["taskId", "workerId"],
+      additionalProperties: true,
+    },
+
+    async execute(args): Promise<ActionResult> {
+      const taskId = String(args.taskId ?? "");
+      const workerId = String(args.workerId ?? "");
+      if (!taskId || !workerId) {
+        return { status: "error", error: "taskId and workerId are required" };
+      }
+
+      const settings = createSettingsRepository(appContext.db);
+      const ledger = createLedgerRepository(appContext.db);
+
+      const managerConfig = settings.get();
+      if (!managerConfig) {
+        return { status: "error", error: "manager is not configured. Run manager:setup first." };
+      }
+
+      // The prompt lives on the Started fact, so the worker reads its brief
+      // from the ledger like everything else — this action carries no context
+      // of its own from the pass that launched it.
+      const started = ledger
+        .factsFor(taskId)
+        .find((fact) => fact.kind === "Started" && fact.payload.workerId === workerId);
+      if (!started || started.kind !== "Started") {
+        return {
+          status: "error",
+          error: `no Started fact for worker ${workerId} on task ${taskId}`,
+        };
+      }
+
+      log.info("worker starting", { taskId, workerId, agent: managerConfig.workerAgent });
+
+      let outcome: string;
+      try {
+        const result = await appContext.runAction("system:summon", {
+          agentName: managerConfig.workerAgent,
+          prompt: started.payload.prompt,
+        });
+
+        if (result.status === "ok") {
+          const reply = readSummonReply(result.data);
+          const written = ledger.appendWorkerOutcome({
+            taskId,
+            kind: "Returned",
+            by: workerId,
+            source: "manager:run_worker, on the worker's behalf",
+            payload: { workerId, reply },
+          });
+          outcome = written ? "Returned" : "dropped (worker already closed)";
+        } else {
+          const error =
+            result.status === "error" ? result.error : `summon returned ${result.status}`;
+          const written = ledger.appendWorkerOutcome({
+            taskId,
+            kind: "Failed",
+            by: workerId,
+            source: "manager:run_worker, on the worker's behalf",
+            payload: { workerId, error },
+          });
+          outcome = written ? "Failed" : "dropped (worker already closed)";
+        }
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        const written = ledger.appendWorkerOutcome({
+          taskId,
+          kind: "Failed",
+          by: workerId,
+          source: "manager:run_worker, on the worker's behalf",
+          payload: { workerId, error },
+        });
+        outcome = written ? "Failed" : "dropped (worker already closed)";
+      }
+
+      log.info("worker finished", { taskId, workerId, outcome });
+
+      // A new fact exists, so the runtime reconciles now rather than waiting
+      // for the next tick.
+      await appContext.runAction("manager:reconcile", {});
+
+      return { status: "ok", data: { taskId, workerId, outcome } };
+    },
+  };
+}
+
+/** `system:summon` returns `{ result, sessionId, romeSession }`. */
+function readSummonReply(data: unknown): string {
+  if (typeof data === "object" && data !== null) {
+    const result = (data as { result?: unknown }).result;
+    if (typeof result === "string") return result;
+  }
+  return "";
+}

--- a/rome_apps/manager/src/actions/setup/action.yaml
+++ b/rome_apps/manager/src/actions/setup/action.yaml
@@ -1,0 +1,11 @@
+name: setup
+type: custom
+description: >-
+  Configure the Manager and register its recurring reconcile. Takes the absolute
+  directory workers work in, plus optional caps. Safe to run again — it updates
+  the config and re-registers the routine only when the cadence changed.
+entry: ./index.ts
+complexity: simple
+speed: fast
+reliability: high
+sideEffects: write

--- a/rome_apps/manager/src/actions/setup/index.ts
+++ b/rome_apps/manager/src/actions/setup/index.ts
@@ -1,0 +1,122 @@
+import {
+  createAppLogger,
+  type Action,
+  type ActionConfig,
+  type ActionResult,
+  type AppActionRuntimeDeps,
+  type RomeAppContext,
+} from "@rome-os/app-runtime";
+import { createSettingsRepository } from "../../db/repositories/settings.js";
+import {
+  DEFAULT_AGE_CAP_HOURS,
+  DEFAULT_INTERVAL_MINUTES,
+  DEFAULT_MAX_WORKERS,
+  DEFAULT_START_CAP,
+  DEFAULT_WORKER_AGENT,
+  type ManagerConfig,
+  parseConfig,
+  RECONCILE_ROUTINE_KEY,
+  RECONCILE_ROUTINE_NAME,
+  reconcileTrigger,
+} from "../../lib/config.js";
+
+const log = createAppLogger("manager:setup");
+
+/** What `setup` did to the routine, reported back to the guardian. */
+export type RoutineOutcome = "created" | "replaced" | "unchanged";
+
+export function createAction(config: ActionConfig, deps: AppActionRuntimeDeps): Action {
+  const { appContext } = deps;
+
+  return {
+    config,
+    inputSchema: {
+      type: "object",
+      properties: {
+        workingDir: {
+          type: "string",
+          description: "Absolute path of the directory every worker works in.",
+        },
+        workerAgent: {
+          type: "string",
+          description: `Canonical id of the agent a worker runs. Defaults to ${DEFAULT_WORKER_AGENT}.`,
+        },
+        startCap: {
+          type: "number",
+          description: `Workers one task may be given since the last thing a person said, before the runtime asks them a question. Defaults to ${DEFAULT_START_CAP}.`,
+        },
+        maxWorkers: {
+          type: "number",
+          description: `Workers allowed to run at once across every task. Defaults to ${DEFAULT_MAX_WORKERS}.`,
+        },
+        ageCapHours: {
+          type: "number",
+          description: `Hours a worker may be silent before it is declared lost. Defaults to ${DEFAULT_AGE_CAP_HOURS}.`,
+        },
+        intervalMinutes: {
+          type: "number",
+          description: `How often the reconcile routine fires. Defaults to ${DEFAULT_INTERVAL_MINUTES}.`,
+        },
+      },
+      required: ["workingDir"],
+      additionalProperties: true,
+    },
+
+    async execute(args): Promise<ActionResult> {
+      const parsed = parseConfig(args);
+      if (!parsed.ok) return { status: "error", error: parsed.error };
+
+      createSettingsRepository(appContext.db).put(parsed.config);
+
+      const routine = await ensureRoutine(appContext, parsed.config);
+      if (!routine.ok) return { status: "error", error: routine.error };
+
+      log.info("setup finished", { config: parsed.config, routine: routine.outcome });
+      return { status: "ok", data: { config: parsed.config, routine: routine.outcome } };
+    },
+  };
+}
+
+/**
+ * Register the reconcile routine, once. `create_routine` is not idempotent, so
+ * the guard is the routine `key` — Rome enforces it as unique, unlike the
+ * display name. A cadence change is a delete and a re-create, because a trigger
+ * cannot be edited in place.
+ */
+async function ensureRoutine(
+  appContext: RomeAppContext,
+  config: ManagerConfig,
+): Promise<{ ok: true; outcome: RoutineOutcome } | { ok: false; error: string }> {
+  const trigger = reconcileTrigger(config.intervalMinutes);
+  const existing = (await appContext.listRoutines()).find(
+    (routine) => routine.key === RECONCILE_ROUTINE_KEY || routine.name === RECONCILE_ROUTINE_NAME,
+  );
+
+  if (existing) {
+    const current = existing.trigger as { rrule?: string };
+    if (current.rrule === trigger.rrule) {
+      return { ok: true, outcome: "unchanged" };
+    }
+    const deleted = await appContext.runAction("system:delete_routine", {
+      routineId: existing.id,
+    });
+    if (deleted.status !== "ok") {
+      const reason = deleted.status === "error" ? deleted.error : `returned ${deleted.status}`;
+      return { ok: false, error: `could not replace the reconcile routine: ${reason}` };
+    }
+  }
+
+  const created = await appContext.runAction("system:create_routine", {
+    name: RECONCILE_ROUTINE_NAME,
+    key: RECONCILE_ROUTINE_KEY,
+    trigger,
+    actionName: "manager:reconcile",
+    args: {},
+  });
+  if (created.status !== "ok") {
+    const reason = created.status === "error" ? created.error : `returned ${created.status}`;
+    return { ok: false, error: `could not register the reconcile routine: ${reason}` };
+  }
+
+  return { ok: true, outcome: existing ? "replaced" : "created" };
+}

--- a/rome_apps/manager/src/actions/snapshot/action.yaml
+++ b/rome_apps/manager/src/actions/snapshot/action.yaml
@@ -1,0 +1,11 @@
+name: snapshot
+type: custom
+description: >-
+  Read every task and where it stands: its state, its position, its brief, and
+  the last few facts on it. Read this before writing anything, so you name a task
+  the person means rather than opening a second one for the same work.
+entry: ./index.ts
+complexity: simple
+speed: fast
+reliability: high
+sideEffects: read-only

--- a/rome_apps/manager/src/actions/snapshot/index.ts
+++ b/rome_apps/manager/src/actions/snapshot/index.ts
@@ -1,0 +1,58 @@
+import type {
+  Action,
+  ActionConfig,
+  ActionResult,
+  AppActionRuntimeDeps,
+} from "@rome-os/app-runtime";
+import { createLedgerRepository } from "../../db/repositories/ledger.js";
+import { describeFact } from "../../lib/facts.js";
+import { fold } from "../../lib/fold.js";
+
+/** How many recent facts each task carries into the summary. */
+const HISTORY_LINES = 6;
+
+/**
+ * The ledger as the manager agent sees it: enough to tell which task a person's
+ * words are about, and nothing about how the runtime decides anything.
+ */
+export function createAction(config: ActionConfig, deps: AppActionRuntimeDeps): Action {
+  const { appContext } = deps;
+
+  return {
+    config,
+    inputSchema: {
+      type: "object",
+      properties: {
+        includeClosed: {
+          type: "boolean",
+          description: "Include completed and cancelled tasks. Defaults to false.",
+        },
+      },
+      additionalProperties: false,
+    },
+
+    async execute(args): Promise<ActionResult> {
+      const includeClosed = args.includeClosed === true;
+      const ledger = createLedgerRepository(appContext.db);
+      if (!ledger.reachable()) {
+        return { status: "error", error: "the ledger is unreachable" };
+      }
+
+      const snapshot = fold(new Date(), ledger.all());
+      const tasks = snapshot.tasks
+        .filter(
+          (task) => includeClosed || (task.state !== "completed" && task.state !== "cancelled"),
+        )
+        .map((task) => ({
+          id: task.id,
+          brief: task.brief,
+          state: task.state,
+          position: task.position,
+          workerRunning: task.liveWorker?.workerId,
+          history: task.facts.slice(-HISTORY_LINES).map(describeFact),
+        }));
+
+      return { status: "ok", data: { tasks } };
+    },
+  };
+}

--- a/rome_apps/manager/src/agents/manager.yaml
+++ b/rome_apps/manager/src/agents/manager.yaml
@@ -1,0 +1,39 @@
+name: manager
+description: >-
+  Turns what a person says about their tasks into ledger facts. The one place
+  language enters the Manager app.
+tier: medium
+reasoningEffort: high
+permissionMode: default
+tools: []
+actions:
+  - manager:snapshot
+  - manager:create
+  - manager:reply
+  - manager:complete
+  - manager:cancel
+maxTurns: 30
+systemPromptPrefix: |
+  You are the Manager. People talk to you about work they want done, and you
+  record what they said as facts about tasks. You do not do the work, you do not
+  schedule it, and you do not decide when anything runs.
+
+  Read manager:snapshot first, every time. It tells you which tasks exist, what
+  each one is, and where each one stands.
+
+  Then map the person's words onto exactly one of:
+
+  - manager:create — they are asking for work that is not already a task.
+  - manager:reply — they are answering a question on a task, or steering one.
+  - manager:complete — their words approve a result.
+  - manager:cancel — their words drop the work.
+
+  Pass their message verbatim as `source` on every one of these. You choose the
+  task and the wording; you never choose who said it.
+
+  When the words map to none of these — a question, small talk, something you
+  cannot place on a task — just answer in chat and write nothing. Guessing costs
+  more than asking.
+
+  Never call manager:complete on your own reading of a result. Only a person
+  ends a task.

--- a/rome_apps/manager/src/assets/icon.svg
+++ b/rome_apps/manager/src/assets/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <rect width="24" height="24" rx="5.5" fill="#dbe4f5" />
+  <g fill="none" stroke="#1f3a68" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="7" y1="7" x2="17" y2="7" />
+    <line x1="7" y1="10.5" x2="17" y2="10.5" />
+    <line x1="7" y1="14" x2="13" y2="14" />
+    <path d="M13.5 17.2 L15.2 18.9 L18 15.6" />
+  </g>
+</svg>

--- a/rome_apps/manager/src/db/migrations/0000_tan_rachel_grey.sql
+++ b/rome_apps/manager/src/db/migrations/0000_tan_rachel_grey.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `manager__config` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `manager__facts` (
+	`seq` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`id` text NOT NULL,
+	`task_id` text NOT NULL,
+	`kind` text NOT NULL,
+	`by` text NOT NULL,
+	`source` text,
+	`payload` text NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `manager__facts_task_idx` ON `manager__facts` (`task_id`);--> statement-breakpoint
+CREATE INDEX `manager__facts_id_idx` ON `manager__facts` (`id`);--> statement-breakpoint
+CREATE TABLE `manager__locks` (
+	`name` text PRIMARY KEY NOT NULL,
+	`held_until` integer NOT NULL
+);

--- a/rome_apps/manager/src/db/migrations/meta/0000_snapshot.json
+++ b/rome_apps/manager/src/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,154 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2e136cdc-7244-490b-bc24-d673c13c9f64",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "manager__config": {
+      "name": "manager__config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "manager__facts": {
+      "name": "manager__facts",
+      "columns": {
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "by": {
+          "name": "by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "manager__facts_task_idx": {
+          "name": "manager__facts_task_idx",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "manager__facts_id_idx": {
+          "name": "manager__facts_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "manager__locks": {
+      "name": "manager__locks",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "held_until": {
+          "name": "held_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/rome_apps/manager/src/db/migrations/meta/_journal.json
+++ b/rome_apps/manager/src/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1788840779645,
+      "tag": "0000_tan_rachel_grey",
+      "breakpoints": true
+    }
+  ]
+}

--- a/rome_apps/manager/src/db/repositories/ledger.ts
+++ b/rome_apps/manager/src/db/repositories/ledger.ts
@@ -1,0 +1,116 @@
+import { asc, eq } from "drizzle-orm";
+import type { AppDbContext, DrizzleDb } from "@rome-os/app-runtime";
+import { type Fact, type FactKind, type NewFact, isWorkerTerminalKind } from "../../lib/facts.js";
+import { createAppDbSchema } from "../schema.js";
+
+/**
+ * The ledger, as the only way into the `facts` table. It appends and it reads;
+ * there is no update and no delete, because a fact that could be rewritten
+ * would stop being a fact.
+ */
+export class LedgerRepository {
+  private readonly tables;
+
+  constructor(
+    private readonly db: DrizzleDb,
+    tablePrefix: string,
+  ) {
+    this.tables = createAppDbSchema(tablePrefix);
+  }
+
+  /**
+   * Whether the ledger can be read right now. A pass that gets `false` ends
+   * without writing anything. With SQLite on the same host this is nearly
+   * always true, so the check is deliberately one cheap row.
+   */
+  reachable(): boolean {
+    try {
+      this.db.select().from(this.tables.facts).limit(1).all();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  append(fact: NewFact): Fact {
+    const id = crypto.randomUUID();
+    const createdAt = new Date();
+    const row = this.db
+      .insert(this.tables.facts)
+      .values({
+        id,
+        taskId: fact.taskId,
+        kind: fact.kind,
+        by: fact.by,
+        source: fact.source,
+        payload: JSON.stringify(fact.payload),
+        createdAt,
+      })
+      .returning()
+      .get();
+    return toFact(row);
+  }
+
+  /**
+   * Append a worker's own outcome, unless the runtime already closed that
+   * worker. The runtime records a stop as a Lost fact, and the stopped worker
+   * keeps running and eventually reports back; without this guard that late
+   * reply would move a task the runtime has already moved on from.
+   */
+  appendWorkerOutcome(fact: NewFact & { payload: { workerId: string } }): Fact | undefined {
+    const closed = this.factsFor(fact.taskId).some(
+      (existing) =>
+        isWorkerTerminalKind(existing.kind) &&
+        (existing.payload as { workerId?: string }).workerId === fact.payload.workerId,
+    );
+    if (closed) return undefined;
+    return this.append(fact);
+  }
+
+  all(): Fact[] {
+    return this.db
+      .select()
+      .from(this.tables.facts)
+      .orderBy(asc(this.tables.facts.seq))
+      .all()
+      .map(toFact);
+  }
+
+  factsFor(taskId: string): Fact[] {
+    return this.db
+      .select()
+      .from(this.tables.facts)
+      .where(eq(this.tables.facts.taskId, taskId))
+      .orderBy(asc(this.tables.facts.seq))
+      .all()
+      .map(toFact);
+  }
+}
+
+type FactRow = {
+  seq: number;
+  id: string;
+  taskId: string;
+  kind: string;
+  by: string;
+  source: string | null;
+  payload: string;
+  createdAt: Date;
+};
+
+function toFact(row: FactRow): Fact {
+  return {
+    seq: row.seq,
+    id: row.id,
+    taskId: row.taskId,
+    kind: row.kind as FactKind,
+    by: row.by,
+    source: row.source ?? undefined,
+    payload: JSON.parse(row.payload),
+    createdAt: row.createdAt,
+  } as Fact;
+}
+
+export function createLedgerRepository(ctx: AppDbContext): LedgerRepository {
+  return new LedgerRepository(ctx.connection, ctx.tablePrefix);
+}

--- a/rome_apps/manager/src/db/repositories/lock.ts
+++ b/rome_apps/manager/src/db/repositories/lock.ts
@@ -1,0 +1,51 @@
+import { and, eq, lt } from "drizzle-orm";
+import type { AppDbContext, DrizzleDb } from "@rome-os/app-runtime";
+import { createAppDbSchema } from "../schema.js";
+
+export const RECONCILE_LOCK = "reconcile";
+
+/**
+ * One reconcile at a time. The lock is a leased row rather than a flag in
+ * memory, because an action may run in a worker process and a pass that dies
+ * mid-list must not wedge the loop — the lease expires and the next scheduled
+ * pass picks the work up.
+ */
+export class LockRepository {
+  private readonly tables;
+
+  constructor(
+    private readonly db: DrizzleDb,
+    tablePrefix: string,
+  ) {
+    this.tables = createAppDbSchema(tablePrefix);
+  }
+
+  /**
+   * Take the lock, or report that someone else holds it. The conditional
+   * update is the whole mechanism: SQLite applies it atomically, so exactly one
+   * caller sees a changed row.
+   */
+  tryAcquire(name: string, leaseMs: number, now: Date = new Date()): boolean {
+    this.db.insert(this.tables.locks).values({ name, heldUntil: 0 }).onConflictDoNothing().run();
+
+    const result = this.db
+      .update(this.tables.locks)
+      .set({ heldUntil: now.getTime() + leaseMs })
+      .where(and(eq(this.tables.locks.name, name), lt(this.tables.locks.heldUntil, now.getTime())))
+      .run();
+
+    return result.changes === 1;
+  }
+
+  release(name: string): void {
+    this.db
+      .update(this.tables.locks)
+      .set({ heldUntil: 0 })
+      .where(eq(this.tables.locks.name, name))
+      .run();
+  }
+}
+
+export function createLockRepository(ctx: AppDbContext): LockRepository {
+  return new LockRepository(ctx.connection, ctx.tablePrefix);
+}

--- a/rome_apps/manager/src/db/repositories/settings.ts
+++ b/rome_apps/manager/src/db/repositories/settings.ts
@@ -1,0 +1,42 @@
+import { eq } from "drizzle-orm";
+import type { AppDbContext, DrizzleDb } from "@rome-os/app-runtime";
+import { CONFIG_KEY, type ManagerConfig, parseConfig } from "../../lib/config.js";
+import { createAppDbSchema } from "../schema.js";
+
+/** The one config row `manager:setup` writes and every other action reads. */
+export class SettingsRepository {
+  private readonly tables;
+
+  constructor(
+    private readonly db: DrizzleDb,
+    tablePrefix: string,
+  ) {
+    this.tables = createAppDbSchema(tablePrefix);
+  }
+
+  get(): ManagerConfig | undefined {
+    const row = this.db
+      .select()
+      .from(this.tables.config)
+      .where(eq(this.tables.config.key, CONFIG_KEY))
+      .get();
+    if (!row) return undefined;
+    const parsed = parseConfig(JSON.parse(row.value));
+    return parsed.ok ? parsed.config : undefined;
+  }
+
+  put(config: ManagerConfig): void {
+    this.db
+      .insert(this.tables.config)
+      .values({ key: CONFIG_KEY, value: JSON.stringify(config), updatedAt: new Date() })
+      .onConflictDoUpdate({
+        target: this.tables.config.key,
+        set: { value: JSON.stringify(config), updatedAt: new Date() },
+      })
+      .run();
+  }
+}
+
+export function createSettingsRepository(ctx: AppDbContext): SettingsRepository {
+  return new SettingsRepository(ctx.connection, ctx.tablePrefix);
+}

--- a/rome_apps/manager/src/db/schema.ts
+++ b/rome_apps/manager/src/db/schema.ts
@@ -1,0 +1,52 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+/**
+ * The Manager's whole store. `facts` is the ledger: append-only, never updated,
+ * never deleted, and the only description of a task there is. `config` holds
+ * the handful of settings that are not facts about a task, and `locks` holds
+ * the one lock that keeps reconciles from overlapping.
+ */
+export function createAppDbSchema(tablePrefix: string = "manager") {
+  const facts = sqliteTable(
+    `${tablePrefix}__facts`,
+    {
+      /** The ledger's total order. SQLite assigns it; app code never does. */
+      seq: integer("seq").primaryKey({ autoIncrement: true }),
+      id: text("id").notNull(),
+      taskId: text("task_id").notNull(),
+      /** One of the fact kinds in src/lib/facts.ts. */
+      kind: text("kind").notNull(),
+      /** A person's id, a worker id, or "runtime". */
+      by: text("by").notNull(),
+      /** A person's words or the action they took, verbatim. */
+      source: text("source"),
+      /** The kind's payload, as JSON. */
+      payload: text("payload").notNull(),
+      createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    },
+    (t) => [
+      index(`${tablePrefix}__facts_task_idx`).on(t.taskId),
+      index(`${tablePrefix}__facts_id_idx`).on(t.id),
+    ],
+  );
+
+  const config = sqliteTable(`${tablePrefix}__config`, {
+    key: text("key").primaryKey(),
+    value: text("value").notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+  });
+
+  const locks = sqliteTable(`${tablePrefix}__locks`, {
+    name: text("name").primaryKey(),
+    /** Epoch milliseconds the current holder's lease runs out. */
+    heldUntil: integer("held_until").notNull(),
+  });
+
+  return { facts, config, locks };
+}
+
+const defaultSchema = createAppDbSchema();
+
+export const facts = defaultSchema.facts;
+export const config = defaultSchema.config;
+export const locks = defaultSchema.locks;

--- a/rome_apps/manager/src/lib/config.test.ts
+++ b/rome_apps/manager/src/lib/config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "@rstest/core";
+import {
+  DEFAULT_INTERVAL_MINUTES,
+  DEFAULT_MAX_WORKERS,
+  DEFAULT_WORKER_AGENT,
+  normalizeIntervalMinutes,
+  parseConfig,
+  reconcileTrigger,
+} from "./config.js";
+
+describe("parseConfig", () => {
+  it("rejects a working directory that is not absolute", () => {
+    const parsed = parseConfig({ workingDir: "project" });
+    expect(parsed.ok).toBe(false);
+  });
+
+  it("fills in every cap the caller left out", () => {
+    const parsed = parseConfig({ workingDir: "/srv/project" });
+    if (!parsed.ok) throw new Error(parsed.error);
+    expect(parsed.config.workerAgent).toBe(DEFAULT_WORKER_AGENT);
+    expect(parsed.config.maxWorkers).toBe(DEFAULT_MAX_WORKERS);
+    expect(parsed.config.intervalMinutes).toBe(DEFAULT_INTERVAL_MINUTES);
+  });
+
+  it("degrades a nonsense cap to its default rather than failing", () => {
+    const parsed = parseConfig({ workingDir: "/srv/project", maxWorkers: -4, startCap: "many" });
+    if (!parsed.ok) throw new Error(parsed.error);
+    expect(parsed.config.maxWorkers).toBe(DEFAULT_MAX_WORKERS);
+    expect(parsed.config.startCap).toBe(2);
+  });
+});
+
+describe("normalizeIntervalMinutes", () => {
+  it("snaps to a cadence the cron conversion reproduces exactly", () => {
+    expect(normalizeIntervalMinutes(5)).toBe(5);
+    expect(normalizeIntervalMinutes(7)).toBe(6);
+    expect(normalizeIntervalMinutes(45)).toBe(30);
+    expect(normalizeIntervalMinutes(0)).toBe(DEFAULT_INTERVAL_MINUTES);
+  });
+});
+
+describe("reconcileTrigger", () => {
+  it("builds a MINUTELY rule the scheduler accepts", () => {
+    expect(reconcileTrigger(5)).toEqual({
+      type: "schedule",
+      tzid: "UTC",
+      tzMode: "floating",
+      localTime: "00:00",
+      rrule: "FREQ=MINUTELY;INTERVAL=5",
+    });
+  });
+});

--- a/rome_apps/manager/src/lib/config.ts
+++ b/rome_apps/manager/src/lib/config.ts
@@ -1,0 +1,101 @@
+/** Everything `manager:setup` stores and every action reads back. */
+export interface ManagerConfig {
+  /** Absolute directory every worker is told to work in. */
+  workingDir: string;
+  /** Canonical id of the agent a worker runs. */
+  workerAgent: string;
+  /** Started facts one task may collect since the last person fact before the runtime asks. */
+  startCap: number;
+  /** Workers allowed to be running at once, across every task. */
+  maxWorkers: number;
+  /** Hours a worker may be silent before the runtime declares it Lost. */
+  ageCapHours: number;
+  /** How often the reconcile routine fires. */
+  intervalMinutes: number;
+}
+
+export const DEFAULT_WORKER_AGENT = "coding:coding";
+export const DEFAULT_START_CAP = 2;
+export const DEFAULT_MAX_WORKERS = 3;
+export const DEFAULT_AGE_CAP_HOURS = 3;
+export const DEFAULT_INTERVAL_MINUTES = 5;
+
+/** Key the single config row lives under. */
+export const CONFIG_KEY = "manager_config";
+
+/** Stable identity of the routine `manager:setup` owns. */
+export const RECONCILE_ROUTINE_KEY = "manager-reconcile";
+export const RECONCILE_ROUTINE_NAME = "Manager: reconcile";
+
+export type ParseConfigResult = { ok: true; config: ManagerConfig } | { ok: false; error: string };
+
+function positiveInt(value: unknown, fallback: number, max: number): number {
+  const n = Math.round(Number(value));
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return Math.min(n, max);
+}
+
+/**
+ * Project a loose object onto {@link ManagerConfig}. Only `workingDir` has no
+ * safe default, so it is the only field that can reject the whole config; a
+ * nonsense cap degrades to its default rather than stopping the loop, because
+ * the routine that reads this fires unattended.
+ */
+export function parseConfig(raw: unknown): ParseConfigResult {
+  const args = (raw ?? {}) as Record<string, unknown>;
+  const workingDir = typeof args.workingDir === "string" ? args.workingDir.trim() : "";
+  if (!workingDir.startsWith("/")) {
+    return {
+      ok: false,
+      error: `workingDir must be an absolute path; got ${JSON.stringify(args.workingDir ?? null)}. Run manager:setup first.`,
+    };
+  }
+
+  const workerAgent =
+    typeof args.workerAgent === "string" && args.workerAgent.trim()
+      ? args.workerAgent.trim()
+      : DEFAULT_WORKER_AGENT;
+
+  return {
+    ok: true,
+    config: {
+      workingDir,
+      workerAgent,
+      startCap: positiveInt(args.startCap, DEFAULT_START_CAP, 20),
+      maxWorkers: positiveInt(args.maxWorkers, DEFAULT_MAX_WORKERS, 20),
+      ageCapHours: positiveInt(args.ageCapHours, DEFAULT_AGE_CAP_HOURS, 168),
+      intervalMinutes: normalizeIntervalMinutes(args.intervalMinutes),
+    },
+  };
+}
+
+/**
+ * Minute cadences that survive Rome's RRULE-to-cron conversion unchanged. The
+ * scheduler turns `FREQ=MINUTELY;INTERVAL=n` into a cron step field of n, so an
+ * interval that does not divide the hour would drift at every hour boundary.
+ */
+export const INTERVAL_OPTIONS = [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30] as const;
+
+/** Snap an arbitrary minute count to the nearest cadence cron reproduces exactly. */
+export function normalizeIntervalMinutes(raw: unknown): number {
+  const n = Math.round(Number(raw));
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_INTERVAL_MINUTES;
+  let best: number = INTERVAL_OPTIONS[0];
+  for (const option of INTERVAL_OPTIONS) {
+    if (Math.abs(option - n) < Math.abs(best - n)) best = option;
+  }
+  return best;
+}
+
+/** The schedule trigger `manager:setup` registers for `manager:reconcile`. */
+export function reconcileTrigger(intervalMinutes: number): Record<string, unknown> {
+  return {
+    type: "schedule",
+    tzid: "UTC",
+    // Floating so the routine follows the guardian; for a MINUTELY rule the
+    // scheduler ignores localTime anyway, and this keeps the shape uniform.
+    tzMode: "floating",
+    localTime: "00:00",
+    rrule: `FREQ=MINUTELY;INTERVAL=${normalizeIntervalMinutes(intervalMinutes)}`,
+  };
+}

--- a/rome_apps/manager/src/lib/facts.ts
+++ b/rome_apps/manager/src/lib/facts.ts
@@ -1,0 +1,146 @@
+/**
+ * The ledger's vocabulary. Every fact kind is named by one rule: a participle
+ * is something that happened, a noun is something somebody said.
+ *
+ * Facts are append-only. Nothing in this app updates or deletes one, so a
+ * task's state and position are always a fold over its facts rather than a
+ * column somebody has to keep true.
+ */
+
+/** Task state facts. Only a person writes the three that end a task. */
+export const TASK_STATE_KINDS = ["Created", "Taken", "Completed", "Cancelled"] as const;
+
+/** Execution facts. A worker writes two of them; the runtime writes the rest. */
+export const EXECUTION_KINDS = ["Started", "Returned", "Failed", "Lost"] as const;
+
+/** Dialogue facts. The runtime asks and reports; a person replies. */
+export const DIALOGUE_KINDS = ["Question", "Report", "Reply"] as const;
+
+export const FACT_KINDS = [...TASK_STATE_KINDS, ...EXECUTION_KINDS, ...DIALOGUE_KINDS] as const;
+
+export type FactKind = (typeof FACT_KINDS)[number];
+
+/** The `by` this app stamps on every fact the runtime writes itself. */
+export const RUNTIME = "runtime";
+
+/**
+ * Kinds only a person may write. `reconcile` has no path to any of them, which
+ * is what makes "only a person ends a task" mechanical rather than a promise.
+ */
+export const PERSON_KINDS: readonly FactKind[] = ["Created", "Completed", "Cancelled", "Reply"];
+
+/** Kinds the runtime writes. The position of a task is read off the last one. */
+export const RUNTIME_KINDS: readonly FactKind[] = [
+  "Taken",
+  "Started",
+  "Lost",
+  "Question",
+  "Report",
+];
+
+/** Kinds that end a worker's run. A Started with none of these after it is live. */
+export const WORKER_TERMINAL_KINDS: readonly FactKind[] = ["Returned", "Failed", "Lost"];
+
+export function isPersonKind(kind: FactKind): boolean {
+  return PERSON_KINDS.includes(kind);
+}
+
+export function isRuntimeKind(kind: FactKind): boolean {
+  return RUNTIME_KINDS.includes(kind);
+}
+
+export function isWorkerTerminalKind(kind: FactKind): boolean {
+  return WORKER_TERMINAL_KINDS.includes(kind);
+}
+
+/** Fields every fact carries, whoever wrote it. */
+export interface FactHeader {
+  /** The ledger's total order. Assigned by the database, never by app code. */
+  seq: number;
+  id: string;
+  taskId: string;
+  /** Who wrote it: a person's id, a worker id, or {@link RUNTIME}. */
+  by: string;
+  /**
+   * A person's own words or the action they took, verbatim. Set on every fact
+   * a person writes; the runtime and workers cite their call site instead.
+   */
+  source?: string;
+  createdAt: Date;
+}
+
+type FactOf<K extends FactKind, P> = FactHeader & { kind: K; payload: P };
+
+export type CreatedFact = FactOf<"Created", { brief: string }>;
+export type TakenFact = FactOf<"Taken", Record<string, never>>;
+export type CompletedFact = FactOf<"Completed", { reason?: string }>;
+export type CancelledFact = FactOf<"Cancelled", { reason?: string }>;
+export type StartedFact = FactOf<"Started", { workerId: string; prompt: string }>;
+export type ReturnedFact = FactOf<"Returned", { workerId: string; reply: string }>;
+export type FailedFact = FactOf<"Failed", { workerId: string; error: string }>;
+export type LostFact = FactOf<"Lost", { workerId: string; why: string }>;
+export type QuestionFact = FactOf<"Question", { why: string }>;
+export type ReportFact = FactOf<"Report", { what: string; evidence: string }>;
+export type ReplyFact = FactOf<"Reply", { text: string }>;
+
+export type Fact =
+  | CreatedFact
+  | TakenFact
+  | CompletedFact
+  | CancelledFact
+  | StartedFact
+  | ReturnedFact
+  | FailedFact
+  | LostFact
+  | QuestionFact
+  | ReportFact
+  | ReplyFact;
+
+/** A fact before the ledger gives it a place in the order. */
+export type NewFact = Omit<Fact, "seq" | "id" | "createdAt">;
+
+/** The worker id carried by an execution fact, or undefined for the rest. */
+export function workerIdOf(fact: Fact): string | undefined {
+  switch (fact.kind) {
+    case "Started":
+    case "Returned":
+    case "Failed":
+    case "Lost":
+      return fact.payload.workerId;
+    default:
+      return undefined;
+  }
+}
+
+/** One line of a task's history, for a worker brief or a chat summary. */
+export function describeFact(fact: Fact): string {
+  const stamp = fact.createdAt.toISOString();
+  const head = `${stamp} ${fact.kind} by ${fact.by}`;
+  const body = (() => {
+    switch (fact.kind) {
+      case "Created":
+        return fact.payload.brief;
+      case "Taken":
+        return "";
+      case "Completed":
+      case "Cancelled":
+        return fact.payload.reason ?? "";
+      case "Started":
+        return `worker ${fact.payload.workerId}`;
+      case "Returned":
+        return `worker ${fact.payload.workerId}: ${fact.payload.reply}`;
+      case "Failed":
+        return `worker ${fact.payload.workerId}: ${fact.payload.error}`;
+      case "Lost":
+        return `worker ${fact.payload.workerId}: ${fact.payload.why}`;
+      case "Question":
+        return fact.payload.why;
+      case "Report":
+        return `${fact.payload.what} (evidence: ${fact.payload.evidence})`;
+      case "Reply":
+        return fact.payload.text;
+    }
+  })();
+  const cited = fact.source ? ` [source: ${fact.source}]` : "";
+  return body ? `${head} — ${body}${cited}` : `${head}${cited}`;
+}

--- a/rome_apps/manager/src/lib/fold.test.ts
+++ b/rome_apps/manager/src/lib/fold.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "@rstest/core";
+import { RUNTIME } from "./facts.js";
+import { fold, foldTask, MalformedTaskError } from "./fold.js";
+import { LedgerBuilder } from "./test-facts.js";
+
+const ANN = "ann";
+
+function created(taskId = "t1") {
+  return new LedgerBuilder().add({
+    taskId,
+    kind: "Created",
+    by: ANN,
+    source: "add rate limiting",
+    payload: { brief: "add rate limiting to the upload endpoint" },
+  });
+}
+
+describe("foldTask", () => {
+  it("reads the brief and the opening state off the Created fact", () => {
+    const task = foldTask(created().facts);
+    expect(task.id).toBe("t1");
+    expect(task.brief).toBe("add rate limiting to the upload endpoint");
+    expect(task.state).toBe("created");
+    expect(task.position).toBeUndefined();
+  });
+
+  it("refuses facts that open no task", () => {
+    const ledger = new LedgerBuilder().add({
+      taskId: "t1",
+      kind: "Taken",
+      by: RUNTIME,
+      payload: {},
+    });
+    expect(() => foldTask(ledger.facts)).toThrow(MalformedTaskError);
+  });
+
+  it("has no position on a Taken task until the runtime writes past Taken", () => {
+    const task = foldTask(
+      created().add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} }).facts,
+    );
+    expect(task.state).toBe("taken");
+    expect(task.position).toBeUndefined();
+  });
+
+  it("is working while a Started is the runtime's last word", () => {
+    const task = foldTask(
+      created()
+        .add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} })
+        .add({
+          taskId: "t1",
+          kind: "Started",
+          by: RUNTIME,
+          payload: { workerId: "w1", prompt: "go" },
+        }).facts,
+    );
+    expect(task.position).toBe("working");
+    expect(task.liveWorker?.workerId).toBe("w1");
+  });
+
+  it("is stuck on a Question and reported on a Report", () => {
+    const stuck = created()
+      .add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} })
+      .add({
+        taskId: "t1",
+        kind: "Started",
+        by: RUNTIME,
+        payload: { workerId: "w1", prompt: "go" },
+      })
+      .add({ taskId: "t1", kind: "Failed", by: "w1", payload: { workerId: "w1", error: "boom" } })
+      .add({ taskId: "t1", kind: "Question", by: RUNTIME, payload: { why: "boom" } });
+    expect(foldTask(stuck.facts).position).toBe("stuck");
+
+    const reported = created()
+      .add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} })
+      .add({
+        taskId: "t1",
+        kind: "Started",
+        by: RUNTIME,
+        payload: { workerId: "w1", prompt: "go" },
+      })
+      .add({
+        taskId: "t1",
+        kind: "Returned",
+        by: "w1",
+        payload: { workerId: "w1", reply: "PR 88" },
+      })
+      .add({
+        taskId: "t1",
+        kind: "Report",
+        by: RUNTIME,
+        payload: { what: "PR 88", evidence: "worker w1" },
+      });
+    expect(foldTask(reported.facts).position).toBe("reported");
+  });
+
+  it("clears the live worker on the terminal fact that names it", () => {
+    const ledger = created()
+      .add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} })
+      .add({
+        taskId: "t1",
+        kind: "Started",
+        by: RUNTIME,
+        payload: { workerId: "w1", prompt: "go" },
+      })
+      .add({
+        taskId: "t1",
+        kind: "Returned",
+        by: "w1",
+        payload: { workerId: "w1", reply: "done" },
+      });
+    expect(foldTask(ledger.facts).liveWorker).toBeUndefined();
+  });
+
+  it("keeps the live worker when a terminal fact names an older one", () => {
+    const ledger = created()
+      .add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} })
+      .add({
+        taskId: "t1",
+        kind: "Started",
+        by: RUNTIME,
+        payload: { workerId: "w1", prompt: "go" },
+      })
+      .add({
+        taskId: "t1",
+        kind: "Lost",
+        by: RUNTIME,
+        payload: { workerId: "w1", why: "stopped by runtime" },
+      })
+      .add({
+        taskId: "t1",
+        kind: "Started",
+        by: RUNTIME,
+        payload: { workerId: "w2", prompt: "go again" },
+      })
+      .add({ taskId: "t1", kind: "Failed", by: "w1", payload: { workerId: "w1", error: "late" } });
+    expect(foldTask(ledger.facts).liveWorker?.workerId).toBe("w2");
+  });
+
+  it("counts starts from the newest fact a person wrote", () => {
+    const ledger = created()
+      .add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} })
+      .add({
+        taskId: "t1",
+        kind: "Started",
+        by: RUNTIME,
+        payload: { workerId: "w1", prompt: "go" },
+      })
+      .add({ taskId: "t1", kind: "Failed", by: "w1", payload: { workerId: "w1", error: "boom" } })
+      .add({
+        taskId: "t1",
+        kind: "Started",
+        by: RUNTIME,
+        payload: { workerId: "w2", prompt: "go" },
+      })
+      .add({ taskId: "t1", kind: "Failed", by: "w2", payload: { workerId: "w2", error: "boom" } });
+    expect(foldTask(ledger.facts).startsSinceLastPersonFact).toBe(2);
+
+    ledger.add({
+      taskId: "t1",
+      kind: "Reply",
+      by: ANN,
+      source: "0041 was reverted",
+      payload: { text: "rebase" },
+    });
+    expect(foldTask(ledger.facts).startsSinceLastPersonFact).toBe(0);
+  });
+
+  it("ends the task on a person's Completed and drops the position", () => {
+    const ledger = created()
+      .add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} })
+      .add({
+        taskId: "t1",
+        kind: "Started",
+        by: RUNTIME,
+        payload: { workerId: "w1", prompt: "go" },
+      })
+      .add({ taskId: "t1", kind: "Completed", by: "bob", source: "merged 88", payload: {} });
+    const task = foldTask(ledger.facts);
+    expect(task.state).toBe("completed");
+    expect(task.position).toBeUndefined();
+    expect(task.liveWorker?.workerId).toBe("w1");
+  });
+
+  it("orders by the ledger's seq, not by arrival", () => {
+    const ledger = created().add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} });
+    const shuffled = [ledger.facts[1], ledger.facts[0]];
+    expect(foldTask(shuffled).latest.kind).toBe("Taken");
+  });
+});
+
+describe("fold", () => {
+  it("splits facts by task and orders tasks oldest first", () => {
+    const ledger = new LedgerBuilder()
+      .add({ taskId: "t1", kind: "Created", by: ANN, source: "one", payload: { brief: "one" } })
+      .add({ taskId: "t2", kind: "Created", by: ANN, source: "two", payload: { brief: "two" } })
+      .add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} });
+
+    const snapshot = fold(ledger.now(), ledger.facts);
+    expect(snapshot.tasks.map((task) => task.id)).toEqual(["t1", "t2"]);
+    expect(snapshot.tasks[0].state).toBe("taken");
+    expect(snapshot.tasks[1].state).toBe("created");
+  });
+});

--- a/rome_apps/manager/src/lib/fold.ts
+++ b/rome_apps/manager/src/lib/fold.ts
@@ -1,0 +1,159 @@
+import {
+  type Fact,
+  type FactKind,
+  isPersonKind,
+  isRuntimeKind,
+  isWorkerTerminalKind,
+} from "./facts.js";
+
+/**
+ * Folding the ledger. Everything this module returns is derived from the facts
+ * on a task and nothing else — no state column, no cached counter. A wake that
+ * reads the same facts computes the same view, which is what lets the runtime
+ * crash between any two writes and pick up exactly where it left off.
+ */
+
+/** The four states, which are about ownership. */
+export type TaskState = "created" | "taken" | "completed" | "cancelled";
+
+/** Where a Taken task sits between wakes, named by what the runtime waits for. */
+export type Position = "working" | "stuck" | "reported";
+
+/** A worker with a Started and no terminal fact after it. */
+export interface WorkerRef {
+  workerId: string;
+  startedAt: Date;
+  startedSeq: number;
+}
+
+export interface TaskView {
+  id: string;
+  /** What the person asked for, from the Created fact. */
+  brief: string;
+  state: TaskState;
+  /** Set only inside Taken, and only once the runtime has written past Taken. */
+  position?: Position;
+  /** The newest fact on the task. Reconcile keys most of its decisions on this. */
+  latest: Fact;
+  /** Every fact on the task, oldest first. */
+  facts: readonly Fact[];
+  liveWorker?: WorkerRef;
+  /** Order of the newest fact a person wrote. The start cap counts from here. */
+  lastPersonFactSeq: number;
+  /** Started facts newer than {@link lastPersonFactSeq}. This is the cap's counter. */
+  startsSinceLastPersonFact: number;
+}
+
+export interface LedgerSnapshot {
+  now: Date;
+  tasks: readonly TaskView[];
+}
+
+/** Thrown when a task's facts cannot describe a task — no Created to open it. */
+export class MalformedTaskError extends Error {}
+
+const POSITION_BY_KIND: Partial<Record<FactKind, Position>> = {
+  Started: "working",
+  Question: "stuck",
+  Report: "reported",
+};
+
+/**
+ * Fold one task's facts into the view reconcile reads. `facts` may arrive in
+ * any order; the ledger's `seq` is the authority, so they are sorted here.
+ */
+export function foldTask(facts: readonly Fact[]): TaskView {
+  const ordered = [...facts].sort((a, b) => a.seq - b.seq);
+  const created = ordered.find((fact) => fact.kind === "Created");
+  if (!created) {
+    throw new MalformedTaskError(`task ${ordered[0]?.taskId ?? "(unknown)"} has no Created fact`);
+  }
+
+  let state: TaskState = "created";
+  let position: Position | undefined;
+  let liveWorker: WorkerRef | undefined;
+  let lastPersonFactSeq = created.seq;
+
+  for (const fact of ordered) {
+    switch (fact.kind) {
+      case "Taken":
+        if (state === "created") state = "taken";
+        break;
+      case "Completed":
+        state = "completed";
+        break;
+      case "Cancelled":
+        state = "cancelled";
+        break;
+      case "Started":
+        liveWorker = {
+          workerId: fact.payload.workerId,
+          startedAt: fact.createdAt,
+          startedSeq: fact.seq,
+        };
+        break;
+      default:
+        break;
+    }
+
+    if (isWorkerTerminalKind(fact.kind) && liveWorker) {
+      // A terminal fact only closes the worker it names, so a stale outcome
+      // arriving after a replacement started does not clear the live one.
+      const named = (fact.payload as { workerId?: string }).workerId;
+      if (named === liveWorker.workerId) liveWorker = undefined;
+    }
+
+    if (isRuntimeKind(fact.kind)) {
+      position = POSITION_BY_KIND[fact.kind];
+    }
+
+    if (isPersonKind(fact.kind)) {
+      lastPersonFactSeq = fact.seq;
+    }
+  }
+
+  const startsSinceLastPersonFact = ordered.filter(
+    (fact) => fact.kind === "Started" && fact.seq > lastPersonFactSeq,
+  ).length;
+
+  return {
+    id: created.taskId,
+    brief: created.payload.brief,
+    state,
+    position: state === "taken" ? position : undefined,
+    latest: ordered[ordered.length - 1],
+    facts: ordered,
+    liveWorker,
+    lastPersonFactSeq,
+    startsSinceLastPersonFact,
+  };
+}
+
+/**
+ * Fold the whole ledger. Tasks come back in the order they were created, so a
+ * concurrency cap spends its budget on the oldest work first.
+ */
+export function fold(now: Date, facts: readonly Fact[]): LedgerSnapshot {
+  const byTask = new Map<string, Fact[]>();
+  for (const fact of facts) {
+    const bucket = byTask.get(fact.taskId);
+    if (bucket) bucket.push(fact);
+    else byTask.set(fact.taskId, [fact]);
+  }
+
+  const tasks = [...byTask.values()]
+    .map((bucket) => foldTask(bucket))
+    .sort((a, b) => a.facts[0].seq - b.facts[0].seq);
+
+  return { now, tasks };
+}
+
+/** Whether a task is finished. Reconcile only ever stops a worker on these. */
+export function isTerminal(state: TaskState): boolean {
+  return state === "completed" || state === "cancelled";
+}
+
+/** How long a worker has been running, in milliseconds. */
+export function workerAgeMs(worker: WorkerRef, now: Date): number {
+  return now.getTime() - worker.startedAt.getTime();
+}

--- a/rome_apps/manager/src/lib/identity.ts
+++ b/rome_apps/manager/src/lib/identity.ts
@@ -1,0 +1,19 @@
+import { getCurrentActionContext } from "@rome-os/app-runtime";
+
+/**
+ * Who wrote a person's fact.
+ *
+ * The runtime stamps `by`, never the manager agent, so the agent can pick the
+ * task and the words but not the author. What it can stamp is limited by what
+ * the platform tells an action: `getCurrentActionContext()` carries the calling
+ * session, agent, and channel thread, but no guardian or user id — that is
+ * deliberately dropped before the context reaches app code. So a chat message
+ * from the guardian is stamped `guardian`, and only a channel that names its
+ * sender narrows it further.
+ */
+export const DEFAULT_PERSON = "guardian";
+
+export function personFromContext(): string {
+  const channelUserId = getCurrentActionContext()?.channelContext?.channelUserId;
+  return channelUserId?.trim() || DEFAULT_PERSON;
+}

--- a/rome_apps/manager/src/lib/judge.test.ts
+++ b/rome_apps/manager/src/lib/judge.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "@rstest/core";
+import type { TaskView } from "./fold.js";
+import { hasBlockedLine, judge } from "./judge.js";
+
+// The default judge reads the reply only, so the task it is handed never
+// changes the verdict. One empty stand-in keeps that visible.
+const TASK = {} as TaskView;
+
+describe("judge", () => {
+  it("accepts a worker that said something", () => {
+    expect(judge(TASK, "Opened PR 88, CI green", "worker w1")).toEqual({ done: true });
+  });
+
+  it("rejects an empty reply", () => {
+    const verdict = judge(TASK, "   \n  ", "worker w1");
+    expect(verdict.done).toBe(false);
+    expect(verdict.why).toBe("the worker returned an empty reply");
+  });
+
+  it("rejects a reply that declares itself blocked, and quotes the line", () => {
+    const reply = ["Looked at the migration.", "BLOCKED: 0042 conflicts with 0041"].join("\n");
+    expect(judge(TASK, reply, "worker w1")).toEqual({
+      done: false,
+      why: "BLOCKED: 0042 conflicts with 0041",
+    });
+  });
+
+  it("ignores the word BLOCKED in the middle of a line", () => {
+    expect(judge(TASK, "the queue was BLOCKED: it is not now", "worker w1").done).toBe(true);
+  });
+
+  it("reads a blocked line through leading whitespace", () => {
+    expect(hasBlockedLine("  BLOCKED: no credentials")).toBe(true);
+    expect(hasBlockedLine("all clear")).toBe(false);
+  });
+});

--- a/rome_apps/manager/src/lib/judge.ts
+++ b/rome_apps/manager/src/lib/judge.ts
@@ -1,0 +1,51 @@
+import type { TaskView } from "./fold.js";
+
+/**
+ * The judge is one of the two places a model may enter this app. It answers a
+ * single question — is the task done, given what the worker returned — and the
+ * default answer needs no model at all.
+ *
+ * Nothing else in the runtime asks that question, so an instance that wants a
+ * model-graded "done" swaps the function here and changes nothing else.
+ */
+
+export interface JudgeVerdict {
+  done: boolean;
+  /** Why not, in words the next worker can act on. Set only when `done` is false. */
+  why?: string;
+}
+
+export type Judge = (task: TaskView, reply: string, evidence: string) => JudgeVerdict;
+
+/**
+ * The line prefix a worker uses to say it could not finish. It is part of the
+ * worker's brief, so a worker that hits a wall says so in a form the judge can
+ * read without a model.
+ */
+export const BLOCKED_PREFIX = "BLOCKED:";
+
+/** Whether any line of `reply` opens with {@link BLOCKED_PREFIX}. */
+export function hasBlockedLine(reply: string): boolean {
+  return reply.split("\n").some((line) => line.trimStart().startsWith(BLOCKED_PREFIX));
+}
+
+/**
+ * The default, deterministic judge: a task is done when the worker said
+ * something and did not declare itself blocked. It reads the reply only —
+ * `task` and `evidence` are in the signature so a model-backed replacement has
+ * the history and the pointer to the result without a different call site.
+ */
+export const judge: Judge = (_task, reply, _evidence) => {
+  const text = reply.trim();
+  if (!text) {
+    return { done: false, why: "the worker returned an empty reply" };
+  }
+  const blocked = reply
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith(BLOCKED_PREFIX));
+  if (blocked) {
+    return { done: false, why: blocked };
+  }
+  return { done: true };
+};

--- a/rome_apps/manager/src/lib/person-fact.ts
+++ b/rome_apps/manager/src/lib/person-fact.ts
@@ -1,0 +1,63 @@
+import type { ActionResult, RomeAppContext } from "@rome-os/app-runtime";
+import { createLedgerRepository } from "../db/repositories/ledger.js";
+import type { Fact, NewFact } from "./facts.js";
+import { foldTask, type TaskState, type TaskView } from "./fold.js";
+import { personFromContext } from "./identity.js";
+
+/** A person's fact, minus the author — the runtime fills that in. */
+export type UnstampedFact = Omit<NewFact, "by"> & { source: string };
+
+/**
+ * The four actions the manager agent can call all do the same three things:
+ * stamp the person, append one fact, and reconcile so the new fact is acted on
+ * without waiting for the next tick. The words and the task are the agent's
+ * choice; `by` is not.
+ */
+export async function writePersonFact(
+  appContext: RomeAppContext,
+  unstamped: UnstampedFact,
+): Promise<ActionResult> {
+  const ledger = createLedgerRepository(appContext.db);
+  if (!ledger.reachable()) {
+    return { status: "error", error: "the ledger is unreachable" };
+  }
+
+  const fact = ledger.append({ ...unstamped, by: personFromContext() } as NewFact);
+
+  await appContext.runAction("manager:reconcile", {});
+
+  return { status: "ok", data: summarize(fact, ledger.factsFor(unstamped.taskId)) };
+}
+
+/** Load a task, or say why it cannot be acted on. */
+export function loadTask(
+  appContext: RomeAppContext,
+  taskId: string,
+): { ok: true; task: TaskView } | { ok: false; error: string } {
+  const ledger = createLedgerRepository(appContext.db);
+  const facts = ledger.factsFor(taskId);
+  if (facts.length === 0) {
+    return { ok: false, error: `no task ${taskId}` };
+  }
+  return { ok: true, task: foldTask(facts) };
+}
+
+/** Only a person ends a task, and only one that is still open. */
+export function rejectIfClosed(task: TaskView): string | undefined {
+  const closed: TaskState[] = ["completed", "cancelled"];
+  if (closed.includes(task.state)) {
+    return `task ${task.id} is already ${task.state}`;
+  }
+  return undefined;
+}
+
+function summarize(fact: Fact, facts: readonly Fact[]) {
+  const task = foldTask(facts);
+  return {
+    taskId: fact.taskId,
+    wrote: fact.kind,
+    by: fact.by,
+    state: task.state,
+    position: task.position,
+  };
+}

--- a/rome_apps/manager/src/lib/prompt.ts
+++ b/rome_apps/manager/src/lib/prompt.ts
@@ -1,0 +1,54 @@
+import type { ManagerConfig } from "./config.js";
+import { describeFact } from "./facts.js";
+import type { TaskView } from "./fold.js";
+import { BLOCKED_PREFIX } from "./judge.js";
+
+/**
+ * The brief a worker is launched with. It is the task's whole history, because
+ * a worker is started fresh every time and reads nothing else: a retry learns
+ * what failed, and a steered worker learns what the person said, from the same
+ * lines. The brief is stored on the Started fact, so the ledger records the
+ * exact words a worker was given.
+ */
+export function buildWorkerPrompt(input: {
+  task: TaskView;
+  config: ManagerConfig;
+  /** What made the runtime start this worker, when it is not the first one. */
+  reason?: string;
+}): string {
+  const { task, config, reason } = input;
+
+  const lines = [
+    `You are working on task ${task.id}.`,
+    "",
+    `Working directory: ${config.workingDir}`,
+    "Start by moving there; every path below is relative to it.",
+    "",
+    "What was asked for:",
+    task.brief,
+    "",
+    "The task's history, oldest first. This is everything anyone recorded about",
+    "it, including earlier attempts and what the person said:",
+    ...task.facts.map((fact) => `  ${describeFact(fact)}`),
+  ];
+
+  if (reason) {
+    lines.push("", `Why you were started: ${reason}`);
+  }
+
+  lines.push(
+    "",
+    "When you finish, end your turn with a short summary of what you did and",
+    "where the result is — a branch, a pull request, a path. That summary is",
+    "recorded as the task's Returned fact and is what gets judged.",
+    "",
+    `If you cannot finish, say so on a line starting with "${BLOCKED_PREFIX}"`,
+    "followed by what is in the way. A blocked reply is not a failure; it is how",
+    "you hand the question back to a person.",
+    "",
+    "Do not wait for anything, do not poll, and do not ask a question you cannot",
+    "get an answer to inside this turn.",
+  );
+
+  return lines.join("\n");
+}

--- a/rome_apps/manager/src/lib/reconcile.test.ts
+++ b/rome_apps/manager/src/lib/reconcile.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, it } from "@rstest/core";
+import { DEFAULT_WORKER_AGENT, type ManagerConfig } from "./config.js";
+import { RUNTIME } from "./facts.js";
+import { fold } from "./fold.js";
+import type { Judge } from "./judge.js";
+import { LOST_SILENT, LOST_STOPPED, reconcile, type ReconcileAction } from "./reconcile.js";
+import { LedgerBuilder } from "./test-facts.js";
+
+const ANN = "ann";
+
+const CONFIG: ManagerConfig = {
+  workingDir: "/srv/project",
+  workerAgent: DEFAULT_WORKER_AGENT,
+  startCap: 2,
+  maxWorkers: 3,
+  ageCapHours: 3,
+  intervalMinutes: 5,
+};
+
+const ALWAYS_DONE: Judge = () => ({ done: true });
+const NEVER_DONE: Judge = () => ({ done: false, why: "no pull request" });
+
+function run(
+  ledger: LedgerBuilder,
+  overrides: { config?: Partial<ManagerConfig>; judge?: Judge; now?: Date } = {},
+): ReconcileAction[] {
+  let n = 0;
+  return reconcile({
+    snapshot: fold(overrides.now ?? ledger.now(), ledger.facts),
+    config: { ...CONFIG, ...overrides.config },
+    judge: overrides.judge ?? ALWAYS_DONE,
+    newWorkerId: () => `w${++n}`,
+  });
+}
+
+/** The shape of an action list, with prompts elided — those are prompt.ts's job. */
+function shape(actions: ReconcileAction[]) {
+  return actions.map((action) => {
+    if (action.type === "append") {
+      return { type: "append", taskId: action.fact.taskId, kind: action.fact.kind };
+    }
+    return { type: action.type, taskId: action.taskId, workerId: action.workerId };
+  });
+}
+
+function created(taskId = "t1", brief = "add rate limiting") {
+  return new LedgerBuilder().add({
+    taskId,
+    kind: "Created",
+    by: ANN,
+    source: brief,
+    payload: { brief },
+  });
+}
+
+function working(taskId = "t1", workerId = "w0") {
+  return created(taskId)
+    .add({ taskId, kind: "Taken", by: RUNTIME, payload: {} })
+    .add({ taskId, kind: "Started", by: RUNTIME, payload: { workerId, prompt: "go" } });
+}
+
+describe("reconcile: a new task", () => {
+  it("takes it and starts a worker in one pass", () => {
+    expect(shape(run(created()))).toEqual([
+      { type: "append", taskId: "t1", kind: "Taken" },
+      { type: "append", taskId: "t1", kind: "Started" },
+      { type: "launch", taskId: "t1", workerId: "w1" },
+    ]);
+  });
+
+  it("puts the task's brief and the working directory in the worker's prompt", () => {
+    const actions = run(created());
+    const started = actions[1];
+    if (started.type !== "append" || started.fact.kind !== "Started")
+      throw new Error("expected Started");
+    expect(started.fact.payload.prompt).toContain("add rate limiting");
+    expect(started.fact.payload.prompt).toContain("/srv/project");
+  });
+
+  it("leaves it Created when every worker slot is taken", () => {
+    const ledger = created("t1");
+    ledger.add({ taskId: "t2", kind: "Created", by: ANN, source: "b", payload: { brief: "b" } });
+    ledger.add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} });
+    ledger.add({
+      taskId: "t1",
+      kind: "Started",
+      by: RUNTIME,
+      payload: { workerId: "w0", prompt: "go" },
+    });
+
+    expect(shape(run(ledger, { config: { maxWorkers: 1 } }))).toEqual([]);
+  });
+
+  it("spends the last slot on the oldest task", () => {
+    const ledger = created("t1", "older");
+    ledger.add({
+      taskId: "t2",
+      kind: "Created",
+      by: ANN,
+      source: "newer",
+      payload: { brief: "newer" },
+    });
+
+    expect(shape(run(ledger, { config: { maxWorkers: 1 } }))).toEqual([
+      { type: "append", taskId: "t1", kind: "Taken" },
+      { type: "append", taskId: "t1", kind: "Started" },
+      { type: "launch", taskId: "t1", workerId: "w1" },
+    ]);
+  });
+});
+
+describe("reconcile: a task the runtime already owns", () => {
+  it("does nothing while a worker is running", () => {
+    expect(shape(run(working()))).toEqual([]);
+  });
+
+  it("starts a worker for a Taken that never got one", () => {
+    const ledger = created().add({ taskId: "t1", kind: "Taken", by: RUNTIME, payload: {} });
+    expect(shape(run(ledger))).toEqual([
+      { type: "append", taskId: "t1", kind: "Started" },
+      { type: "launch", taskId: "t1", workerId: "w1" },
+    ]);
+  });
+
+  it("waits on a Question and on a Report", () => {
+    const stuck = working().add({
+      taskId: "t1",
+      kind: "Failed",
+      by: "w0",
+      payload: { workerId: "w0", error: "boom" },
+    });
+    stuck.add({ taskId: "t1", kind: "Question", by: RUNTIME, payload: { why: "boom" } });
+    expect(shape(run(stuck))).toEqual([]);
+
+    const reported = working().add({
+      taskId: "t1",
+      kind: "Returned",
+      by: "w0",
+      payload: { workerId: "w0", reply: "PR 88" },
+    });
+    reported.add({
+      taskId: "t1",
+      kind: "Report",
+      by: RUNTIME,
+      payload: { what: "PR 88", evidence: "worker w0" },
+    });
+    expect(shape(run(reported))).toEqual([]);
+  });
+});
+
+describe("reconcile: judging what came back", () => {
+  it("reports when the judge says yes", () => {
+    const ledger = working().add({
+      taskId: "t1",
+      kind: "Returned",
+      by: "w0",
+      payload: { workerId: "w0", reply: "Opened PR 88" },
+    });
+    const actions = run(ledger, { judge: ALWAYS_DONE });
+    expect(shape(actions)).toEqual([{ type: "append", taskId: "t1", kind: "Report" }]);
+    const report = actions[0];
+    if (report.type !== "append" || report.fact.kind !== "Report")
+      throw new Error("expected Report");
+    expect(report.fact.payload).toEqual({ what: "Opened PR 88", evidence: "worker w0" });
+  });
+
+  it("starts again with the judge's reason when it says no", () => {
+    const ledger = working().add({
+      taskId: "t1",
+      kind: "Returned",
+      by: "w0",
+      payload: { workerId: "w0", reply: "wrote some code" },
+    });
+    const actions = run(ledger, { judge: NEVER_DONE });
+    expect(shape(actions)).toEqual([
+      { type: "append", taskId: "t1", kind: "Started" },
+      { type: "launch", taskId: "t1", workerId: "w1" },
+    ]);
+    const started = actions[0];
+    if (started.type !== "append" || started.fact.kind !== "Started")
+      throw new Error("expected Started");
+    expect(started.fact.payload.prompt).toContain("no pull request");
+  });
+});
+
+describe("reconcile: failure and the start cap", () => {
+  it("retries while the task is under the cap", () => {
+    const ledger = working().add({
+      taskId: "t1",
+      kind: "Failed",
+      by: "w0",
+      payload: { workerId: "w0", error: "0042 conflicts with 0041" },
+    });
+    const actions = run(ledger);
+    expect(shape(actions)).toEqual([
+      { type: "append", taskId: "t1", kind: "Started" },
+      { type: "launch", taskId: "t1", workerId: "w1" },
+    ]);
+    const started = actions[0];
+    if (started.type !== "append" || started.fact.kind !== "Started")
+      throw new Error("expected Started");
+    expect(started.fact.payload.prompt).toContain("0042 conflicts with 0041");
+  });
+
+  it("asks once the task is over the cap", () => {
+    const ledger = working()
+      .add({ taskId: "t1", kind: "Failed", by: "w0", payload: { workerId: "w0", error: "boom" } })
+      .add({
+        taskId: "t1",
+        kind: "Started",
+        by: RUNTIME,
+        payload: { workerId: "w1", prompt: "go" },
+      })
+      .add({ taskId: "t1", kind: "Failed", by: "w1", payload: { workerId: "w1", error: "boom" } });
+
+    const actions = run(ledger);
+    expect(shape(actions)).toEqual([{ type: "append", taskId: "t1", kind: "Question" }]);
+    const question = actions[0];
+    if (question.type !== "append" || question.fact.kind !== "Question")
+      throw new Error("expected Question");
+    expect(question.fact.payload.why).toContain("boom");
+    expect(question.fact.payload.why).toContain("2 attempts");
+  });
+
+  it("treats a Lost like a Failed", () => {
+    const ledger = working().add({
+      taskId: "t1",
+      kind: "Lost",
+      by: RUNTIME,
+      payload: { workerId: "w0", why: "host restart" },
+    });
+    expect(shape(run(ledger))).toEqual([
+      { type: "append", taskId: "t1", kind: "Started" },
+      { type: "launch", taskId: "t1", workerId: "w1" },
+    ]);
+  });
+
+  it("counts starts again from zero after a person replies", () => {
+    const ledger = working()
+      .add({ taskId: "t1", kind: "Failed", by: "w0", payload: { workerId: "w0", error: "boom" } })
+      .add({
+        taskId: "t1",
+        kind: "Started",
+        by: RUNTIME,
+        payload: { workerId: "w1", prompt: "go" },
+      })
+      .add({ taskId: "t1", kind: "Failed", by: "w1", payload: { workerId: "w1", error: "boom" } })
+      .add({ taskId: "t1", kind: "Question", by: RUNTIME, payload: { why: "boom" } })
+      .add({
+        taskId: "t1",
+        kind: "Reply",
+        by: ANN,
+        source: "0041 was reverted",
+        payload: { text: "rebase and retry" },
+      });
+
+    expect(shape(run(ledger))).toEqual([
+      { type: "append", taskId: "t1", kind: "Started" },
+      { type: "launch", taskId: "t1", workerId: "w1" },
+    ]);
+  });
+});
+
+describe("reconcile: the age cap", () => {
+  it("declares a silent worker lost and retries it in the same pass", () => {
+    const ledger = working();
+    const fourHoursOn = new Date(ledger.now().getTime() + 4 * 3_600_000);
+
+    const actions = run(ledger, { now: fourHoursOn });
+    expect(shape(actions)).toEqual([
+      { type: "append", taskId: "t1", kind: "Lost" },
+      { type: "append", taskId: "t1", kind: "Started" },
+      { type: "launch", taskId: "t1", workerId: "w1" },
+    ]);
+    const lost = actions[0];
+    if (lost.type !== "append" || lost.fact.kind !== "Lost") throw new Error("expected Lost");
+    expect(lost.fact.payload).toEqual({ workerId: "w0", why: LOST_SILENT });
+  });
+
+  it("leaves a worker inside the cap alone", () => {
+    const ledger = working();
+    const twoHoursOn = new Date(ledger.now().getTime() + 2 * 3_600_000);
+    expect(shape(run(ledger, { now: twoHoursOn }))).toEqual([]);
+  });
+
+  it("frees the slot the lost worker held", () => {
+    const ledger = working("t1", "w0");
+    ledger.add({ taskId: "t2", kind: "Created", by: ANN, source: "b", payload: { brief: "b" } });
+    const fourHoursOn = new Date(ledger.now().getTime() + 4 * 3_600_000);
+
+    expect(shape(run(ledger, { now: fourHoursOn, config: { maxWorkers: 1 } }))).toEqual([
+      { type: "append", taskId: "t1", kind: "Lost" },
+      { type: "append", taskId: "t1", kind: "Started" },
+      { type: "launch", taskId: "t1", workerId: "w1" },
+    ]);
+  });
+});
+
+describe("reconcile: steering", () => {
+  it("stops the running worker and starts one that can read the reply", () => {
+    const ledger = working().add({
+      taskId: "t1",
+      kind: "Reply",
+      by: ANN,
+      source: "use the token bucket",
+      payload: { text: "use the token bucket" },
+    });
+
+    const actions = run(ledger);
+    expect(shape(actions)).toEqual([
+      { type: "stop", taskId: "t1", workerId: "w0" },
+      { type: "append", taskId: "t1", kind: "Started" },
+      { type: "launch", taskId: "t1", workerId: "w1" },
+    ]);
+    const started = actions[1];
+    if (started.type !== "append" || started.fact.kind !== "Started")
+      throw new Error("expected Started");
+    expect(started.fact.payload.prompt).toContain("use the token bucket");
+  });
+
+  it("just starts when no worker is running", () => {
+    const ledger = working()
+      .add({
+        taskId: "t1",
+        kind: "Returned",
+        by: "w0",
+        payload: { workerId: "w0", reply: "PR 88" },
+      })
+      .add({
+        taskId: "t1",
+        kind: "Report",
+        by: RUNTIME,
+        payload: { what: "PR 88", evidence: "worker w0" },
+      })
+      .add({
+        taskId: "t1",
+        kind: "Reply",
+        by: ANN,
+        source: "also add a test",
+        payload: { text: "also add a test" },
+      });
+
+    expect(shape(run(ledger))).toEqual([
+      { type: "append", taskId: "t1", kind: "Started" },
+      { type: "launch", taskId: "t1", workerId: "w1" },
+    ]);
+  });
+});
+
+describe("reconcile: a person ends the task", () => {
+  it("stops the live worker and writes nothing", () => {
+    const ledger = working().add({
+      taskId: "t1",
+      kind: "Cancelled",
+      by: ANN,
+      source: "closed the issue as not planned",
+      payload: { reason: "not planned" },
+    });
+
+    expect(shape(run(ledger))).toEqual([{ type: "stop", taskId: "t1", workerId: "w0" }]);
+    const stop = run(ledger)[0];
+    if (stop.type !== "stop") throw new Error("expected a stop");
+    expect(stop.why).toBe(LOST_STOPPED);
+  });
+
+  it("does nothing at all once the worker is closed", () => {
+    const ledger = working()
+      .add({ taskId: "t1", kind: "Completed", by: "bob", source: "merged 88", payload: {} })
+      .add({
+        taskId: "t1",
+        kind: "Lost",
+        by: RUNTIME,
+        payload: { workerId: "w0", why: LOST_STOPPED },
+      });
+
+    expect(shape(run(ledger))).toEqual([]);
+  });
+});
+
+describe("reconcile: the host died between two writes", () => {
+  it("finishes the list the dead pass started, and duplicates nothing", () => {
+    const ledger = new LedgerBuilder()
+      .add({
+        taskId: "t3",
+        kind: "Created",
+        by: ANN,
+        source: "issue 3",
+        payload: { brief: "three" },
+      })
+      .add({
+        taskId: "t4",
+        kind: "Created",
+        by: ANN,
+        source: "issue 4",
+        payload: { brief: "four" },
+      })
+      .add({ taskId: "t3", kind: "Taken", by: RUNTIME, payload: {} });
+
+    expect(shape(run(ledger))).toEqual([
+      { type: "append", taskId: "t3", kind: "Started" },
+      { type: "launch", taskId: "t3", workerId: "w1" },
+      { type: "append", taskId: "t4", kind: "Taken" },
+      { type: "append", taskId: "t4", kind: "Started" },
+      { type: "launch", taskId: "t4", workerId: "w2" },
+    ]);
+  });
+});

--- a/rome_apps/manager/src/lib/reconcile.ts
+++ b/rome_apps/manager/src/lib/reconcile.ts
@@ -1,0 +1,195 @@
+import type { ManagerConfig } from "./config.js";
+import { type NewFact, RUNTIME } from "./facts.js";
+import { isTerminal, type LedgerSnapshot, type TaskView, workerAgeMs } from "./fold.js";
+import type { Judge } from "./judge.js";
+import { buildWorkerPrompt } from "./prompt.js";
+
+/**
+ * The runtime's whole decision, as a pure function of a ledger snapshot.
+ *
+ * It returns a list of things to do rather than doing them, which is what makes
+ * every rule here testable without a database and what lets the caller stop
+ * after any single item: each one leaves the ledger consistent on its own.
+ */
+
+export type ReconcileAction =
+  /** Append one fact. */
+  | { type: "append"; fact: NewFact }
+  /** Run the worker named by a Started that was just appended. */
+  | { type: "launch"; taskId: string; workerId: string }
+  /**
+   * Ask a running worker to end. The runtime does this when a person ends or
+   * steers a task; see the applier for what "stop" costs on today's platform.
+   */
+  | { type: "stop"; taskId: string; workerId: string; why: string };
+
+export interface ReconcileInput {
+  snapshot: LedgerSnapshot;
+  config: ManagerConfig;
+  /** The second of the app's two model call sites. */
+  judge: Judge;
+  /** Injected so the output is a value tests can compare. */
+  newWorkerId: () => string;
+}
+
+/** Reasons that appear on a Lost fact the runtime writes for itself. */
+export const LOST_SILENT = "silent past cap";
+export const LOST_STOPPED = "stopped by runtime";
+
+export function reconcile(input: ReconcileInput): ReconcileAction[] {
+  const { snapshot, config, judge, newWorkerId } = input;
+
+  const running = snapshot.tasks.filter((task) => task.liveWorker !== undefined).length;
+  // One budget for the whole pass. Every launch spends from it and every stop
+  // returns to it, so the cap holds across tasks rather than per task.
+  let budget = config.maxWorkers - running;
+  const actions: ReconcileAction[] = [];
+
+  /** Write Started and launch a worker, unless the cap says not yet. */
+  const start = (task: TaskView, reason?: string): boolean => {
+    if (budget <= 0) return false;
+    const workerId = newWorkerId();
+    const prompt = buildWorkerPrompt({ task, config, reason });
+    actions.push({
+      type: "append",
+      fact: { taskId: task.id, kind: "Started", by: RUNTIME, payload: { workerId, prompt } },
+    });
+    actions.push({ type: "launch", taskId: task.id, workerId });
+    budget -= 1;
+    return true;
+  };
+
+  /** Ask a worker to end, and take its slot back for this pass. */
+  const stop = (task: TaskView, why: string): void => {
+    if (!task.liveWorker) return;
+    actions.push({
+      type: "stop",
+      taskId: task.id,
+      workerId: task.liveWorker.workerId,
+      why,
+    });
+    budget += 1;
+  };
+
+  /**
+   * What to do about a worker that did not return: retry while the task is
+   * under the start cap, and ask a person once it is over. The cap counts
+   * Started facts since the last fact a person wrote, so a reply resets it
+   * without anyone keeping a counter.
+   */
+  const afterFailure = (task: TaskView, why: string): void => {
+    if (task.startsSinceLastPersonFact < config.startCap) {
+      start(task, why);
+      return;
+    }
+    actions.push({
+      type: "append",
+      fact: {
+        taskId: task.id,
+        kind: "Question",
+        by: RUNTIME,
+        payload: { why: `${why} (${task.startsSinceLastPersonFact} attempts)` },
+      },
+    });
+  };
+
+  for (const task of snapshot.tasks) {
+    // A person ended it. The only thing left to do is get out of the worker's
+    // way — the runtime writes nothing more on a terminal task.
+    if (isTerminal(task.state)) {
+      stop(task, LOST_STOPPED);
+      continue;
+    }
+
+    // Nobody owns it yet. Take it and start, or leave it Created for a pass
+    // that has room; a Taken with no worker would only be work for later.
+    if (task.state === "created") {
+      if (budget <= 0) continue;
+      actions.push({
+        type: "append",
+        fact: { taskId: task.id, kind: "Taken", by: RUNTIME, payload: {} },
+      });
+      start(task);
+      continue;
+    }
+
+    // A worker that has been silent past the age cap is treated as dead. The
+    // runtime writes the Lost the worker never could, then handles it as one.
+    const worker = task.liveWorker;
+    if (worker && workerAgeMs(worker, snapshot.now) > config.ageCapHours * 3_600_000) {
+      actions.push({
+        type: "append",
+        fact: {
+          taskId: task.id,
+          kind: "Lost",
+          by: RUNTIME,
+          payload: { workerId: worker.workerId, why: LOST_SILENT },
+        },
+      });
+      budget += 1;
+      afterFailure(task, `worker ${worker.workerId} was ${LOST_SILENT}`);
+      continue;
+    }
+
+    switch (task.latest.kind) {
+      case "Returned": {
+        const { workerId, reply } = task.latest.payload;
+        const evidence = `worker ${workerId}`;
+        const verdict = judge(task, reply, evidence);
+        if (verdict.done) {
+          actions.push({
+            type: "append",
+            fact: {
+              taskId: task.id,
+              kind: "Report",
+              by: RUNTIME,
+              payload: { what: reply, evidence },
+            },
+          });
+        } else {
+          start(task, `the last result was not accepted: ${verdict.why ?? "not done"}`);
+        }
+        break;
+      }
+
+      case "Failed":
+        afterFailure(task, task.latest.payload.error);
+        break;
+
+      case "Lost":
+        afterFailure(
+          task,
+          `worker ${task.latest.payload.workerId} was lost: ${task.latest.payload.why}`,
+        );
+        break;
+
+      case "Reply":
+        // Steering. A worker started before the reply cannot read it, so it is
+        // stopped and replaced by one whose brief carries the reply.
+        stop(task, LOST_STOPPED);
+        start(task, `a person replied: ${task.latest.payload.text}`);
+        break;
+
+      case "Taken":
+        // Taken with no Started after it. Either the first pass ended between
+        // the two writes, or the last pass had no budget.
+        start(task);
+        break;
+
+      case "Started":
+        // working: a worker is running and nothing has come back yet.
+        break;
+
+      case "Question":
+      case "Report":
+        // stuck and reported. Both wait for a person; the runtime never leaves
+        // Taken on its own.
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  return actions;
+}

--- a/rome_apps/manager/src/lib/test-facts.ts
+++ b/rome_apps/manager/src/lib/test-facts.ts
@@ -1,0 +1,33 @@
+import type { Fact, NewFact } from "./facts.js";
+
+/**
+ * Builds fact lists for the pure-logic tests. Everything the fold and the
+ * reconcile need is a value, so no test here touches a database.
+ */
+export class LedgerBuilder {
+  private seq = 0;
+  private clock: number;
+  readonly facts: Fact[] = [];
+
+  constructor(startMs = Date.parse("2026-09-08T09:00:00.000Z")) {
+    this.clock = startMs;
+  }
+
+  /** Append one fact, `minutesLater` after the previous one. */
+  add(fact: NewFact, minutesLater = 1): this {
+    this.seq += 1;
+    this.clock += minutesLater * 60_000;
+    this.facts.push({
+      ...fact,
+      seq: this.seq,
+      id: `f-${this.seq}`,
+      createdAt: new Date(this.clock),
+    } as Fact);
+    return this;
+  }
+
+  /** The moment just after the last fact, for a snapshot's `now`. */
+  now(minutesLater = 1): Date {
+    return new Date(this.clock + minutesLater * 60_000);
+  }
+}

--- a/rome_apps/manager/tsconfig.build.json
+++ b/rome_apps/manager/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "sourceMap": true
+  }
+}

--- a/rome_apps/manager/tsconfig.json
+++ b/rome_apps/manager/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@rome-os/app-runtime/tsconfig.app.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "src/lib/test-facts.ts"]
+}


### PR DESCRIPTION
A prototype. It works end to end and is not proposed for merge as it stands.

## What this PR does

An agent that works across many sessions needs something that decides, on every wake, what to do next about each task. Put that decision in a prompt and it is neither testable nor repeatable: a model that skips a task loses a pass, a model that miscounts retries loops, and no part of it can be unit tested. The `prototype/engineer-bot` branch puts a whole pass in one prompt and shows the cost.

This app puts the loop in code. `manager:reconcile` folds an append-only ledger and writes the next fact each task calls for. A model runs at two points only: when a person says something, and when a worker returns and someone has to say whether the task is done.

Tell it what you want in chat. It records a task, puts a coding session on it, retries what fails, asks you when it is stuck, and reports when there is something to look at. Only a person closes a task.

## Design & Invariants

**The ledger is the only input.** One append-only `facts` table. A task's state, its position, and the retry count are folded from the facts on every pass, never stored. Two passes over the same facts write the same thing, which is what lets the host die between any two writes.

**Reconcile is pure.** `src/lib/reconcile.ts` takes a snapshot value and returns a list of actions. The action layer applies them. Every action leaves the ledger consistent on its own, so a pass cut short costs nothing and the next pass sees what it missed.

**Only a person ends a task.** The runtime writes `Taken`, `Started`, `Question`, `Report`, and `Lost`. It never writes `Completed` or `Cancelled`. A task whose worker fails past the cap gets a `Question` and waits.

**The manager and the worker never talk.** Both read and write the ledger and hold no handle on each other. A person who opens the pull request by hand looks the same to the runtime as a coding session.

**Names carry their own rule.** A participle is something that happened: `Created`, `Taken`, `Started`, `Returned`, `Failed`, `Lost`. A noun is something somebody said: `Question`, `Report`, `Reply`. A reader can tell a state from a message by the word.

Two designs lost. A model driving the pass, which is the engineer-bot branch and the reason for this one. And the manager agent doing its own reconciling, which keeps the omission failure a model brings and buys nothing, since the app already runs code on a schedule.

The vocabulary behind these names has no home in `docs/concepts/` yet. `rome_apps/manager/README.md` and `rome_apps/manager/docs/2026-09-08-first-cut.md` carry it for now.

## Test plan

- [x] `pnpm typecheck` at the root.
- [x] 42 unit tests over `fold`, `reconcile`, `judge`, and `config`, none of which touch a database.
- [x] `pnpm test:unit` at the root, to check nothing else broke.
- [x] `pnpm build:apps`, which packs `manager@0.1.0`.
- [x] A live run on `pnpm dev:all`: `setup` stored the config and registered the routine, `create` opened a task, reconcile wrote `Taken` and `Started` and launched a worker, the worker failed, reconcile retried under the cap and wrote a `Question` over it, a `Reply` reset the cap and reached the next worker's brief, and a `cancel` left every later pass with nothing to do.
- [ ] A worker that returns. The container running the live test has no model provider, so every worker failed and the happy path stayed unproven.

## Not in this PR

- **A real stop.** Nothing in `@rome-os/app-runtime` cancels a detached execution, so a steer or a cancel records `Lost(why="stopped by runtime")` and the worker runs to its own end. `ActionEngine.cancel(rootExecutionId)` in core takes exactly the id `runAction` returns; a `system:cancel_execution` action would close this.
- **A working directory on the worker.** `system:summon` does not pass `RunParams.workingDir` through, so the configured path is stated in the worker's brief.
- **Boot-time loss detection.** An app cannot ask whether an execution it launched is alive. The age cap covers a host restart at the cost of waiting the cap out.
- **A person's identity.** Core drops the resolved `SessionActor` before an action sees its context, so a fact from chat is stamped `by="guardian"`.
- **A model-backed judge.** `src/lib/judge.ts` is deterministic and is the only file that would change.
- **A web UI.** `manager:snapshot` is the only view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
