### PR TITLE
feat(analytics): record app visitor emails for app opens

### DIFF
--- a/docs/adrs/raw-analytics-urls-over-client-side-sanitization.md
+++ b/docs/adrs/raw-analytics-urls-over-client-side-sanitization.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-Rome counts page visits on the dashboard, on every app, and on the public-access gateway page. The desktop shell runs that same dashboard, so it counts as the dashboard rather than as a fourth surface. Apps have no document of their own — every app surface renders inside the one `rome-web` shell. Instrumentation placed in that shell covers every app, including the ones an agent writes after this decision ships. The goal is raw visit counting. Identity, funnels, and session replay stay out of scope, so the instrumentation earns very little code.
+Rome counts page visits on the dashboard, on every app, and on the public-access gateway page. The desktop shell runs that same dashboard, so it counts as the dashboard rather than as a fourth surface. Apps have no document of their own — every app surface renders inside the one `rome-web` shell. Instrumentation placed in that shell covers every app, including the ones an agent writes after this decision ships. The goal is raw visit counting with an [app visitor breakdown](../observability/app-visits.md). Funnels and session replay stay out of scope.
 
 Rome puts meaning in the URL path. `/share/<token>` carries a bearer credential granting access to a shared chat. `/memory/<file>`, `/chat/<sessionId>`, and `/projects/<name>` carry personal metadata, and apps mint arbitrary sub-routes under their own ids. Any page-view report that includes the URL carries those values to Google and into the operator's GA property.
 

--- a/docs/observability/app-visits.md
+++ b/docs/observability/app-visits.md
@@ -1,0 +1,16 @@
+# App visit analytics
+
+The `rome_app_open` event carries `app_id`, `surface`, and `visitor_email`.
+The surfaces are `embedded`, `full`, and `inline`.
+The [page-view decision](../adrs/raw-analytics-urls-over-client-side-sanitization.md) governs the GA loader and widget exclusion.
+
+The app manifest supplies the authenticated caller identity for each mount.
+The event records the verified visitor email or the cloud guardian email when available.
+A guardian session takes precedence when both guardian and visitor sessions are present.
+Anonymous callers and local guardian accounts without an email use `guest`.
+The value belongs to each event, so one app open cannot carry identity into another.
+
+The Rome Cloud admin table groups opens by app and visitor from the GA BigQuery export.
+Each app total includes all visitor groups, and the table ranks apps by that total.
+Events without `visitor_email` count toward `guest`.
+Email attribution starts when the instance runs an instrumented version. Historical events cannot recover an email.

--- a/packages/core/src/api/routes/apps.test.ts
+++ b/packages/core/src/api/routes/apps.test.ts
@@ -14,7 +14,13 @@ import type {
   SubscriberHandler,
   Unsubscribe,
 } from "../../apps/state.js";
-import { COOKIE_NAME, createSession } from "../../lib/auth.js";
+import {
+  COOKIE_NAME,
+  createSession,
+  createVisitorSession,
+  VISITOR_COOKIE_NAME,
+} from "../../lib/auth.js";
+import { createCloudGuardian } from "../../lib/guardian-auth-state.js";
 import { buildTestDeps, createTestDb } from "../../test/helpers.js";
 
 function buildResolvedApp(
@@ -156,6 +162,54 @@ describe("deriveAppProjectPath", () => {
     expect(
       deriveAppProjectPath({ mode: "source", path: "/home/user/other/weather" }, root),
     ).toBeNull();
+  });
+});
+
+describe("GET /apps/:appId/manifest caller email", () => {
+  it("uses the authenticated caller email and gives the guardian precedence over a visitor", async () => {
+    const testDb = createTestDb();
+    try {
+      await createCloudGuardian(testDb.db, "owner-id", "owner@example.com");
+      const resolved = buildResolvedApp("test-app");
+      resolved.web = {
+        appId: "test-app",
+        version: "0.0.1",
+        entry: "entry.js",
+        styles: [],
+        assetVersion: "abcdef123456",
+        displayName: "Test app",
+        routing: "client",
+        manifestPath: "/tmp/unused-web-manifest.json",
+        distPath: "/tmp/unused-dist",
+      };
+      const deps = {
+        ...(await buildTestDeps(testDb.db)),
+        appCatalog: catalogWith(resolved),
+      };
+      const app = new Hono().route("/", appsRoutes(deps));
+      const visitorCookie = `${VISITOR_COOKIE_NAME}=${createVisitorSession("visitor-id", "visitor@example.com")}`;
+      const guardianCookie = `${COOKIE_NAME}=${createSession("owner-id")}`;
+      const cases = [
+        { cookie: "", caller: { kind: "anonymous" } },
+        { cookie: `${VISITOR_COOKIE_NAME}=invalid`, caller: { kind: "anonymous" } },
+        {
+          cookie: visitorCookie,
+          caller: { kind: "visitor", accountId: "visitor-id", email: "visitor@example.com" },
+        },
+        {
+          cookie: `${guardianCookie}; ${visitorCookie}`,
+          caller: { kind: "guardian", userId: "owner-id", email: "owner@example.com" },
+        },
+      ];
+      for (const { cookie, caller } of cases) {
+        const res = await app.request("/apps/test-app/manifest", { headers: { cookie } });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { bootstrap: { caller: unknown } };
+        expect(body.bootstrap.caller).toEqual(caller);
+      }
+    } finally {
+      testDb.close();
+    }
   });
 });
 

--- a/packages/core/src/api/routes/apps.ts
+++ b/packages/core/src/api/routes/apps.ts
@@ -38,6 +38,7 @@ import {
 } from "../../lib/public-access-config.js";
 import { resolveGuardianSession } from "../../lib/guardian-session.js";
 import { resolveVisitorSession } from "../../lib/visitor-session.js";
+import { enrichGuardianActor } from "../../lib/session-actor.js";
 import type { ApiDeps } from "../deps.js";
 import { APP_MANAGER_ERROR_STATUS } from "@rome/api-types/app-manager-errors";
 import { getEmbeddedAppHref, getFullAppHref } from "../../lib/app-routes.js";
@@ -494,9 +495,18 @@ export function appsRoutes(deps: ApiDeps): Hono {
     // resolved here, per manifest fetch, and delivered on the bootstrap so the
     // app UI can gate owner-only affordances without probing a route. Advisory
     // only — enforcement stays in the app's API handler.
+    const guardianActor = guardianSession
+      ? await enrichGuardianActor(deps.db, guardianSession)
+      : null;
     const caller =
       guardianSession !== null
-        ? ({ kind: "guardian", userId: guardianSession.userId } as const)
+        ? ({
+            kind: "guardian",
+            userId: guardianSession.userId,
+            ...(guardianActor?.kind === "guardian" && guardianActor.email
+              ? { email: guardianActor.email }
+              : {}),
+          } as const)
         : viewer !== null
           ? ({ kind: "visitor", accountId: viewer.accountId, email: viewer.email } as const)
           : ({ kind: "anonymous" } as const);

--- a/packages/web/src/components/chat/blocks/AppComponentBlock.tsx
+++ b/packages/web/src/components/chat/blocks/AppComponentBlock.tsx
@@ -142,7 +142,11 @@ export function AppComponentBlock({
         });
         // Inline components bypass RomeAppHost (the URL stays on /chat), so
         // this mount path reports its own app open.
-        trackAppOpen(appId, "inline");
+        trackAppOpen(
+          appId,
+          "inline",
+          bootstrap.caller && "email" in bootstrap.caller ? bootstrap.caller.email : undefined,
+        );
       } catch (err) {
         if (!disposed) setError(err instanceof Error ? err.message : String(err));
       }

--- a/packages/web/src/components/rome-app-host.tsx
+++ b/packages/web/src/components/rome-app-host.tsx
@@ -17,7 +17,7 @@ export interface RomeAppBootstrap {
   };
   /** Host-resolved caller identity for this mount (advisory, UI gating only). */
   caller?:
-    | { kind: "guardian"; userId: string }
+    | { kind: "guardian"; userId: string; email?: string }
     | { kind: "visitor"; accountId: string; email: string }
     | { kind: "anonymous" };
   globalParams?: {
@@ -174,7 +174,13 @@ export function RomeAppHost({
         // chat surface has its own mount path in AppComponentBlock. Together
         // the two call sites are the complete record of app
         // opens — including surfaces that never change the URL.
-        trackAppOpen(appId, currentBootstrap.shell.mode);
+        trackAppOpen(
+          appId,
+          currentBootstrap.shell.mode,
+          currentBootstrap.caller && "email" in currentBootstrap.caller
+            ? currentBootstrap.caller.email
+            : undefined,
+        );
       } catch (err) {
         if (!disposed) setError(err instanceof Error ? err.message : String(err));
       }

--- a/packages/web/src/lib/analytics.test.ts
+++ b/packages/web/src/lib/analytics.test.ts
@@ -114,11 +114,53 @@ describe("initAnalytics with a measurement id", () => {
     trackAppOpen("morning-brief", "inline");
     trackWidgetRender("morning-brief");
     expect(eventsNamed("rome_app_open")).toEqual([
-      ["event", "rome_app_open", { app_id: "morning-brief", surface: "inline" }],
+      [
+        "event",
+        "rome_app_open",
+        { app_id: "morning-brief", surface: "inline", visitor_email: "guest" },
+      ],
     ]);
     expect(eventsNamed("rome_widget_render")).toEqual([
       ["event", "rome_widget_render", { app_id: "morning-brief" }],
     ]);
+  });
+
+  it("records the visitor for each open without carrying identity into the next open", async () => {
+    window.__ROME_RUNTIME_CONFIG__ = { gaMeasurementId: "G-TEST1" };
+    const { initAnalytics, trackAppOpen } = await loadAnalytics();
+    initAnalytics();
+    trackAppOpen("morning-brief", "embedded", "visitor@example.com");
+    trackAppOpen("morning-brief", "full");
+    trackAppOpen("morning-brief", "inline", "another@example.com");
+    expect(eventsNamed("rome_app_open")).toEqual([
+      [
+        "event",
+        "rome_app_open",
+        { app_id: "morning-brief", surface: "embedded", visitor_email: "visitor@example.com" },
+      ],
+      [
+        "event",
+        "rome_app_open",
+        { app_id: "morning-brief", surface: "full", visitor_email: "guest" },
+      ],
+      [
+        "event",
+        "rome_app_open",
+        { app_id: "morning-brief", surface: "inline", visitor_email: "another@example.com" },
+      ],
+    ]);
+  });
+
+  it.each([null, "", "   "])("records guest when the visitor email is %j", async (email) => {
+    window.__ROME_RUNTIME_CONFIG__ = { gaMeasurementId: "G-TEST1" };
+    const { initAnalytics, trackAppOpen } = await loadAnalytics();
+    initAnalytics();
+    trackAppOpen("morning-brief", "full", email);
+    expect(eventsNamed("rome_app_open")[0]?.[2]).toEqual({
+      app_id: "morning-brief",
+      surface: "full",
+      visitor_email: "guest",
+    });
   });
 });
 

--- a/packages/web/src/lib/analytics.ts
+++ b/packages/web/src/lib/analytics.ts
@@ -106,8 +106,16 @@ export type AppOpenSurface = "embedded" | "full" | "inline";
 // AppComponentBlock (inline chat components bypass RomeAppHost), so every app
 // open is one event regardless of surface. Custom names are rome_-prefixed to
 // avoid GA/Firebase auto-collected semantics.
-export function trackAppOpen(appId: string, surface: AppOpenSurface): void {
-  trackEvent("rome_app_open", { app_id: appId, surface });
+export function trackAppOpen(
+  appId: string,
+  surface: AppOpenSurface,
+  visitorEmail?: string | null,
+): void {
+  trackEvent("rome_app_open", {
+    app_id: appId,
+    surface,
+    visitor_email: visitorEmail?.trim() || "guest",
+  });
 }
 
 // Widget renders are counted from the PARENT window when the host mounts the

--- a/packages/web/src/pages/AppEmbeddedPage.tsx
+++ b/packages/web/src/pages/AppEmbeddedPage.tsx
@@ -32,7 +32,7 @@ interface AppManifestResponse {
       mode: "embedded" | "full";
     };
     caller?:
-      | { kind: "guardian"; userId: string }
+      | { kind: "guardian"; userId: string; email?: string }
       | { kind: "visitor"; accountId: string; email: string }
       | { kind: "anonymous" };
     globalParams?: Record<string, never>;

--- a/packages/web/src/pages/AppFullPage.tsx
+++ b/packages/web/src/pages/AppFullPage.tsx
@@ -23,7 +23,7 @@ interface AppManifestResponse {
     assetBase: string;
     shell: { theme: "light" | "dark"; themeName: string; mode: "embedded" | "full" };
     caller?:
-      | { kind: "guardian"; userId: string }
+      | { kind: "guardian"; userId: string; email?: string }
       | { kind: "visitor"; accountId: string; email: string }
       | { kind: "anonymous" };
     globalParams?: Record<string, never>;


### PR DESCRIPTION
## What this PR does

App-open analytics cannot identify which visitor opened an app. Each `rome_app_open` event now records the authenticated caller email in `visitor_email`, or `guest` when no email is available.

Embedded, full-page, and inline chat mounts use the manifest identity. Cloud guardians include their email, and guardian sessions take precedence over coexisting visitor sessions.

The [companion Rome Cloud PR](https://github.com/amantru/rome-cloud/pull/94) adds expandable visitor counts to the admin App opens table.

## Design & Invariants

[App visit analytics](docs/observability/app-visits.md) defines the event and reporting contract. Identity belongs to each event. Anonymous callers and local guardians without an email use `guest`. Existing page-view and widget behavior stays intact.

Emails apply to new events. Historical events lack visitor attribution and remain in the guest group.

## Test plan

- [x] Core and web package type checks.
- [x] `pnpm --filter @rome/core test src/api/routes/apps.test.ts` — 14 tests, including anonymous, invalid-session, visitor, and guardian precedence cases.
- [x] `pnpm test:unit:web` — 1,393 web tests and 559 UI tests passed, including 13 analytics tests.
- [x] Biome checks on changed source files and `git diff --check`.
- [ ] `pnpm typecheck` — blocked by the existing Rslib `autoExternal` type mismatch in app-web-sdk.
- [ ] `pnpm test:unit` — blocked by the incomplete local Electron installation.
- [ ] `pnpm dev:all` and container startup — Traefik cannot bind the occupied host port 80.
- [ ] `pnpm lint:prose` — Vale and Nix are unavailable locally. Checks ran with installed Node 24.
