### PR TITLE
fix(docker): include git-lfs in the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -201,7 +201,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       BROWSER_PACKAGE="chromium"; \
       BROWSER_BINARY="/usr/bin/chromium"; \
     fi && \
-    apt-get install -y --no-install-recommends tini git gh jq ripgrep openssh-server gosu rsync iptables iproute2 sudo caddy sshfs fuse3 tigervnc-standalone-server novnc websockify openbox xterm socat python3 python3-websocket xclip unzip fonts-noto fonts-noto-cjk fonts-noto-color-emoji fonts-liberation "$BROWSER_PACKAGE" && \
+    apt-get install -y --no-install-recommends tini git git-lfs gh jq ripgrep openssh-server gosu rsync iptables iproute2 sudo caddy sshfs fuse3 tigervnc-standalone-server novnc websockify openbox xterm socat python3 python3-websocket xclip unzip fonts-noto fonts-noto-cjk fonts-noto-color-emoji fonts-liberation "$BROWSER_PACKAGE" && \
+    git lfs version && \
     printf '%s\n' "$BROWSER_BINARY" > /etc/rome-browser-binary
 
 # Install AI tool CLIs globally (early for better layer caching).


### PR DESCRIPTION
## What this PR does

Manager cannot create worker worktrees for repositories with required LFS filters because the runtime image has Git but lacks `git-lfs`. Checkout fails with `git-lfs filter-process: 1: git-lfs: not found`.

Install `git-lfs` in the production image and run `git lfs version` during the build to verify the executable is available. Repository LFS configuration stays unchanged.

## Test plan

- [x] `git diff --check`
- [x] `bash scripts/check-pr-title.sh 'fix(docker): include git-lfs in the runtime image'`
- [x] Extract the changed Dockerfile RUN command and validate it with `sh -n`.
- [ ] Build the production image and confirm its `git lfs version` check passes. Docker is unavailable in the editing environment.
- [ ] Run the host typecheck, unit tests, and fullstack boot verification. Nix and Docker are unavailable in the editing environment.
- [ ] Create a worktree for an LFS-enabled repository in the rebuilt image.

## Not in this PR

- Manager's diagnostic worker-ID substitution is a separate UI fix.
- Retrying failed tasks and cleaning up residual branches require separate runtime actions.
