### PR TITLE
feat(skills): add a system-modeling skill

### DIFF
--- a/.claude/skills/system-modeling/DIAGRAMS.md
+++ b/.claude/skills/system-modeling/DIAGRAMS.md
@@ -1,0 +1,63 @@
+# Sequence diagrams and the state machine
+
+Mermaid inside `<topic>-scenarios.md`, rendered to HTML with `render/render.sh` so the user reviews pictures. Diagrams are drawn to find problems, so each scenario ends with the problems it exposed.
+
+## The scenarios file
+
+Header: revision, date, and a line saying which pass this file is ahead of or behind. Then the participants, one short paragraph per noun saying what it does in the diagrams and what it never does. Then the state machine section, then the scenarios.
+
+## Sequence diagrams
+
+- Participants are the nouns, plus persons as `actor` with plain names (ann, bob). Two persons, so the diagrams show that who hands a task is not who closes it.
+- One activation bar is one execution. Its trigger is a note over the bar: `wake(Person(ann, message))`, `wake(Schedule)`.
+- Every arrow into the store is one write. A note over the store after it shows the store's state: `t1: Taken`.
+- A model turn is a note, never an arrow: `model turn: t2 stuck + these words -> reply tool, bound to ann`.
+- A passive store never sends. When a component reacts to a new fact, draw it as a note on that component, `wake(Event: new fact seen)`, followed by its own read.
+- When a person has two routes, such as talking to the agent or acting on the store directly, draw both.
+
+## Scenario checklist
+
+Every model gets the happy path and then these. Each one broke a revision of the model this skill came from.
+
+1. A person's words become a unit of work, on both routes.
+2. The worker finishes and someone judges the result.
+3. A different person than the one who asked closes it.
+4. Failure, retry under a cap, a question over the cap, a reply that resets the cap.
+5. The process dies between two writes. Show that each write is consistent alone and that the next pass duplicates nothing.
+6. A trigger arrives during a pass.
+7. The host restarts and a worker is gone. Show who writes the fact the worker cannot.
+8. The store is unreachable.
+9. A person does the worker's job by hand.
+10. A person cancels while work is running.
+
+## The state machine
+
+Two diagrams, not one.
+
+- **States.** About ownership and termination only, so four or fewer: who wants it, who owns it, how it ended. Every transition is labelled with the verb and the actor class. Terminal states are entered by a person only, if the model says so.
+- **Positions.** Inside the owned state, where the thing sits between passes, named by what the owner is waiting for: working, stuck, reported. Derived from the latest fact, never stored. Drawn as a separate flat diagram with one edge per fact that moves it.
+- Keep everything that resolves within one pass out of the position diagram. A "not yet started" or "returned but unjudged" is the owner's work in progress, not a position.
+- Draw orthogonal regions only when the two regions are truly independent. Two coupled machines drawn side by side hide the coupling; replace them with the reachable combinations.
+- When a table restates the edges of a diagram row by row, cut the table and keep the four sentences it added as prose.
+
+## Problems each diagram should be read for
+
+- An actor calling something they cannot call. A person who only speaks has no arrow to the store.
+- A read that bypasses the store. One component asking another for its status is a second input, and the model's "the store is the only input" rule is broken.
+- A state with no way back. Ask who can take it.
+- A fact whose writer can be dead when it is needed. Someone else must write it, and the diagram must show who.
+- A noun with one incoming arrow and no state of its own.
+
+## Mermaid rules that cost time
+
+- `#` and `;` inside a message or note label truncate it. Write "PR 88", not "PR #88", and use a comma instead of a semicolon.
+- A self-loop on a node in a `stateDiagram-v2` collides with the neighbouring labels. Put the retry in prose and draw only the edges that change position.
+- `direction LR` on a small state diagram crowds the labels. Let it lay out top-down.
+- Long labels overlap. Shorten the label and move the detail into the table or the note.
+- Rendering one diagram at a time in the header script, with a try/catch around each, keeps one broken diagram from blanking the rest and prints the parse error in place.
+
+## Rendering
+
+`render/render.sh OUT_DIR file.md [file.md ...]` converts each markdown file to `OUT_DIR/<name>.html` with pandoc, adds the stylesheet and the Mermaid loader, and post-processes the headings. It uses `pandoc` from PATH or `nix run nixpkgs#pandoc`. Serve `OUT_DIR` however the environment says to and give the user a link they can open. Check the result in a headless browser with a virtual time budget, since Mermaid loads from a CDN after page load; a screenshot taken too early shows raw source.
+
+The style is a monochrome infographic: off-white paper, near-black ink, one grey, Lato light headings with the last word in a black box, hatched title rule, rule-only tables, monochrome diagrams with black actor boxes.

--- a/.claude/skills/system-modeling/PSEUDOCODE.md
+++ b/.claude/skills/system-modeling/PSEUDOCODE.md
@@ -1,0 +1,96 @@
+# The pseudocode file
+
+Python-shaped text that is not meant to run. It exists so that every verb has a signature, every rule has a place it holds, and every scenario can be walked line by line.
+
+## Conventions
+
+- Nouns are classes. Verbs are methods on the noun they act on. Rules are `assert` lines with the rule number in the comment.
+- Enums are sum types. Each variant carries its data, and each variant has a comment that says when it is written and by whom.
+- Every method has a one-line comment. A method whose comment repeats its name is either misnamed or does not need to exist.
+- Strip syntax a reader does not need: no `self`, no type imports, no `pass`, no `__init__`. Field types are written as `name: Type`, maps as `{Key: Value}`, optional as `Type?`, lists as `[Type]`.
+- Facts and states share one enum when every state is also the fact that put it there.
+- Persons are actors, not classes. They appear only as the `by` of a fact.
+
+## Shape
+
+```
+enum Trigger:
+    Schedule(due_at)
+    Event(source)
+    Person(who, message)      # only in this pass do the person-bound tools exist
+
+enum Fact:                     # everything written to the ledger, in one family
+    Created(by, brief, source) # a person wants it. State.
+    Taken                      # the runtime owns it. State.
+    Started(worker, prompt)    # runtime launched a worker
+    Returned(worker, reply)    # the worker is done, or someone wrote it on its behalf
+    Failed(worker, error)
+    Lost(worker, why)          # written by someone other than the worker: it cannot
+    Question(why)              # runtime to a person. Message.
+    Report(what, evidence)     # runtime to a person. Message.
+    Reply(by, text, source)    # a person to the runtime. Message.
+    Completed(by, source)      # terminal. Only a person writes it.
+    Cancelled(by, source)      # terminal. Only a person writes it.
+
+class Ledger:
+    facts: [Fact]
+    reachable() -> bool
+    append(task_id, fact)      # the only write; every verb is one of these
+    snapshot() -> Snapshot     # the fold: tasks, states, positions, live workers
+
+class Task:
+    id
+    latest: Fact               # reconcile keys on this
+    facts: [Fact]
+    state                      # created | taken | completed | cancelled, derived
+    position?                  # working | stuck | reported, derived inside taken
+```
+
+## The deterministic part
+
+One pure function. It takes a snapshot value and returns the list of things to do, so it is testable with no store and the caller may stop after any item.
+
+```
+def reconcile(snapshot, config, judge) -> [Action]:
+    for task in snapshot.tasks:
+        match task.latest:
+            Created:                 Take(task), Start(task)
+            Taken:                   Start(task)
+            Started:                 nothing                     # working
+            Returned(_, reply):      Report(task) if judge(task, reply) else Start(task, reason)
+            Failed | Lost:           Start(task) if under_cap(task) else Ask(task)
+            Question | Report:       nothing                     # stuck, reported
+            Reply:                   Stop(task.worker), Start(task)
+            Completed | Cancelled:   Stop(task.worker) if task.worker
+```
+
+Name each place a model is called, and keep the list short. In the example there are two: `judge`, and the model turn on a `Person` trigger that maps words to `create`, `reply`, `complete`, or `cancel` through tools whose `by` and `source` the runtime has already bound.
+
+## Scenario walkthroughs
+
+After the classes, one block per scenario. Each line is a call or a write, and after every write a comment shows the store:
+
+```
+# --- 4. Failure, cap, question, reply ---
+ann says "migrate the sessions table"
+    # t2: Created(by=ann)
+reconcile -> [Take(t2), Start(t2)]
+    # t2: Taken; Started(w2)
+w2 -> Failed(w2, "0042 conflicts with 0041")
+reconcile -> [Start(t2)]            # one start since ann spoke, under the cap
+    # t2: Started(w2')
+w2' -> Failed(w2', same)
+reconcile -> [Ask(t2)]              # two starts, over the cap
+    # t2: Question(why)
+ann says "0041 was reverted, retry"
+    # t2: Reply(by=ann)             # a person spoke: the cap resets
+reconcile -> [Start(t2)]
+```
+
+Walk every scenario in the checklist in DIAGRAMS.md. A scenario the code cannot walk is a hole in the vocabulary. Record it under Open decisions before patching the code.
+
+## What to hand back to the vocabulary
+
+- Any method the classes needed that no verb names (a `snapshot()` read, a private `steer()` step). List it under Open decisions as "verb or rule?".
+- Any counter the code wanted to keep in memory. Either it becomes derivable from the store, such as a count of `Started` since the last person fact, or it becomes a fact.
+- Any place a component read another component directly instead of through the store. That is a coupling the model should either name or remove.

--- a/.claude/skills/system-modeling/SKILL.md
+++ b/.claude/skills/system-modeling/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: system-modeling
+description: Design a system's model as a few nouns, their verbs, and rules, then sharpen it with pseudocode, sequence diagrams, and a state machine until every scenario holds. Use when the user wants to design or rethink an architecture, wants a shared vocabulary and mental model before building, or asks for nouns and verbs, pseudocode of a model, sequence diagrams, or a state machine.
+---
+
+# System modeling
+
+Three passes, each producing one file the user reviews, each feeding the problems it finds back into the pass before. The vocabulary is the model. The pseudocode and the diagrams exist to find what the vocabulary got wrong.
+
+Work one revision at a time with the user in the loop. Every file carries a revision number and a change log, so a reader can tell which pass is ahead of which.
+
+## 1. Frame the general problem
+
+- Name the general thing the request is an instance of. An "engineer bot" is one instance of "an agent whose lifetime spans sessions and who keeps working with people across them". Model the general thing. The instance becomes a mapping table at the end of the vocabulary.
+- Write the one invariant everything else serves, in one sentence. For the agent above: correctness never depends on a session continuing.
+- Done when the user agrees with both sentences.
+
+## 2. Nouns, verbs, rules
+
+Produce `<topic>-vocabulary.md` in the format in [VOCABULARY.md](VOCABULARY.md).
+
+- Propose few nouns, five or fewer. Each noun has a description and its verbs. Each verb has what it acts on, who does it, and a description. Rules are numbered invariants.
+- Define every term by the property that must hold, never by how the current code achieves it. Test: if a different implementation would falsify the sentence, the sentence is implementation and comes out.
+- Noun test: a noun carries state that outlives a verb and appears in at least one rule. Anything else is a verb. A reified verb with one verb of its own ("end" on "Wake") is a call, and a call is a verb.
+- State or message test: a fact that changes who owns a thing is a state. A fact that records something somebody said is a message. Name states as participles (Created, Taken) and messages as nouns (Question, Reply), so a reader can tell them apart by the word alone.
+- Check every name against the host project's existing terms and against words the user has rejected. Colliding words go on the Avoid list.
+- Have a subagent review the model for feasibility, soundness, and minimality. Word the brief as a review of the model itself; conformance to an existing prototype is a different question and is not this review.
+- Done when every noun has a verb and a rule, the user has chosen every name, and every unresolved point is listed under Open decisions.
+
+## 3. Pseudocode
+
+Produce `<topic>.py` in the conventions in [PSEUDOCODE.md](PSEUDOCODE.md).
+
+- Nouns are classes, verbs are methods, rules are asserts. Enums are sum types whose variants carry their data. Every method and every variant has a comment. Strip syntax that a reader does not need.
+- Split what is deterministic from what needs a model. The deterministic part is one pure function from a snapshot of the store to a list of actions, so it can be tested without a database and can stop after any single action. The model appears at named call sites only, and each is listed.
+- A person interacts only in natural language. Model the language boundary as tool use whose author fields the runtime binds, so the model picks the words and never the author.
+- Walk the scenarios in code, showing the store after every write.
+- Whatever the code needed that the tables did not name goes under Open decisions in the vocabulary.
+- Done when every verb in the tables is a method, every rule is an assert or has a comment saying where it holds, and every scenario in the checklist in DIAGRAMS.md has been walked.
+
+## 4. Diagrams
+
+Produce `<topic>-scenarios.md` following [DIAGRAMS.md](DIAGRAMS.md), and render it with `render/render.sh` so the user reads pictures, not Mermaid source.
+
+- One sequence diagram per scenario. Participants are the nouns plus named persons. One activation bar is one execution. Every arrow into the store is one write, and a note under it shows the store afterwards.
+- A state machine for the central noun. States are about ownership and are few. Positions inside a state are derived from the latest fact and are drawn as a second, separate diagram.
+- After each diagram, write down the problems it exposed. Fix them in the vocabulary first, then let the change flow down.
+- Done when the user has seen every diagram rendered and every problem found is either fixed upstream or listed as an open decision.
+
+## 5. Propagate and hand off
+
+- A decision lands in the vocabulary first, then the pseudocode, then the scenarios, in that order, with a change-log entry in each.
+- When the model is signed off, hand the glossary to the `domain-modeling` skill for `CONTEXT.md`, and the deterministic function and the scenarios to whoever builds the prototype: the scenarios are its test cases.
+
+## Questions that find problems
+
+Ask these of the model at every pass. Each one found a real defect in the sessions this skill came from.
+
+- Why is X a noun?
+- Is X a state or a message?
+- Who writes this fact, and can they be dead when it needs writing?
+- What happens if the process dies between these two writes?
+- Can these two parties be fully decoupled through the store?
+- Which parts need a model at all, and where exactly is it called?
+- Is there a way back from this state? Who can take it?
+- Does this table say anything the diagram does not? If not, cut the table.

--- a/.claude/skills/system-modeling/VOCABULARY.md
+++ b/.claude/skills/system-modeling/VOCABULARY.md
@@ -1,0 +1,63 @@
+# The vocabulary file
+
+One markdown file the user reviews. Sections in this order. Every section is short; the tables carry the content.
+
+## Header
+
+Title, date, revision number, and one line with the counts: "Five nouns, thirteen verbs, five rules." Then two paragraphs: what the general thing is and its one invariant, and which instance the user has in mind and how it maps.
+
+## Nouns
+
+| Noun | Description | Verbs |
+|---|---|---|
+| **Ledger** | Everything the agent remembers outside any session. The only thing it may rely on. | write |
+| **Task** | Work a person handed the agent, recorded in the ledger. A person decides when it is done. | create, take, ask, report, reply, complete, cancel |
+
+The description states the property that must hold. It names what the noun is not when a nearby term in the host project could be mistaken for it ("Not Rome's Memory").
+
+## Verbs
+
+| Verb | On | By | Description |
+|---|---|---|---|
+| take | Task | runtime | Record that the runtime is on the task. Stops the next pass and other people from handing it again. |
+| complete | Task | a person | Close the task as done. Written only from a person's own words or action, and cites them. |
+
+"By" names the actor class, never a component name the instance happens to use. When a verb has two routes, such as speaking to the agent or acting on the store directly, say so in the description.
+
+## Rules
+
+Numbered invariants, each with a bold name and one or two sentences. A rule is something a test could check.
+
+1. **The ledger is the only input.** A pass's writes depend only on the ledger and the trigger.
+2. **One pass at a time.** A trigger that arrives during a pass causes the next pass.
+
+## Instance as values of the model
+
+| General | Instance |
+|---|---|
+| Ledger | One GitHub repository: issues, labels, comments, pull requests |
+| complete | Merge the pull request, or say so in chat and the agent records it citing the message |
+
+## Not in the model
+
+Two lists. Words that are implementation or instance-local and were deliberately left out, with a phrase each on why. And an Avoid list: words that collide with the host project or that the user rejected.
+
+## Open decisions
+
+Numbered, each with the choice, what each side costs, and a recommendation. Anything the pseudocode or diagrams needed that the tables do not name lands here.
+
+## Changes in revision N
+
+One entry per revision, newest first, listing what changed and why. Keep every revision's entry, so the file records how the model was reached.
+
+## Tests to run on a draft
+
+- Every noun appears in a rule. A noun in no rule is a verb or is out.
+- Every verb's "By" is an actor class. A component name in "By" means the instance has leaked in.
+- No description mentions a session, a process, a file, or a table unless the noun is one.
+- Names for states are participles. Names for messages are nouns. Names for actors are plain words.
+- The counts in the header match the tables.
+
+## The review brief
+
+Hand the file to a subagent with this scope: "Judge whether this model is feasible to implement, whether its rules are sound and sufficient for the invariant, and whether any noun, verb, or rule can be removed or merged without losing a rule. Report each finding with the sentence in the file it concerns. Do not compare the model to existing code." Fold the findings into Open decisions and the next revision.

--- a/.claude/skills/system-modeling/render/header.html
+++ b/.claude/skills/system-modeling/render/header.html
@@ -1,0 +1,70 @@
+<meta name="color-scheme" content="light">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap">
+<link rel="stylesheet" href="style.css">
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+  // Pandoc emits fenced mermaid blocks as <pre class="mermaid"><code>...</code></pre>.
+  // Mermaid wants the source as the pre's own text, so unwrap the <code>.
+  const blocks = [];
+  document.querySelectorAll("pre.mermaid > code, pre > code.mermaid").forEach(code => {
+    const pre = code.parentElement;
+    pre.classList.add("mermaid");
+    pre.textContent = code.textContent;
+    blocks.push(pre);
+  });
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: "base",
+    fontFamily: "Lato, sans-serif",
+    themeVariables: {
+      fontFamily: "Lato, sans-serif",
+      fontSize: "15px",
+      background: "#f4f4f4",
+      primaryColor: "#f4f4f4",
+      primaryTextColor: "#111",
+      primaryBorderColor: "#111",
+      lineColor: "#111",
+      textColor: "#111",
+      secondaryColor: "#f4f4f4",
+      secondaryTextColor: "#111",
+      secondaryBorderColor: "#111",
+      tertiaryColor: "#f4f4f4",
+      tertiaryTextColor: "#111",
+      tertiaryBorderColor: "#111",
+      noteBkgColor: "#fff",
+      noteBorderColor: "#111",
+      noteTextColor: "#111",
+      // Sequence diagrams: actors are black boxes with white text, like the heading marks.
+      actorBkg: "#111",
+      actorBorder: "#111",
+      actorTextColor: "#fff",
+      actorLineColor: "#111",
+      signalColor: "#111",
+      signalTextColor: "#111",
+      labelBoxBkgColor: "#fff",
+      labelBoxBorderColor: "#111",
+      labelTextColor: "#111",
+      loopTextColor: "#111",
+      activationBkgColor: "#111",
+      activationBorderColor: "#111",
+      sequenceNumberColor: "#fff",
+    },
+    sequence: { useMaxWidth: true, mirrorActors: false, actorFontWeight: 400, noteFontWeight: 400, messageFontWeight: 400 },
+  });
+  // Render each block with its own id. mermaid.run() derives ids from the
+  // clock, and blocks rendered in the same millisecond collide and lose
+  // their viewBox.
+  let i = 0;
+  for (const pre of blocks) {
+    try {
+      const { svg } = await mermaid.render("seq-" + (i++), pre.textContent);
+      pre.innerHTML = svg;
+      pre.dataset.processed = "true";
+    } catch (e) {
+      pre.insertAdjacentHTML("afterbegin", "<p class=\"diagram-error\">diagram failed: " + String(e.message || e) + "</p>");
+      console.error("mermaid", e);
+    }
+  }
+</script>

--- a/.claude/skills/system-modeling/render/postprocess.py
+++ b/.claude/skills/system-modeling/render/postprocess.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Post-process a pandoc HTML page into the monochrome infographic style.
+
+- Wraps the last word(s) of every h1 and h2 in <mark> (h1 can name an
+  explicit phrase with --h1-mark).
+- Optionally inserts a row of big numbers (--stats) counted from the page's
+  own Nouns/Verbs tables and Rules list.
+- Appends the colophon footer.
+
+Idempotent: existing <mark> in headings, an existing stats row, and an
+existing colophon are removed before being re-added.
+"""
+import argparse
+import re
+import sys
+
+MARK_RE = re.compile(r"</?mark[^>]*>")
+HEADING_RE = re.compile(r"(<h([12])\b[^>]*>)(.*?)(</h\2>)", re.S)
+TAG_RE = re.compile(r"<[^>]+>")
+# Trailing tags or punctuation that should stay outside the mark.
+TRAIL_RE = re.compile(r"((?:</[a-z]+>)*[\s.:;,!?]*)$", re.S)
+
+
+def mark_phrase(inner: str, phrase: str) -> str | None:
+    """Wrap the last occurrence of `phrase` in `inner` (outside of tags)."""
+    idx = inner.rfind(phrase)
+    if idx < 0:
+        return None
+    # Refuse if the match sits inside a tag.
+    if inner.rfind("<", 0, idx) > inner.rfind(">", 0, idx):
+        return None
+    return inner[:idx] + "<mark>" + phrase + "</mark>" + inner[idx + len(phrase):]
+
+
+def mark_last_words(inner: str) -> str:
+    """Wrap the last word in <mark>; take two words when the last is short
+    (so "revision 2.2" and "revision 1" are marked whole)."""
+    trail = TRAIL_RE.search(inner)
+    tail = trail.group(1) if trail else ""
+    head = inner[: len(inner) - len(tail)] if tail else inner
+    words = head.rsplit(None, 2)
+    if not words:
+        return inner
+    n = 1
+    if len(words) >= 2 and len(TAG_RE.sub("", words[-1])) <= 3:
+        n = 2
+    n = min(n, len(words))
+    # rsplit collapsed whitespace; find the true start by scanning back n words.
+    pos = len(head)
+    for _ in range(n):
+        pos = len(head[:pos].rstrip())
+        m = re.search(r"\S+$", head[:pos])
+        pos = m.start() if m else 0
+    phrase_start = pos
+    return head[:phrase_start] + "<mark>" + head[phrase_start:].rstrip() + "</mark>" + head[len(head.rstrip()):] + tail
+
+
+def process_headings(html: str, h1_mark: str | None) -> str:
+    def repl(m: re.Match) -> str:
+        open_tag, level, inner, close_tag = m.group(1), m.group(2), m.group(3), m.group(4)
+        inner = MARK_RE.sub("", inner)
+        marked = None
+        if level == "1" and h1_mark:
+            marked = mark_phrase(inner, h1_mark)
+        if marked is None:
+            marked = mark_last_words(inner)
+        return open_tag + marked + close_tag
+
+    return HEADING_RE.sub(repl, html)
+
+
+def count_rows_after(html: str, heading_text: str, block: str) -> int | None:
+    """Count <tr> in the first <table> (or <li> in the first <ol>) after the
+    h2 whose text is heading_text."""
+    m = re.search(r"<h2\b[^>]*>(?:<mark>)?" + re.escape(heading_text) + r"(?:</mark>)?</h2>", html)
+    if not m:
+        return None
+    rest = html[m.end():]
+    b = re.search(r"<%s\b.*?</%s>" % (block, block), rest, re.S)
+    if not b:
+        return None
+    if block == "table":
+        body = re.search(r"<tbody>.*?</tbody>", b.group(0), re.S)
+        return len(re.findall(r"<tr\b", body.group(0))) if body else None
+    return len(re.findall(r"<li\b", b.group(0)))
+
+
+def insert_stats(html: str) -> str:
+    html = re.sub(r'<div class="stats">.*?</div>\s*', "", html, flags=re.S)
+    parts = []
+    for label, heading, block in (("nouns", "Nouns", "table"), ("verbs", "Verbs", "table"), ("rules", "Rules", "ol")):
+        n = count_rows_after(html, heading, block)
+        if n:
+            parts.append('<div class="stat"><span class="n">%d</span><span class="l">%s</span></div>' % (n, label))
+    if not parts:
+        return html
+    stats = '<div class="stats">' + "".join(parts) + "</div>\n"
+    # After the first paragraph that follows the h1.
+    m = re.search(r"</h1>.*?</p>\s*", html, re.S)
+    if not m:
+        return html
+    return html[: m.end()] + stats + html[m.end():]
+
+
+def append_footer(html: str, source: str) -> str:
+    html = re.sub(r'\s*<footer class="colophon">.*?</footer>', "", html, flags=re.S)
+    footer = (
+        '<footer class="colophon"><span>Source: %s</span>'
+        "<span>Design: after Evelina Judeikyte</span></footer>\n" % source
+    )
+    if "</body>" in html:
+        return html.replace("</body>", footer + "</body>", 1)
+    return html + footer
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("html")
+    ap.add_argument("--h1-mark", default=None, help="phrase in the h1 to put in the black box")
+    ap.add_argument("--source", required=True, help="text after 'Source: ' in the footer")
+    ap.add_argument("--stats", action="store_true", help="insert the nouns/verbs/rules number row")
+    args = ap.parse_args()
+
+    with open(args.html, encoding="utf-8") as f:
+        html = f.read()
+    html = process_headings(html, args.h1_mark)
+    if args.stats:
+        html = insert_stats(html)
+    html = append_footer(html, args.source)
+    with open(args.html, "w", encoding="utf-8") as f:
+        f.write(html)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/system-modeling/render/render.sh
+++ b/.claude/skills/system-modeling/render/render.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# render.sh OUT_DIR file.md [file.md ...]
+#
+# Render each markdown file to OUT_DIR/<name>.html in the monochrome
+# infographic style, with Mermaid blocks rendered client-side. Idempotent.
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "usage: render.sh OUT_DIR file.md [file.md ...]" >&2
+  exit 2
+fi
+
+OUT=$1
+shift
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+mkdir -p "$OUT"
+cp "$HERE/style.css" "$OUT/style.css"
+
+if command -v pandoc >/dev/null 2>&1; then
+  pandoc() { command pandoc "$@"; }
+else
+  pandoc() { nix run nixpkgs#pandoc -- "$@"; }
+fi
+
+for src in "$@"; do
+  name=$(basename "${src%.md}")
+  out="$OUT/$name.html"
+  title=$(grep -m1 '^# ' "$src" | sed 's/^# //')
+  pandoc -s --from gfm --to html5 --wrap=none \
+    --metadata pagetitle="${title:-$name}" \
+    -H "$HERE/header.html" \
+    "$src" -o "$out"
+  # --stats adds the noun/verb/rule number row, and does nothing on a file
+  # that has no such tables, so every page can ask for it.
+  python3 "$HERE/postprocess.py" "$out" --stats --source "$(basename "$src")"
+  echo "rendered: $out"
+done

--- a/.claude/skills/system-modeling/render/style.css
+++ b/.claude/skills/system-modeling/render/style.css
@@ -1,0 +1,244 @@
+/* Monochrome infographic style, after Evelina Judeikyte's
+   "Hope for Girls and Women in Tanzania". Two inks plus one grey. */
+
+:root {
+  --paper: #f4f4f4;
+  --ink: #111;
+  --grey: #8a8a8a;
+  --hair: #ccc;
+  --sans: "Lato", system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+html { background: var(--paper); color-scheme: light; }
+
+body {
+  max-width: 62em;
+  margin: 4em auto 3em;
+  padding: 0 1.5em;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 17px;
+  font-weight: 400;
+  line-height: 1.5;
+  text-align: left;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Headings ---------------------------------------------------------- */
+
+h1, h2, h3, h4 {
+  font-family: var(--sans);
+  font-weight: 300;
+  color: var(--ink);
+  margin: 0;
+}
+
+h1 {
+  font-size: 60px;
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  margin: 0 0 0.35em;
+}
+
+/* Hatched title rule: the reference's texture, used once per page. */
+h1::after {
+  content: "";
+  display: block;
+  height: 8px;
+  margin-top: 0.45em;
+  background: repeating-linear-gradient(45deg, var(--ink) 0 2px, #fff 2px 7px);
+}
+
+h2 {
+  font-size: 30px;
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+  margin: 2.6em 0 0.7em;
+}
+
+h3 {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 2em 0 0.5em;
+}
+
+/* Signature device: white on a solid black box. Applied by the
+   post-processor to the last word(s) of h1 and h2 only. */
+mark, h1 mark, h2 mark {
+  background: var(--ink);
+  color: #fff;
+  padding: 0 0.18em;
+  border-radius: 0;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+/* Prose ------------------------------------------------------------- */
+
+p { margin: 0 0 1em; }
+
+h1 + p {
+  font-size: 19px;
+  font-weight: 300;
+  line-height: 1.45;
+}
+
+a { color: var(--ink); text-decoration: underline; text-underline-offset: 0.12em; }
+a:hover { background: var(--ink); color: #fff; text-decoration: none; }
+
+/* Bold lead-ins read as all-caps labels, like "FEMALE GENITAL MUTILATION". */
+p > strong:first-child,
+li > strong:first-child,
+td > strong:first-child {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.88em;
+}
+strong { font-weight: 700; }
+em { font-style: italic; }
+
+ul, ol { padding-left: 1.4em; margin: 0 0 1.2em; }
+li { margin: 0 0 0.45em; }
+li::marker { color: var(--ink); }
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--ink);
+  margin: 3em 0;
+}
+
+blockquote {
+  margin: 1.5em 0;
+  padding: 0.2em 0 0.2em 1.2em;
+  border-left: 3px solid var(--ink);
+  background: none;
+}
+blockquote p:last-child { margin-bottom: 0; }
+
+/* Big standalone numbers with a small label beside them. */
+.stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 3em;
+  margin: 1.2em 0 2em;
+}
+.stat { display: flex; align-items: baseline; gap: 0.5em; }
+.stat .n { font-size: 60px; font-weight: 300; line-height: 1; letter-spacing: -0.03em; }
+.stat .l { font-size: 14px; font-weight: 400; text-transform: uppercase; letter-spacing: 0.08em; }
+
+/* Tables ------------------------------------------------------------ */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.2em 0 2.2em;
+  font-size: 16px;
+}
+thead th {
+  text-align: left;
+  vertical-align: bottom;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0 1.2em 0.7em 0;
+  border-bottom: 1px solid var(--ink);
+  background: none;
+}
+tbody td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.85em 1.2em 0.85em 0;
+  border-bottom: 1px solid var(--hair);
+  background: none;
+}
+tbody tr:last-child td { border-bottom: 1px solid var(--ink); }
+tbody tr:nth-child(even), tbody tr:nth-child(odd) { background: none; }
+th:last-child, td:last-child { padding-right: 0; }
+td:first-child { white-space: nowrap; }
+
+/* Code -------------------------------------------------------------- */
+
+code, pre, kbd, samp {
+  font-family: var(--mono);
+  font-size: 0.92em;
+  color: var(--ink);
+  background: none;
+}
+
+pre {
+  margin: 1.2em 0 2em;
+  padding: 1em 0;
+  border-top: 1px solid var(--hair);
+  border-bottom: 1px solid var(--hair);
+  overflow-x: auto;
+  white-space: pre;
+  tab-size: 4;
+  line-height: 1.45;
+  font-size: 14.5px;
+}
+pre code { font-size: inherit; padding: 0; white-space: inherit; }
+div.sourceCode { margin: 0; background: none; }
+
+/* Pandoc's syntax highlighting is overridden to black, comments grey. */
+pre code span,
+pre code span[class] {
+  color: var(--ink) !important;
+  font-weight: 400 !important;
+  font-style: normal !important;
+  text-decoration: none !important;
+  background: none !important;
+}
+pre code span.co { color: var(--grey) !important; }
+
+/* Mermaid ----------------------------------------------------------- */
+
+pre.mermaid {
+  border: 0;
+  padding: 0;
+  margin: 1.5em 0 2.5em;
+  background: none;
+  white-space: normal;
+  overflow: visible;
+  font-family: var(--sans);
+}
+pre.mermaid svg { display: block; max-width: 100%; height: auto; }
+/* `actor ann` draws a stick figure on the page, not a black box, so its
+   label must be ink rather than the white used inside actor boxes. */
+pre.mermaid svg text.actor-man,
+pre.mermaid svg text.actor-man tspan { fill: var(--ink) !important; }
+/* Message labels cross lifelines and black activation bars; a paper-coloured
+   halo keeps them legible. */
+pre.mermaid svg .messageText,
+pre.mermaid svg .loopText,
+pre.mermaid svg .loopText tspan {
+  /* !important: mermaid scopes its own rules under the svg id, which outranks this. */
+  paint-order: stroke !important;
+  stroke: var(--paper) !important;
+  stroke-width: 4px !important;
+  stroke-linejoin: round !important;
+}
+
+/* Footer ------------------------------------------------------------ */
+
+footer.colophon {
+  display: flex;
+  justify-content: space-between;
+  gap: 2em;
+  margin-top: 5em;
+  padding-top: 0.8em;
+  border-top: 1px solid var(--ink);
+  font-size: 13px;
+  color: var(--grey);
+}
+
+@media (max-width: 40em) {
+  body { font-size: 16px; margin-top: 2.5em; }
+  h1 { font-size: 40px; }
+  h2 { font-size: 26px; }
+  .stat .n { font-size: 48px; }
+  td:first-child { white-space: normal; }
+}


### PR DESCRIPTION
## What this PR does

Designing a system in conversation leaves the model in the transcript. The next session rebuilds it from scratch and rediscovers the same defects: a verb reified into a noun, a message mistaken for a state, one component reading another component's memory instead of the shared store, a state with no way back.

This adds a skill that makes the process repeatable and produces three artifacts a reader can review without the conversation.

## Design & Invariants

Three passes, one file each, ordered so that every pass can falsify the one before it.

1. **Vocabulary.** Five or fewer nouns, their verbs, and numbered rules. Every term is defined by the property that must hold, never by how the current code achieves it.
2. **Pseudocode.** Nouns become classes, verbs become methods, rules become asserts. The deterministic part is one pure function from a store snapshot to a list of actions, and every place a model is called is named. Whatever the code needs that no verb names goes back into the vocabulary as an open decision.
3. **Diagrams.** One sequence diagram per scenario, plus a state machine split into ownership states and derived positions. Each diagram is read for a specific class of defect.

The invariant that holds the three together: **the vocabulary is the model, and the other two artifacts are instruments.** A defect a diagram exposes is fixed in the vocabulary first and flows back down, so the files never disagree about what the system is.

Two decisions worth naming:

- **Separate from `domain-modeling` rather than folded into it.** That skill maintains a glossary in `CONTEXT.md` as an ongoing habit. This one designs a model from nothing and hands the glossary over when it is signed off. Merging them would have put a five-step design process behind a skill whose job is a one-line reading habit.
- **The scenario checklist is fixed, not suggested.** Ten scenarios, including a process death between two writes, a restart that leaves a worker unreachable, and a person doing the worker's job by hand. Each one broke a revision of the model the skill was extracted from, which is what earns it a place in the list.

`render/` renders the markdown to the monochrome style the artifacts were reviewed in, so the user reads diagrams rather than Mermaid source.

## Test plan

- [x] `scripts/lint-shell.sh` passes on `render/render.sh` (shfmt and shellcheck), after `pnpm format:sh`
- [x] `scripts/check-pr-title.sh` accepts the title
- [x] `render/render.sh` rendered two real design documents end to end: 15 Mermaid diagrams present, the noun/verb/rule count row computed from the vocabulary tables, footer applied
- [x] Confirmed the prose gate does not reach here — `scripts/check-prose.mjs` scopes Vale to `docs/*.md` and tracked `.ts`/`.tsx`
- [ ] Not yet driven from step 1 on a fresh design; the skill is written from one worked case

## Not in this PR

- The design documents the skill was extracted from. They belong with the system they describe, not with the method.
- Any change to `domain-modeling`. The handoff is named in `SKILL.md` and needs nothing on that side.
- A worked example under the skill. Adding one costs context load on every run, and the formats already carry the shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)