### PR TITLE
feat(web): add Storybook MCP workflow

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[mcp_servers.rome_storybook]
+url = "http://127.0.0.1:6046/mcp"

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "rome-storybook": {
+      "type": "http",
+      "url": "http://127.0.0.1:6046/mcp"
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "rome-storybook": {
+      "type": "http",
+      "url": "http://127.0.0.1:6046/mcp"
+    }
+  }
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "romeStorybook": {
+      "type": "http",
+      "url": "http://127.0.0.1:6046/mcp"
+    }
+  }
+}

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -40,6 +40,8 @@ Storybook provides parallel design demonstrations. It does not replace runtime d
 
 Each story imports a production renderer and passes typed fixtures or callbacks. The initial render
 does not use mock handlers, fetch overrides, or request guards.
+Storybook uses the preview browser's detected locale. In a browser check, set the locale before
+asserting translated text. Otherwise, assert a role, fixture identity, or local control label.
 
 | Source component | Fixture and state | Story ID | Iframe |
 | --- | --- | --- | --- |
@@ -48,6 +50,9 @@ does not use mock handlers, fetch overrides, or request guards.
 | `ChatBlockPreview` → `renderSingleBlock` | `StreamBlock` resolved question | [`dev-chat-blocks--resolved-question`](http://localhost:6006/?path=/story/dev-chat-blocks--resolved-question) | [iframe](http://localhost:6006/iframe.html?id=dev-chat-blocks--resolved-question&viewMode=story) |
 | `ConnectionDetailDialog` | typed Discord channel, not connected | [`dev-connections-channel-status--not-connected`](http://localhost:6006/?path=/story/dev-connections-channel-status--not-connected) | [iframe](http://localhost:6006/iframe.html?id=dev-connections-channel-status--not-connected&viewMode=story) |
 | `ConnectionDetailDialog` | typed Discord channel, connected | [`dev-connections-channel-status--connected`](http://localhost:6006/?path=/story/dev-connections-channel-status--connected) | [iframe](http://localhost:6006/iframe.html?id=dev-connections-channel-status--connected&viewMode=story) |
+| `ConnectionSlotCard` | typed Telegram bot, unconnected | [`dev-connections-slot-card--unconnected-bot`](http://localhost:6006/?path=/story/dev-connections-slot-card--unconnected-bot) | [iframe](http://localhost:6006/iframe.html?id=dev-connections-slot-card--unconnected-bot&viewMode=story) |
+| `ConnectionSlotCard` | typed Telegram bot, connected | [`dev-connections-slot-card--connected-bot`](http://localhost:6006/?path=/story/dev-connections-slot-card--connected-bot) | [iframe](http://localhost:6006/iframe.html?id=dev-connections-slot-card--connected-bot&viewMode=story) |
+| `ConnectionSlotCard` | typed Telegram session, available to add | [`dev-connections-slot-card--add-session`](http://localhost:6006/?path=/story/dev-connections-slot-card--add-session) | [iframe](http://localhost:6006/iframe.html?id=dev-connections-slot-card--add-session&viewMode=story) |
 
 `/dev/connections` stays out of Storybook because it loads application data and owns selected-connection
 state. The connection stories pass typed `ConnectionCard` fixtures directly to the production
@@ -70,6 +75,28 @@ user or workstation configuration, and do not commit the file for this workflow.
 url = "http://127.0.0.1:6046/mcp"
 ```
 
+Codex asks for approval before an MCP call by default. If an unattended run uses the loopback
+Storybook instance started by this checkout, replace the minimal table with this allowlisted table.
+Do not use the approval setting for a remote or untrusted endpoint.
+
+```toml
+[mcp_servers.rome_storybook]
+url = "http://127.0.0.1:6046/mcp"
+enabled_tools = [
+  "stories-preview",
+  "get-storybook-story-instructions",
+  "stories-changed",
+  "stories-find-by-component",
+  "docs-list",
+  "docs-show",
+  "docs-show-story",
+]
+default_tools_approval_mode = "approve"
+```
+
+Start a new Codex task after changing the project MCP configuration. An existing task retains its
+tool catalog.
+
 For another MCP client, use its project-scoped connection flow. The Storybook helper can create a
 project-scoped entry when the client supports it:
 
@@ -81,10 +108,11 @@ The endpoint page at `http://127.0.0.1:6046/mcp` shows enabled toolsets. The cur
 exposes `stories-preview`, `get-storybook-story-instructions`, `stories-changed`,
 `stories-find-by-component`, `docs-list`, `docs-show`, and `docs-show-story`.
 
+Before creating or changing a `*.stories.*` file, call `get-storybook-story-instructions`.
 Use `docs-list` to discover the current story IDs. Use `docs-show` or `docs-show-story` for the
 generated documentation. Use `stories-find-by-component` with a source path to map an edited
-component to its story. Use `stories-changed` after an edit to list changed or related stories.
-Use `stories-preview` to return the matching manager link.
+component to its story. After a visual edit, call `stories-changed`, then use `stories-preview`
+to return the matching manager link.
 
 The manifest covers the current page and fixture stories. It is not a complete props catalog for
 published packages. The `test-run` MCP tool stays disabled because this repository does not install
@@ -93,17 +121,19 @@ does not receive `review-create` without Storybook's experimental review feature
 repository does not enable. Return the manager and iframe links from [Pages](#pages) for review.
 
 `stories-changed` follows Storybook's module graph and Git state. A changed preview or configuration
-file can be unreachable from a story. In that case, use the documented source location and
-`stories-find-by-component` for the affected renderer instead of inventing a story ID.
+file can be unreachable from a story. A browser-check file is also unreachable because it has no
+visual import. For a renderer, use `stories-find-by-component` instead of inventing a story ID.
+Run an unreachable browser check directly.
 
 ### Clean local exercise
 
 1. In a clean worktree, run `pnpm storybook --port 6046`.
-2. Discover `dev-design-styleguide--default` with `docs-list` or use its source and links in [Pages](#pages) when MCP is unavailable.
-3. Open the [style guide iframe](http://localhost:6046/iframe.html?id=dev-design-styleguide--default&viewMode=story) and confirm the `Design System — Styleguide` heading.
-4. Make a temporary source edit in `packages/web/src/pages/dev/StyleGuidePage.tsx`. Confirm HMR updates the open iframe, then restore the source.
-5. Run `STORYBOOK_PORT=6046 pnpm --filter rome-web test:storybook`.
-6. Return the [style guide manager link](http://localhost:6046/?path=/story/dev-design-styleguide--default) and iframe link. Replace `6046` with the active port.
+2. Call `get-storybook-story-instructions`, then discover `dev-design-styleguide--default` with `docs-list`.
+3. If MCP is unavailable, use its source and links in [Pages](#pages).
+4. Open the [style guide iframe](http://localhost:6046/iframe.html?id=dev-design-styleguide--default&viewMode=story) and confirm the `Design System — Styleguide` heading.
+5. Make a temporary source edit in `packages/web/src/pages/dev/StyleGuidePage.tsx`. Confirm HMR updates the open iframe, then restore the source.
+6. Run `STORYBOOK_PORT=6046 pnpm --filter rome-web test:storybook`.
+7. Return the [style guide manager link](http://localhost:6046/?path=/story/dev-design-styleguide--default) and iframe link. Replace `6046` with the active port.
 
 The same workflow works without MCP. Run `pnpm storybook --port 6047` for a concurrent second
 instance. Both commands keep Storybook's exact-port behavior.

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -9,7 +9,8 @@ Storybook serves self-contained design demonstrations without a Rome backend. It
 3. Run `pnpm storybook` from the repository root.
 4. Open a page from [Pages](#pages).
 
-The default port is 6006. Use `pnpm storybook --port 6007` for a second instance.
+The default port is 6006. Use `pnpm storybook --port 6046` for an explicit local instance.
+Start `pnpm storybook --port 6047` for a second instance at the same time.
 An occupied port fails with an error instead of selecting another port or prompting.
 The local development command uses `--no-open` to prevent automatic browser launch while retaining interactive prompts.
 For CI, add `--ci` explicitly with `pnpm storybook --ci`.
@@ -18,14 +19,14 @@ For CI, add `--ci` explicitly with `pnpm storybook --ci`.
 
 Each story imports its existing page directly. The pages have one implementation.
 
-| Existing development URL | Source | Stable story ID |
-| --- | --- | --- |
-| `/dev/styleguide` | `src/pages/dev/StyleGuidePage.tsx` | [`dev-design-styleguide--default`](http://localhost:6006/?path=/story/dev-design-styleguide--default) |
-| `/dev/typography` | `src/pages/dev/TypographyPage.tsx` | [`dev-design-typography--default`](http://localhost:6006/?path=/story/dev-design-typography--default) |
-| `/dev/gallery` | `src/pages/dev/gallery/ComponentGalleryPage.tsx` | [`dev-design-gallery--default`](http://localhost:6006/?path=/story/dev-design-gallery--default) |
-| `/dev/mdx` | `src/pages/dev/mdx/MdxDocsPage.tsx` | [`dev-design-mdx--default`](http://localhost:6006/?path=/story/dev-design-mdx--default) |
+| Existing development URL | Source | Manager link | Iframe link |
+| --- | --- | --- | --- |
+| `/dev/styleguide` | `src/pages/dev/StyleGuidePage.tsx` | [`dev-design-styleguide--default`](http://localhost:6006/?path=/story/dev-design-styleguide--default) | [iframe](http://localhost:6006/iframe.html?id=dev-design-styleguide--default&viewMode=story) |
+| `/dev/typography` | `src/pages/dev/TypographyPage.tsx` | [`dev-design-typography--default`](http://localhost:6006/?path=/story/dev-design-typography--default) | [iframe](http://localhost:6006/iframe.html?id=dev-design-typography--default&viewMode=story) |
+| `/dev/gallery` | `src/pages/dev/gallery/ComponentGalleryPage.tsx` | [`dev-design-gallery--default`](http://localhost:6006/?path=/story/dev-design-gallery--default) | [iframe](http://localhost:6006/iframe.html?id=dev-design-gallery--default&viewMode=story) |
+| `/dev/mdx` | `src/pages/dev/mdx/MdxDocsPage.tsx` | [`dev-design-mdx--default`](http://localhost:6006/?path=/story/dev-design-mdx--default) | [iframe](http://localhost:6006/iframe.html?id=dev-design-mdx--default&viewMode=story) |
 
-The [style guide iframe](http://localhost:6006/iframe.html?id=dev-design-styleguide--default&viewMode=story) omits the manager UI. Replace the port in these links when you start another instance.
+The iframe link omits the manager UI. Replace the port in these links when you start another instance.
 
 ## Retained development routes
 
@@ -56,18 +57,70 @@ production behavior and belong to application-flow coverage.
 `/dev/login` and `/dev/onboard` stay in `/dev` and E2E. Their views depend on `BootstrapPreview`,
 the auth query cache, and service-backed submit or setup flows.
 
+## Agent workflow
+
+Start Storybook before connecting an agent. The official `@storybook/addon-mcp` exposes a local
+Streamable HTTP endpoint at `http://127.0.0.1:<port>/mcp`. It does not change an agent's settings.
+
+For Codex, add this entry to a trusted project's local `.codex/config.toml`. Do not add it to a
+user or workstation configuration, and do not commit the file for this workflow.
+
+```toml
+[mcp_servers.rome_storybook]
+url = "http://127.0.0.1:6046/mcp"
+```
+
+For another MCP client, use its project-scoped connection flow. The Storybook helper can create a
+project-scoped entry when the client supports it:
+
+```bash
+npx mcp-add --type http --url "http://127.0.0.1:6046/mcp" --scope project
+```
+
+The endpoint page at `http://127.0.0.1:6046/mcp` shows enabled toolsets. The current local setup
+exposes `stories-preview`, `get-storybook-story-instructions`, `stories-changed`,
+`stories-find-by-component`, `docs-list`, `docs-show`, and `docs-show-story`.
+
+Use `docs-list` to discover the current story IDs. Use `docs-show` or `docs-show-story` for the
+generated documentation. Use `stories-find-by-component` with a source path to map an edited
+component to its story. Use `stories-changed` after an edit to list changed or related stories.
+Use `stories-preview` to return the matching manager link.
+
+The manifest covers the current page and fixture stories. It is not a complete props catalog for
+published packages. The `test-run` MCP tool stays disabled because this repository does not install
+`@storybook/addon-vitest`. Run the existing Playwright command instead. A direct project MCP client
+does not receive `review-create` without Storybook's experimental review feature, which this
+repository does not enable. Return the manager and iframe links from [Pages](#pages) for review.
+
+`stories-changed` follows Storybook's module graph and Git state. A changed preview or configuration
+file can be unreachable from a story. In that case, use the documented source location and
+`stories-find-by-component` for the affected renderer instead of inventing a story ID.
+
+### Clean local exercise
+
+1. In a clean worktree, run `pnpm storybook --port 6046`.
+2. Discover `dev-design-styleguide--default` with `docs-list` or use its source and links in [Pages](#pages) when MCP is unavailable.
+3. Open the [style guide iframe](http://localhost:6046/iframe.html?id=dev-design-styleguide--default&viewMode=story) and confirm the `Design System — Styleguide` heading.
+4. Make a temporary source edit in `packages/web/src/pages/dev/StyleGuidePage.tsx`. Confirm HMR updates the open iframe, then restore the source.
+5. Run `STORYBOOK_PORT=6046 pnpm --filter rome-web test:storybook`.
+6. Return the [style guide manager link](http://localhost:6046/?path=/story/dev-design-styleguide--default) and iframe link. Replace `6046` with the active port.
+
+The same workflow works without MCP. Run `pnpm storybook --port 6047` for a concurrent second
+instance. Both commands keep Storybook's exact-port behavior.
+
 ## Browser checks
 
 Run `pnpm --filter rome-web test:storybook` to start Storybook and check the direct iframe stories.
 Set `STORYBOOK_PORT` to use another development port. Set `STORYBOOK_BASE_URL` to check a running
-static build instead. The check observes initial-render requests and fails for `/api` or another service
-origin. It does not intercept or rewrite requests.
+static build instead. The check covers the selected design story and network-free component states.
+It observes initial-render requests and fails for `/api` or another service origin. It does not
+intercept or rewrite requests.
 
 ## Build and check
 
 1. Run `pnpm build:storybook` in the devShell.
-2. Serve the output with `python3 -m http.server 6008 --bind 127.0.0.1 --directory storybook-static`.
-3. Open a page from [Pages](#pages), replacing port `6006` with `6008`.
+2. Serve the output with `python3 -m http.server 6048 --bind 127.0.0.1 --directory storybook-static`.
+3. Open a page from [Pages](#pages), replacing port `6006` with `6048`.
 4. Refresh the page to check the direct link.
 
 The build writes only to the root `storybook-static` directory. The dashboard output stays in `packages/web/dist`.

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -146,6 +146,9 @@ static build instead. The check covers the selected design story and network-fre
 It observes initial-render requests and fails for `/api` or another service origin. It does not
 intercept or rewrite requests.
 
+Storybook disables lazy compilation. Its dynamic-import proxy can race HMR during a cold CI render.
+Keep it disabled unless the Playwright container check passes with the builder version in this repository.
+
 ## Build and check
 
 1. Run `pnpm build:storybook` in the devShell.

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -67,42 +67,23 @@ the auth query cache, and service-backed submit or setup flows.
 Start Storybook before connecting an agent. The official `@storybook/addon-mcp` exposes a local
 Streamable HTTP endpoint at `http://127.0.0.1:<port>/mcp`. It does not change an agent's settings.
 
-For Codex, add this entry to a trusted project's local `.codex/config.toml`. Do not add it to a
-user or workstation configuration, and do not commit the file for this workflow.
+The repository tracks project-scoped connections for Codex, Claude Code, Cursor, and VS Code. Run
+`pnpm storybook --port 6046` before opening an agent client. Each configuration points to the
+loopback endpoint and keeps the client's normal tool-approval flow.
 
-```toml
-[mcp_servers.rome_storybook]
-url = "http://127.0.0.1:6046/mcp"
-```
+| Client | Project configuration | Server name |
+| --- | --- | --- |
+| Codex | `.codex/config.toml` | `rome_storybook` |
+| Claude Code | `.mcp.json` | `rome-storybook` |
+| Cursor | `.cursor/mcp.json` | `rome-storybook` |
+| VS Code | `.vscode/mcp.json` | `romeStorybook` |
 
-Codex asks for approval before an MCP call by default. If an unattended run uses the loopback
-Storybook instance started by this checkout, replace the minimal table with this allowlisted table.
-Do not use the approval setting for a remote or untrusted endpoint.
+Codex loads `.codex/config.toml` only for a trusted project. Start a new Codex task after changing
+that file because an existing task retains its tool catalog.
 
-```toml
-[mcp_servers.rome_storybook]
-url = "http://127.0.0.1:6046/mcp"
-enabled_tools = [
-  "stories-preview",
-  "get-storybook-story-instructions",
-  "stories-changed",
-  "stories-find-by-component",
-  "docs-list",
-  "docs-show",
-  "docs-show-story",
-]
-default_tools_approval_mode = "approve"
-```
-
-Start a new Codex task after changing the project MCP configuration. An existing task retains its
-tool catalog.
-
-For another MCP client, use its project-scoped connection flow. The Storybook helper can create a
-project-scoped entry when the client supports it:
-
-```bash
-npx mcp-add --type http --url "http://127.0.0.1:6046/mcp" --scope project
-```
+Do not add automatic approval to a tracked configuration. If an unattended local run needs it, add
+the approval policy to the user's own configuration after verifying that this checkout started the
+loopback endpoint.
 
 The endpoint page at `http://127.0.0.1:6046/mcp` shows enabled toolsets. The current local setup
 exposes `stories-preview`, `get-storybook-story-instructions`, `stories-changed`,

--- a/packages/web/.storybook/ConnectionSlotCard.stories.tsx
+++ b/packages/web/.storybook/ConnectionSlotCard.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "storybook-react-rsbuild";
+import "../src/i18n";
+import { ConnectionBrandBadge } from "../src/components/brand-icons/connection-badges";
+import { Button } from "../src/components/ui/button";
+import { AvailableToAddLabel, ConnectionSlotCard } from "../src/components/connection-slot-card";
+import type { ConnectionSlot } from "../src/lib/connection-cards";
+
+const telegramBot: ConnectionSlot = {
+  key: "bot",
+  connectionId: null,
+  grant: "bot",
+  state: "unauthorized",
+  display: null,
+  identity: null,
+  activeSetupCid: null,
+};
+
+const telegramSession: ConnectionSlot = {
+  key: "session",
+  connectionId: null,
+  grant: "session",
+  state: "unauthorized",
+  display: null,
+  identity: null,
+  activeSetupCid: null,
+};
+
+const meta = {
+  title: "Dev/Connections/Slot card",
+  component: ConnectionSlotCard,
+  parameters: { layout: "padded" },
+  argTypes: {
+    service: { control: false },
+    slot: { control: false },
+    state: { control: false },
+    role: { control: false },
+    icon: { control: false },
+    identityTitle: { control: false },
+    connectedSubtitle: { control: false },
+    action: { control: false },
+    children: { control: false },
+  },
+} satisfies Meta<typeof ConnectionSlotCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const UnconnectedBot: Story = {
+  args: {
+    service: "telegram",
+    slot: telegramBot,
+    state: "unconnected",
+    role: "primary",
+    icon: <ConnectionBrandBadge connection="telegram" />,
+    children: <Button>Connect</Button>,
+  },
+};
+
+export const ConnectedBot: Story = {
+  args: {
+    service: "telegram",
+    slot: {
+      ...telegramBot,
+      connectionId: "storybook-telegram",
+      state: "authorized",
+      identity: "@rome_bot",
+    },
+    state: "connected",
+    role: "primary",
+    icon: <ConnectionBrandBadge connection="telegram" />,
+    identityTitle: "@rome_bot",
+    action: (
+      <Button variant="destructive" size="sm">
+        Disconnect
+      </Button>
+    ),
+  },
+};
+
+export const AddSession: Story = {
+  render: (args) => (
+    <div className="space-y-2">
+      <AvailableToAddLabel />
+      <ConnectionSlotCard {...args} />
+    </div>
+  ),
+  args: {
+    service: "telegram",
+    slot: telegramSession,
+    state: "unconnected",
+    role: "secondary",
+    icon: <ConnectionBrandBadge connection="telegram" />,
+    children: (
+      <Button variant="outline" size="sm">
+        Add session
+      </Button>
+    ),
+  },
+};

--- a/packages/web/.storybook/main.ts
+++ b/packages/web/.storybook/main.ts
@@ -6,6 +6,13 @@ const config: StorybookConfig = {
     options: { builder: { rsbuildConfigPath: ".storybook/rsbuild.config.ts" } },
   },
   stories: ["./*.stories.tsx"],
+  addons: [
+    {
+      name: "@storybook/addon-mcp",
+      options: { toolsets: { test: false } },
+    },
+  ],
+  features: { componentsManifest: true },
   core: { disableTelemetry: true },
 };
 

--- a/packages/web/.storybook/main.ts
+++ b/packages/web/.storybook/main.ts
@@ -3,7 +3,12 @@ import type { StorybookConfig } from "storybook-react-rsbuild";
 const config: StorybookConfig = {
   framework: {
     name: "storybook-react-rsbuild",
-    options: { builder: { rsbuildConfigPath: ".storybook/rsbuild.config.ts" } },
+    options: {
+      builder: {
+        rsbuildConfigPath: ".storybook/rsbuild.config.ts",
+        lazyCompilation: false,
+      },
+    },
   },
   stories: ["./*.stories.tsx"],
   addons: [

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -65,6 +65,7 @@
     "@rsbuild/plugin-react": "^2.0.0",
     "@rsbuild/plugin-svgr": "^2.0.2",
     "@rstest/core": "^0.11.11",
+    "@storybook/addon-mcp": "10.6.0",
     "@tailwindcss/postcss": "^4.1.0",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "pnpm build:kit && rsbuild dev",
     "dev:mock": "pnpm build:kit && rsbuild dev --config mock/rsbuild.config.ts",
-    "storybook": "storybook dev --port 6006 --exact-port --no-open",
+    "storybook": "storybook dev --host 127.0.0.1 --port 6006 --exact-port --no-open",
     "build:storybook": "storybook build --output-dir ../../storybook-static",
     "build:kit": "pnpm --filter \"rome-web^...\" run build",
     "build": "tsc --noEmit && rsbuild build",

--- a/packages/web/playwright.storybook.config.ts
+++ b/packages/web/playwright.storybook.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   webServer: process.env.STORYBOOK_BASE_URL
     ? undefined
     : {
-        command: `pnpm exec storybook dev --port ${port} --exact-port --no-open`,
+        command: `pnpm exec storybook dev --host 127.0.0.1 --port ${port} --exact-port --no-open`,
         url: baseURL,
         reuseExistingServer: !isCI,
         timeout: isCI ? 180_000 : 60_000,

--- a/packages/web/storybook-e2e/network-free-stories.spec.ts
+++ b/packages/web/storybook-e2e/network-free-stories.spec.ts
@@ -15,6 +15,18 @@ function watchServiceRequests(page: import("@playwright/test").Page) {
 test("network-free stories stay isolated and issue no service requests", async ({ page }) => {
   const requests = watchServiceRequests(page);
 
+  await page.goto("/?path=/story/dev-design-styleguide--default");
+  const styleGuide = page.frameLocator("#storybook-preview-iframe");
+  await expect(
+    styleGuide.getByRole("heading", { name: "Design System — Styleguide" }),
+  ).toBeVisible();
+  await expect(styleGuide.getByRole("heading", { name: "Semantic tokens" })).toHaveCount(1);
+  await page.getByRole("switch", { name: "compareModes" }).press("Space");
+  await expect(
+    styleGuide.getByText("Light and dark specimens are shown together for comparison."),
+  ).toBeVisible();
+  await expect(styleGuide.getByRole("heading", { name: "Semantic tokens" })).toHaveCount(2);
+
   await page.goto("/iframe.html?id=dev-chat-blocks--compact-question&viewMode=story");
   const warm = page.getByRole("button", { name: "Warm" });
   await expect(warm).toHaveAttribute("aria-pressed", "false");

--- a/packages/web/storybook-e2e/network-free-stories.spec.ts
+++ b/packages/web/storybook-e2e/network-free-stories.spec.ts
@@ -50,6 +50,16 @@ test("network-free stories stay isolated and issue no service requests", async (
   await expect(page.getByText("This connection lets your agent", { exact: true })).toBeVisible();
   await expect(page.getByRole("button", { name: "Disconnect" })).toBeVisible();
 
+  await page.goto("/iframe.html?id=dev-connections-slot-card--unconnected-bot&viewMode=story");
+  await expect(page.getByRole("button", { name: "Connect" })).toBeVisible();
+
+  await page.goto("/iframe.html?id=dev-connections-slot-card--connected-bot&viewMode=story");
+  await expect(page.getByText("@rome_bot", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Disconnect" })).toBeVisible();
+
+  await page.goto("/iframe.html?id=dev-connections-slot-card--add-session&viewMode=story");
+  await expect(page.getByRole("button", { name: "Add session" })).toBeVisible();
+
   await page.goto("/iframe.html?id=dev-chat-blocks--compact-question&viewMode=story");
   await expect(page.getByRole("button", { name: "Warm" })).toHaveAttribute("aria-pressed", "false");
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,7 +534,7 @@ importers:
     dependencies:
       '@statsig/statsig-node-core':
         specifier: ^0.19.6
-        version: 0.19.6(encoding@0.1.13)
+        version: 0.19.6(encoding@0.1.13)(supports-color@8.1.1)
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -851,6 +851,9 @@ importers:
       '@rstest/core':
         specifier: ^0.11.11
         version: 0.11.11(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0)(jsdom@29.1.1)
+      '@storybook/addon-mcp':
+        specifier: 10.6.0
+        version: 10.6.0(storybook@10.6.0(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@5.0.10))(typescript@5.9.3)
       '@tailwindcss/postcss':
         specifier: ^4.1.0
         version: 4.1.18
@@ -6168,6 +6171,15 @@ packages:
     resolution: {integrity: sha512-rgVwReIU7QRaFvq0m0mdpdCApnvz/Oaqitt+73vtLUq/yy35X/hmXItn575+TeEpKsIbzbFbEoEimKSQsSJ8+w==}
     engines: {node: '>= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0'}
 
+  '@storybook/addon-mcp@10.6.0':
+    resolution: {integrity: sha512-aQza4iMVgB3OXPMJvcnA193xMdt0sG/0+otGCQu8il6LIuFDP60jD5BXWlQiaVog+swqHrjJCFzuUPE+azz7Kg==}
+    peerDependencies:
+      '@storybook/addon-vitest': ^10.6.0
+      storybook: ^10.6.0
+    peerDependenciesMeta:
+      '@storybook/addon-vitest':
+        optional: true
+
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
@@ -6575,6 +6587,26 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tmcp/adapter-valibot@0.1.6':
+    resolution: {integrity: sha512-drirZeNinhYLiRSMksN+m//u0ImFxtGRk1Vp425Xp/7CbBXFQdjAG+f7grssyHAukbVTGzmWsMMP6ejrGVErUA==}
+    peerDependencies:
+      tmcp: ^1.17.0
+      valibot: ^1.1.0
+
+  '@tmcp/session-manager@0.2.2':
+    resolution: {integrity: sha512-UrCRpTsxh5XnMbplspvftEYboiZWgAiXqqAUbyFTHoHMJ0LoNDy8bQd0+7qtxtT4S5Qsnv650gvs/Nbec5NTCQ==}
+    peerDependencies:
+      tmcp: ^1.16.3
+
+  '@tmcp/transport-http@0.8.6':
+    resolution: {integrity: sha512-iLcxu+tEMbkVHbhFfyXQhxfPDDTfm+F0kEw8Xg/a1rm29s4cBg1vwcpbtk02XTxsdDh8RJ1AZkQwF9WDGeb/IA==}
+    peerDependencies:
+      '@tmcp/auth': ^0.3.3 || ^0.4.0
+      tmcp: ^1.18.0
+    peerDependenciesMeta:
+      '@tmcp/auth':
+        optional: true
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -6914,6 +6946,11 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@valibot/to-json-schema@1.7.1':
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+    peerDependencies:
+      valibot: ^1.4.0
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -8590,6 +8627,9 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   esniff@2.0.1:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
@@ -9628,6 +9668,9 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-rpc-2.0@1.8.0:
+    resolution: {integrity: sha512-4nw+XlJbk5XokA7BtqHGu+0PEiUPfAkRzXXd1Cgjy1c3F2UI/3Gy7yr76wyJEv3X1F1SRGGF8xPAPPhelBiGmA==}
 
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
@@ -11940,6 +11983,9 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  sqids@0.3.0:
+    resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
+
   ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -12254,6 +12300,9 @@ packages:
     resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
     hasBin: true
 
+  tmcp@1.20.0:
+    resolution: {integrity: sha512-dcDximKQBGqLP/aEAVA26HcWRHhKipstg1w0fbDDJ0HcFZ6lolLU1YYmStYEn/73f534i7WrDNcjRfRYdV9CoA==}
+
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
@@ -12511,6 +12560,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  uri-template-matcher@1.1.2:
+    resolution: {integrity: sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==}
+
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
     engines: {node: '>= 0.4'}
@@ -12570,6 +12622,14 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  valibot@1.5.0:
+    resolution: {integrity: sha512-nil6AkP2TChWL43Z5uJ6GTxX01CUA+g8LWUM+N/rB9NBbkUMaUsi9PUNzlUPgoKASgmx9f7eGOYpJ04/fSa6FQ==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   valid-data-url@3.0.1:
     resolution: {integrity: sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==}
@@ -13069,7 +13129,7 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.0(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -13127,7 +13187,7 @@ snapshots:
 
   '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
@@ -13140,14 +13200,14 @@ snapshots:
 
   '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.4.0
       semver: 6.3.1
 
   '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       debug: 4.4.3(supports-color@8.1.1)
@@ -13183,7 +13243,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
@@ -13192,7 +13252,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7
@@ -13207,7 +13267,7 @@ snapshots:
 
   '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-wrap-function': 7.29.7
       '@babel/traverse': 7.29.7
@@ -13216,7 +13276,7 @@ snapshots:
 
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/traverse': 7.29.7
@@ -13265,7 +13325,7 @@ snapshots:
 
   '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.0)
@@ -13274,52 +13334,52 @@ snapshots:
 
   '@babel/plugin-proposal-export-default-from@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-export-default-from@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.0)
       '@babel/traverse': 7.29.7
@@ -13328,7 +13388,7 @@ snapshots:
 
   '@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.0)
@@ -13337,12 +13397,12 @@ snapshots:
 
   '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
@@ -13350,7 +13410,7 @@ snapshots:
 
   '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
@@ -13358,7 +13418,7 @@ snapshots:
 
   '@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-globals': 7.29.7
@@ -13370,7 +13430,7 @@ snapshots:
 
   '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
@@ -13378,18 +13438,18 @@ snapshots:
 
   '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.0)
 
   '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
@@ -13397,12 +13457,12 @@ snapshots:
 
   '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
@@ -13410,18 +13470,18 @@ snapshots:
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.0)
@@ -13432,12 +13492,12 @@ snapshots:
 
   '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
     transitivePeerDependencies:
@@ -13445,12 +13505,12 @@ snapshots:
 
   '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
@@ -13458,7 +13518,7 @@ snapshots:
 
   '@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
@@ -13467,19 +13527,19 @@ snapshots:
 
   '@babel/plugin-transform-react-display-name@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-development@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
@@ -13490,13 +13550,13 @@ snapshots:
 
   '@babel/plugin-transform-react-pure-annotations@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.0)(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)(supports-color@8.1.1)
@@ -13508,7 +13568,7 @@ snapshots:
 
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
@@ -13519,13 +13579,13 @@ snapshots:
 
   '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/preset-typescript@7.29.7(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.0)
@@ -14416,7 +14476,7 @@ snapshots:
   '@expo/metro-config@57.0.10(bufferutil@4.1.0)(expo@57.0.16)(typescript@6.0.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@expo/config': 57.0.9(typescript@6.0.3)
       '@expo/env': 2.4.2
@@ -14516,7 +14576,7 @@ snapshots:
   '@expo/require-utils@57.0.4(typescript@6.0.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
     optionalDependencies:
       typescript: 6.0.3
@@ -14526,7 +14586,7 @@ snapshots:
   '@expo/require-utils@57.0.5(typescript@6.0.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
     optionalDependencies:
       typescript: 6.0.3
@@ -14564,7 +14624,7 @@ snapshots:
       sf-symbols-typescript: 2.2.0
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.3))(react@19.2.3)
     optionalDependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       react-dom: 19.2.6(react@19.2.3)
     transitivePeerDependencies:
       - '@types/react'
@@ -15233,7 +15293,7 @@ snapshots:
     dependencies:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       lru-cache: 10.4.3
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -17661,7 +17721,7 @@ snapshots:
 
   '@react-native/codegen@0.86.2(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/parser': 7.29.7
       hermes-parser: 0.36.0
       invariant: 2.2.4
@@ -17775,7 +17835,7 @@ snapshots:
   '@rsbuild/plugin-svgr@2.0.2(@rsbuild/core@2.2.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(typescript@5.9.3)':
     dependencies:
       '@rsbuild/plugin-react': 2.0.1(@rsbuild/core@2.2.3(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.46.0))(@rspack/core@2.2.2(@module-federation/runtime-tools@2.5.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
       deepmerge: 4.3.1
@@ -18045,10 +18105,10 @@ snapshots:
   '@statsig/statsig-node-core-win32-x64-msvc@0.19.6':
     optional: true
 
-  '@statsig/statsig-node-core@0.19.6(encoding@0.1.13)':
+  '@statsig/statsig-node-core@0.19.6(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:
       '@octokit/core': 6.1.6
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       node-fetch: 2.7.0(encoding@0.1.13)
     optionalDependencies:
       '@statsig/statsig-node-core-darwin-arm64': 0.19.6
@@ -18063,6 +18123,17 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@storybook/addon-mcp@10.6.0(storybook@10.6.0(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@5.0.10))(typescript@5.9.3)':
+    dependencies:
+      '@tmcp/adapter-valibot': 0.1.6(tmcp@1.20.0(typescript@5.9.3))(valibot@1.5.0(typescript@5.9.3))
+      '@tmcp/transport-http': 0.8.6(tmcp@1.20.0(typescript@5.9.3))
+      storybook: 10.6.0(@types/react@19.2.15)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@5.0.10)
+      tmcp: 1.20.0(typescript@5.9.3)
+      valibot: 1.5.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@tmcp/auth'
+      - typescript
 
   '@storybook/global@5.0.0': {}
 
@@ -18130,39 +18201,39 @@ snapshots:
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
 
   '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
       '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
       '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
@@ -18172,9 +18243,9 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
 
-  '@svgr/core@8.1.0(typescript@5.9.3)':
+  '@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
@@ -18190,9 +18261,9 @@ snapshots:
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -18200,7 +18271,7 @@ snapshots:
 
   '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       deepmerge: 4.3.1
       svgo: 3.3.3
@@ -18431,6 +18502,23 @@ snapshots:
   '@testing-library/user-event@14.6.7(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
+
+  '@tmcp/adapter-valibot@0.1.6(tmcp@1.20.0(typescript@5.9.3))(valibot@1.5.0(typescript@5.9.3))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@valibot/to-json-schema': 1.7.1(valibot@1.5.0(typescript@5.9.3))
+      tmcp: 1.20.0(typescript@5.9.3)
+      valibot: 1.5.0(typescript@5.9.3)
+
+  '@tmcp/session-manager@0.2.2(tmcp@1.20.0(typescript@5.9.3))':
+    dependencies:
+      tmcp: 1.20.0(typescript@5.9.3)
+
+  '@tmcp/transport-http@0.8.6(tmcp@1.20.0(typescript@5.9.3))':
+    dependencies:
+      '@tmcp/session-manager': 0.2.2(tmcp@1.20.0(typescript@5.9.3))
+      esm-env: 1.2.2
+      tmcp: 1.20.0(typescript@5.9.3)
 
   '@tokenizer/inflate@0.4.1(supports-color@8.1.1)':
     dependencies:
@@ -18844,6 +18932,10 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@valibot/to-json-schema@1.7.1(valibot@1.5.0(typescript@5.9.3))':
+    dependencies:
+      valibot: 1.5.0(typescript@5.9.3)
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -19228,7 +19320,7 @@ snapshots:
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0)(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
@@ -19236,7 +19328,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
@@ -19244,7 +19336,7 @@ snapshots:
 
   babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -19490,7 +19582,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       js-yaml: 4.1.1
       sanitize-filename: 1.6.3
       source-map-support: 0.5.21
@@ -20704,6 +20796,8 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  esm-env@1.2.2: {}
+
   esniff@2.0.1:
     dependencies:
       d: 1.0.2
@@ -21250,7 +21344,7 @@ snapshots:
   gaxios@6.7.1(encoding@0.1.13):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-stream: 2.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       uuid: 9.0.1
@@ -21674,7 +21768,7 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -21978,6 +22072,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-rpc-2.0@1.8.0: {}
 
   json-schema-to-ts@3.1.1:
     dependencies:
@@ -22637,7 +22733,7 @@ snapshots:
 
   metro-babel-transformer@0.84.4:
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       flow-enums-runtime: 0.0.6
       hermes-parser: 0.35.0
       metro-cache-key: 0.84.4
@@ -22647,7 +22743,7 @@ snapshots:
 
   metro-babel-transformer@0.84.5:
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       flow-enums-runtime: 0.0.6
       hermes-parser: 0.35.0
       metro-cache-key: 0.84.5
@@ -22667,7 +22763,7 @@ snapshots:
     dependencies:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       metro-core: 0.84.4
     transitivePeerDependencies:
       - supports-color
@@ -22676,7 +22772,7 @@ snapshots:
     dependencies:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       metro-core: 0.84.5
     transitivePeerDependencies:
       - supports-color
@@ -22831,7 +22927,7 @@ snapshots:
 
   metro-transform-plugins@0.84.4:
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.7
@@ -22842,7 +22938,7 @@ snapshots:
 
   metro-transform-plugins@0.84.5:
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.7
@@ -22853,7 +22949,7 @@ snapshots:
 
   metro-transform-worker@0.84.4(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
@@ -22873,7 +22969,7 @@ snapshots:
 
   metro-transform-worker@0.84.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
@@ -22894,7 +22990,7 @@ snapshots:
   metro@0.84.4(bufferutil@4.1.0)(supports-color@8.1.1)(utf-8-validate@5.0.10):
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -22940,7 +23036,7 @@ snapshots:
   metro@0.84.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -23478,7 +23574,7 @@ snapshots:
 
   node-edge-tts@1.2.10(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -24199,7 +24295,7 @@ snapshots:
 
   react-docgen@8.0.3:
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
@@ -25046,6 +25142,8 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  sqids@0.3.0: {}
+
   ssri@12.0.0:
     dependencies:
       minipass: 7.1.2
@@ -25435,6 +25533,16 @@ snapshots:
     dependencies:
       tldts-core: 7.0.30
 
+  tmcp@1.20.0(typescript@5.9.3):
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      json-rpc-2.0: 1.8.0
+      sqids: 0.3.0
+      uri-template-matcher: 1.1.2
+      valibot: 1.5.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
   tmp-promise@3.0.3:
     dependencies:
       tmp: 0.2.5
@@ -25662,6 +25770,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  uri-template-matcher@1.1.2: {}
+
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
@@ -25724,6 +25834,10 @@ snapshots:
   uuid@7.0.3: {}
 
   uuid@9.0.1: {}
+
+  valibot@1.5.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   valid-data-url@3.0.1: {}
 


### PR DESCRIPTION
## What this PR does

Storybook lacked a project-local agent workflow. This adds the official MCP addon and documents a reproducible local path from source discovery to an HMR check and review link.

## Design & Invariants

- The addon is a web dev dependency only. The dashboard build and published packages do not receive Storybook MCP runtime code.
- The development and Playwright Storybook servers bind to `127.0.0.1`. The unauthenticated MCP endpoint does not accept network-interface connections.
- The existing Playwright Storybook gate remains the browser check. It observes requests and fails on service origins or `/api/`. It does not intercept or rewrite requests.
- MCP exposes the supported discovery, documentation, and development tools. `test-run` stays disabled because the repository does not install `@storybook/addon-vitest`.
- The documentation uses local project configuration examples only. It does not change global Codex or workstation settings.

## Test plan

- [x] `nix develop --command pnpm install --frozen-lockfile`
- [x] `nix develop --command pnpm typecheck`
- [x] `nix develop --command pnpm test:unit`
- [x] `nix develop --command pnpm --filter rome-web build`
- [x] `nix develop --command pnpm --filter rome-web build:storybook`
- [x] Development and static `test:storybook` checks, including the Styleguide manager control and request guard
- [x] Browser checks of the manager and iframe, temporary HMR edit and restore, and the static build on port 6048
- [x] MCP endpoint discovery and calls to `docs-list`, `docs-show-story`, `stories-find-by-component`, `stories-changed`, and `stories-preview`
- [x] Concurrent ports 6046 and 6047. An occupied 6046 exits because `--exact-port` is set.
- [x] Loopback binding. MCP initialization succeeds at `127.0.0.1:6046` and fails through the local network interface.
- [x] `CI=1 STORYBOOK_PORT=6047 pnpm --filter rome-web test:storybook`
- [x] `nix develop --command pnpm dev:all`. Current worktree logs contain `Rome started`.

## Follow-up validation

- Added typed `ConnectionSlotCard` stories for an unconnected bot, a connected bot, and an addable session.
- Direct and static Storybook Playwright checks cover the new fixtures and the request guard.
- A fresh read-only Codex process loaded the project MCP config and called `docs-list` and `docs-show`. The docs record project-local connections and each client's normal approval flow.

## Not in this PR

- `@storybook/test-runner`, Vitest, and `@storybook/addon-vitest`. The existing Playwright gate is sufficient.
- Storybook experimental review creation. Direct project MCP clients return the documented manager and iframe links instead.
