### PR TITLE
feat(web): add design page stories to Storybook

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,7 +50,7 @@ pnpm dev:all          # Rome container + obs singleton + Traefik singleton
 
 ## Running processes
 
-For the standalone style guide, run `pnpm storybook`. Startup, source HMR, static builds, and browser checks are in [Storybook](docs/storybook.md).
+For standalone design pages, run `pnpm storybook`. Startup, source HMR, static builds, and browser checks are in [Storybook](docs/storybook.md).
 
 `pnpm dev:all` is the single entry point. It calls `scripts/dev-up.sh`, which:
 

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -76,7 +76,7 @@ Published package exports stay unchanged.
 Theme context lives in a separate module so changing palette definitions does not recreate its identity during HMR.
 Shared UI CSS registers its component sources through `@source`, and the preview uses the dashboard PostCSS configuration.
 
-Storybook has its own Rsbuild configuration and entry points. Its MDX rule matches the dashboard's design-document compiler without loading the dashboard configuration.
+Storybook has its own Rsbuild configuration and entry points. Both configurations consume the same pure MDX rule fragment without loading the dashboard configuration.
 It does not load the dashboard entry, authentication gate, analytics initialization, backend proxy, or mock entry.
 The pages require no API fixtures.
 Storybook configuration and story wrappers live outside the dashboard source tree.

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -1,6 +1,6 @@
 # Storybook
 
-Storybook serves design demonstration pages without a Rome backend. The dashboard stays on Rsbuild, and unit tests stay on Rstest.
+Storybook serves self-contained design demonstrations without a Rome backend. The four stories make no service requests. Runtime diagnostic tools and application flows remain in `/dev` and E2E. The dashboard stays on Rsbuild, and unit tests stay on Rstest.
 
 ## Start
 
@@ -27,15 +27,13 @@ Each story imports its existing page directly. The pages have one implementation
 
 The [style guide iframe](http://localhost:6006/iframe.html?id=dev-design-styleguide--default&viewMode=story) omits the manager UI. Replace the port in these links when you start another instance.
 
-The adjacent `/dev/connections`, `/dev/chat-blocks`, `/dev/login`, and `/dev/onboard` pages are separate migration candidates. This Storybook surface does not select them.
-
 ## Retained development routes
 
-The four `/dev` routes stay registered in `dev-routes.ts` and stay linked from `DevIndexPage.tsx`.
+The four `/dev` routes stay registered by default in `dev-routes.ts` and stay linked from `DevIndexPage.tsx`.
 `App.tsx` maps that registry to the development routes.
 `layout-invariants.spec.ts` opens `/dev/styleguide` and `/dev/typography`.
 `glyph-size.spec.ts` and `control-size-vocabulary.spec.ts` open `/dev/gallery`.
-Keep the routes until those callers move to stable Storybook links.
+Storybook provides parallel design demonstrations. It does not replace runtime diagnostic tools or application flows.
 
 ## Build and check
 

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -1,35 +1,54 @@
 # Storybook
 
-Storybook serves the existing style guide without a Rome backend. The dashboard stays on Rsbuild, and unit tests stay on Rstest.
+Storybook serves design demonstration pages without a Rome backend. The dashboard stays on Rsbuild, and unit tests stay on Rstest.
 
 ## Start
 
 1. Enter the repository devShell with `nix develop`.
 2. Install the workspace dependencies with `pnpm install`.
 3. Run `pnpm storybook` from the repository root.
-4. Open [the style guide](http://localhost:6006/?path=/story/dev-design-styleguide--default).
+4. Open a page from [Pages](#pages).
 
 The default port is 6006. Use `pnpm storybook --port 6007` for a second instance.
 An occupied port fails with an error instead of selecting another port or prompting.
 The local development command uses `--no-open` to prevent automatic browser launch while retaining interactive prompts.
 For CI, add `--ci` explicitly with `pnpm storybook --ci`.
 
-The stable story ID is `dev-design-styleguide--default`.
-The [direct iframe](http://localhost:6006/iframe.html?id=dev-design-styleguide--default&viewMode=story) omits the manager UI.
-Replace the port in either link when you start another instance.
+## Pages
+
+Each story imports its existing page directly. The pages have one implementation.
+
+| Existing development URL | Source | Stable story ID |
+| --- | --- | --- |
+| `/dev/styleguide` | `src/pages/dev/StyleGuidePage.tsx` | [`dev-design-styleguide--default`](http://localhost:6006/?path=/story/dev-design-styleguide--default) |
+| `/dev/typography` | `src/pages/dev/TypographyPage.tsx` | [`dev-design-typography--default`](http://localhost:6006/?path=/story/dev-design-typography--default) |
+| `/dev/gallery` | `src/pages/dev/gallery/ComponentGalleryPage.tsx` | [`dev-design-gallery--default`](http://localhost:6006/?path=/story/dev-design-gallery--default) |
+| `/dev/mdx` | `src/pages/dev/mdx/MdxDocsPage.tsx` | [`dev-design-mdx--default`](http://localhost:6006/?path=/story/dev-design-mdx--default) |
+
+The [style guide iframe](http://localhost:6006/iframe.html?id=dev-design-styleguide--default&viewMode=story) omits the manager UI. Replace the port in these links when you start another instance.
+
+The adjacent `/dev/connections`, `/dev/chat-blocks`, `/dev/login`, and `/dev/onboard` pages are separate migration candidates. This Storybook surface does not select them.
+
+## Retained development routes
+
+The four `/dev` routes stay registered in `dev-routes.ts` and stay linked from `DevIndexPage.tsx`.
+`App.tsx` maps that registry to the development routes.
+`layout-invariants.spec.ts` opens `/dev/styleguide` and `/dev/typography`.
+`glyph-size.spec.ts` and `control-size-vocabulary.spec.ts` open `/dev/gallery`.
+Keep the routes until those callers move to stable Storybook links.
 
 ## Build and check
 
 1. Run `pnpm build:storybook` in the devShell.
 2. Serve the output with `python3 -m http.server 6008 --bind 127.0.0.1 --directory storybook-static`.
-3. Open [the static style guide](http://localhost:6008/?path=/story/dev-design-styleguide--default).
+3. Open a page from [Pages](#pages), replacing port `6006` with `6008`.
 4. Refresh the page to check the direct link.
 
 The build writes only to the root `storybook-static` directory. The dashboard output stays in `packages/web/dist`.
 
 ## Source and theme wiring
 
-[`StyleGuide.stories.tsx`](../packages/web/.storybook/StyleGuide.stories.tsx) imports the page directly.
+The story files in [`packages/web/.storybook/`](../packages/web/.storybook/) import each page directly.
 The production-empty development route registry does not select stories.
 The preview imports the dashboard stylesheet and uses the real `injectThemeCss` and `ThemeProvider`.
 The [design system](design-system.md) owns the theme contract.
@@ -45,7 +64,7 @@ Comparison columns scope semantic tokens independently. Tailwind `dark:` utiliti
 Use the single-mode view to verify component variants in each mode.
 The palette still comes from `rome-theme-name` in the preview origin's local storage.
 
-The story imports the existing page rather than copying it. Theme values come from `packages/web/src/lib/themes.ts`, and shared CSS and components resolve to workspace source.
+The stories import the existing pages rather than copying them. Theme values come from `packages/web/src/lib/themes.ts`, and shared CSS and components resolve to workspace source.
 Edits to existing definitions update the development preview through HMR. A served static build must be rebuilt.
 The page's token groups and component examples are curated lists, so adding a new token or component does not automatically add an example.
 
@@ -57,9 +76,9 @@ Published package exports stay unchanged.
 Theme context lives in a separate module so changing palette definitions does not recreate its identity during HMR.
 Shared UI CSS registers its component sources through `@source`, and the preview uses the dashboard PostCSS configuration.
 
-Storybook has its own Rsbuild configuration and entry points.
+Storybook has its own Rsbuild configuration and entry points. Its MDX rule matches the dashboard's design-document compiler without loading the dashboard configuration.
 It does not load the dashboard entry, authentication gate, analytics initialization, backend proxy, or mock entry.
-The style guide requires no API fixtures.
+The pages require no API fixtures.
 Storybook configuration and story wrappers live outside the dashboard source tree.
 The existing `/dev` routes stay available for their current callers.
 

--- a/packages/web/.storybook/Gallery.stories.tsx
+++ b/packages/web/.storybook/Gallery.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from "storybook-react-rsbuild";
+import ComponentGalleryPage from "../src/pages/dev/gallery/ComponentGalleryPage";
+
+const meta = {
+  title: "Dev/Design/Gallery",
+  component: ComponentGalleryPage,
+} satisfies Meta<typeof ComponentGalleryPage>;
+
+export default meta;
+export const Default: StoryObj<typeof meta> = {};

--- a/packages/web/.storybook/Mdx.stories.tsx
+++ b/packages/web/.storybook/Mdx.stories.tsx
@@ -1,15 +1,35 @@
-import { MemoryRouter } from "react-router-dom";
+import { Link, MemoryRouter, Route, Routes } from "react-router-dom";
 import type { Meta, StoryObj } from "storybook-react-rsbuild";
 import "../src/i18n";
 import MdxDocsPage from "../src/pages/dev/mdx/MdxDocsPage";
+
+function StorybookDevIndex() {
+  return (
+    <main className="min-h-screen bg-background px-6 py-8 text-foreground">
+      <h1 className="text-title">Dev pages</h1>
+      <p className="mt-2 text-body text-muted-foreground">
+        Use Storybook’s Dev/Design group to open another design page.
+      </p>
+      <Link
+        to="/dev/mdx?doc=people-page"
+        className="mt-6 inline-block text-ui text-foreground hover:underline"
+      >
+        Design docs
+      </Link>
+    </main>
+  );
+}
 
 const meta = {
   title: "Dev/Design/MDX",
   component: MdxDocsPage,
   decorators: [
     (Story) => (
-      <MemoryRouter initialEntries={["/?doc=people-page"]}>
-        <Story />
+      <MemoryRouter initialEntries={["/dev/mdx?doc=people-page"]}>
+        <Routes>
+          <Route path="/dev" element={<StorybookDevIndex />} />
+          <Route path="/dev/mdx" element={<Story />} />
+        </Routes>
       </MemoryRouter>
     ),
   ],

--- a/packages/web/.storybook/Mdx.stories.tsx
+++ b/packages/web/.storybook/Mdx.stories.tsx
@@ -1,0 +1,19 @@
+import { MemoryRouter } from "react-router-dom";
+import type { Meta, StoryObj } from "storybook-react-rsbuild";
+import "../src/i18n";
+import MdxDocsPage from "../src/pages/dev/mdx/MdxDocsPage";
+
+const meta = {
+  title: "Dev/Design/MDX",
+  component: MdxDocsPage,
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={["/?doc=people-page"]}>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+} satisfies Meta<typeof MdxDocsPage>;
+
+export default meta;
+export const Default: StoryObj<typeof meta> = {};

--- a/packages/web/.storybook/Typography.stories.tsx
+++ b/packages/web/.storybook/Typography.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from "storybook-react-rsbuild";
+import TypographyPage from "../src/pages/dev/TypographyPage";
+
+const meta = {
+  title: "Dev/Design/Typography",
+  component: TypographyPage,
+} satisfies Meta<typeof TypographyPage>;
+
+export default meta;
+export const Default: StoryObj<typeof meta> = {};

--- a/packages/web/.storybook/preview-color-mode.test.tsx
+++ b/packages/web/.storybook/preview-color-mode.test.tsx
@@ -1,0 +1,52 @@
+// @rstest-environment jsdom
+import { afterEach, expect, test } from "@rstest/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SegmentedControl } from "../src/components/ui/segmented-control";
+import { ThemeProvider, useTheme } from "../src/hooks/use-theme";
+import type { ThemePreference } from "../src/lib/theme";
+import { ColorMode } from "./preview";
+
+const modes: { value: ThemePreference; label: string }[] = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "system", label: "System" },
+];
+
+function StoryColorModeControl() {
+  const { preference, setPreference } = useTheme();
+
+  return (
+    <SegmentedControl
+      aria-label="Color mode"
+      options={modes}
+      value={preference}
+      onValueChange={(value) => setPreference(value as ThemePreference)}
+    />
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  document.documentElement.classList.remove("dark");
+  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.style.removeProperty("color-scheme");
+  document.getElementById("rome-theme-tokens")?.remove();
+});
+
+test("a story color-mode control can override the toolbar preference", async () => {
+  const user = userEvent.setup();
+
+  render(
+    <ThemeProvider>
+      <ColorMode mode="dark">
+        <StoryColorModeControl />
+      </ColorMode>
+    </ThemeProvider>,
+  );
+
+  await user.click(screen.getByRole("radio", { name: "Light" }));
+
+  expect(screen.getByRole("radio", { name: "Light" }).getAttribute("aria-checked")).toBe("true");
+});

--- a/packages/web/.storybook/preview.tsx
+++ b/packages/web/.storybook/preview.tsx
@@ -16,11 +16,11 @@ injectThemeCss();
 applyThemeName(readStoredThemeName());
 applyTheme(resolveTheme(readStoredPreference()));
 
-function ColorMode({ mode, children }: { mode: ThemePreference; children: ReactNode }) {
-  const { preference, setPreference } = useTheme();
+export function ColorMode({ mode, children }: { mode: ThemePreference; children: ReactNode }) {
+  const { setPreference } = useTheme();
   useLayoutEffect(() => {
-    if (preference !== mode) setPreference(mode);
-  }, [mode, preference, setPreference]);
+    setPreference(mode);
+  }, [mode, setPreference]);
   return children;
 }
 

--- a/packages/web/.storybook/rsbuild.config.ts
+++ b/packages/web/.storybook/rsbuild.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "@rsbuild/core";
 import { pluginReact } from "@rsbuild/plugin-react";
 import { fileURLToPath } from "node:url";
-import remarkGfm from "remark-gfm";
+import { createMdxRspackRule } from "../mdx-rspack-rule.js";
 import { sourceAliases } from "./source-aliases.js";
 
 export default defineConfig({
@@ -16,12 +16,7 @@ export default defineConfig({
   tools: {
     rspack: {
       module: {
-        rules: [
-          {
-            test: /\.mdx$/,
-            use: [{ loader: "@mdx-js/loader", options: { remarkPlugins: [remarkGfm] } }],
-          },
-        ],
+        rules: [createMdxRspackRule()],
       },
       resolve: { extensionAlias: { ".js": [".ts", ".tsx", ".js"] } },
     },

--- a/packages/web/.storybook/rsbuild.config.ts
+++ b/packages/web/.storybook/rsbuild.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "@rsbuild/core";
 import { pluginReact } from "@rsbuild/plugin-react";
 import { fileURLToPath } from "node:url";
+import remarkGfm from "remark-gfm";
 import { sourceAliases } from "./source-aliases.js";
 
 export default defineConfig({
@@ -12,5 +13,17 @@ export default defineConfig({
       ...sourceAliases(new URL("../../web-content/", import.meta.url)),
     },
   },
-  tools: { rspack: { resolve: { extensionAlias: { ".js": [".ts", ".tsx", ".js"] } } } },
+  tools: {
+    rspack: {
+      module: {
+        rules: [
+          {
+            test: /\.mdx$/,
+            use: [{ loader: "@mdx-js/loader", options: { remarkPlugins: [remarkGfm] } }],
+          },
+        ],
+      },
+      resolve: { extensionAlias: { ".js": [".ts", ".tsx", ".js"] } },
+    },
+  },
 });

--- a/packages/web/mdx-rspack-rule.ts
+++ b/packages/web/mdx-rspack-rule.ts
@@ -1,0 +1,9 @@
+import remarkGfm from "remark-gfm";
+
+/** MDX design docs use GFM tables for their rule/reason columns. */
+export function createMdxRspackRule() {
+  return {
+    test: /\.mdx$/,
+    use: [{ loader: "@mdx-js/loader", options: { remarkPlugins: [remarkGfm] } }],
+  };
+}

--- a/packages/web/rsbuild.config.ts
+++ b/packages/web/rsbuild.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig, loadEnv } from "@rsbuild/core";
 import { pluginReact } from "@rsbuild/plugin-react";
 import { pluginSvgr } from "@rsbuild/plugin-svgr";
-import remarkGfm from "remark-gfm";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
+import { createMdxRspackRule } from "./mdx-rspack-rule.js";
 
 const workspaceRoot = fileURLToPath(new URL("../..", import.meta.url));
 const srcDir = fileURLToPath(new URL("./src", import.meta.url));
@@ -68,14 +68,7 @@ export default defineConfig({
     },
     rspack: {
       module: {
-        rules: [
-          {
-            test: /\.mdx$/,
-            // remark-gfm buys the table syntax a design doc needs for its
-            // rule/reason columns; plain MDX would render the pipes as text.
-            use: [{ loader: "@mdx-js/loader", options: { remarkPlugins: [remarkGfm] } }],
-          },
-        ],
+        rules: [createMdxRspackRule()],
       },
     },
   },

--- a/packages/web/rstest.config.mts
+++ b/packages/web/rstest.config.mts
@@ -26,5 +26,10 @@ export default defineConfig({
     prebundle: "auto",
   },
   setupFiles: ["./src/test/setup.ts"],
-  include: ["src/**/*.test.ts", "src/**/*.test.tsx", ".storybook/*.test.ts"],
+  include: [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    ".storybook/*.test.ts",
+    ".storybook/*.test.tsx",
+  ],
 });


### PR DESCRIPTION
## What this PR does

Adds direct page-level Storybook stories for four existing self-contained design demonstrations: the style guide, typography specimen, component gallery, and MDX document. The stories import their page implementations directly and provide stable, backend-free review links.

Implements theme B of #267.

## Design & invariants

- Every story imports the existing page, so each surface has one implementation.
- B covers self-contained design demonstrations only. It does not establish a pattern for full runtime page migration.
- The existing style guide story ID and preview theme contract remain intact.
- The gallery remains a single navigation and search page.
- Storybook adds only the dashboard-equivalent MDX compiler rule. It does not load dashboard runtime configuration.
- The four existing `/dev` routes stay registered by default for Dev links and browser checks.
- The adjacent connections, chat-blocks, login, and onboard pages stay in `/dev` and E2E as runtime diagnostic or application-flow pages.
- This PR does not add fetch overrides, MSW, or global request guards.

## Test plan

- [x] nix develop --command pnpm typecheck
- [x] nix develop --command pnpm test:unit
- [x] nix develop --command pnpm build:storybook
- [x] Dev Storybook at port 6016 and static Storybook at port 6018: direct links, refresh, theme, controls, gallery navigation, and MDX rendering
- [x] Browser request observation across all four stories: only Storybook assets and metadata requests, with zero `/api` or external service requests
- [x] pnpm --filter rome-web exec playwright test e2e/layout-invariants.spec.ts e2e/glyph-size.spec.ts e2e/control-size-vocabulary.spec.ts
- [x] nix develop --command pnpm dev:all, including Rome started
- [x] nix develop --command pnpm lint:prose

## Not in this PR

- Runtime diagnostic pages or application flows. They remain in `/dev` and E2E.