### PR TITLE
feat(web): organize chat apps in tabs

### DIFF
--- a/packages/web/src/components/chat/Chat.test.tsx
+++ b/packages/web/src/components/chat/Chat.test.tsx
@@ -198,7 +198,7 @@ afterEach(() => {
 });
 
 describe("Chat agent identity", () => {
-  it("always offers Show apps, including an empty or already expanded panel", async () => {
+  it("shows the expand control only while the apps panel is collapsed", async () => {
     const user = userEvent.setup();
     const { rerender } = renderChat(<Chat sessionId="session-1" />);
     await user.click(screen.getByRole("button", { name: "chat.expandTools" }));
@@ -209,9 +209,14 @@ describe("Chat agent identity", () => {
         <Chat sessionId="session-1" />
       </MemoryRouter>,
     );
-    expect(
-      screen.getByRole("button", { name: "chat.expandTools" }).getAttribute("aria-expanded"),
-    ).toBe("true");
+    expect(screen.queryByRole("button", { name: "chat.expandTools" })).toBeNull();
+    appsPanel.collapsed = true;
+    rerender(
+      <MemoryRouter>
+        <Chat sessionId="session-1" />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("button", { name: "chat.expandTools" })).toBeTruthy();
   });
 
   it("shows the session model in the chat header", () => {

--- a/packages/web/src/components/chat/Chat.test.tsx
+++ b/packages/web/src/components/chat/Chat.test.tsx
@@ -16,6 +16,7 @@ import {
 
 const t = (key: string) => key;
 const mockUseSessionIdentity = rs.hoisted(() => rs.fn());
+const appsPanel = rs.hoisted(() => ({ collapsed: true, setCollapsed: rs.fn() }));
 
 rs.mock("react-i18next", () => ({
   useTranslation: () => ({ t }),
@@ -36,7 +37,12 @@ rs.mock("@/pages/free/workspace-event-bus", () => ({
 
 rs.mock("@/pages/free/use-free-cells", () => ({
   autoPlaceApp: rs.fn(),
-  useFreeCells: () => ({ addWidget: rs.fn(), placements: [] }),
+  useFreeCells: () => ({
+    addWidget: rs.fn(),
+    placements: [],
+    toolView: { activeId: null, collapsed: appsPanel.collapsed, unreadIds: [] },
+    setToolsCollapsed: appsPanel.setCollapsed,
+  }),
 }));
 
 // Mutable so a test can put the viewport away from the tail; reset in beforeEach.
@@ -174,6 +180,7 @@ class MockEventSource {
 }
 
 beforeEach(() => {
+  appsPanel.collapsed = true;
   stickToBottom.isAtBottom = true;
   mockUseSessionIdentity.mockReturnValue({
     sessionName: null,
@@ -191,6 +198,22 @@ afterEach(() => {
 });
 
 describe("Chat agent identity", () => {
+  it("always offers Show apps, including an empty or already expanded panel", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderChat(<Chat sessionId="session-1" />);
+    await user.click(screen.getByRole("button", { name: "chat.expandTools" }));
+    expect(appsPanel.setCollapsed).toHaveBeenCalledWith(false);
+    appsPanel.collapsed = false;
+    rerender(
+      <MemoryRouter>
+        <Chat sessionId="session-1" />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByRole("button", { name: "chat.expandTools" }).getAttribute("aria-expanded"),
+    ).toBe("true");
+  });
+
   it("shows the session model in the chat header", () => {
     mockUseSessionIdentity.mockReturnValue({
       sessionName: "A conversation",

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -16,7 +16,7 @@ import {
   MoreHorizontal,
   Pin,
   PinOff,
-  Plus,
+  PanelRightOpen,
   Share2,
   Trash2,
 } from "lucide-react";
@@ -51,9 +51,8 @@ import {
   type HandoffNode,
 } from "@/components/chat/chat-view";
 import { ShareBar } from "@/components/chat/ShareBar";
-import { WidgetPicker } from "@/pages/free/WidgetPicker";
 import { useWorkspaceEventBus } from "@/pages/free/workspace-event-bus";
-import { useFreeCells, type WidgetType } from "@/pages/free/use-free-cells";
+import { useFreeCells } from "@/pages/free/use-free-cells";
 import type { TraceSegment, TraceSnapshot, TraceSummary } from "@rome/api-types/trace-segments";
 import { useSmoothText } from "@/hooks/use-smooth-text";
 import { useStickToBottom } from "@/hooks/use-stick-to-bottom";
@@ -259,11 +258,8 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
   const navigate = useNavigate();
   // `null` outside the workspace shell; sends simply skip injection.
   const workspaceContextRegistry = useWorkspaceContextRegistry();
-  // The "+" widget picker that used to float as a desktop FAB now lives in the
-  // top navbar. `useFreeCells` is a module-level store, so calling it here drives
-  // the same workspace layout as FreeGrid — no prop drilling or context needed.
-  const { addWidget, placements } = useFreeCells();
-  const hasApps = placements.length > 0;
+  const { toolView, setToolsCollapsed } = useFreeCells();
+  const hasApps = !toolView.collapsed;
   // Multiple sessions are in scope at once. Pick the right one deliberately:
   //   • mainSessionId  — the session THIS <Chat> owns (the prop). Use for the
   //     owned transcript's load / delete / agent lookup / scroll / navigation.
@@ -1605,10 +1601,8 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
               {t("composer.dropFiles")}
             </div>
           )}
-          {/* Top toolbar: the bound agent, the session title, and the "+" widget
-              picker / "⋯" menu. Hidden on mobile, where the global header + tab
-              pill already cover this. The handoff seam lives inline, not here. */}
-          <div className="z-20 flex shrink-0 items-center gap-3 border-b border-border bg-background/80 px-4 py-2 backdrop-blur-md supports-[backdrop-filter]:bg-background/65 max-md:hidden">
+
+          <div className="z-20 flex h-12 shrink-0 items-center gap-1 border-b border-border bg-background/80 pl-4 pr-2 backdrop-blur-md supports-[backdrop-filter]:bg-background/65 max-md:hidden">
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <AgentAvatar
                 iconUrl={pinnedAgentMention?.iconUrl}
@@ -1626,22 +1620,6 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
                 </span>
               )}
             </div>
-            <WidgetPicker
-              onSelect={(type: WidgetType, targetId?: string) => addWidget(type, targetId)}
-            >
-              <Button
-                type="button"
-                data-coach="add-widget"
-                variant="outline"
-                size="sm"
-                className="hidden md:inline-flex"
-                aria-label={t("navbar.add")}
-                title={t("navbar.add")}
-              >
-                <Plus data-icon="inline-start" className="size-3.5" />
-                {t("navbar.addShort")}
-              </Button>
-            </WidgetPicker>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <IconButton
@@ -1677,6 +1655,24 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
+            <IconButton
+              size="sm"
+              data-coach={toolView.collapsed ? "add-widget" : undefined}
+              aria-expanded={!toolView.collapsed}
+              onClick={() => setToolsCollapsed(false)}
+              label={t("chat.expandTools", { ns: "common" })}
+              icon={
+                <span className="relative">
+                  <PanelRightOpen />
+                  {toolView.unreadIds.length > 0 && (
+                    <span
+                      className="absolute -right-1 -top-1 size-1.5 rounded-full bg-info"
+                      aria-label={t("chat.toolUpdated", { ns: "common" })}
+                    />
+                  )}
+                </span>
+              }
+            />
           </div>
           {/* The message scroller — the ONLY scrolling node in the chat. It is
               bounded by the /chat viewport shell, so message reflow (mermaid,

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -259,7 +259,7 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
   // `null` outside the workspace shell; sends simply skip injection.
   const workspaceContextRegistry = useWorkspaceContextRegistry();
   const { toolView, setToolsCollapsed } = useFreeCells();
-  const hasApps = !toolView.collapsed;
+  const isAppsPanelOpen = !toolView.collapsed;
   // Multiple sessions are in scope at once. Pick the right one deliberately:
   //   • mainSessionId  — the session THIS <Chat> owns (the prop). Use for the
   //     owned transcript's load / delete / agent lookup / scroll / navigation.
@@ -1586,14 +1586,14 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
         onDrop={handleDrop}
       >
         {/* ---- Main Chat Area ---- */}
-        {/* When the trace drawer is open as a side panel (wide / no-apps layout,
+        {/* When the trace drawer is open as a side panel (wide / apps panel closed,
             @5xl/chat) it's `fixed` and out of flow, so reserve its 480px here to
             keep the toolbar, messages, and composer clear of it. In the narrow /
             apps-open layout the drawer covers the chat instead, so no reserve. */}
         <div
           className={`relative flex min-h-0 min-w-0 flex-1 flex-col @5xl/chat:transition-[width] @5xl/chat:duration-200 @5xl/chat:ease-out ${traceDrawerContentInsetClass(
             traceDrawerTarget !== null,
-            hasApps,
+            isAppsPanelOpen,
           )}`}
         >
           {isDraggingFiles && (
@@ -1842,7 +1842,7 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
         <TraceDrawer
           target={traceDrawerTarget}
           onClose={closeTraceDrawer}
-          hasApps={hasApps}
+          hasApps={isAppsPanelOpen}
           renderInlineBlock={(block, key) =>
             renderSingleBlock(block as StreamBlock, key, {
               onApprovalResolved: refreshActiveSession,

--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -1655,24 +1655,26 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <IconButton
-              size="sm"
-              data-coach={toolView.collapsed ? "add-widget" : undefined}
-              aria-expanded={!toolView.collapsed}
-              onClick={() => setToolsCollapsed(false)}
-              label={t("chat.expandTools", { ns: "common" })}
-              icon={
-                <span className="relative">
-                  <PanelRightOpen />
-                  {toolView.unreadIds.length > 0 && (
-                    <span
-                      className="absolute -right-1 -top-1 size-1.5 rounded-full bg-info"
-                      aria-label={t("chat.toolUpdated", { ns: "common" })}
-                    />
-                  )}
-                </span>
-              }
-            />
+            {toolView.collapsed && (
+              <IconButton
+                size="sm"
+                data-coach="add-widget"
+                aria-expanded={false}
+                onClick={() => setToolsCollapsed(false)}
+                label={t("chat.expandTools", { ns: "common" })}
+                icon={
+                  <span className="relative">
+                    <PanelRightOpen />
+                    {toolView.unreadIds.length > 0 && (
+                      <span
+                        className="absolute -right-1 -top-1 size-1.5 rounded-full bg-info"
+                        aria-label={t("chat.toolUpdated", { ns: "common" })}
+                      />
+                    )}
+                  </span>
+                }
+              />
+            )}
           </div>
           {/* The message scroller — the ONLY scrolling node in the chat. It is
               bounded by the /chat viewport shell, so message reflow (mermaid,

--- a/packages/web/src/components/chat/ChatLink.test.tsx
+++ b/packages/web/src/components/chat/ChatLink.test.tsx
@@ -123,7 +123,7 @@ describe("ChatLink", () => {
     renderInWorkspace(<ChatLink href="/apps/calendar">calendar</ChatLink>, { store, bus });
     fireEvent.click(screen.getByText("calendar"));
 
-    expect(autoPlaceApp).toHaveBeenCalledWith("calendar", undefined, undefined);
+    expect(autoPlaceApp).toHaveBeenCalledWith("calendar", undefined, undefined, true);
   });
 
   it("preserves the in-app sub-route for a deep /apps link", () => {
@@ -133,7 +133,7 @@ describe("ChatLink", () => {
     renderInWorkspace(<ChatLink href="/apps/calendar/week/2024-06">cal</ChatLink>, { store, bus });
     fireEvent.click(screen.getByText("cal"));
 
-    expect(autoPlaceApp).toHaveBeenCalledWith("calendar", "week/2024-06", undefined);
+    expect(autoPlaceApp).toHaveBeenCalledWith("calendar", "week/2024-06", undefined, true);
   });
 
   it("preserves query params for an /apps link", () => {
@@ -146,10 +146,15 @@ describe("ChatLink", () => {
     });
     fireEvent.click(screen.getByText("go"));
 
-    expect(autoPlaceApp).toHaveBeenCalledWith("connector", undefined, {
-      connector: "gmail",
-      status: "ok",
-    });
+    expect(autoPlaceApp).toHaveBeenCalledWith(
+      "connector",
+      undefined,
+      {
+        connector: "gmail",
+        status: "ok",
+      },
+      true,
+    );
   });
 
   it("leaves the /apps index page to react-router (no app tile)", () => {

--- a/packages/web/src/components/chat/ChatLink.tsx
+++ b/packages/web/src/components/chat/ChatLink.tsx
@@ -125,7 +125,7 @@ export function ChatLink(props: MarkdownLinkProps) {
       return (
         <WorkspaceLink
           {...props}
-          onActivate={() => autoPlaceApp(resolveAppToOpen(app.appId), app.route, app.params)}
+          onActivate={() => autoPlaceApp(resolveAppToOpen(app.appId), app.route, app.params, true)}
         />
       );
     }

--- a/packages/web/src/components/chat/TurnFeedbackButtons.test.tsx
+++ b/packages/web/src/components/chat/TurnFeedbackButtons.test.tsx
@@ -51,7 +51,12 @@ describe("TurnFeedbackButtons", () => {
     fireEvent.click(screen.getByRole("button", { name: "message.feedback.submit" }));
 
     await waitFor(() => {
-      expect(autoPlaceApp).toHaveBeenCalledWith("sessions", "feedback-fork-session");
+      expect(autoPlaceApp).toHaveBeenCalledWith(
+        "sessions",
+        "feedback-fork-session",
+        undefined,
+        true,
+      );
     });
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/chat/sessions/chat-session/turns/turn-1/feedback",

--- a/packages/web/src/components/chat/TurnFeedbackButtons.tsx
+++ b/packages/web/src/components/chat/TurnFeedbackButtons.tsx
@@ -84,7 +84,7 @@ export function TurnFeedbackButtons({ sessionId, turnId }: { sessionId: string; 
           setSubmitted(true);
           setDraftRating(null);
           if (body.processing) {
-            autoPlaceApp(body.processing.appId, body.processing.route);
+            autoPlaceApp(body.processing.appId, body.processing.route, undefined, true);
           }
         } else if (res.status === 409) {
           // Another surface beat us to it — adopt the server's record and lock.

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -16,8 +16,6 @@
   },
   "navbar": {
     "sessionModel": "Session model: {{model}}",
-    "add": "Add widget",
-    "addShort": "Add widget",
     "more": "More actions",
     "pin": "Pin chat",
     "unpin": "Unpin chat",

--- a/packages/web/src/i18n/locales/en/common.json
+++ b/packages/web/src/i18n/locales/en/common.json
@@ -157,17 +157,27 @@
     "iframeTitle": "Rome Desktop"
   },
   "chat": {
-    "add": "Add widget",
+    "add": "Open an app",
     "addChat": "Chat",
     "addDesktop": "Browser",
     "addProjects": "Projects",
     "addApp": "App",
     "back": "Back",
     "noApps": "No apps available",
-    "searchWidgets": "Search widgets",
-    "noWidgetMatches": "No widgets match “{{query}}”.",
+    "searchWidgets": "Search apps",
+    "noWidgetMatches": "No apps match “{{query}}”.",
     "newChat": "New chat",
-    "orPickSession": "or pick an existing session"
+    "orPickSession": "or pick an existing session",
+    "tools": "Apps",
+    "toolOpened": "Open",
+    "toolUpdated": "New content",
+    "closeTool": "Close {{name}}",
+    "allTools": "All open apps",
+    "collapseTools": "Hide apps",
+    "expandTools": "Show apps",
+    "resizeTools": "Resize chat and apps",
+    "emptyAppsTitle": "No apps open",
+    "emptyAppsDescription": "Open an app to use it alongside this chat."
   },
   "connectChatApp": {
     "title": "Connect your chat app",

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -16,8 +16,6 @@
   },
   "navbar": {
     "sessionModel": "会话模型：{{model}}",
-    "add": "添加小组件",
-    "addShort": "加组件",
     "more": "更多操作",
     "pin": "置顶对话",
     "unpin": "取消置顶",

--- a/packages/web/src/i18n/locales/zh-CN/common.json
+++ b/packages/web/src/i18n/locales/zh-CN/common.json
@@ -157,17 +157,27 @@
     "iframeTitle": "Rome 桌面"
   },
   "chat": {
-    "add": "添加组件",
+    "add": "打开一个应用",
     "addChat": "对话",
     "addDesktop": "浏览器",
     "addProjects": "项目",
     "addApp": "应用",
     "back": "返回",
     "noApps": "暂无可用应用",
-    "searchWidgets": "搜索组件",
-    "noWidgetMatches": "没有组件匹配 “{{query}}”。",
+    "searchWidgets": "搜索应用",
+    "noWidgetMatches": "没有应用匹配 “{{query}}”。",
     "newChat": "新对话",
-    "orPickSession": "或选择已有对话"
+    "orPickSession": "或选择已有对话",
+    "tools": "应用",
+    "toolOpened": "已打开",
+    "toolUpdated": "新内容",
+    "closeTool": "关闭{{name}}",
+    "allTools": "所有已打开应用",
+    "collapseTools": "收起应用",
+    "expandTools": "显示应用",
+    "resizeTools": "调整聊天与应用区宽度",
+    "emptyAppsTitle": "尚未打开应用",
+    "emptyAppsDescription": "打开一个应用，在聊天时查看和使用它。"
   },
   "connectChatApp": {
     "title": "连接你的聊天应用",

--- a/packages/web/src/pages/free/FreeGrid.tsx
+++ b/packages/web/src/pages/free/FreeGrid.tsx
@@ -1,31 +1,16 @@
 import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  type DragStartEvent,
-  MouseSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import { horizontalListSortingStrategy, SortableContext, useSortable } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import {
   Chrome,
   FolderKanban,
-  GripVertical,
   LayoutGrid,
   MessageSquare,
   MoreHorizontal,
   Pin,
   PinOff,
-  Plus,
+  PanelRightOpen,
   Share2,
   Trash2,
-  X,
 } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import type { AgentMention } from "@/lib/chat-types";
@@ -51,18 +36,16 @@ import { ChatWidget } from "./ChatWidget";
 import { DesktopWidget } from "./DesktopWidget";
 import { ProjectsWidget } from "./ProjectsWidget";
 import { PinnedChatWidget } from "./PinnedChatWidget";
-import { WidgetPicker } from "./WidgetPicker";
+import { ToolWorkspace } from "./ToolWorkspace";
 import {
   autoPlaceApp,
   autoPlaceProjects,
   loadLayoutForSession,
   placeWidgetsIfSessionActive,
   setActiveSession,
-  STRIP_ITEM_MIN_WIDTH,
   updatePlacementLink,
   type WidgetPlacement,
   type WidgetSeed,
-  type WidgetType,
   useFreeCells,
 } from "./use-free-cells";
 import {
@@ -71,13 +54,6 @@ import {
 } from "./workspace-context";
 import { createWorkspaceEventBus, WorkspaceEventBusContext } from "./workspace-event-bus";
 import { createWorkspaceStore, WorkspaceStoreContext } from "./workspace-store";
-
-// Width of the chat column when a widget is open (desktop). Fluid so a wide
-// screen gives the conversation more room without starving the app strip, and
-// clamped at both ends. Single source of truth, consumed in two coupled spots:
-// the chat column's own width, and the app overlay's left offset (which must
-// stay flush against it) — each reads it through a self-scoped CSS var.
-const CHAT_COLUMN_WIDTH = "clamp(420px, 34vw, 680px)";
 
 // App widgets render their real installed-app identity (icon + display name),
 // matching the sidebar pins and the composer context chips; the lucide grid is
@@ -104,21 +80,6 @@ function WidgetIcon({ widget, className }: { widget: WidgetPlacement; className?
       ) : (
         <LayoutGrid className={className ?? "h-3.5 w-3.5"} />
       );
-  }
-}
-
-function WidgetLabel({ widget }: { widget: WidgetPlacement }) {
-  const { t } = useTranslation("common");
-  const app = useWidgetApp(widget);
-  switch (widget.type) {
-    case "chat":
-      return <span>{t("nav.chat")}</span>;
-    case "desktop":
-      return <span>{t("nav.desktop")}</span>;
-    case "projects":
-      return <span>{t("nav.projects")}</span>;
-    case "app":
-      return <span>{app?.displayName ?? widget.targetId ?? t("nav.apps")}</span>;
   }
 }
 
@@ -165,93 +126,32 @@ function WidgetContent({
   }
 }
 
-function SortableWidgetCard({
-  widget,
-  activeId,
-  dragging,
-  onRemove,
-  minWidth,
-  mobileHidden,
-  sessionId,
-  interaction,
-}: {
-  widget: WidgetPlacement;
-  activeId: string | null;
-  dragging: boolean;
-  onRemove: () => void;
-  minWidth: number;
-  mobileHidden: boolean;
-  sessionId?: string;
-  interaction?: boolean;
-}) {
-  const prefersReducedMotion = useReducedMotion();
-  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition } =
-    useSortable({ id: widget.id });
-
-  const isActive = widget.id === activeId;
-
-  return (
-    <div
-      ref={setNodeRef}
-      className={`relative flex h-full min-w-0 flex-1 flex-shrink-0 flex-col overflow-hidden rounded-12 border bg-surface pb-safe md:pb-0 ${
-        isActive ? "z-40 border-ring shadow-25" : "z-10 border-border"
-      } ${mobileHidden ? "max-md:hidden" : ""}`}
-      style={{
-        minWidth: minWidth,
-        transform: CSS.Transform.toString(transform),
-        transition: prefersReducedMotion ? "none" : (transition ?? undefined),
-      }}
-    >
-      {/* Card header — drag handle + close. Hidden on mobile because the
-          top tab pill already owns title + close affordance there. */}
-      <div
-        ref={setActivatorNodeRef}
-        className="flex cursor-grab items-center gap-2 border-b border-border-subtle px-2 py-1 select-none active:cursor-grabbing max-md:hidden"
-        {...attributes}
-        {...listeners}
-      >
-        <GripVertical className="h-3.5 w-3.5 shrink-0 text-subtle-foreground" />
-        <WidgetIcon widget={widget} />
-        <span className="flex-1 truncate text-aux text-subtle-foreground">
-          <WidgetLabel widget={widget} />
-        </span>
-        {/* The design surface is system-managed while the handoff holds the
-            floor: leaving is the chat's "Main" back bar (non-destructive) and
-            cancelling is the surface's own Cancel button — so it carries no
-            generic close affordance that could be mistaken for either. */}
-        {!interaction && (
-          <button
-            type="button"
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={onRemove}
-            className="rounded-4 p-1 text-subtle-foreground hover:bg-surface-hover hover:text-foreground"
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        )}
-      </div>
-      <div className="relative min-h-0 flex-1 overflow-auto overscroll-y-contain">
-        <WidgetContent
-          widget={widget}
-          dragging={dragging}
-          sessionId={sessionId}
-          interaction={interaction}
-        />
-      </div>
-    </div>
-  );
-}
-
 export function FreeGrid() {
   const { t } = useTranslation("common");
   const params = useParams<{ "*"?: string }>();
   const location = useLocation();
   const navigate = useNavigate();
-  const { placements, addWidget, removeWidget, moveWidget } = useFreeCells();
+  const { placements, addWidget, removeWidget, toolView, selectTool, setToolsCollapsed } =
+    useFreeCells();
+  const { apps } = useApps();
+  const widgetLabel = (widget: WidgetPlacement) => {
+    if (widget.type === "app")
+      return (
+        apps?.find((app) => app.id === widget.targetId)?.displayName ??
+        widget.targetId ??
+        t("nav.apps")
+      );
+    return t(
+      widget.type === "chat"
+        ? "nav.chat"
+        : widget.type === "desktop"
+          ? "nav.desktop"
+          : "nav.projects",
+    );
+  };
   // Latest placements for the teardown flush handlers, which register once.
   const placementsRef = useRef(placements);
   placementsRef.current = placements;
-  const [activeId, setActiveId] = useState<string | null>(null);
   const [workspaceStore] = useState(() => createWorkspaceStore());
   const [eventBus] = useState(() => createWorkspaceEventBus());
   const [workspaceContextRegistry] = useState(() => createWorkspaceContextRegistry());
@@ -286,14 +186,18 @@ export function FreeGrid() {
     return JSON.stringify(initialWidgets);
   }, [initialWidgets]);
   const [chatSessionId, setChatSessionId] = useState<string | undefined>(urlSessionId);
-  const stripRef = useRef<HTMLDivElement>(null);
-  const [itemMinWidth, setItemMinWidth] = useState(STRIP_ITEM_MIN_WIDTH);
-  // "chat" or a widget placement id.
-  const [mobileTab, setMobileTab] = useState<"chat" | string>("chat");
-  const prefersReducedMotion = useReducedMotion();
+  const flushLayout = useCallback(() => {
+    for (const p of placementsRef.current) {
+      if (p.type !== "app") continue;
+      const link = workspaceContextRegistry.resolveLink(p.id);
+      if (link) updatePlacementLink(p.id, link.route, link.params);
+    }
+  }, [workspaceContextRegistry]);
 
   const suppressProjectsRef = useRef(false);
   useEffect(() => {
+    flushLayout();
+    suppressProjectsRef.current = false;
     setChatSessionId(urlSessionId);
     setActiveSession(urlSessionId ?? null);
     const applyInitialWidgets = (targetSessionId: string | null) => {
@@ -310,7 +214,7 @@ export function FreeGrid() {
     } else {
       applyInitialWidgets(null);
     }
-  }, [urlSessionId, initialWidgets, initialWidgetsKey]);
+  }, [urlSessionId, initialWidgets, initialWidgetsKey, flushLayout]);
 
   useEffect(() => {
     return eventBus.on<{ appId: string }>("app:installed", ({ appId }) => {
@@ -326,80 +230,9 @@ export function FreeGrid() {
       // path (no force) still respects that close.
       if (payload.force) suppressProjectsRef.current = false;
       else if (suppressProjectsRef.current) return;
-      autoPlaceProjects();
+      autoPlaceProjects(payload.force === true);
     });
   }, [eventBus]);
-
-  // Scroll to end of strip when a widget is added; on mobile, jump to the
-  // newly added widget's tab.
-  const prevCountRef = useRef(placements.length);
-  useEffect(() => {
-    if (placements.length > prevCountRef.current) {
-      const newest = [...placements].sort((a, b) => b.order - a.order)[0];
-      // An app widget often opens *alongside* an in-progress draft (an agent
-      // `show_app` placed a glanceable surface mid-turn). Stealing the mobile
-      // tab would hide the composer, so keep chat focused for apps and let the
-      // user reveal them; user-added builtins (projects/desktop) still jump.
-      if (newest && newest.type !== "app") setMobileTab(newest.id);
-      if (stripRef.current) {
-        requestAnimationFrame(() => {
-          const el = stripRef.current;
-          if (el) el.scrollTo({ left: el.scrollWidth });
-        });
-      }
-    } else if (placements.length === 0) {
-      setMobileTab("chat");
-    }
-    prevCountRef.current = placements.length;
-  }, [placements]);
-
-  // If the active mobile tab's widget gets removed, fall back to chat.
-  useEffect(() => {
-    if (mobileTab !== "chat" && !placements.some((p) => p.id === mobileTab)) {
-      setMobileTab("chat");
-    }
-  }, [placements, mobileTab]);
-
-  const hasApps = placements.length > 0;
-  const isDragging = activeId !== null;
-
-  useEffect(() => {
-    const el = stripRef.current;
-    if (!el || !hasApps) return;
-    const observer = new ResizeObserver(([entry]) => {
-      const w = entry.contentBoxSize[0].inlineSize;
-      setItemMinWidth(Math.max(STRIP_ITEM_MIN_WIDTH, Math.floor((w - 8) / 2)));
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [hasApps]);
-
-  const sorted = useMemo(() => [...placements].sort((a, b) => a.order - b.order), [placements]);
-  const sortedIds = useMemo(() => sorted.map((p) => p.id), [sorted]);
-
-  const sensors = useSensors(
-    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(TouchSensor, { activationConstraint: { distance: 5 } }),
-  );
-
-  const handleDragStart = useCallback((event: DragStartEvent) => {
-    setActiveId(String(event.active.id));
-  }, []);
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (over && active.id !== over.id) {
-        moveWidget(String(active.id), String(over.id));
-      }
-      setActiveId(null);
-    },
-    [moveWidget],
-  );
-
-  const handleDragCancel = useCallback(() => {
-    setActiveId(null);
-  }, []);
 
   // Persist each app tile's live in-app location back onto its placement so the
   // addressed screen survives a reload. AppWidget freezes its `src` at mount, so
@@ -409,23 +242,16 @@ export function FreeGrid() {
   // `pagehide` (desktop reload). Same-origin reads only; cross-origin tiles
   // resolve to null and keep their stored link.
   useEffect(() => {
-    const flush = () => {
-      for (const p of placementsRef.current) {
-        if (p.type !== "app") continue;
-        const link = workspaceContextRegistry.resolveLink(p.id);
-        if (link) updatePlacementLink(p.id, link.route, link.params);
-      }
-    };
     const onVisibility = () => {
-      if (document.visibilityState === "hidden") flush();
+      if (document.visibilityState === "hidden") flushLayout();
     };
-    window.addEventListener("pagehide", flush);
+    window.addEventListener("pagehide", flushLayout);
     document.addEventListener("visibilitychange", onVisibility);
     return () => {
-      window.removeEventListener("pagehide", flush);
+      window.removeEventListener("pagehide", flushLayout);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [workspaceContextRegistry]);
+  }, [flushLayout]);
 
   useEffect(() => {
     return workspaceStore.subscribe<string | null>("activeTurnId", (value) => {
@@ -488,20 +314,31 @@ export function FreeGrid() {
     <WorkspaceEventBusContext.Provider value={eventBus}>
       <WorkspaceStoreContext.Provider value={workspaceStore}>
         <WorkspaceContextRegistryContext.Provider value={workspaceContextRegistry}>
-          {/*
-          Chat-as-base layout with mobile tab switching:
-          - Desktop (md+): chat is a fluid column (CHAT_COLUMN_WIDTH); apps slide
-            in from the right as an overlay positioned flush against the chat.
-          - Mobile: chat and apps each take the full viewport, and a bottom
-            tab pill switches between them. Adding a widget auto-switches
-            to the Apps tab.
-        */}
-          <div
-            style={{ "--rome-chat-col": CHAT_COLUMN_WIDTH } as CSSProperties}
-            className={`relative flex min-h-0 flex-1 flex-col transition-[width] duration-300 ${
-              hasApps ? "md:w-[var(--rome-chat-col)]" : "w-full"
-            } ${mobileTab !== "chat" ? "max-md:hidden" : ""}`}
+          <ToolWorkspace
+            placements={placements}
+            view={toolView}
+            selectTool={selectTool}
+            setCollapsed={setToolsCollapsed}
+            addWidget={addWidget}
+            removeWidget={handleRemoveWidget}
+            label={widgetLabel}
+            icon={(widget) => <WidgetIcon widget={widget} />}
+            content={(widget, dragging) => (
+              <WidgetContent widget={widget} dragging={dragging} sessionId={chatSessionId} />
+            )}
           >
+            {!chatSessionId && (
+              <div className="flex h-12 shrink-0 items-center justify-end border-b border-border px-2 max-md:hidden">
+                <IconButton
+                  size="sm"
+                  data-coach={toolView.collapsed ? "add-widget" : undefined}
+                  aria-expanded={!toolView.collapsed}
+                  onClick={() => setToolsCollapsed(false)}
+                  label={t("chat.expandTools")}
+                  icon={<PanelRightOpen />}
+                />
+              </div>
+            )}
             <ChatWidget
               sessionId={chatSessionId}
               onSessionChosen={handleSessionChosen}
@@ -510,155 +347,30 @@ export function FreeGrid() {
               initialDraftText={initialDraftText}
               initialSkillName={initialSkillName}
             />
-          </div>
+          </ToolWorkspace>
 
-          {/* Apps overlay — slides in from the right above the chat.
-            On md+ it sits flush against the chat; its left offset is the
-            sidebar width the shell publishes as --rome-chat-left (16rem
-            expanded, 4rem collapsed, 0 hidden) plus the chat column width. The
-            calc lives in the inline style (plain CSS) so Tailwind's
-            arbitrary-value operator spacing never mangles the var names. On
-            mobile it covers the full screen, toggled via the bottom tab pill. */}
-          <AnimatePresence>
-            {hasApps && (
-              <motion.aside
-                key="apps-overlay"
-                initial={{ x: "100%" }}
-                animate={{ x: 0 }}
-                exit={{ x: "100%" }}
-                transition={
-                  prefersReducedMotion
-                    ? { duration: 0 }
-                    : { type: "spring", stiffness: 320, damping: 32 }
-                }
-                style={
-                  {
-                    "--rome-apps-left": `calc(var(--rome-chat-left, 16rem) + ${CHAT_COLUMN_WIDTH})`,
-                  } as CSSProperties
-                }
-                className={`fixed inset-0 z-20 bg-background md:h-dvh md:left-[var(--rome-apps-left)] max-md:top-[var(--rome-mobile-header-height)] ${
-                  mobileTab === "chat" ? "max-md:hidden" : ""
-                }`}
-              >
-                <DndContext
-                  sensors={sensors}
-                  collisionDetection={closestCenter}
-                  onDragStart={handleDragStart}
-                  onDragEnd={handleDragEnd}
-                  onDragCancel={handleDragCancel}
-                >
-                  <SortableContext items={sortedIds} strategy={horizontalListSortingStrategy}>
-                    <div
-                      ref={stripRef}
-                      className="flex h-full gap-2 overflow-x-auto overscroll-x-contain p-2 max-md:flex-col max-md:overflow-x-visible max-md:overflow-y-auto"
-                    >
-                      {sorted.map((widget) => (
-                        <SortableWidgetCard
-                          key={widget.id}
-                          widget={widget}
-                          activeId={activeId}
-                          dragging={isDragging}
-                          onRemove={() => handleRemoveWidget(widget.id)}
-                          minWidth={itemMinWidth}
-                          mobileHidden={widget.id !== mobileTab}
-                          sessionId={chatSessionId}
-                        />
-                      ))}
-                    </div>
-                  </SortableContext>
-                </DndContext>
-              </motion.aside>
-            )}
-          </AnimatePresence>
-
-          {/* Mobile header bar — portaled into the shell's top header so the chat
-            route shows one cohesive bar (like the desktop chat navbar) instead
-            of the generic Rome wordmark. The leading center region is the
-            session identity when there are no apps, and a horizontally-scrolling
-            [Chat] [App1] [App2] … tab strip once apps are open. The trailing
-            "+" / "⋯" mirror the desktop navbar actions. */}
           <SlotContent name="mobileHeader">
-            {hasApps ? (
-              <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
-                <button
-                  type="button"
-                  onClick={() => setMobileTab("chat")}
-                  className={`flex shrink-0 items-center gap-1 rounded-full px-3 py-1 text-aux transition ${
-                    mobileTab === "chat"
-                      ? "bg-surface-hover text-foreground"
-                      : "text-subtle-foreground hover:text-foreground"
-                  }`}
-                >
-                  <MessageSquare className="h-3.5 w-3.5" />
-                  <span>{t("nav.chat")}</span>
-                </button>
-                {sorted.map((widget) => {
-                  const active = mobileTab === widget.id;
-                  return (
-                    <div
-                      key={widget.id}
-                      className={`flex shrink-0 items-center rounded-full text-aux transition ${
-                        active ? "bg-surface-hover text-foreground" : "text-subtle-foreground"
-                      }`}
-                    >
-                      <button
-                        type="button"
-                        onClick={() => setMobileTab(widget.id)}
-                        className="flex items-center gap-1 rounded-full py-1 pl-3 pr-2"
-                      >
-                        <WidgetIcon widget={widget} />
-                        <WidgetLabel widget={widget} />
-                      </button>
-                      {active && (
-                        <button
-                          type="button"
-                          onClick={() => handleRemoveWidget(widget.id)}
-                          className="-ml-1 mr-1 rounded-full p-1 hover:text-foreground"
-                          aria-label={t("sidebar.remove")}
-                          title={t("sidebar.remove")}
-                        >
-                          <X className="h-3 w-3" />
-                        </button>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="flex min-w-0 flex-1 items-center gap-2">
-                <AgentAvatar
-                  iconUrl={pinnedAgentMention?.iconUrl}
-                  label={pinnedAgentMention?.appLabel}
-                  size="sm"
-                  className="shrink-0"
-                />
-                <div className="flex min-w-0 flex-1 flex-col">
-                  <span className="truncate text-ui text-foreground">
-                    {sessionName?.trim() ||
-                      pinnedAgentMention?.appLabel ||
-                      t("recentChats.newChat")}
-                  </span>
-                  <div className="flex min-w-0 items-center gap-2">
-                    <SessionModelLabel model={model} />
-                    {sessionName?.trim() && pinnedAgentMention && (
-                      <span className="truncate text-aux text-muted-foreground">
-                        {pinnedAgentMention.appLabel}
-                      </span>
-                    )}
-                  </div>
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <AgentAvatar
+                iconUrl={pinnedAgentMention?.iconUrl}
+                label={pinnedAgentMention?.appLabel}
+                size="sm"
+                className="shrink-0"
+              />
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-ui text-foreground">
+                  {sessionName?.trim() || pinnedAgentMention?.appLabel || t("recentChats.newChat")}
+                </span>
+                <div className="flex min-w-0 items-center gap-2">
+                  <SessionModelLabel model={model} />
+                  {sessionName?.trim() && pinnedAgentMention && (
+                    <span className="truncate text-aux text-muted-foreground">
+                      {pinnedAgentMention.appLabel}
+                    </span>
+                  )}
                 </div>
               </div>
-            )}
-            <WidgetPicker
-              onSelect={(type: WidgetType, targetId?: string) => addWidget(type, targetId)}
-            >
-              <IconButton
-                size="md"
-                label={t("chat.add")}
-                icon={<Plus />}
-                className="text-muted-foreground hover:text-foreground"
-              />
-            </WidgetPicker>
+            </div>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <IconButton
@@ -687,6 +399,23 @@ export function FreeGrid() {
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
+            <IconButton
+              size="md"
+              label={t("chat.expandTools")}
+              aria-expanded={!toolView.collapsed}
+              icon={
+                <span className="relative">
+                  <PanelRightOpen />
+                  {toolView.unreadIds.length > 0 && (
+                    <span
+                      className="absolute -right-1 -top-1 size-1.5 rounded-full bg-info"
+                      aria-label={t("chat.toolUpdated")}
+                    />
+                  )}
+                </span>
+              }
+              onClick={() => setToolsCollapsed(false)}
+            />
           </SlotContent>
         </WorkspaceContextRegistryContext.Provider>
       </WorkspaceStoreContext.Provider>

--- a/packages/web/src/pages/free/FreeGrid.tsx
+++ b/packages/web/src/pages/free/FreeGrid.tsx
@@ -7,6 +7,7 @@ import {
   Pin,
   PinOff,
   PanelRightOpen,
+  PanelRightClose,
   Share2,
   Trash2,
 } from "lucide-react";
@@ -329,14 +330,16 @@ export function FreeGrid() {
           >
             {!chatSessionId && (
               <div className="flex h-12 shrink-0 items-center justify-end border-b border-border px-2 max-md:hidden">
-                <IconButton
-                  size="sm"
-                  data-coach={toolView.collapsed ? "add-widget" : undefined}
-                  aria-expanded={!toolView.collapsed}
-                  onClick={() => setToolsCollapsed(false)}
-                  label={t("chat.expandTools")}
-                  icon={<PanelRightOpen />}
-                />
+                {toolView.collapsed && (
+                  <IconButton
+                    size="sm"
+                    data-coach="add-widget"
+                    aria-expanded={false}
+                    onClick={() => setToolsCollapsed(false)}
+                    label={t("chat.expandTools")}
+                    icon={<PanelRightOpen />}
+                  />
+                )}
               </div>
             )}
             <ChatWidget
@@ -401,12 +404,12 @@ export function FreeGrid() {
             </DropdownMenu>
             <IconButton
               size="md"
-              label={t("chat.expandTools")}
+              label={t(toolView.collapsed ? "chat.expandTools" : "chat.collapseTools")}
               aria-expanded={!toolView.collapsed}
               icon={
                 <span className="relative">
-                  <PanelRightOpen />
-                  {toolView.unreadIds.length > 0 && (
+                  {toolView.collapsed ? <PanelRightOpen /> : <PanelRightClose />}
+                  {toolView.collapsed && toolView.unreadIds.length > 0 && (
                     <span
                       className="absolute -right-1 -top-1 size-1.5 rounded-full bg-info"
                       aria-label={t("chat.toolUpdated")}
@@ -414,7 +417,7 @@ export function FreeGrid() {
                   )}
                 </span>
               }
-              onClick={() => setToolsCollapsed(false)}
+              onClick={() => setToolsCollapsed(!toolView.collapsed)}
             />
           </SlotContent>
         </WorkspaceContextRegistryContext.Provider>

--- a/packages/web/src/pages/free/ToolWorkspace.test.tsx
+++ b/packages/web/src/pages/free/ToolWorkspace.test.tsx
@@ -1,0 +1,146 @@
+// @rstest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, rs } from "@rstest/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
+import i18n from "@/i18n";
+import { ToolWorkspace } from "./ToolWorkspace";
+import type { ToolView, WidgetPlacement } from "./use-free-cells";
+
+rs.mock("@/hooks/use-apps", () => ({ useApps: () => ({ apps: [] }) }));
+
+let viewportWidth = 1200;
+const mounted = rs.fn();
+function ToolContent({ id }: { id: string }) {
+  useEffect(() => {
+    mounted(id);
+  }, [id]);
+  return <input aria-label={`Draft ${id}`} defaultValue="" />;
+}
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+  Element.prototype.scrollIntoView = () => {};
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+});
+
+beforeEach(() => {
+  mounted.mockClear();
+  localStorage.clear();
+  viewportWidth = 1200;
+  rs.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(private callback: ResizeObserverCallback) {}
+      observe(target: Element) {
+        if (target.getAttribute("data-testid") === "tool-workspace") {
+          this.callback(
+            [{ target, contentRect: { width: viewportWidth } } as ResizeObserverEntry],
+            this as unknown as ResizeObserver,
+          );
+        }
+      }
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+afterEach(() => {
+  cleanup();
+  rs.unstubAllGlobals();
+});
+
+const placements: WidgetPlacement[] = [
+  { id: "a", type: "desktop", order: 0 },
+  { id: "b", type: "projects", order: 1 },
+];
+
+function workspace(view: ToolView, items = placements, addWidget = rs.fn()) {
+  return (
+    <ToolWorkspace
+      placements={items}
+      view={view}
+      selectTool={rs.fn()}
+      setCollapsed={rs.fn()}
+      addWidget={addWidget}
+      removeWidget={rs.fn()}
+      label={(widget) => widget.type}
+      icon={() => null}
+      content={(widget) => <ToolContent id={widget.id} />}
+    >
+      <input aria-label="Chat draft" />
+    </ToolWorkspace>
+  );
+}
+
+describe("ToolWorkspace", () => {
+  it("guides an empty workspace into opening its first app", async () => {
+    const user = userEvent.setup();
+    const addWidget = rs.fn();
+    render(workspace({ activeId: null, collapsed: false, unreadIds: [] }, [], addWidget));
+    expect(screen.getByRole("heading", { name: "No apps open" })).toBeTruthy();
+    expect(screen.getByRole("textbox", { name: "Chat draft" })).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Open an app" }));
+    await user.click(screen.getByRole("option", { name: "Projects" }));
+    expect(addWidget).toHaveBeenCalledWith("projects", undefined);
+  });
+
+  it("keeps draft state and mounted contents across switching, reordering and collapse", async () => {
+    const user = userEvent.setup();
+    const view = { activeId: "a", collapsed: false, unreadIds: [] };
+    const { rerender } = render(workspace(view));
+    const first = screen.getByRole("textbox", { name: "Draft a" });
+    await user.type(first, "unfinished work");
+    expect(screen.queryByRole("textbox", { name: "Draft b" })).toBeNull();
+    rerender(workspace({ ...view, activeId: "b" }));
+    expect(screen.queryByRole("textbox", { name: "Draft a" })).toBeNull();
+    expect(screen.getAllByRole("tabpanel")).toHaveLength(1);
+    rerender(
+      workspace({ ...view, activeId: "b" }, [
+        { ...placements[1], order: 0 },
+        { ...placements[0], order: 1 },
+      ]),
+    );
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "projects",
+      "desktop",
+    ]);
+    rerender(workspace({ ...view, collapsed: true }));
+    expect(screen.queryByRole("tabpanel")).toBeNull();
+    rerender(workspace(view));
+    expect(screen.getByRole("textbox", { name: "Draft a" })).toBe(first);
+    expect((first as HTMLInputElement).value).toBe("unfinished work");
+    expect(mounted).toHaveBeenCalledTimes(2);
+  });
+
+  it("adjusts and resets the separator with the keyboard without losing chat input", async () => {
+    const user = userEvent.setup();
+    render(workspace({ activeId: "a", collapsed: false, unreadIds: [] }));
+    await user.type(screen.getByRole("textbox", { name: "Chat draft" }), "keep this prompt");
+    const separator = screen.getByRole("separator");
+    const initial = Number(separator.getAttribute("aria-valuenow"));
+    separator.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(Number(separator.getAttribute("aria-valuenow"))).toBe(initial + 24);
+    expect(Number(localStorage.getItem("rome:tool-chat-ratio"))).toBeGreaterThan(0.4);
+    await user.keyboard("{Home}");
+    expect(Number(separator.getAttribute("aria-valuenow"))).toBe(initial);
+    expect((screen.getByRole("textbox", { name: "Chat draft" }) as HTMLInputElement).value).toBe(
+      "keep this prompt",
+    );
+  });
+
+  it("shows one surface at a time in a narrow workspace", () => {
+    viewportWidth = 390;
+    const view = { activeId: "a", collapsed: false, unreadIds: [] };
+    const { rerender } = render(workspace(view));
+    expect(screen.queryByRole("separator")).toBeNull();
+    expect(screen.queryByRole("textbox", { name: "Chat draft" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Chat", exact: true })).toBeTruthy();
+    rerender(workspace({ ...view, collapsed: true }));
+    expect(screen.getByRole("textbox", { name: "Chat draft" })).toBeTruthy();
+    expect(screen.queryByRole("tabpanel")).toBeNull();
+  });
+});

--- a/packages/web/src/pages/free/ToolWorkspace.test.tsx
+++ b/packages/web/src/pages/free/ToolWorkspace.test.tsx
@@ -138,7 +138,7 @@ describe("ToolWorkspace", () => {
     const { rerender } = render(workspace(view));
     expect(screen.queryByRole("separator")).toBeNull();
     expect(screen.queryByRole("textbox", { name: "Chat draft" })).toBeNull();
-    expect(screen.getByRole("button", { name: "Chat", exact: true })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Chat", exact: true })).toBeNull();
     rerender(workspace({ ...view, collapsed: true }));
     expect(screen.getByRole("textbox", { name: "Chat draft" })).toBeTruthy();
     expect(screen.queryByRole("tabpanel")).toBeNull();

--- a/packages/web/src/pages/free/ToolWorkspace.tsx
+++ b/packages/web/src/pages/free/ToolWorkspace.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, LayoutGrid, MessageSquare, PanelRightClose, Plus, X } from "lucide-react";
+import { ChevronDown, LayoutGrid, PanelRightClose, Plus, X } from "lucide-react";
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -223,14 +223,6 @@ export function ToolWorkspace({
         style={{ display: open ? undefined : "none" }}
       >
         <div className="flex h-12 shrink-0 items-center gap-1 border-b border-border px-2">
-          {compact && (
-            <IconButton
-              size="sm"
-              label={t("nav.chat")}
-              icon={<MessageSquare />}
-              onClick={() => setCollapsed(true)}
-            />
-          )}
           {sorted.length > 0 ? (
             <TabsList
               aria-label={t("chat.tools")}
@@ -278,14 +270,14 @@ export function ToolWorkspace({
               <IconButton size="sm" data-coach="add-widget" label={t("chat.add")} icon={<Plus />} />
             </WidgetPicker>
           )}
-          {!compact && (
-            <IconButton
-              size="sm"
-              label={t("chat.collapseTools")}
-              icon={<PanelRightClose />}
-              onClick={() => setCollapsed(true)}
-            />
-          )}
+          <IconButton
+            size="sm"
+            className="max-md:hidden"
+            label={t("chat.collapseTools")}
+            aria-expanded={true}
+            icon={<PanelRightClose />}
+            onClick={() => setCollapsed(true)}
+          />
         </div>
         <div className="relative min-h-0 flex-1">
           {placements.length === 0 && (

--- a/packages/web/src/pages/free/ToolWorkspace.tsx
+++ b/packages/web/src/pages/free/ToolWorkspace.tsx
@@ -23,7 +23,8 @@ import type { ToolView, WidgetPlacement, WidgetType } from "./use-free-cells";
 const WIDTH_KEY = "rome:tool-chat-ratio";
 const DEFAULT_RATIO = 0.4;
 const MIN_PANE_WIDTH = 360;
-const COMPACT_WIDTH = MIN_PANE_WIDTH * 2 + 8;
+const SEPARATOR_WIDTH = 1;
+const COMPACT_WIDTH = MIN_PANE_WIDTH * 2 + SEPARATOR_WIDTH;
 
 function readRatio() {
   try {
@@ -120,7 +121,7 @@ export function ToolWorkspace({
   const sorted = [...placements].sort((a, b) => a.order - b.order);
   const compact = width < COMPACT_WIDTH;
   const open = !view.collapsed;
-  const available = Math.max(0, width - 8);
+  const available = Math.max(0, width - SEPARATOR_WIDTH);
   const chatWidth = Math.max(
     MIN_PANE_WIDTH,
     Math.min(available - MIN_PANE_WIDTH, available * ratio),
@@ -185,7 +186,8 @@ export function ToolWorkspace({
           aria-valuemin={MIN_PANE_WIDTH}
           aria-valuemax={Math.round(available - MIN_PANE_WIDTH)}
           aria-valuenow={Math.round(chatWidth)}
-          className="z-40 w-2 shrink-0 cursor-col-resize touch-none border-x border-border-subtle hover:bg-surface-hover focus-visible:outline-2 focus-visible:outline-ring"
+          data-resizing={resizing || undefined}
+          className="relative z-40 w-px shrink-0 cursor-col-resize touch-none before:absolute before:inset-y-0 before:-inset-x-1 after:pointer-events-none after:absolute after:inset-y-0 after:left-1/2 after:w-px after:-translate-x-1/2 after:bg-border-subtle after:transition-[width] hover:after:w-1 focus-visible:outline-2 focus-visible:outline-ring focus-visible:after:w-1 data-[resizing]:after:w-1"
           onDoubleClick={() => changeRatio(DEFAULT_RATIO)}
           onPointerDown={(event) => {
             if (event.button !== 0) return;

--- a/packages/web/src/pages/free/ToolWorkspace.tsx
+++ b/packages/web/src/pages/free/ToolWorkspace.tsx
@@ -50,13 +50,16 @@ function ToolTab({ widget, label, icon, active, unread, onClose }: ToolTabProps)
   }, [active]);
 
   return (
-    <div ref={tabRef} className="relative flex h-10 shrink-0 items-center gap-1">
+    <div
+      ref={tabRef}
+      className={`relative flex h-9 shrink-0 items-center gap-1 rounded-12 pr-1 transition-colors ${active ? "bg-surface-muted" : ""}`}
+    >
       <TabsTrigger
         value={widget.id}
         role="tab"
         aria-selected={active}
         title={label}
-        className="max-w-48 gap-2 group-data-horizontal/tabs:after:bottom-0"
+        className="h-full max-w-48 gap-2 after:hidden"
         onKeyDown={(event) => {
           if (event.key === "Delete") {
             event.preventDefault();

--- a/packages/web/src/pages/free/ToolWorkspace.tsx
+++ b/packages/web/src/pages/free/ToolWorkspace.tsx
@@ -1,0 +1,330 @@
+import { ChevronDown, LayoutGrid, MessageSquare, PanelRightClose, Plus, X } from "lucide-react";
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import {
+  EmptyState,
+  EmptyStateAction,
+  EmptyStateDescription,
+  EmptyStateIcon,
+  EmptyStateTitle,
+} from "@/components/ui/empty-state";
+import { IconButton } from "@/components/ui/icon-button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { WidgetPicker } from "./WidgetPicker";
+import type { ToolView, WidgetPlacement, WidgetType } from "./use-free-cells";
+
+const WIDTH_KEY = "rome:tool-chat-ratio";
+const DEFAULT_RATIO = 0.4;
+const MIN_PANE_WIDTH = 360;
+const COMPACT_WIDTH = MIN_PANE_WIDTH * 2 + 8;
+
+function readRatio() {
+  try {
+    const value = Number(localStorage.getItem(WIDTH_KEY));
+    if (value >= 0.2 && value <= 0.8) return value;
+  } catch {}
+  return DEFAULT_RATIO;
+}
+
+interface ToolTabProps {
+  widget: WidgetPlacement;
+  label: string;
+  icon: ReactNode;
+  active: boolean;
+  unread: boolean;
+  onClose: () => void;
+}
+
+function ToolTab({ widget, label, icon, active, unread, onClose }: ToolTabProps) {
+  const { t } = useTranslation("common");
+  const tabRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (active) tabRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [active]);
+
+  return (
+    <div ref={tabRef} className="relative flex h-10 shrink-0 items-center gap-1">
+      <TabsTrigger
+        value={widget.id}
+        role="tab"
+        aria-selected={active}
+        title={label}
+        className="max-w-48 gap-2 group-data-horizontal/tabs:after:bottom-0"
+        onKeyDown={(event) => {
+          if (event.key === "Delete") {
+            event.preventDefault();
+            onClose();
+          }
+        }}
+      >
+        {icon}
+        <span className="truncate">{label}</span>
+        {unread && (
+          <span
+            className="size-1.5 shrink-0 rounded-full bg-info"
+            aria-label={t("chat.toolUpdated")}
+          />
+        )}
+      </TabsTrigger>
+      <IconButton
+        size="xs"
+        icon={<X />}
+        label={t("chat.closeTool", { name: label })}
+        onClick={onClose}
+        className="text-subtle-foreground"
+      />
+    </div>
+  );
+}
+
+interface ToolWorkspaceProps {
+  placements: WidgetPlacement[];
+  view: ToolView;
+  selectTool: (id: string) => void;
+  setCollapsed: (collapsed: boolean) => void;
+  addWidget: (type: WidgetType, targetId?: string) => void;
+  removeWidget: (id: string) => void;
+  label: (widget: WidgetPlacement) => string;
+  icon: (widget: WidgetPlacement) => ReactNode;
+  content: (widget: WidgetPlacement, dragging: boolean) => ReactNode;
+  children: ReactNode;
+}
+
+export function ToolWorkspace({
+  placements,
+  view,
+  selectTool,
+  setCollapsed,
+  addWidget,
+  removeWidget,
+  label,
+  icon,
+  content,
+  children,
+}: ToolWorkspaceProps) {
+  const { t } = useTranslation("common");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+  const [ratio, setRatio] = useState(readRatio);
+  const [resizing, setResizing] = useState(false);
+  const sorted = [...placements].sort((a, b) => a.order - b.order);
+  const compact = width < COMPACT_WIDTH;
+  const open = !view.collapsed;
+  const available = Math.max(0, width - 8);
+  const chatWidth = Math.max(
+    MIN_PANE_WIDTH,
+    Math.min(available - MIN_PANE_WIDTH, available * ratio),
+  );
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const observer = new ResizeObserver(([entry]) => setWidth(entry.contentRect.width));
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, []);
+
+  function changeRatio(next: number) {
+    const constrained = Math.max(0.2, Math.min(0.8, next));
+    setRatio(constrained);
+    try {
+      localStorage.setItem(WIDTH_KEY, String(constrained));
+    } catch {}
+  }
+
+  function closeTab(id: string) {
+    const focused = document.activeElement;
+    const restoreFocus =
+      focused instanceof Element &&
+      rootRef.current?.contains(focused) &&
+      (focused.closest('[role="tablist"]') || focused.closest('[role="tabpanel"]'));
+    removeWidget(id);
+    if (restoreFocus)
+      requestAnimationFrame(() => {
+        const target =
+          rootRef.current?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]') ??
+          rootRef.current?.querySelector<HTMLElement>('[data-coach="add-widget"]');
+        target?.focus();
+      });
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      data-testid="tool-workspace"
+      className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden"
+      style={{ "--rome-chat-col": open && !compact ? `${chatWidth}px` : "100%" } as CSSProperties}
+    >
+      <div
+        className="relative flex min-h-0 min-w-0 flex-col"
+        data-testid="workspace-chat"
+        style={{
+          display: compact && open ? "none" : undefined,
+          width: open && !compact ? chatWidth : "100%",
+          flexShrink: 0,
+        }}
+      >
+        {children}
+      </div>
+      {open && !compact && (
+        <div
+          role="separator"
+          tabIndex={0}
+          aria-label={t("chat.resizeTools")}
+          aria-orientation="vertical"
+          aria-valuemin={MIN_PANE_WIDTH}
+          aria-valuemax={Math.round(available - MIN_PANE_WIDTH)}
+          aria-valuenow={Math.round(chatWidth)}
+          className="z-40 w-2 shrink-0 cursor-col-resize touch-none border-x border-border-subtle hover:bg-surface-hover focus-visible:outline-2 focus-visible:outline-ring"
+          onDoubleClick={() => changeRatio(DEFAULT_RATIO)}
+          onPointerDown={(event) => {
+            if (event.button !== 0) return;
+            event.preventDefault();
+            event.currentTarget.setPointerCapture(event.pointerId);
+            setResizing(true);
+          }}
+          onPointerMove={(event) => {
+            if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+            const left = rootRef.current?.getBoundingClientRect().left ?? 0;
+            changeRatio(
+              Math.max(MIN_PANE_WIDTH, Math.min(available - MIN_PANE_WIDTH, event.clientX - left)) /
+                available,
+            );
+          }}
+          onPointerUp={(event) => {
+            if (event.currentTarget.hasPointerCapture(event.pointerId))
+              event.currentTarget.releasePointerCapture(event.pointerId);
+            setResizing(false);
+          }}
+          onLostPointerCapture={() => setResizing(false)}
+          onKeyDown={(event) => {
+            if (!["ArrowLeft", "ArrowRight", "Home"].includes(event.key)) return;
+            event.preventDefault();
+            changeRatio(
+              event.key === "Home"
+                ? DEFAULT_RATIO
+                : (chatWidth + (event.key === "ArrowLeft" ? -24 : 24)) / available,
+            );
+          }}
+        />
+      )}
+      <Tabs
+        value={view.activeId ?? ""}
+        onValueChange={selectTool}
+        activationMode="automatic"
+        className="min-h-0 min-w-0 flex-1 gap-0 bg-background"
+        style={{ display: open ? undefined : "none" }}
+      >
+        <div className="flex h-12 shrink-0 items-center gap-1 border-b border-border px-2">
+          {compact && (
+            <IconButton
+              size="sm"
+              label={t("nav.chat")}
+              icon={<MessageSquare />}
+              onClick={() => setCollapsed(true)}
+            />
+          )}
+          {sorted.length > 0 ? (
+            <TabsList
+              aria-label={t("chat.tools")}
+              className="min-w-0 flex-1 justify-start overflow-x-auto p-0 group-data-horizontal/tabs:h-full"
+            >
+              {sorted.map((widget) => (
+                <ToolTab
+                  key={widget.id}
+                  widget={widget}
+                  label={label(widget)}
+                  icon={icon(widget)}
+                  active={widget.id === view.activeId}
+                  unread={view.unreadIds.includes(widget.id)}
+                  onClose={() => closeTab(widget.id)}
+                />
+              ))}
+            </TabsList>
+          ) : (
+            <span className="flex h-full flex-1 items-center px-2 text-ui text-muted-foreground">
+              {t("chat.tools")}
+            </span>
+          )}
+          {sorted.length > 0 && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <IconButton size="sm" label={t("chat.allTools")} icon={<ChevronDown />} />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {sorted.map((widget) => (
+                  <DropdownMenuItem key={widget.id} onSelect={() => selectTool(widget.id)}>
+                    {icon(widget)}
+                    {label(widget)}
+                    {view.unreadIds.includes(widget.id) && (
+                      <span className="ml-auto text-aux text-muted-foreground">
+                        {t("chat.toolUpdated")}
+                      </span>
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+          {sorted.length > 0 && (
+            <WidgetPicker onSelect={addWidget} placements={placements}>
+              <IconButton size="sm" data-coach="add-widget" label={t("chat.add")} icon={<Plus />} />
+            </WidgetPicker>
+          )}
+          {!compact && (
+            <IconButton
+              size="sm"
+              label={t("chat.collapseTools")}
+              icon={<PanelRightClose />}
+              onClick={() => setCollapsed(true)}
+            />
+          )}
+        </div>
+        <div className="relative min-h-0 flex-1">
+          {placements.length === 0 && (
+            <EmptyState className="h-full" role="region">
+              <EmptyStateIcon>
+                <LayoutGrid />
+              </EmptyStateIcon>
+              <EmptyStateTitle>{t("chat.emptyAppsTitle")}</EmptyStateTitle>
+              <EmptyStateDescription>{t("chat.emptyAppsDescription")}</EmptyStateDescription>
+              <EmptyStateAction>
+                <WidgetPicker onSelect={addWidget}>
+                  <Button data-coach="add-widget" variant="outline">
+                    <Plus data-icon="inline-start" />
+                    {t("chat.add")}
+                  </Button>
+                </WidgetPicker>
+              </EmptyStateAction>
+            </EmptyState>
+          )}
+          {/* Moving an iframe's DOM node reloads it. Keep content in a stable
+                order when loading a saved layout. */}
+          {[...placements]
+            .sort((a, b) => a.id.localeCompare(b.id))
+            .map((widget) => (
+              <TabsContent
+                key={widget.id}
+                value={widget.id}
+                forceMount
+                inert={widget.id !== view.activeId}
+                aria-hidden={widget.id !== view.activeId}
+                style={{ display: widget.id === view.activeId ? undefined : "none" }}
+                className="absolute inset-0 overflow-auto overscroll-y-contain pb-safe md:pb-0"
+              >
+                {content(widget, resizing)}
+              </TabsContent>
+            ))}
+        </div>
+      </Tabs>
+      {resizing && <div className="absolute inset-0 z-30 cursor-col-resize" />}
+    </div>
+  );
+}

--- a/packages/web/src/pages/free/WidgetPicker.test.tsx
+++ b/packages/web/src/pages/free/WidgetPicker.test.tsx
@@ -82,7 +82,7 @@ describe("WidgetPicker", () => {
     await user.type(search, "zzz");
 
     expect(optionNames()).toEqual([]);
-    expect(screen.getByText("No widgets match “zzz”.")).toBeTruthy();
+    expect(screen.getByText("No apps match “zzz”.")).toBeTruthy();
   });
 
   it("selects the app behind a searched row on Enter", async () => {

--- a/packages/web/src/pages/free/WidgetPicker.tsx
+++ b/packages/web/src/pages/free/WidgetPicker.tsx
@@ -12,14 +12,15 @@ import {
 import { EmptyState, EmptyStateTitle } from "@/components/ui/empty-state";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useApps } from "@/hooks/use-apps";
-import type { WidgetType } from "./use-free-cells";
+import type { WidgetPlacement, WidgetType } from "./use-free-cells";
 
 interface WidgetPickerProps {
   onSelect: (type: WidgetType, targetId?: string) => void;
   children: React.ReactNode;
+  placements?: WidgetPlacement[];
 }
 
-export function WidgetPicker({ onSelect, children }: WidgetPickerProps) {
+export function WidgetPicker({ onSelect, children, placements = [] }: WidgetPickerProps) {
   const { t } = useTranslation("common");
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -128,6 +129,11 @@ export function WidgetPicker({ onSelect, children }: WidgetPickerProps) {
                   >
                     {widget.icon}
                     {widget.label}
+                    {placements.some((p) => p.type === widget.type) && (
+                      <span className="ml-auto text-aux text-muted-foreground">
+                        {t("chat.toolOpened")}
+                      </span>
+                    )}
                   </CommandItem>
                 ))}
               </CommandGroup>
@@ -169,6 +175,11 @@ export function WidgetPicker({ onSelect, children }: WidgetPickerProps) {
                       </span>
                     )}
                     <span className="truncate">{app.displayName}</span>
+                    {placements.some((p) => p.type === "app" && p.targetId === app.id) && (
+                      <span className="ml-auto text-aux text-muted-foreground">
+                        {t("chat.toolOpened")}
+                      </span>
+                    )}
                   </CommandItem>
                 ))}
               </CommandGroup>

--- a/packages/web/src/pages/free/use-free-cells.test.ts
+++ b/packages/web/src/pages/free/use-free-cells.test.ts
@@ -1,15 +1,158 @@
 // @rstest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, rs } from "@rstest/core";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { setActiveSession } from "./use-free-cells";
 
 beforeEach(() => {
-  rs.resetModules();
   localStorage.clear();
+  setActiveSession("reset");
+  setActiveSession(null);
   rs.stubGlobal("fetch", rs.fn().mockResolvedValue(new Response(null, { status: 200 })));
 });
 
 afterEach(() => {
+  cleanup();
   rs.unstubAllGlobals();
   localStorage.clear();
+});
+
+describe("tool tabs", () => {
+  async function setup() {
+    const store = await import("./use-free-cells");
+    store.setActiveSession("workspace");
+    return { store, ...renderHook(() => store.useFreeCells()) };
+  }
+
+  it("opens an empty apps panel and restores it after loading or switching sessions", async () => {
+    const { store, result } = await setup();
+    act(() => result.current.setToolsCollapsed(false));
+    expect(result.current.toolView).toEqual({ activeId: null, collapsed: false, unreadIds: [] });
+    rs.mocked(fetch).mockResolvedValueOnce(Response.json({ layout: [] }));
+    await act(() => store.loadLayoutForSession("workspace"));
+    expect(result.current.toolView.collapsed).toBe(false);
+    act(() => store.setActiveSession("other"));
+    act(() => store.setActiveSession("workspace"));
+    expect(result.current.toolView.collapsed).toBe(false);
+    act(() => result.current.setToolsCollapsed(true));
+    expect(result.current.toolView.collapsed).toBe(true);
+  });
+
+  it("focuses an existing manual tool without replacing its route or id", async () => {
+    const { store, result } = await setup();
+    act(() => {
+      store.autoPlaceApp("notes", "draft", { id: 4 });
+    });
+    const id = result.current.placements[0].id;
+    act(() => result.current.addWidget("app", "notes"));
+    expect(result.current.placements).toEqual([
+      expect.objectContaining({ id, route: "draft", params: { id: 4 } }),
+    ]);
+    expect(result.current.toolView).toEqual({ activeId: id, collapsed: false, unreadIds: [] });
+    act(() => result.current.addWidget("app", "notes"));
+    expect(result.current.placements).toHaveLength(1);
+  });
+
+  it("keeps the current view and collapse state when an agent opens a tool", async () => {
+    const { store, result } = await setup();
+    act(() => result.current.addWidget("projects"));
+    const activeId = result.current.toolView.activeId;
+    act(() => {
+      store.autoPlaceApp("notes");
+    });
+    expect(result.current.toolView.activeId).toBe(activeId);
+    expect(result.current.toolView.unreadIds).toHaveLength(1);
+    act(() => result.current.setToolsCollapsed(true));
+    act(() => {
+      store.autoPlaceApp("calendar");
+    });
+    expect(result.current.toolView.collapsed).toBe(true);
+    expect(result.current.toolView.unreadIds).toHaveLength(2);
+  });
+
+  it("selects the right neighbor on close, then the left, and preserves selection on background close", async () => {
+    const { result } = await setup();
+    act(() => {
+      result.current.addWidget("desktop");
+      result.current.addWidget("projects");
+      result.current.addWidget("app", "notes");
+    });
+    const [browser, projects, notes] = result.current.placements;
+    act(() => result.current.selectTool(projects.id));
+    act(() => result.current.removeWidget(projects.id));
+    expect(result.current.toolView.activeId).toBe(notes.id);
+    act(() => result.current.removeWidget(browser.id));
+    expect(result.current.toolView.activeId).toBe(notes.id);
+    act(() => result.current.removeWidget(notes.id));
+    expect(result.current.toolView).toEqual({ activeId: null, collapsed: false, unreadIds: [] });
+  });
+
+  it("restores session selection and collapse state while retaining legacy duplicate views", async () => {
+    const { store, result } = await setup();
+    localStorage.setItem(
+      "rome:free-layout:legacy",
+      JSON.stringify([
+        { id: "a", type: "desktop", order: 0 },
+        { id: "b", type: "desktop", order: 1 },
+      ]),
+    );
+    act(() => store.setActiveSession("legacy"));
+    expect(result.current.placements).toHaveLength(2);
+    act(() => {
+      result.current.selectTool("b");
+      result.current.setToolsCollapsed(true);
+    });
+    act(() => store.setActiveSession("other"));
+    act(() => store.setActiveSession("legacy"));
+    expect(result.current.toolView).toEqual({ activeId: "b", collapsed: true, unreadIds: [] });
+    act(() => result.current.addWidget("desktop"));
+    expect(result.current.placements).toHaveLength(2);
+    expect(result.current.toolView.activeId).toBe("a");
+  });
+
+  it("keeps the active app selected when agent navigation changes its mount id", async () => {
+    const { store, result } = await setup();
+    act(() => result.current.addWidget("app", "notes"));
+    const before = result.current.toolView.activeId;
+    act(() => {
+      store.autoPlaceApp("notes", "another-page");
+    });
+    expect(result.current.placements).toHaveLength(1);
+    expect(result.current.toolView.activeId).not.toBe(before);
+    expect(result.current.toolView.activeId).toBe(result.current.placements[0].id);
+    expect(result.current.toolView.collapsed).toBe(false);
+  });
+
+  it("carries selected tools from a draft into its created session", async () => {
+    const { store, result } = await setup();
+    act(() => store.setActiveSession(null));
+    act(() => result.current.addWidget("desktop"));
+    const activeId = result.current.toolView.activeId;
+    act(() => store.setActiveSession("created"));
+    expect(result.current.toolView.activeId).toBe(activeId);
+    expect(result.current.toolView.collapsed).toBe(false);
+    expect(JSON.parse(localStorage.getItem("rome:tool-view:created") ?? "null").activeId).toBe(
+      activeId,
+    );
+  });
+
+  it("does not let a delayed layout load erase a newly opened tool", async () => {
+    const { store, result } = await setup();
+    let respond!: (response: Response) => void;
+    rs.mocked(fetch).mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          respond = resolve;
+        }),
+    );
+    const loading = store.loadLayoutForSession("workspace");
+    act(() => result.current.addWidget("desktop"));
+    await act(async () => {
+      respond(Response.json({ layout: [] }));
+      await loading;
+    });
+    expect(result.current.placements).toHaveLength(1);
+    expect(result.current.toolView.collapsed).toBe(false);
+  });
 });
 
 describe("placeWidgetsIfSessionActive", () => {

--- a/packages/web/src/pages/free/use-free-cells.test.ts
+++ b/packages/web/src/pages/free/use-free-cells.test.ts
@@ -69,6 +69,81 @@ describe("tool tabs", () => {
     expect(result.current.toolView.unreadIds).toHaveLength(2);
   });
 
+  it("navigates an existing app to its root when an explicit root link is opened", async () => {
+    const { store, result } = await setup();
+    act(() => store.autoPlaceApp("notes", "draft", { id: 4 }, true));
+    const previous = result.current.placements[0];
+    act(() => result.current.setToolsCollapsed(true));
+    act(() => store.autoPlaceApp("notes", undefined, undefined, true));
+    const current = result.current.placements[0];
+    expect(result.current.placements).toHaveLength(1);
+    expect(current).toEqual({
+      id: expect.any(String),
+      type: "app",
+      targetId: "notes",
+      order: previous.order,
+    });
+    expect(current.id).not.toBe(previous.id);
+    expect(result.current.toolView).toEqual({
+      activeId: current.id,
+      collapsed: false,
+      unreadIds: [],
+    });
+  });
+
+  it.each([
+    "inactive",
+    "collapsed",
+  ])("marks repeated passive Projects opens unread while %s without changing the view", async (visibility) => {
+    const { store, result } = await setup();
+    act(() => store.autoPlaceProjects(true));
+    const projects = result.current.placements[0];
+    act(() => {
+      if (visibility === "inactive") result.current.addWidget("desktop");
+      else result.current.setToolsCollapsed(true);
+    });
+    const before = result.current.toolView;
+    act(() => {
+      store.autoPlaceProjects();
+      store.autoPlaceProjects();
+    });
+    expect(result.current.placements[0]).toEqual(projects);
+    expect(result.current.toolView).toEqual({ ...before, unreadIds: [projects.id] });
+    expect(JSON.parse(localStorage.getItem("rome:tool-view:workspace") ?? "null")).toEqual(
+      result.current.toolView,
+    );
+    act(() => store.autoPlaceProjects(true));
+    expect(result.current.toolView).toEqual({
+      activeId: projects.id,
+      collapsed: false,
+      unreadIds: [],
+    });
+  });
+
+  it("does not mark visible Projects updates unread", async () => {
+    const { store, result } = await setup();
+    act(() => store.autoPlaceProjects(true));
+    const projects = result.current.placements[0];
+    act(() => {
+      store.autoPlaceProjects();
+      store.updateProjectsSelection(projects.id, "projects/default/report.md");
+    });
+    expect(result.current.toolView.unreadIds).toEqual([]);
+  });
+
+  it("marks a later file update unread after Projects was read and hidden in the same turn", async () => {
+    const { store, result } = await setup();
+    act(() => store.autoPlaceProjects(true));
+    const projects = result.current.placements[0];
+    act(() => {
+      store.updateProjectsSelection(projects.id, "projects/default/first.md");
+      result.current.addWidget("desktop");
+    });
+    const before = result.current.toolView;
+    act(() => store.updateProjectsSelection(projects.id, "projects/default/second.md"));
+    expect(result.current.toolView).toEqual({ ...before, unreadIds: [projects.id] });
+  });
+
   it("selects the right neighbor on close, then the left, and preserves selection on background close", async () => {
     const { result } = await setup();
     act(() => {

--- a/packages/web/src/pages/free/use-free-cells.ts
+++ b/packages/web/src/pages/free/use-free-cells.ts
@@ -37,7 +37,6 @@ export type WidgetSeed =
     };
 
 const STORAGE_PREFIX = "rome:free-layout:";
-export const STRIP_ITEM_MIN_WIDTH = 320;
 
 let listeners: Array<() => void> = [];
 let snapshot: WidgetPlacement[] = [];
@@ -132,7 +131,10 @@ function reconcileToolView(next: WidgetPlacement[]) {
     null;
   const unread = new Set(toolView.unreadIds);
   for (const p of next) {
-    if (!snapshot.some((previous) => previous.id === p.id)) unread.add(p.id);
+    const previous = snapshot.find((previous) => previous.id === p.id);
+    if (!previous || (p.type === "projects" && p.selectedPath !== previous.selectedPath)) {
+      unread.add(p.id);
+    }
   }
   saveToolView({
     activeId,
@@ -216,6 +218,13 @@ export function autoPlaceProjects(activate = false): string | null {
   const existing = current.find((p) => p.type === "projects");
   if (existing) {
     if (activate) selectTool(existing.id);
+    else if (
+      (toolView.collapsed || toolView.activeId !== existing.id) &&
+      !toolView.unreadIds.includes(existing.id)
+    ) {
+      saveToolView({ ...toolView, unreadIds: [...toolView.unreadIds, existing.id] });
+      notify();
+    }
     return existing.id;
   }
 
@@ -257,10 +266,6 @@ export function autoPlaceApp(
   // (`order`) so it doesn't jump, but mint a fresh id so the iframe remounts
   // at the new src.
   const existing = current.find((p) => p.type === "app" && p.targetId === appId);
-  if (existing && activate && route === undefined && params === undefined) {
-    selectTool(existing.id);
-    return existing.id;
-  }
   const order = existing ? existing.order : nextOrder(current);
   if (existing) {
     current = current.filter((p) => p.id !== existing.id);
@@ -433,22 +438,6 @@ export function updateProjectsSelection(placementId: string, selectedPath: strin
   );
 }
 
-export function reorderPlacements(
-  placements: WidgetPlacement[],
-  activeId: string,
-  overId: string,
-): WidgetPlacement[] | null {
-  const sorted = [...placements].sort((a, b) => a.order - b.order);
-  const oldIndex = sorted.findIndex((p) => p.id === activeId);
-  const newIndex = sorted.findIndex((p) => p.id === overId);
-  if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return null;
-
-  const [moved] = sorted.splice(oldIndex, 1);
-  sorted.splice(newIndex, 0, moved);
-
-  return sorted.map((p, i) => ({ ...p, order: i + 1 }));
-}
-
 export function setActiveSession(sessionId: string | null) {
   if (activeSessionId === sessionId) return;
   const previousSessionId = activeSessionId;
@@ -522,17 +511,10 @@ export function useFreeCells() {
     persist(getSnapshot().filter((p) => p.id !== id));
   }, []);
 
-  const moveWidget = useCallback((activeId: string, overId: string) => {
-    const current = getSnapshot();
-    const result = reorderPlacements(current, activeId, overId);
-    if (result) persist(result);
-  }, []);
-
   return {
     placements,
     addWidget,
     removeWidget,
-    moveWidget,
     toolView: view,
     selectTool,
     setToolsCollapsed,

--- a/packages/web/src/pages/free/use-free-cells.ts
+++ b/packages/web/src/pages/free/use-free-cells.ts
@@ -42,6 +42,106 @@ export const STRIP_ITEM_MIN_WIDTH = 320;
 let listeners: Array<() => void> = [];
 let snapshot: WidgetPlacement[] = [];
 let activeSessionId: string | null = null;
+const layoutRevisions = new Map<string | null, number>();
+
+export interface ToolView {
+  activeId: string | null;
+  collapsed: boolean;
+  unreadIds: string[];
+}
+
+let toolView: ToolView = { activeId: null, collapsed: true, unreadIds: [] };
+const VIEW_PREFIX = "rome:tool-view:";
+
+function readToolView(sessionId: string | null, layout: WidgetPlacement[]): ToolView {
+  const fallback: ToolView = {
+    activeId: [...layout].sort((a, b) => a.order - b.order)[0]?.id ?? null,
+    collapsed: layout.length === 0,
+    unreadIds: [],
+  };
+  if (!sessionId) return fallback;
+  try {
+    const saved = JSON.parse(localStorage.getItem(`${VIEW_PREFIX}${sessionId}`) ?? "null");
+    if (!saved || typeof saved.collapsed !== "boolean") return fallback;
+    return {
+      activeId: layout.some((p) => p.id === saved.activeId) ? saved.activeId : fallback.activeId,
+      collapsed: saved.collapsed,
+      unreadIds: Array.isArray(saved.unreadIds)
+        ? layout.filter((p) => saved.unreadIds.includes(p.id)).map((p) => p.id)
+        : [],
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function saveToolView(next: ToolView) {
+  toolView = next;
+  if (activeSessionId) {
+    try {
+      localStorage.setItem(`${VIEW_PREFIX}${activeSessionId}`, JSON.stringify(next));
+    } catch {}
+  }
+}
+
+export function selectTool(id: string) {
+  if (!snapshot.some((p) => p.id === id)) return;
+  saveToolView({
+    activeId: id,
+    collapsed: false,
+    unreadIds: toolView.unreadIds.filter((x) => x !== id),
+  });
+  notify();
+}
+
+export function setToolsCollapsed(collapsed: boolean) {
+  if (!collapsed && toolView.activeId) {
+    selectTool(toolView.activeId);
+    return;
+  }
+  saveToolView({ ...toolView, collapsed });
+  notify();
+}
+
+function reconcileToolView(next: WidgetPlacement[]) {
+  const sorted = [...next].sort((a, b) => a.order - b.order);
+  const old = [...snapshot].sort((a, b) => a.order - b.order);
+  const oldActive = old.find((p) => p.id === toolView.activeId);
+  // App navigation replaces its mount id. Keep that tab selected by matching
+  // its identity and position, including layouts with duplicate app views.
+  const replacement =
+    oldActive &&
+    sorted.find(
+      (p) =>
+        p.type === oldActive.type &&
+        p.targetId === oldActive.targetId &&
+        p.order === oldActive.order,
+    );
+  const activeId =
+    sorted.find((p) => p.id === toolView.activeId)?.id ??
+    replacement?.id ??
+    sorted[
+      Math.min(
+        Math.max(
+          0,
+          old.findIndex((p) => p.id === toolView.activeId),
+        ),
+        sorted.length - 1,
+      )
+    ]?.id ??
+    null;
+  const unread = new Set(toolView.unreadIds);
+  for (const p of next) {
+    if (!snapshot.some((previous) => previous.id === p.id)) unread.add(p.id);
+  }
+  saveToolView({
+    activeId,
+    collapsed: toolView.collapsed,
+    unreadIds: next
+      .filter((p) => unread.has(p.id) && (toolView.collapsed || p.id !== activeId))
+      .map((p) => p.id),
+  });
+}
 
 function storageKey(sessionId: string): string {
   return `${STORAGE_PREFIX}${sessionId}`;
@@ -71,6 +171,8 @@ function notify() {
 }
 
 function persist(next: WidgetPlacement[]) {
+  layoutRevisions.set(activeSessionId, (layoutRevisions.get(activeSessionId) ?? 0) + 1);
+  reconcileToolView(next);
   snapshot = next;
   writeStorage(activeSessionId, next);
   notify();
@@ -109,13 +211,17 @@ function nextOrder(placements: WidgetPlacement[]): number {
   return placements.reduce((max, p) => Math.max(max, p.order), 0) + 1;
 }
 
-export function autoPlaceProjects(): string | null {
+export function autoPlaceProjects(activate = false): string | null {
   const current = getSnapshot();
   const existing = current.find((p) => p.type === "projects");
-  if (existing) return existing.id;
+  if (existing) {
+    if (activate) selectTool(existing.id);
+    return existing.id;
+  }
 
   const id = genId();
   persist([...current, { id, type: "projects", order: nextOrder(current) }]);
+  if (activate) selectTool(id);
   return id;
 }
 
@@ -127,10 +233,14 @@ export function autoPlaceProjects(): string | null {
 export function placeChatWidget(sessionId: string): string {
   const current = getSnapshot();
   const existing = current.find((p) => p.type === "chat" && p.targetId === sessionId);
-  if (existing) return existing.id;
+  if (existing) {
+    selectTool(existing.id);
+    return existing.id;
+  }
 
   const id = genId();
   persist([...current, { id, type: "chat", targetId: sessionId, order: nextOrder(current) }]);
+  selectTool(id);
   return id;
 }
 
@@ -138,6 +248,7 @@ export function autoPlaceApp(
   appId: string,
   route?: string,
   params?: Record<string, string | number | boolean>,
+  activate = false,
 ): string {
   let current = getSnapshot();
 
@@ -146,6 +257,10 @@ export function autoPlaceApp(
   // (`order`) so it doesn't jump, but mint a fresh id so the iframe remounts
   // at the new src.
   const existing = current.find((p) => p.type === "app" && p.targetId === appId);
+  if (existing && activate && route === undefined && params === undefined) {
+    selectTool(existing.id);
+    return existing.id;
+  }
   const order = existing ? existing.order : nextOrder(current);
   if (existing) {
     current = current.filter((p) => p.id !== existing.id);
@@ -163,6 +278,7 @@ export function autoPlaceApp(
       ...(params !== undefined ? { params } : {}),
     },
   ]);
+  if (activate) selectTool(id);
   return id;
 }
 
@@ -234,6 +350,13 @@ export function placeWidgetsIfSessionActive(
 ): boolean {
   if (activeSessionId !== sessionId) return false;
   placeWidgets(widgets);
+  const last = widgets[widgets.length - 1];
+  const placed =
+    last &&
+    snapshot.find(
+      (p) => p.type === last.type && (last.type !== "app" || p.targetId === last.appId),
+    );
+  if (placed) selectTool(placed.id);
   return true;
 }
 
@@ -327,6 +450,7 @@ export function reorderPlacements(
 }
 
 export function setActiveSession(sessionId: string | null) {
+  if (activeSessionId === sessionId) return;
   const previousSessionId = activeSessionId;
   // Carry over draft-mode layout when the user moves from "no session" to
   // a freshly created one. The widgets they placed before hitting send
@@ -351,10 +475,12 @@ export function setActiveSession(sessionId: string | null) {
     return;
   }
   snapshot = readStorage(sessionId);
+  toolView = readToolView(sessionId, snapshot);
   notify();
 }
 
 export async function loadLayoutForSession(sessionId: string): Promise<void> {
+  const revision = layoutRevisions.get(sessionId);
   try {
     const res = await fetch(`/api/chat/sessions/${encodeURIComponent(sessionId)}/layout`, {
       credentials: "include",
@@ -363,9 +489,12 @@ export async function loadLayoutForSession(sessionId: string): Promise<void> {
     const data = (await res.json()) as { layout?: unknown };
     if (!Array.isArray(data.layout)) return;
     const layout = data.layout as WidgetPlacement[];
+    // A delayed load must not erase tools opened or closed since it started.
+    if (layoutRevisions.get(sessionId) !== revision) return;
     writeStorage(sessionId, layout);
     if (sessionId === activeSessionId) {
       snapshot = layout;
+      toolView = readToolView(sessionId, layout);
       notify();
     }
   } catch {
@@ -375,10 +504,18 @@ export async function loadLayoutForSession(sessionId: string): Promise<void> {
 
 export function useFreeCells() {
   const placements = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const view = useSyncExternalStore(subscribe, getToolView, getToolView);
 
   const addWidget = useCallback((type: WidgetType, targetId?: string) => {
     const current = getSnapshot();
-    persist([...current, { id: genId(), type, targetId, order: nextOrder(current) }]);
+    const existing = current.find((p) => p.type === type && p.targetId === targetId);
+    if (existing) {
+      selectTool(existing.id);
+      return;
+    }
+    const id = genId();
+    persist([...current, { id, type, targetId, order: nextOrder(current) }]);
+    selectTool(id);
   }, []);
 
   const removeWidget = useCallback((id: string) => {
@@ -391,5 +528,17 @@ export function useFreeCells() {
     if (result) persist(result);
   }, []);
 
-  return { placements, addWidget, removeWidget, moveWidget };
+  return {
+    placements,
+    addWidget,
+    removeWidget,
+    moveWidget,
+    toolView: view,
+    selectTool,
+    setToolsCollapsed,
+  };
+}
+
+function getToolView() {
+  return toolView;
 }


### PR DESCRIPTION
## What this PR does

Chat widgets compete for horizontal space and lack a shared way to switch between open apps. This PR groups them into one app panel with tabs and a resizable boundary beside the chat.

Every viewport shows exactly one icon-only app panel control at the top right. The control shows **Show apps** when collapsed and **Hide apps** when expanded, at the same position. An empty panel guides the user to open an app, including after they close the last tab.

The selected app tab uses a rounded background around its icon, title, and close button. Inactive tabs stay transparent, and tabs have no bottom underline.

The divider occupies 1px and thickens to 4px on hover, keyboard focus, or dragging. Its transparent hit area keeps it easy to grab without shifting either pane.

Closes #310.

## Design & Invariants

- Only one app tab is visible at a time. Inactive app frames stay mounted so switching tabs or hiding the panel preserves their state.
- Picker opens select an existing matching tab without navigating. Explicit app links navigate and activate their target, including root links. Passive agent opens and Projects file updates mark hidden tabs unread while preserving the current tab and panel visibility.
- Each session remembers its selected tab and panel visibility on the device. The chat width is a device preference. Existing layout records and duplicate saved views remain compatible.
- A delayed layout load cannot overwrite apps opened or closed after the request started.
- Narrow windows show either the chat or the app panel. Keyboard tab navigation and closing remain available.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm --filter rome-web test`: 171 files, 1,406 tests passed
- [x] `pnpm test:unit`: complete suite passed, including 4,367 core tests, 1,406 web tests, and 559 shared UI tests
- [x] Biome checks on all 17 changed files and `git diff --check`
- [x] Fresh branch backend startup: container logged `Rome started`
- [ ] Complete `pnpm dev:all` readiness: its Rome Cloud connectivity check failed because `https://romeos.cc` was unreachable from the container
- [x] Browser checks for opening and closing tabs, duplicate opens, session restoration, and empty-panel guidance
- [x] Actual Browser and terminal app checks in the existing development stack for switching and hiding the panel without losing in-frame input
- [x] 390px, 768px, 1024px, and 1440px viewport checks: exactly one visible app panel toggle, with matching Show/Hide coordinates in each viewport
- [x] Desktop and 390px browser checks: selected tab has a rounded background including its close button; inactive tabs are transparent; no underline
- [x] Divider browser checks: 1px at rest, 4px on hover, restored to 1px after leaving; dragging from the transparent hit area resizes the panes

- [x] Regression tests for explicit root navigation, hidden Projects unread state, visible updates, and later file updates in the same turn
- [x] Browser clicks using temporary mock links: picker reuse preserves the Notes draft iframe and tab ID; an explicit root link replaces the tab mount and navigates its iframe to `/full/apps/notes`. Mock app manifests are unavailable, so this check covers workspace navigation rather than app content. Temporary fixtures were restored.

Host checks used the installed Node 24.11.1 environment because Nix was unavailable.

## Not in this PR

- Split views: the app panel displays one tab at a time.
- Tab drag sorting: deferred as a lower-priority feature.
