### PR TITLE
feat(web): migrate diagnostic previews to Storybook

### DIFF
--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -27,6 +27,21 @@ Replace the port in either link when you start another instance.
 
 The build writes only to the root `storybook-static` directory. The dashboard output stays in `packages/web/dist`.
 
+## Diagnostic previews
+
+The diagnostic previews render without the dashboard entry or a Rome backend.
+
+| Development route | Page source | Story ID |
+| --- | --- | --- |
+| `/dev/connections` | [`ConnectionGalleryPage.tsx`](../packages/web/src/pages/dev/ConnectionGalleryPage.tsx) | [`dev-previews-connections--default`](http://localhost:6006/?path=/story/dev-previews-connections--default) |
+| `/dev/chat-blocks` | [`ChatBlocksPage.tsx`](../packages/web/src/pages/dev/ChatBlocksPage.tsx) | [`dev-previews-chat-blocks--default`](http://localhost:6006/?path=/story/dev-previews-chat-blocks--default) |
+| `/dev/login` | [`LoginPreviewPage.tsx`](../packages/web/src/pages/dev/LoginPreviewPage.tsx) | [`dev-previews-login--default`](http://localhost:6006/?path=/story/dev-previews-login--default) |
+| `/dev/onboard` | [`OnboardPreviewPage.tsx`](../packages/web/src/pages/dev/OnboardPreviewPage.tsx) | [`dev-previews-onboarding--default`](http://localhost:6006/?path=/story/dev-previews-onboarding--default) |
+
+The `/dev` routes remain available. [`dev-routes.ts`](../packages/web/src/pages/dev/dev-routes.ts) feeds the development index and `App.tsx`. [`layout-invariants.spec.ts`](../packages/web/e2e/layout-invariants.spec.ts) also visits the connections and chat-blocks routes.
+
+`BootstrapPreview` keeps each auth preview's query seed local. The preview fetch guard answers only the onboarding reads and rejects every other `/api` request. Run `pnpm --filter rome-web test:storybook:previews` to switch the previews on port 6026 and check that no service request escapes.
+
 ## Source and theme wiring
 
 [`StyleGuide.stories.tsx`](../packages/web/.storybook/StyleGuide.stories.tsx) imports the page directly.

--- a/packages/web/.storybook/ChatBlocks.stories.tsx
+++ b/packages/web/.storybook/ChatBlocks.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from "storybook-react-rsbuild";
+import ChatBlocksPage from "../src/pages/dev/ChatBlocksPage";
+
+const meta = {
+  title: "Dev/Previews/Chat blocks",
+  component: ChatBlocksPage,
+} satisfies Meta<typeof ChatBlocksPage>;
+
+export default meta;
+export const Default: StoryObj<typeof meta> = {};

--- a/packages/web/.storybook/ConnectionGallery.stories.tsx
+++ b/packages/web/.storybook/ConnectionGallery.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from "storybook-react-rsbuild";
+import ConnectionGalleryPage from "../src/pages/dev/ConnectionGalleryPage";
+
+const meta = {
+  title: "Dev/Previews/Connections",
+  component: ConnectionGalleryPage,
+} satisfies Meta<typeof ConnectionGalleryPage>;
+
+export default meta;
+export const Default: StoryObj<typeof meta> = {};

--- a/packages/web/.storybook/Login.stories.tsx
+++ b/packages/web/.storybook/Login.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from "storybook-react-rsbuild";
+import LoginPreviewPage from "../src/pages/dev/LoginPreviewPage";
+
+const meta = {
+  title: "Dev/Previews/Login",
+  component: LoginPreviewPage,
+} satisfies Meta<typeof LoginPreviewPage>;
+
+export default meta;
+export const Default: StoryObj<typeof meta> = {};

--- a/packages/web/.storybook/Onboard.stories.tsx
+++ b/packages/web/.storybook/Onboard.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from "storybook-react-rsbuild";
+import OnboardPreviewPage from "../src/pages/dev/OnboardPreviewPage";
+
+const meta = {
+  title: "Dev/Previews/Onboarding",
+  component: OnboardPreviewPage,
+} satisfies Meta<typeof OnboardPreviewPage>;
+
+export default meta;
+export const Default: StoryObj<typeof meta> = {};

--- a/packages/web/.storybook/preview-api.ts
+++ b/packages/web/.storybook/preview-api.ts
@@ -1,0 +1,34 @@
+function pathnameOf(input: RequestInfo | URL): string | null {
+  const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+  try {
+    return new URL(url, window.location.origin).pathname;
+  } catch {
+    return null;
+  }
+}
+
+if (typeof window !== "undefined") {
+  const realFetch = window.fetch;
+  window.fetch = (input, init) => {
+    const pathname = pathnameOf(input);
+    const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+
+    if (method === "GET" && pathname === "/api/onboard/draft") {
+      return Promise.resolve(Response.json({ settings: {} }));
+    }
+    if (method === "GET" && pathname === "/api/ai-tools/status") {
+      return Promise.resolve(
+        Response.json({ claude: { loggedIn: false }, codex: { loggedIn: false } }),
+      );
+    }
+    if (method === "GET" && pathname === "/api/ai-tools/anthropic-compatible-providers") {
+      return Promise.resolve(Response.json({ providers: [], configured: null }));
+    }
+    if (pathname?.startsWith("/api/")) {
+      return Promise.reject(
+        new Error(`Blocked by the Storybook preview fetch guard: ${method} ${pathname}`),
+      );
+    }
+    return realFetch(input, init);
+  };
+}

--- a/packages/web/.storybook/preview.tsx
+++ b/packages/web/.storybook/preview.tsx
@@ -1,6 +1,8 @@
 import type { Preview } from "storybook-react-rsbuild";
 import { useLayoutEffect, type ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
 import { ThemeProvider, useTheme } from "../src/hooks/use-theme";
+import "../src/i18n";
 import {
   applyTheme,
   applyThemeName,
@@ -10,6 +12,7 @@ import {
   resolveTheme,
   type ThemePreference,
 } from "../src/lib/theme";
+import "./preview-api";
 import "../src/globals.css";
 
 injectThemeCss();
@@ -45,15 +48,17 @@ const preview: Preview = {
   decorators: [
     (Story, { globals }) => (
       <ThemeProvider>
-        <ColorMode
-          mode={
-            globals.colorMode === "light" || globals.colorMode === "dark"
-              ? globals.colorMode
-              : "system"
-          }
-        >
-          <Story />
-        </ColorMode>
+        <MemoryRouter>
+          <ColorMode
+            mode={
+              globals.colorMode === "light" || globals.colorMode === "dark"
+                ? globals.colorMode
+                : "system"
+            }
+          >
+            <Story />
+          </ColorMode>
+        </MemoryRouter>
       </ThemeProvider>
     ),
   ],

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,6 +15,7 @@
     "test": "../../scripts/test-env.sh rstest --silent passed-only",
     "test:desktop-vnc": "playwright test --config playwright.desktop-vnc.config.ts",
     "test:desktop-vnc:docker": "playwright test --config playwright.desktop-vnc.docker.config.ts",
+    "test:storybook:previews": "playwright test --config playwright.storybook.config.ts",
     "test:layout": "playwright test"
   },
   "dependencies": {

--- a/packages/web/playwright.storybook.config.ts
+++ b/packages/web/playwright.storybook.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "@playwright/test";
+
+const isCI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: "./storybook-e2e",
+  fullyParallel: true,
+  forbidOnly: isCI,
+  retries: 0,
+  reporter: isCI ? [["github"], ["list"]] : [["list"]],
+  use: {
+    baseURL: "http://localhost:6026",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  webServer: {
+    command: "pnpm storybook --port 6026 --ci",
+    url: "http://localhost:6026",
+    reuseExistingServer: !isCI,
+    timeout: isCI ? 180_000 : 60_000,
+  },
+});

--- a/packages/web/storybook-e2e/diagnostic-previews.spec.ts
+++ b/packages/web/storybook-e2e/diagnostic-previews.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+const STORIES = [
+  ["dev-previews-login--default", "input[type=password]"],
+  ["dev-previews-onboarding--default", "#guardianName"],
+  ["dev-previews-connections--default", "text=Connection dialog gallery"],
+  ["dev-previews-chat-blocks--default", "text=Transcript blocks"],
+  ["dev-previews-login--default", "input[type=password]"],
+  ["dev-previews-onboarding--default", "#guardianName"],
+] as const;
+
+test("diagnostic previews switch without service requests", async ({ page }) => {
+  const serviceRequests: string[] = [];
+  await page.route("**/api/**", async (route) => {
+    serviceRequests.push(new URL(route.request().url()).pathname);
+    await route.fulfill({ status: 500 });
+  });
+
+  for (const [storyId, readySelector] of STORIES) {
+    await page.goto(`/iframe.html?id=${storyId}&viewMode=story`);
+    await expect(page.locator(readySelector).first()).toBeVisible();
+  }
+
+  expect(serviceRequests).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- add page-level Storybook previews for the four existing diagnostic routes
- keep preview data and request blocking scoped to Storybook
- document the route-to-story mapping and add direct-iframe coverage

## Validation

- pnpm typecheck
- pnpm test:unit
- pnpm --filter rome-web test:layout
- pnpm --filter rome-web test:storybook:previews
- pnpm --filter rome-web build
- pnpm build:storybook