### PR TITLE
fix(discord): authorize linked guardian commands

### DIFF
--- a/packages/core/src/channels/discord-configuration.test.ts
+++ b/packages/core/src/channels/discord-configuration.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it, rs } from "@rstest/core";
+import type {
+  ConversationDescriptor,
+  ConversationId,
+  ConversationSettings,
+  ConversationSettingsControl,
+  ConversationSettingsSnapshot,
+} from "@rome-os/app-runtime";
+import type { ChatInputCommandInteraction } from "discord.js";
+import { buildDiscordSlashCommands, DiscordAdapter } from "./discord.js";
+
+const CONNECTION_ID = "connection:discord";
+const CHANNEL_ID = "channel-1" as ConversationId;
+const GUARDIAN_ID = "discord-guardian-777";
+const UNLINKED_ID = "discord-user-888";
+
+function makeConversationSettings() {
+  const effective: ConversationSettings = {
+    enabled: true,
+    activation: {
+      mode: "mention",
+      botMessages: "ignore",
+      whenOthersMentioned: "ignore",
+    },
+    replies: { placement: "thread" },
+    routing: { agentName: null },
+    session: { reset: { mode: "idle", idleMinutes: 10_080 } },
+  };
+  const descriptor: ConversationDescriptor = {
+    ref: { connectionId: CONNECTION_ID, conversationId: CHANNEL_ID },
+    service: "discord",
+    kind: "channel",
+    displayName: "general",
+    containerName: "Rome",
+  };
+  const snapshot: ConversationSettingsSnapshot = {
+    conversation: descriptor,
+    supportedFields: [
+      "enabled",
+      "activation.mode",
+      "activation.botMessages",
+      "activation.whenOthersMentioned",
+      "replies.placement",
+      "routing.agentName",
+    ],
+    effective,
+    overrides: {},
+  };
+  const get = rs.fn(async () => snapshot);
+  const update = rs.fn(async () => snapshot);
+  const reset = rs.fn(async () => snapshot);
+  const control = {
+    observe: rs.fn(),
+    get,
+    update,
+    reset,
+    list: rs.fn(async () => ({ items: [] })),
+  } as unknown as ConversationSettingsControl & {
+    observe(descriptor: ConversationDescriptor): void;
+  };
+  return { control, get, update, reset };
+}
+
+function makeInteraction(input: {
+  userId: string;
+  subcommand: string;
+  subcommandGroup?: string | null;
+  strings?: Record<string, string>;
+}) {
+  const deferReply = rs.fn(async () => undefined);
+  const editReply = rs.fn(async () => undefined);
+  const interaction = {
+    commandName: "channel",
+    channelId: CHANNEL_ID,
+    channel: { name: "general", isThread: () => false },
+    guild: { name: "Rome" },
+    user: { id: input.userId },
+    options: {
+      getSubcommandGroup: () => input.subcommandGroup ?? null,
+      getSubcommand: () => input.subcommand,
+      getString: (name: string) => input.strings?.[name] ?? null,
+    },
+    deferReply,
+    editReply,
+  } as unknown as ChatInputCommandInteraction;
+  return { interaction, deferReply, editReply };
+}
+
+async function runCommand(
+  adapter: DiscordAdapter,
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  await (
+    adapter as unknown as {
+      handleSlashCommand(interaction: ChatInputCommandInteraction): Promise<void>;
+    }
+  ).handleSlashCommand(interaction);
+}
+
+afterEach(() => {
+  rs.restoreAllMocks();
+});
+
+describe("Discord configuration command authorization", () => {
+  it("leaves Discord member permissions open so the linked guardian reaches Rome authorization", () => {
+    const configurationCommands = buildDiscordSlashCommands().filter(({ name }) =>
+      ["channel", "bot"].includes(name),
+    );
+
+    expect(configurationCommands).toHaveLength(2);
+    for (const command of configurationCommands) {
+      expect(command.default_member_permissions).toBeUndefined();
+    }
+  });
+
+  it("lets the linked guardian read channel status", async () => {
+    const settings = makeConversationSettings();
+    const resolveDiscordPerson = rs.fn(async (discordUserId: string) =>
+      discordUserId === GUARDIAN_ID ? { id: "guardian", bondLevel: "guardian" as const } : null,
+    );
+    const adapter = new DiscordAdapter({
+      botToken: "test-token",
+      connectionId: CONNECTION_ID,
+      conversationSettings: settings.control,
+      resolveDiscordPerson,
+    });
+    const { interaction, editReply } = makeInteraction({
+      userId: GUARDIAN_ID,
+      subcommand: "status",
+    });
+
+    await runCommand(adapter, interaction);
+
+    expect(resolveDiscordPerson).toHaveBeenCalledWith(GUARDIAN_ID);
+    expect(settings.get).toHaveBeenCalled();
+    expect(editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining("**#general configuration**"),
+    });
+  });
+
+  it("lets the linked guardian set a channel agent", async () => {
+    const settings = makeConversationSettings();
+    const resolveDiscordPerson = rs.fn(async () => ({
+      id: "guardian",
+      bondLevel: "guardian" as const,
+    }));
+    const adapter = new DiscordAdapter({
+      botToken: "test-token",
+      connectionId: CONNECTION_ID,
+      conversationSettings: settings.control,
+      resolveDiscordPerson,
+      listAgents: () => ["main", "pm-assistant"],
+    });
+    const { interaction, editReply } = makeInteraction({
+      userId: GUARDIAN_ID,
+      subcommandGroup: "agent",
+      subcommand: "set",
+      strings: { name: "pm-assistant" },
+    });
+
+    await runCommand(adapter, interaction);
+
+    expect(settings.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ref: { connectionId: CONNECTION_ID, conversationId: CHANNEL_ID },
+        set: { routing: { agentName: "pm-assistant" } },
+        actor: { kind: "guardian", id: "discord-slash" },
+      }),
+    );
+    expect(editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining("now routes to agent `pm-assistant`"),
+    });
+  });
+
+  it("refuses an unlinked Discord user and records safe structured diagnostics", async () => {
+    const warn = rs.spyOn(console, "warn").mockImplementation(() => undefined);
+    const settings = makeConversationSettings();
+    const resolveDiscordPerson = rs.fn(async () => null);
+    const adapter = new DiscordAdapter({
+      botToken: "credential-must-not-appear",
+      connectionId: CONNECTION_ID,
+      conversationSettings: settings.control,
+      resolveDiscordPerson,
+      listAgents: () => ["pm-assistant"],
+    });
+    const { interaction, editReply } = makeInteraction({
+      userId: UNLINKED_ID,
+      subcommandGroup: "agent",
+      subcommand: "set",
+      strings: { name: "pm-assistant" },
+    });
+
+    await runCommand(adapter, interaction);
+
+    expect(resolveDiscordPerson).toHaveBeenCalledWith(UNLINKED_ID);
+    expect(settings.get).not.toHaveBeenCalled();
+    expect(settings.update).not.toHaveBeenCalled();
+    expect(editReply).toHaveBeenCalledWith({
+      content: "Only the linked guardian can configure this Discord conversation.",
+    });
+
+    const entry = JSON.parse(warn.mock.calls.at(-1)?.[0] as string) as {
+      message: string;
+      data: Record<string, unknown>;
+    };
+    expect(entry).toMatchObject({
+      message: "discord configuration command authorization rejected",
+      data: {
+        connectionId: CONNECTION_ID,
+        discordUserId: UNLINKED_ID,
+        command: "channel",
+        authorized: false,
+        decision: "deny",
+        authorizationResult: "unlinked",
+        personId: null,
+        bondLevel: null,
+      },
+    });
+    expect(warn.mock.calls.at(-1)?.[0]).not.toContain("credential-must-not-appear");
+  });
+});

--- a/packages/core/src/channels/discord-configuration.test.ts
+++ b/packages/core/src/channels/discord-configuration.test.ts
@@ -6,7 +6,7 @@ import type {
   ConversationSettingsControl,
   ConversationSettingsSnapshot,
 } from "@rome-os/app-runtime";
-import type { ChatInputCommandInteraction } from "discord.js";
+import type { AutocompleteInteraction, ChatInputCommandInteraction } from "discord.js";
 import { buildDiscordSlashCommands, DiscordAdapter } from "./discord.js";
 
 const CONNECTION_ID = "connection:discord";
@@ -95,6 +95,32 @@ async function runCommand(
       handleSlashCommand(interaction: ChatInputCommandInteraction): Promise<void>;
     }
   ).handleSlashCommand(interaction);
+}
+
+function makeAutocompleteInteraction(userId: string) {
+  const respond = rs.fn(async () => undefined);
+  const interaction = {
+    commandName: "channel",
+    user: { id: userId },
+    options: {
+      getSubcommandGroup: () => "agent",
+      getSubcommand: () => "set",
+      getFocused: () => ({ name: "name", value: "" }),
+    },
+    respond,
+  } as unknown as AutocompleteInteraction;
+  return { interaction, respond };
+}
+
+async function runAutocomplete(
+  adapter: DiscordAdapter,
+  interaction: AutocompleteInteraction,
+): Promise<void> {
+  await (
+    adapter as unknown as {
+      handleAutocomplete(interaction: AutocompleteInteraction): Promise<void>;
+    }
+  ).handleAutocomplete(interaction);
 }
 
 afterEach(() => {
@@ -217,5 +243,23 @@ describe("Discord configuration command authorization", () => {
       },
     });
     expect(warn.mock.calls.at(-1)?.[0]).not.toContain("credential-must-not-appear");
+  });
+
+  it("does not expose agent autocomplete choices to an unlinked Discord user", async () => {
+    const resolveDiscordPerson = rs.fn(async () => null);
+    const listAgents = rs.fn(() => ["main", "private-agent"]);
+    const adapter = new DiscordAdapter({
+      botToken: "test-token",
+      connectionId: CONNECTION_ID,
+      resolveDiscordPerson,
+      listAgents,
+    });
+    const { interaction, respond } = makeAutocompleteInteraction(UNLINKED_ID);
+
+    await runAutocomplete(adapter, interaction);
+
+    expect(resolveDiscordPerson).toHaveBeenCalledWith(UNLINKED_ID);
+    expect(listAgents).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith([]);
   });
 });

--- a/packages/core/src/channels/discord-stop.test.ts
+++ b/packages/core/src/channels/discord-stop.test.ts
@@ -25,12 +25,12 @@ describe("Discord stop command", () => {
   it("routes native /stop through chat control before the guardian-only config gate", async () => {
     const stop = rs.fn(async () => ({ status: "stop_requested" as const, turnId: "turn-1" }));
     const chatStop: ChatStopHandler = stop;
-    const isGuardian = rs.fn(async () => false);
+    const resolveDiscordPerson = rs.fn(async () => null);
     const adapter = new DiscordAdapter({
       botToken: "token",
       connectionId: "connection:discord",
       chatStop,
-      isGuardian,
+      resolveDiscordPerson,
     });
     const deferReply = rs.fn(async () => undefined);
     const editReply = rs.fn(async () => undefined);
@@ -55,6 +55,6 @@ describe("Discord stop command", () => {
       senderId: "user-1",
     });
     expect(editReply).toHaveBeenCalledWith({ content: "Stopped." });
-    expect(isGuardian).not.toHaveBeenCalled();
+    expect(resolveDiscordPerson).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/channels/discord.ts
+++ b/packages/core/src/channels/discord.ts
@@ -1187,6 +1187,10 @@ export class DiscordAdapter implements ProviderAdapter {
       const sub = interaction.options.getSubcommand(false);
       const focused = interaction.options.getFocused(true);
       if (subGroup !== "agent" || sub !== "set" || focused.name !== "name") return;
+      if (!(await this.canConfigure(interaction.user.id, interaction.commandName))) {
+        await interaction.respond([]);
+        return;
+      }
 
       const all = this.listAgents?.() ?? [];
       // Hide "main" from typeahead — it's the default; if the guardian wants

--- a/packages/core/src/channels/discord.ts
+++ b/packages/core/src/channels/discord.ts
@@ -10,7 +10,6 @@ import {
   RESTEvents,
   Routes,
   SlashCommandBuilder,
-  PermissionFlagsBits,
   type Message,
   type TextChannel,
   type DMChannel,
@@ -36,6 +35,7 @@ import type {
   ConversationSettingsSnapshot,
   ChatStopHandler,
   MessageAddressing,
+  PersonRecord,
 } from "@rome-os/app-runtime";
 import type {
   NormalizedMessage,
@@ -178,7 +178,6 @@ export function buildDiscordSlashCommands() {
   const channel = new SlashCommandBuilder()
     .setName("channel")
     .setDescription("Configure Rome Bot behavior for this channel")
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
     .addSubcommand((sub) =>
       sub.setName("ignore").setDescription("Permanently silence the bot in this channel"),
     )
@@ -277,7 +276,6 @@ export function buildDiscordSlashCommands() {
   const bot = new SlashCommandBuilder()
     .setName("bot")
     .setDescription("Global Rome Bot status and management")
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
     .addSubcommand((sub) => sub.setName("status").setDescription("Show all channel overrides"));
 
   const help = new SlashCommandBuilder()
@@ -332,7 +330,9 @@ export class DiscordAdapter implements ProviderAdapter {
    * disappears later).
    */
   private listAgents?: () => string[];
-  private isGuardian?: (channelUserId: string) => Promise<boolean>;
+  private resolveDiscordPerson?: (
+    channelUserId: string,
+  ) => Promise<Pick<PersonRecord, "id" | "bondLevel"> | null>;
   private chatStop?: ChatStopHandler;
 
   /**
@@ -357,7 +357,9 @@ export class DiscordAdapter implements ProviderAdapter {
     };
     maxMessagesPerChannel?: number;
     listAgents?: () => string[];
-    isGuardian?: (channelUserId: string) => Promise<boolean>;
+    resolveDiscordPerson?: (
+      channelUserId: string,
+    ) => Promise<Pick<PersonRecord, "id" | "bondLevel"> | null>;
     chatStop?: ChatStopHandler;
     onGatewayFault?: (fault: { kind: "credential" | "transport"; cause: unknown }) => void;
   }) {
@@ -365,7 +367,7 @@ export class DiscordAdapter implements ProviderAdapter {
     this.conversationSettings = config.conversationSettings;
     this.maxMessagesPerChannel = config.maxMessagesPerChannel ?? 100;
     this.listAgents = config.listAgents;
-    this.isGuardian = config.isGuardian;
+    this.resolveDiscordPerson = config.resolveDiscordPerson;
     this.chatStop = config.chatStop;
     this.onGatewayFault = config.onGatewayFault;
     this.client = new Client({
@@ -871,7 +873,7 @@ export class DiscordAdapter implements ProviderAdapter {
         return;
       }
 
-      if (this.isGuardian && !(await this.isGuardian(interaction.user.id))) {
+      if (!(await this.canConfigure(interaction.user.id, interaction.commandName))) {
         await interaction.editReply({
           content: "Only the linked guardian can configure this Discord conversation.",
         });
@@ -1126,6 +1128,45 @@ export class DiscordAdapter implements ProviderAdapter {
         // ignore follow-up error
       }
     }
+  }
+
+  private async canConfigure(discordUserId: string, command: string): Promise<boolean> {
+    let person: Pick<PersonRecord, "id" | "bondLevel"> | null = null;
+    let authorizationResult = "unlinked";
+
+    try {
+      if (this.resolveDiscordPerson) {
+        person = await this.resolveDiscordPerson(discordUserId);
+        authorizationResult = person ? "bond_level_not_guardian" : "unlinked";
+      } else {
+        authorizationResult = "resolver_unavailable";
+      }
+    } catch {
+      authorizationResult = "resolution_failed";
+      log.warn("discord configuration command authorization rejected", {
+        connectionId: this.connectionId ?? null,
+        discordUserId,
+        command,
+        authorized: false,
+        decision: "deny",
+        authorizationResult,
+      });
+      return false;
+    }
+
+    if (person?.bondLevel === "guardian") return true;
+
+    log.warn("discord configuration command authorization rejected", {
+      connectionId: this.connectionId ?? null,
+      discordUserId,
+      command,
+      authorized: false,
+      decision: "deny",
+      authorizationResult,
+      personId: person?.id ?? null,
+      bondLevel: person?.bondLevel ?? null,
+    });
+    return false;
   }
 
   /**

--- a/packages/core/src/connections/integrations/discord.test.ts
+++ b/packages/core/src/connections/integrations/discord.test.ts
@@ -22,6 +22,10 @@ import type { StreamFault, Talker } from "../types.js";
 // and lets a test make start() reject with a chosen error.
 type FakeConfig = {
   botToken: string;
+  resolveDiscordPerson?: (channelUserId: string) => Promise<{
+    id: string;
+    bondLevel: string;
+  } | null>;
   onGatewayFault?: (f: { kind: "credential" | "transport"; cause: unknown }) => void;
 };
 const fakeState: {
@@ -198,6 +202,28 @@ describe("discord descriptor shape", () => {
     const stopped = h.talker.stop();
     expect(stopped).toBeInstanceOf(Promise);
     await stopped;
+  });
+
+  it("resolves command actors through the same Discord person link used by inbound messages", async () => {
+    const guardian = { id: "guardian", bondLevel: "guardian" };
+    const findByChannelUser = rs.fn(async () => guardian);
+    const desc = makeDiscordDescriptor({
+      ...deps,
+      personMappingRepo: { findByChannelUser } as never,
+    });
+    desc.capabilities.talker!.build(
+      { bot: validCred() },
+      {
+        connectionId: "discord-test",
+        persist: async () => {},
+        registerIngress: () => () => {},
+      },
+    );
+
+    await expect(fakeState.lastConfig?.resolveDiscordPerson?.("guardian-777")).resolves.toEqual(
+      guardian,
+    );
+    expect(findByChannelUser).toHaveBeenCalledWith("discord", "guardian-777");
   });
 
   it("passes the opaque conversation id to the adapter", async () => {

--- a/packages/core/src/connections/integrations/discord.ts
+++ b/packages/core/src/connections/integrations/discord.ts
@@ -385,9 +385,8 @@ export function makeDiscordDescriptor(deps: DiscordDeps): ConnectionDescriptor {
             conversationSettings: deps.conversationSettings,
             chatStop: deps.chatStop,
             listAgents: deps.listAgents,
-            isGuardian: async (channelUserId) =>
-              (await deps.personMappingRepo.findByChannelUser("discord", channelUserId))
-                ?.bondLevel === "guardian",
+            resolveDiscordPerson: (channelUserId) =>
+              deps.personMappingRepo.findByChannelUser("discord", channelUserId),
             // Live gateway faults (post-login) route through here; the descriptor
             // maps the adapter's kind onto grant state vs. transport.
             onGatewayFault: ({ kind, cause }) => {


### PR DESCRIPTION
## What this PR does

Discord's `Manage Channels` command default prevented a linked guardian without that guild permission from reaching Rome's account-link authorization. This change lets configuration interactions reach Rome, then resolves the Discord user through the same person mapping used for inbound messages and allows only a guardian bond.

Rejected commands keep the existing refusal, fail closed when identity resolution is unavailable, and emit structured diagnostics containing the connection, Discord user ID, and authorization decision without credentials.

Closes #305

## Design & Invariants

- `/channel` and `/bot` rely on Rome's linked-account authorization rather than unrelated Discord guild permissions.
- Command authorization uses `PersonMappingRepository.findByChannelUser("discord", userId)`, preserving the same person and bond-level resolution as inbound Discord messages.
- Missing, failed, unlinked, and non-guardian resolutions all deny configuration changes.
- `/stop` remains on its dedicated guardian-checked chat-control path.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec biome check packages/core/src/channels/discord.ts packages/core/src/channels/discord-configuration.test.ts packages/core/src/channels/discord-stop.test.ts packages/core/src/connections/integrations/discord.ts packages/core/src/connections/integrations/discord.test.ts`
- [x] `pnpm --filter @rome/core test -- --silent=passed-only` (389 files; 4,516 passed, 2 skipped)
- [x] Linked Discord guardian can run `/channel status` and `/channel agent set`
- [x] Unlinked Discord user gets the existing refusal, cannot read or mutate settings, and produces safe structured diagnostics
