### PR TITLE
fix(core): keep Discord category channels configurable

### DIFF
--- a/packages/core/src/connections/integrations/discord.test.ts
+++ b/packages/core/src/connections/integrations/discord.test.ts
@@ -39,7 +39,7 @@ const fakeState: {
     name: string;
     guildId: string;
     guildName: string;
-    type: "text" | "thread";
+    type: "text" | "news" | "thread" | "forum";
     parentId?: string;
   }>;
 } = {
@@ -267,6 +267,71 @@ describe("discord descriptor shape", () => {
     });
     expect(second?.conversations.map((entry) => entry.ref.conversationId)).toEqual(["channel-2"]);
     expect(second?.nextCursor).toBeUndefined();
+  });
+
+  it("treats category members as settings owners and only threads as children", async () => {
+    fakeState.channels = [
+      {
+        id: "text-1",
+        name: "general",
+        guildId: "guild-1",
+        guildName: "Rome",
+        type: "text",
+        parentId: "category-1",
+      },
+      {
+        id: "news-1",
+        name: "announcements",
+        guildId: "guild-1",
+        guildName: "Rome",
+        type: "news",
+        parentId: "category-1",
+      },
+      {
+        id: "forum-1",
+        name: "support",
+        guildId: "guild-1",
+        guildName: "Rome",
+        type: "forum",
+        parentId: "category-1",
+      },
+      {
+        id: "thread-1",
+        name: "launch",
+        guildId: "guild-1",
+        guildName: "Rome",
+        type: "thread",
+        parentId: "text-1",
+      },
+    ];
+    const directory = buildTalker().talker.feature("directory");
+
+    const settingsOwners = await directory?.listConversations({ limit: 10 });
+    expect(settingsOwners?.conversations).toEqual([
+      expect.objectContaining({
+        ref: { connectionId: "discord-test", conversationId: "news-1" },
+        kind: "channel",
+      }),
+      expect.objectContaining({
+        ref: { connectionId: "discord-test", conversationId: "text-1" },
+        kind: "channel",
+      }),
+      expect.objectContaining({
+        ref: { connectionId: "discord-test", conversationId: "forum-1" },
+        kind: "channel",
+      }),
+    ]);
+    for (const conversation of settingsOwners?.conversations ?? []) {
+      expect(conversation).not.toHaveProperty("parent");
+    }
+
+    const withThreads = await directory?.listConversations({ limit: 10, includeTopics: true });
+    expect(withThreads?.conversations.find(({ ref }) => ref.conversationId === "thread-1")).toEqual(
+      expect.objectContaining({
+        kind: "topic",
+        parent: { connectionId: "discord-test", conversationId: "text-1" },
+      }),
+    );
   });
 
   it("exposes Discord REST through Act", async () => {

--- a/packages/core/src/connections/integrations/discord.ts
+++ b/packages/core/src/connections/integrations/discord.ts
@@ -480,7 +480,9 @@ export function makeDiscordDescriptor(deps: DiscordDeps): ConnectionDescriptor {
                       kind: channel.type === "thread" ? ("topic" as const) : ("channel" as const),
                       displayName: channel.name,
                       containerName: channel.guildName,
-                      ...(channel.parentId
+                      // Discord also uses parentId for a channel's category.
+                      // Only native threads inherit conversation settings.
+                      ...(channel.type === "thread" && channel.parentId
                         ? {
                             parent: {
                               connectionId: kit.connectionId,


### PR DESCRIPTION
## What this PR does

Discord reports a category ID through `parentId` for text, announcement, and forum channels. The directory treated every such ID as a settings parent, so the Channels settings page hid categorized channels as if they were native threads.

This change uses the Discord channel type to decide whether a directory entry has a settings parent. Categorized channels remain settings owners, while native threads keep their parent-channel inheritance.

## Design & Invariants

Only a Discord native thread becomes a `topic` with a parent conversation. A category groups channels in Discord but does not own their routing or activation settings.

## Test plan

- [x] `pnpm --filter @rome/core typecheck`
- [x] `pnpm typecheck`
- [x] `pnpm test:unit:core` (373 files, 4,368 tests)
- [x] `../../scripts/test-env.sh pnpm exec rstest src/connections/integrations/discord.test.ts`
- [x] `pnpm exec biome check packages/core/src/connections/integrations/discord.ts packages/core/src/connections/integrations/discord.test.ts`

Closes #304
