### PR TITLE
fix(web): remove timeline hide control

### DIFF
--- a/packages/web/src/components/chat/ChatTimelineRail.test.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.test.tsx
@@ -1,8 +1,6 @@
 // @rstest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, rs } from "@rstest/core";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
-// Real bundles, so the hide control's accessible name is the shipped
-// string rather than its key — the same thing a screen reader would read.
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import "@/i18n";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ChatTimelineRail } from "./ChatTimelineRail";
@@ -14,7 +12,6 @@ beforeEach(() => {
 afterEach(() => {
   rs.useRealTimers();
   cleanup();
-  localStorage.clear();
 });
 
 const QUESTIONS: TimelineQuestion[] = [
@@ -24,12 +21,8 @@ const QUESTIONS: TimelineQuestion[] = [
   { messageId: "q4", text: "can we cache it?" },
 ];
 
-// The markers, excluding the hide control — which is a button too, but is
-// deliberately focusable and is not one of the questions. Hidden markers stay
-// mounted so the retract animates, and leave the a11y tree via aria-hidden —
-// which is exactly what getAllByRole filters on.
 function markers(): HTMLElement[] {
-  return screen.getAllByRole("button").filter((el) => el.getAttribute("aria-expanded") === null);
+  return screen.getAllByRole("button");
 }
 
 function rect(top: number, height = 0): DOMRect {
@@ -164,9 +157,6 @@ describe("ChatTimelineRail", () => {
       "-1",
       "-1",
     ]);
-    expect(
-      screen.getByRole("button", { name: "Hide timeline" }).getAttribute("tabindex"),
-    ).toBeNull();
   });
 
   it("moves between questions with the arrow keys", () => {
@@ -205,20 +195,6 @@ describe("ChatTimelineRail", () => {
     expect(document.activeElement).toBe(all[3]);
   });
 
-  it("takes hidden markers out of the tab order", () => {
-    // They stay mounted so the retract animates, and carry aria-hidden — which
-    // must never contain something focusable.
-    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    fireEvent.click(screen.getByRole("button", { name: "Hide timeline" }));
-    const hiddenMarkers = [
-      ...document.querySelectorAll<HTMLElement>("[data-timeline-markers] button"),
-    ];
-    expect(hiddenMarkers).toHaveLength(4);
-    for (const marker of hiddenMarkers) {
-      expect(marker.getAttribute("tabindex")).toBe("-1");
-    }
-  });
-
   it("renders no markers below the question floor", () => {
     const { container } = renderRail(
       stubScroller(SPREAD_ANCHORS.slice(0, 2)),
@@ -239,105 +215,10 @@ describe("ChatTimelineRail", () => {
     expect(container.querySelectorAll("button")).toHaveLength(0);
   });
 
-  it("hides the markers and offers to bring them back", () => {
-    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    expect(markers()).toHaveLength(4);
-    expect(screen.getByRole("button", { name: "Hide timeline" }).style.top).toBe("214px");
-
-    fireEvent.click(screen.getByRole("button", { name: "Hide timeline" }));
-    expect(markers()).toHaveLength(0);
-
-    fireEvent.click(screen.getByRole("button", { name: "Show timeline" }));
-    expect(markers()).toHaveLength(4);
-  });
-
-  it("remembers a hide across mounts", () => {
-    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    fireEvent.click(screen.getByRole("button", { name: "Hide timeline" }));
-    cleanup();
-
-    renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-    expect(markers()).toHaveLength(0);
-    expect(screen.getByRole("button", { name: "Show timeline" })).toBeTruthy();
-  });
-
-  it("repositions the show control when the track resizes while hidden", () => {
-    let fire: (() => void) | null = null;
-    const RealRO = globalThis.ResizeObserver;
-    globalThis.ResizeObserver = class {
-      private readonly callback: () => void;
-
-      constructor(callback: () => void) {
-        this.callback = callback;
-        fire = callback;
-      }
-      observe() {}
-      unobserve() {}
-      disconnect() {
-        if (fire === this.callback) fire = null;
-      }
-    } as unknown as typeof ResizeObserver;
-
-    try {
-      const { container } = renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
-      expect(screen.getByRole("button", { name: "Hide timeline" }).style.top).toBe("214px");
-
-      fireEvent.click(screen.getByRole("button", { name: "Hide timeline" }));
-      const track = container.querySelector<HTMLElement>("[data-timeline-track]");
-      expect(track).not.toBeNull();
-      Object.defineProperty(track, "clientHeight", { value: 200, configurable: true });
-
-      act(() => {
-        fire?.();
-        rs.advanceTimersByTime(200);
-      });
-      expect(screen.getByRole("button", { name: "Show timeline" }).style.top).toBe("64px");
-    } finally {
-      globalThis.ResizeObserver = RealRO;
-    }
-  });
-
-  it("keeps watching while hidden with nothing to show", () => {
-    // A hidden rail that measured nothing — too narrow, too short — must stay
-    // subscribed, or becoming eligible later leaves no Show control until the
-    // next message or a reload.
-    const observed: Element[] = [];
-    let fire: (() => void) | null = null;
-    const RealRO = globalThis.ResizeObserver;
-    globalThis.ResizeObserver = class {
-      constructor(cb: () => void) {
-        fire = cb;
-      }
-      observe(el: Element) {
-        observed.push(el);
-      }
-      unobserve() {}
-      disconnect() {}
-    } as unknown as typeof ResizeObserver;
-
-    try {
-      localStorage.setItem("rome-timeline-hidden", "1");
-      // A transcript under two viewports: ineligible, so nothing is measured.
-      const scroller = stubScroller(SPREAD_ANCHORS);
-      Object.defineProperty(scroller, "scrollHeight", { value: 700, configurable: true });
-      renderRail(scroller, QUESTIONS);
-      expect(screen.queryByRole("button")).toBeNull();
-      expect(observed.length).toBeGreaterThan(0);
-
-      // It grows past the threshold; the observer has to bring the control back.
-      Object.defineProperty(scroller, "scrollHeight", { value: 3000, configurable: true });
-      act(() => {
-        fire?.();
-        rs.advanceTimersByTime(200);
-      });
-      expect(screen.getByRole("button", { name: "Show timeline" })).toBeTruthy();
-    } finally {
-      globalThis.ResizeObserver = RealRO;
-    }
-  });
-
-  it("offers no control when there is no timeline to hide", () => {
-    renderRail(stubScroller(SPREAD_ANCHORS.slice(0, 2)), QUESTIONS.slice(0, 2));
-    expect(screen.queryByRole("button")).toBeNull();
+  it("renders no hide control", () => {
+    const { container } = renderRail(stubScroller(SPREAD_ANCHORS), QUESTIONS);
+    expect(container.querySelectorAll("[data-timeline-markers] button")).toHaveLength(4);
+    expect(container.querySelectorAll("button")).toHaveLength(4);
+    expect(container.querySelector("svg")).toBeNull();
   });
 });

--- a/packages/web/src/components/chat/ChatTimelineRail.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from "react";
-import { Eye, EyeOff } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -15,20 +14,8 @@ import {
 // Re-checking is trailing-debounced because a streamed reply can resize the
 // content on every token before the transcript crosses the visibility gate.
 const MEASURE_DEBOUNCE_MS = 150;
-const CONTROL_NODE_GAP_PX = 24;
 
 const EMPTY: TimelineNode[] = [];
-
-// Matches how the sidebar remembers its own collapse (RomeShellLayout).
-const HIDDEN_KEY = "rome-timeline-hidden";
-
-function readHidden(): boolean {
-  try {
-    return localStorage.getItem(HIDDEN_KEY) === "1";
-  } catch {
-    return false;
-  }
-}
 
 export interface ChatTimelineRailProps {
   /** The chat's single scrolling node. */
@@ -55,7 +42,6 @@ export interface ChatTimelineRailProps {
 export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatTimelineRailProps) {
   const { t } = useTranslation("chat");
   const [nodes, setNodes] = useState<TimelineNode[]>(EMPTY);
-  const [hidden, setHidden] = useState(readHidden);
   // The bars are positioned in this element's pixel coordinate space. Measuring
   // the track directly lets the compact step tighten only when the column is
   // truly saturated.
@@ -108,14 +94,7 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
       timer = window.setTimeout(measure, MEASURE_DEBOUNCE_MS);
     };
 
-    // Always measure once, even while hidden: the node count is what decides
-    // whether the show control renders at all, and skipping this would strand a
-    // reader who hid the rail and then reloaded with no way to bring it back.
     measure();
-    // The observer stays active while markers are hidden. The show control is
-    // positioned from the first node, so a resized track must update that node
-    // to keep the control reachable. It also lets an ineligible transcript grow
-    // into a timeline without waiting for another message or a reload.
 
     const observer = new ResizeObserver(schedule);
     observer.observe(scroller);
@@ -124,7 +103,7 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
       window.clearTimeout(timer);
       observer.disconnect();
     };
-  }, [scroller, content, questions, hidden]);
+  }, [scroller, content, questions]);
 
   // Clamped rather than reset: questions arrive while the chat runs, and the
   // caret should not jump back to the top each time one does.
@@ -145,16 +124,6 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
     },
     [nodes.length],
   );
-
-  const toggleHidden = useCallback(() => {
-    setHidden((prev) => {
-      const next = !prev;
-      try {
-        localStorage.setItem(HIDDEN_KEY, next ? "1" : "0");
-      } catch {}
-      return next;
-    });
-  }, []);
 
   // The track stays mounted even with nothing to show. `measure` reads its
   // height, so an early return here would leave `trackRef` null, which would
@@ -187,41 +156,8 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
       aria-label={empty ? undefined : t("timeline.label")}
       className="group pointer-events-none absolute inset-y-0 left-0 z-10 hidden w-8 @min-[48rem]/transcript:block"
     >
-      {/* The control and markers share one coordinate space, so the eye follows
-          the compact group instead of staying stranded at the top of the rail. */}
       <div ref={trackRef} data-timeline-track className="absolute top-16 bottom-32 left-0 w-8">
-        {empty ? null : (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={toggleHidden}
-                aria-label={hidden ? t("timeline.show") : t("timeline.hide")}
-                aria-expanded={!hidden}
-                style={{ top: nodes[0].topPx - CONTROL_NODE_GAP_PX }}
-                className="pointer-events-auto absolute left-4 flex size-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground opacity-30 transition-opacity duration-200 ease-out group-hover:opacity-70 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-ring motion-reduce:transition-none"
-              >
-                {hidden ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right" sideOffset={8}>
-              {hidden ? t("timeline.show") : t("timeline.hide")}
-            </TooltipContent>
-          </Tooltip>
-        )}
-        {/* Hiding slides the markers out to the left and fades them, rather than
-            unmounting them, so the effect runs in both directions. `visibility`
-            carries the safety: it flips discretely at the END of the transition,
-            so the markers stop taking pointer events when they are gone.
-            `aria-hidden` removes them from the accessibility tree at the same
-            time, while the eye remains available to restore them. */}
-        <div
-          data-timeline-markers
-          aria-hidden={hidden}
-          className={`absolute inset-0 transition-[opacity,translate,visibility] duration-200 ease-out motion-reduce:transition-none ${
-            hidden ? "invisible -translate-x-6 opacity-0" : "visible translate-x-0 opacity-100"
-          }`}
-        >
+        <div data-timeline-markers className="absolute inset-0">
           {empty
             ? null
             : nodes.map((node, index) => {
@@ -251,7 +187,7 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
                         ref={(el) => {
                           nodeRefs.current[index] = el;
                         }}
-                        tabIndex={hidden || index !== activeNode ? -1 : 0}
+                        tabIndex={index !== activeNode ? -1 : 0}
                         aria-label={label}
                         onKeyDown={(event) => onNodeKeyDown(event, index)}
                         onFocus={() => setRovingIndex(index)}

--- a/packages/web/src/components/chat/ChatTimelineRail.tsx
+++ b/packages/web/src/components/chat/ChatTimelineRail.tsx
@@ -180,8 +180,7 @@ export function ChatTimelineRail({ scroller, content, questions, onJump }: ChatT
 
                     Focus is styled like hover, so the bar under the caret
                     reads like the one under the cursor. Only the roving marker is
-                    tabbable; hidden markers leave the tab order entirely, so
-                    nothing focusable ever sits inside `aria-hidden`. */}
+                    tabbable. */}
                       <button
                         type="button"
                         ref={(el) => {

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -55,9 +55,7 @@
     "unavailableBody": "The link may have been revoked or is no longer valid."
   },
   "timeline": {
-    "label": "Question timeline",
-    "hide": "Hide timeline",
-    "show": "Show timeline"
+    "label": "Question timeline"
   },
   "jumpToLatest": "Jump to the latest message",
   "roles": {

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -55,9 +55,7 @@
     "unavailableBody": "链接可能已被撤销或失效。"
   },
   "timeline": {
-    "label": "提问时间线",
-    "hide": "隐藏时间线",
-    "show": "显示时间线"
+    "label": "提问时间线"
   },
   "jumpToLatest": "回到最新消息",
   "roles": {


### PR DESCRIPTION
## What this PR does

The timeline hide control adds an eye icon above the question markers even though the timeline should remain available. Remove the control, its persisted hidden state, and its unused translations so eligible timelines always show their markers.

Closes #311

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit`
- [x] `pnpm --filter rome-web build`
- [x] Opened a long mock chat at 1440×500 and verified four visible timeline markers, no timeline SVG, and no browser console errors
