### PR TITLE
feat(people): support LinkedIn replies

### DIFF
--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -11,3 +11,15 @@ Every channel is connected through **one server-owned setup protocol** ([decisio
 - **Setup is uniform.** Enabling any channel drives the same generic surface (a conferral setup addressed by connection + grant). There is no bespoke per-service connect, pairing, or `verify-status` route — a channel that reads connected was guardian-linked during the setup's terminal write, so nothing polls a separate status endpoint afterward.
 - **The dashboard renders setups generically.** The connect UI is a single standard renderer plus a small set of registered custom components for the few steps that need bespoke presentation (e.g. rendering a QR image). Adding a channel adds neither a connect route nor a per-service connect card.
 - **Post-connection configuration is not setup.** Config and feature surfaces that operate *after* a channel is linked — Discord per-channel agent routing, the Telegram personal-account dialog list — live under their own named routes, separate from the setup protocol and never part of connecting.
+
+## LinkedIn replies
+
+LinkedIn replies use the shared [People outbox](../concepts/people.md#outbox) and the browser session that reads the inbox.
+
+### Invariants
+
+- A reply addresses an existing direct conversation. Missing, incomplete, group, or ambiguous membership cannot authorize a send.
+- Before sending, LinkedIn must confirm both the recipient and the sending account by member id. A display name cannot establish either identity.
+- A send receipt and a history read identify the same provider message. A successful click or a matching message body cannot establish acceptance.
+- Once LinkedIn accepts a reply, a local mirror failure cannot turn it into a failed send. Unknown send outcomes require an explicit retry.
+- A retry keeps the original conversation. A changed destination requires a new reply.

--- a/opencli-plugins/README.md
+++ b/opencli-plugins/README.md
@@ -72,6 +72,9 @@ Agents pick up new/changed commands automatically: the `browser-automation` skil
   metadata.
 - `opencli linkedin thread-participants --thread-url URL` — returns one row per participant of an
   exact LinkedIn thread, including participants who have never sent a message.
+- `opencli linkedin reply --thread-url URL --expected-recipient MEMBER_ID --expected-self MEMBER_ID --message TEXT [--send]` — verifies an existing direct conversation against both member ids.
+  With `--send`, it sends the text and returns the provider message id used by the inbox mirror.
+  Without `--send`, it only verifies the destination.
 - `opencli craigslist locations [QUERY]` — discovers site codes from Craigslist's worldwide
   directory; `categories --site SITE` lists the category codes available at that site.
 - `opencli craigslist search [QUERY] --site SITE [options]` — searches public listings across

--- a/opencli-plugins/linkedin/reply-helpers.mjs
+++ b/opencli-plugins/linkedin/reply-helpers.mjs
@@ -85,7 +85,7 @@ export function parseReplyReceipt(json, payload, { threadId, threadUrl, originTo
   function visit(value) {
     if (!value || typeof value !== "object") return;
     if (value.$type === "com.linkedin.messenger.Message") {
-      if (value.originToken && value.originToken !== originToken) return;
+      if (value.originToken !== originToken) return;
       // History prefers the backend id. Without it a receipt can name a different id later.
       if (
         typeof value.backendUrn === "string" &&

--- a/opencli-plugins/linkedin/reply-helpers.mjs
+++ b/opencli-plugins/linkedin/reply-helpers.mjs
@@ -107,3 +107,18 @@ export function parseReplyReceipt(json, payload, { threadId, threadUrl, originTo
   }
   return { ...rows[0], status: "sent" };
 }
+
+export async function confirmReplyReceipt(json, payload, expected, { readHistory, wait }) {
+  try {
+    return parseReplyReceipt(json, payload, expected);
+  } catch {}
+
+  // A lost or partial response can follow a successful send. Re-read, never re-send.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      return parseReplyReceipt(await readHistory(), payload, expected);
+    } catch {}
+    if (attempt < 2) await wait();
+  }
+  throw new Error(UNKNOWN_REPLY_OUTCOME);
+}

--- a/opencli-plugins/linkedin/reply-helpers.mjs
+++ b/opencli-plugins/linkedin/reply-helpers.mjs
@@ -1,0 +1,109 @@
+import {
+  parseThreadMessagePayloads,
+  parseThreadParticipantPayloads,
+  validateThreadConversationPayload,
+} from "./thread-snapshot-helpers.mjs";
+
+export function verifiedReplyTarget(payload, { threadId, threadUrl, recipientId, selfId }) {
+  if (
+    !validateThreadConversationPayload(payload, threadId) ||
+    payload.__opencli?.conversation_participant_refs_complete !== true
+  ) {
+    throw new Error("LinkedIn could not verify the complete conversation membership");
+  }
+  const conversation = payload.included.find(
+    (entity) => entity.$type === "com.linkedin.messenger.Conversation",
+  );
+  const participants = parseThreadParticipantPayloads([payload], { threadId, threadUrl });
+  if (
+    conversation.groupChat !== false ||
+    conversation["*conversationParticipants"]?.length !== 2 ||
+    participants.length !== 2 ||
+    !participants.some(
+      (p) => p.participant_id === recipientId && !p.is_self && p.type === "member",
+    ) ||
+    !participants.some((p) => p.participant_id === selfId && p.is_self && p.type === "member")
+  ) {
+    throw new Error("LinkedIn conversation participants do not match the selected accounts");
+  }
+  const mailboxUrn = `urn:li:fsd_profile:${selfId}`;
+  if (conversation.entityUrn !== `urn:li:msg_conversation:(${mailboxUrn},${threadId})`) {
+    throw new Error("LinkedIn conversation does not belong to the selected sending account");
+  }
+  return { conversationUrn: conversation.entityUrn, mailboxUrn };
+}
+
+// Runs in the signed-in browser. The one POST addresses the verified conversation directly.
+export async function postLinkedInReply(csrf, target, text, originToken, trackingId, threadUrl) {
+  if (
+    location.origin !== "https://www.linkedin.com" ||
+    location.pathname !== new URL(threadUrl).pathname
+  ) {
+    return { error: "LinkedIn navigated away from the selected conversation" };
+  }
+  try {
+    const response = await fetch(
+      "https://www.linkedin.com/voyager/api/voyagerMessagingDashMessengerMessages?action=createMessage",
+      {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "csrf-token": csrf,
+          "content-type": "application/json",
+          accept: "application/vnd.linkedin.normalized+json+2.1",
+          "x-restli-protocol-version": "2.0.0",
+        },
+        body: JSON.stringify({
+          message: {
+            body: { attributes: [], text },
+            renderContentUnions: [],
+            conversationUrn: target.conversationUrn,
+            originToken,
+          },
+          mailboxUrn: target.mailboxUrn,
+          trackingId,
+          dedupeByClientGeneratedToken: false,
+        }),
+      },
+    );
+    if (response.status === 401 || response.status === 403) {
+      return { auth_required: true };
+    }
+    if (!response.ok && response.status < 500)
+      return { error: `LinkedIn rejected the reply (HTTP ${response.status})` };
+    if (!response.ok) return { uncertain: true };
+    return { json: await response.json() };
+  } catch {
+    return { uncertain: true };
+  }
+}
+
+export const UNKNOWN_REPLY_OUTCOME = "Send outcome is unknown. Check LinkedIn before retrying.";
+
+export function parseReplyReceipt(json, payload, { threadId, threadUrl, originToken }) {
+  const messages = new Map();
+  function visit(value) {
+    if (!value || typeof value !== "object") return;
+    if (value.$type === "com.linkedin.messenger.Message") {
+      if (value.originToken && value.originToken !== originToken) return;
+      // History prefers the backend id. Without it a receipt can name a different id later.
+      if (
+        typeof value.backendUrn === "string" &&
+        value.backendUrn.startsWith("urn:li:messagingMessage:")
+      ) {
+        messages.set(value.backendUrn, value);
+      }
+      return;
+    }
+    for (const child of Object.values(value)) visit(child);
+  }
+  visit(json);
+  const rows = parseThreadMessagePayloads(
+    [{ included: [...payload.included, ...messages.values()] }],
+    { threadId, threadUrl, limit: 100 },
+  );
+  if (rows.length !== 1 || !rows[0].sender_is_self || !rows[0].sent_at) {
+    throw new Error(UNKNOWN_REPLY_OUTCOME);
+  }
+  return { ...rows[0], status: "sent" };
+}

--- a/opencli-plugins/linkedin/reply.js
+++ b/opencli-plugins/linkedin/reply.js
@@ -1,0 +1,102 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from "@jackwener/opencli/errors";
+import { cli, Strategy } from "@jackwener/opencli/registry";
+import {
+  LINKEDIN_DOMAIN,
+  fetchFirstConversationPayload,
+  openThread,
+  readThreadCsrf,
+  requireCurrentThread,
+  requireThreadUrl,
+  waitForThreadProbe,
+} from "./thread-read.mjs";
+import { linkedInThreadId, unwrapThreadBrowserResult } from "./thread-snapshot-helpers.mjs";
+import {
+  UNKNOWN_REPLY_OUTCOME,
+  parseReplyReceipt,
+  postLinkedInReply,
+  verifiedReplyTarget,
+} from "./reply-helpers.mjs";
+
+cli({
+  site: "linkedin",
+  name: "reply",
+  access: "write",
+  description: "Reply to a verified direct conversation and return its provider message id",
+  domain: LINKEDIN_DOMAIN,
+  strategy: Strategy.COOKIE,
+  browser: true,
+  args: [
+    { name: "thread-url", required: true, help: "Exact existing LinkedIn thread URL" },
+    { name: "expected-recipient", required: true, help: "Recipient member id" },
+    { name: "expected-self", required: true, help: "Sending account member id" },
+    { name: "message", required: true, help: "Plain text reply, with whitespace preserved" },
+    {
+      name: "send",
+      type: "bool",
+      default: false,
+      help: "Send the reply. Otherwise only verify the destination.",
+    },
+  ],
+  columns: ["status", "thread_id", "message_id", "sent_at", "text"],
+  func: async (page, args) => {
+    if (!page) throw new CommandExecutionError("Browser session required for linkedin reply");
+    const threadUrl = requireThreadUrl(args["thread-url"]);
+    const threadId = linkedInThreadId(threadUrl);
+    const text = args.message;
+    const recipientId = args["expected-recipient"];
+    const selfId = args["expected-self"];
+    if (typeof text !== "string" || !text.trim())
+      throw new ArgumentError("--message must contain text");
+    if (
+      ![recipientId, selfId].every(
+        (id) => typeof id === "string" && /^ACoAA[A-Za-z0-9_-]+$/.test(id),
+      ) ||
+      recipientId === selfId
+    ) {
+      throw new ArgumentError("Expected two distinct LinkedIn member ids");
+    }
+    await openThread(page, threadUrl);
+    const probe = await waitForThreadProbe(page, threadId);
+    requireCurrentThread(probe, threadUrl, "reply");
+    const csrf = await readThreadCsrf(page);
+    const payload = await fetchFirstConversationPayload(page, probe, csrf, threadId, "reply");
+    let target;
+    try {
+      target = verifiedReplyTarget(payload, { threadId, threadUrl, recipientId, selfId });
+    } catch (error) {
+      throw new CommandExecutionError(error.message);
+    }
+    if (!args.send) return [{ status: "verified_dry_run", thread_id: threadId }];
+
+    const originToken = randomUUID();
+    let result;
+    try {
+      result = unwrapThreadBrowserResult(
+        await page.evaluate(
+          postLinkedInReply,
+          csrf,
+          target,
+          text,
+          originToken,
+          randomBytes(16).toString("latin1"),
+          threadUrl,
+        ),
+      );
+    } catch {
+      throw new CommandExecutionError(UNKNOWN_REPLY_OUTCOME);
+    }
+    if (result?.auth_required)
+      throw new AuthRequiredError(
+        LINKEDIN_DOMAIN,
+        "LinkedIn reply requires an active signed-in LinkedIn browser session.",
+      );
+    if (result?.error) throw new CommandExecutionError(result.error);
+    if (!result?.json || result.uncertain) throw new CommandExecutionError(UNKNOWN_REPLY_OUTCOME);
+    try {
+      return [parseReplyReceipt(result.json, payload, { threadId, threadUrl, originToken })];
+    } catch {
+      throw new CommandExecutionError(UNKNOWN_REPLY_OUTCOME);
+    }
+  },
+});

--- a/opencli-plugins/linkedin/reply.js
+++ b/opencli-plugins/linkedin/reply.js
@@ -4,6 +4,7 @@ import { cli, Strategy } from "@jackwener/opencli/registry";
 import {
   LINKEDIN_DOMAIN,
   fetchFirstConversationPayload,
+  fetchThreadPayload,
   openThread,
   readThreadCsrf,
   requireCurrentThread,
@@ -13,7 +14,7 @@ import {
 import { linkedInThreadId, unwrapThreadBrowserResult } from "./thread-snapshot-helpers.mjs";
 import {
   UNKNOWN_REPLY_OUTCOME,
-  parseReplyReceipt,
+  confirmReplyReceipt,
   postLinkedInReply,
   verifiedReplyTarget,
 } from "./reply-helpers.mjs";
@@ -84,7 +85,7 @@ cli({
         ),
       );
     } catch {
-      throw new CommandExecutionError(UNKNOWN_REPLY_OUTCOME);
+      result = { uncertain: true };
     }
     if (result?.auth_required)
       throw new AuthRequiredError(
@@ -92,9 +93,18 @@ cli({
         "LinkedIn reply requires an active signed-in LinkedIn browser session.",
       );
     if (result?.error) throw new CommandExecutionError(result.error);
-    if (!result?.json || result.uncertain) throw new CommandExecutionError(UNKNOWN_REPLY_OUTCOME);
     try {
-      return [parseReplyReceipt(result.json, payload, { threadId, threadUrl, originToken })];
+      return [
+        await confirmReplyReceipt(
+          result?.json,
+          payload,
+          { threadId, threadUrl, originToken },
+          {
+            readHistory: () => fetchThreadPayload(page, probe.initial_url, csrf, threadId, "reply"),
+            wait: () => page.wait(1),
+          },
+        ),
+      ];
     } catch {
       throw new CommandExecutionError(UNKNOWN_REPLY_OUTCOME);
     }

--- a/opencli-plugins/linkedin/reply.test.mjs
+++ b/opencli-plugins/linkedin/reply.test.mjs
@@ -5,6 +5,7 @@ import { getRegistry } from "@jackwener/opencli/registry";
 import { parseThreadMessagePayloads } from "./thread-snapshot-helpers.mjs";
 import {
   UNKNOWN_REPLY_OUTCOME,
+  confirmReplyReceipt,
   parseReplyReceipt,
   postLinkedInReply,
   verifiedReplyTarget,
@@ -24,6 +25,7 @@ const text = "Hello 👋\n\n  Thanks for the details.";
 const originToken = "12345678-1234-4123-8123-123456789012";
 const conversationApi =
   "https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql?queryId=messengerConversations.abcdef&variables=(mailboxUrn:urn%3Ali%3Afsd_profile%3Aowner)";
+const messageApi = `https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql?queryId=messengerMessages.abcdef&variables=${encodeURIComponent(`(conversationUrn:${conversationUrn})`)}`;
 
 function payload() {
   return {
@@ -139,6 +141,85 @@ test("receipt parsing rejects unknown, unrelated, inbound, or incomplete results
   }
 });
 
+test("receipt confirmation reads history after a partial creation response", async () => {
+  let reads = 0;
+  const receipt = await confirmReplyReceipt(
+    { value: {} },
+    payload(),
+    { ...expected, originToken },
+    {
+      readHistory: async () => {
+        reads++;
+        return {
+          included: [
+            message({ originToken: null, backendUrn: "urn:li:messagingMessage:older" }),
+            message(),
+          ],
+        };
+      },
+      wait: async () => assert.fail("The first history read confirmed the reply"),
+    },
+  );
+  assert.equal(receipt.message_id, "sent-123");
+  assert.equal(reads, 1);
+});
+
+test("receipt confirmation retries reads until the exact origin token appears", async () => {
+  let reads = 0;
+  let waits = 0;
+  const receipt = await confirmReplyReceipt(
+    null,
+    payload(),
+    { ...expected, originToken },
+    {
+      readHistory: async () => {
+        reads++;
+        if (reads === 1) throw new Error("temporary read failure");
+        return { included: [message({ originToken: reads === 2 ? "another-send" : originToken })] };
+      },
+      wait: async () => {
+        waits++;
+      },
+    },
+  );
+  assert.equal(receipt.message_id, "sent-123");
+  assert.equal(reads, 3);
+  assert.equal(waits, 2);
+});
+
+test("receipt confirmation stays unknown when history only contains other send attempts", async () => {
+  let reads = 0;
+  await assert.rejects(
+    confirmReplyReceipt(
+      null,
+      payload(),
+      { ...expected, originToken },
+      {
+        readHistory: async () => {
+          reads++;
+          return { included: [message({ originToken: "another-send" })] };
+        },
+        wait: async () => {},
+      },
+    ),
+    { message: UNKNOWN_REPLY_OUTCOME },
+  );
+  assert.equal(reads, 3);
+});
+
+test("a complete receipt needs no additional history read", async () => {
+  const receipt = await confirmReplyReceipt(
+    { value: message() },
+    payload(),
+    { ...expected, originToken },
+    {
+      readHistory: async () => assert.fail("Receipt already confirmed"),
+      wait: async () => assert.fail("Receipt already confirmed"),
+    },
+  );
+  assert.equal(receipt.message_id, "sent-123");
+});
+
 test("the browser write makes exactly one scoped POST and preserves the message", async () => {
   const calls = [];
   const result = await vm.runInNewContext(`(${postLinkedInReply.toString()})(...args)`, {
@@ -190,7 +271,7 @@ test("navigation changes block the POST, and unknown outcomes never trigger a se
   }
 });
 
-function fakePage({ conversation = payload(), outcome = null } = {}) {
+function fakePage({ conversation = payload(), outcome = null, history = null } = {}) {
   const writes = [];
   return {
     writes,
@@ -201,12 +282,19 @@ function fakePage({ conversation = payload(), outcome = null } = {}) {
       if (fn.name === "inspectLinkedInThreadPage")
         return {
           current_url: threadUrl,
-          initial_url: "found",
+          initial_url: messageApi,
           conversation_urls: [conversationApi],
         };
       if (fn.name === "fetchLinkedInConversationApi") return { json: conversation };
+      if (fn.name === "fetchLinkedInThreadApi") {
+        return {
+          json:
+            typeof history === "function" ? history(writes[0]?.[3]) : (history ?? { included: [] }),
+        };
+      }
       if (fn.name === "postLinkedInReply") {
         writes.push(args);
+        if (outcome instanceof Error) throw outcome;
         return outcome ?? { json: { value: message({ originToken: args[3] }) } };
       }
       throw new Error(`Unexpected function ${fn.name}`);
@@ -255,3 +343,20 @@ test("the command reports a missing receipt token as unknown without sending aga
   });
   assert.equal(page.writes.length, 1);
 });
+
+for (const [label, outcome] of [
+  ["partial response", { json: { value: {} } }],
+  ["lost response", new Error("browser response lost")],
+]) {
+  test(`the command confirms a ${label} from history without sending again`, async () => {
+    const page = fakePage({
+      outcome,
+      history: (token) => ({ included: [message({ originToken: token })] }),
+    });
+    const [receipt] = await getRegistry()
+      .get("linkedin/reply")
+      .func(page, { ...args, send: true });
+    assert.equal(receipt.message_id, "sent-123");
+    assert.equal(page.writes.length, 1);
+  });
+}

--- a/opencli-plugins/linkedin/reply.test.mjs
+++ b/opencli-plugins/linkedin/reply.test.mjs
@@ -3,7 +3,12 @@ import test from "node:test";
 import vm from "node:vm";
 import { getRegistry } from "@jackwener/opencli/registry";
 import { parseThreadMessagePayloads } from "./thread-snapshot-helpers.mjs";
-import { parseReplyReceipt, postLinkedInReply, verifiedReplyTarget } from "./reply-helpers.mjs";
+import {
+  UNKNOWN_REPLY_OUTCOME,
+  parseReplyReceipt,
+  postLinkedInReply,
+  verifiedReplyTarget,
+} from "./reply-helpers.mjs";
 import "./reply.js";
 
 const threadId = "2-target==";
@@ -102,12 +107,27 @@ test("a reply receipt and a later snapshot use the same provider id", () => {
   assert.equal(receipt.status, "sent");
 });
 
+for (const [label, token] of [
+  ["missing", undefined],
+  ["null", null],
+  ["empty", ""],
+  ["mismatched", "another-send"],
+]) {
+  test(`receipt parsing treats ${label} origin tokens as unknown outcomes`, () => {
+    const response = JSON.parse(
+      JSON.stringify({ data: { value: message({ originToken: token }) } }),
+    );
+    assert.throws(() => parseReplyReceipt(response, payload(), { ...expected, originToken }), {
+      message: UNKNOWN_REPLY_OUTCOME,
+    });
+  });
+}
+
 test("receipt parsing rejects unknown, unrelated, inbound, or incomplete results", () => {
   for (const value of [
     {},
     { status: "sent" },
     message({ backendUrn: undefined }),
-    message({ originToken: "another-send" }),
     message({ "*sender": recipient }),
     message({ deliveredAt: null }),
     message({ backendConversationUrn: "urn:li:messagingThread:other", "*conversation": "other" }),
@@ -223,4 +243,15 @@ test("the command refuses unverified recipients and reports uncertain outcomes w
   const unknown = fakePage({ outcome: { uncertain: true } });
   await assert.rejects(command.func(unknown, { ...args, send: true }), /outcome is unknown/);
   assert.equal(unknown.writes.length, 1);
+});
+
+test("the command reports a missing receipt token as unknown without sending again", async () => {
+  const command = getRegistry().get("linkedin/reply");
+  const page = fakePage({
+    outcome: JSON.parse(JSON.stringify({ json: { value: message({ originToken: undefined }) } })),
+  });
+  await assert.rejects(command.func(page, { ...args, send: true }), {
+    message: UNKNOWN_REPLY_OUTCOME,
+  });
+  assert.equal(page.writes.length, 1);
 });

--- a/opencli-plugins/linkedin/reply.test.mjs
+++ b/opencli-plugins/linkedin/reply.test.mjs
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import vm from "node:vm";
+import { getRegistry } from "@jackwener/opencli/registry";
+import { parseThreadMessagePayloads } from "./thread-snapshot-helpers.mjs";
+import { parseReplyReceipt, postLinkedInReply, verifiedReplyTarget } from "./reply-helpers.mjs";
+import "./reply.js";
+
+const threadId = "2-target==";
+const threadUrl = `https://www.linkedin.com/messaging/thread/${threadId}/`;
+const recipientId = "ACoAARecipient";
+const selfId = "ACoAAOwner";
+const mailboxUrn = `urn:li:fsd_profile:${selfId}`;
+const conversationUrn = `urn:li:msg_conversation:(${mailboxUrn},${threadId})`;
+const sender = `urn:li:msg_messagingParticipant:${mailboxUrn}`;
+const recipient = `urn:li:msg_messagingParticipant:urn:li:fsd_profile:${recipientId}`;
+const expected = { threadId, threadUrl, recipientId, selfId };
+const text = "Hello 👋\n\n  Thanks for the details.";
+const originToken = "12345678-1234-4123-8123-123456789012";
+const conversationApi =
+  "https://www.linkedin.com/voyager/api/voyagerMessagingGraphQL/graphql?queryId=messengerConversations.abcdef&variables=(mailboxUrn:urn%3Ali%3Afsd_profile%3Aowner)";
+
+function payload() {
+  return {
+    __opencli: { conversation_participant_refs_complete: true },
+    included: [
+      {
+        $type: "com.linkedin.messenger.Conversation",
+        entityUrn: conversationUrn,
+        backendUrn: `urn:li:messagingThread:${threadId}`,
+        groupChat: false,
+        "*conversationParticipants": [sender, recipient],
+      },
+      ...[
+        [sender, "SELF"],
+        [recipient, "DISTANCE_1"],
+      ].map(([entityUrn, distance]) => ({
+        $type: "com.linkedin.messenger.MessagingParticipant",
+        entityUrn,
+        participantType: { member: { firstName: { text: "Member" }, distance } },
+      })),
+    ],
+  };
+}
+function message(overrides = {}) {
+  return {
+    $type: "com.linkedin.messenger.Message",
+    entityUrn: "urn:li:msg_message:(owner,sent-123)",
+    backendUrn: "urn:li:messagingMessage:sent-123",
+    "*conversation": conversationUrn,
+    backendConversationUrn: `urn:li:messagingThread:${threadId}`,
+    "*sender": sender,
+    body: { text },
+    deliveredAt: 1789000000000,
+    originToken,
+    ...overrides,
+  };
+}
+
+test("destination verification requires complete direct membership and both account ids", () => {
+  assert.deepEqual(verifiedReplyTarget(payload(), expected), { conversationUrn, mailboxUrn });
+  for (const mutate of [
+    (p) => {
+      p.__opencli.conversation_participant_refs_complete = false;
+    },
+    (p) => {
+      p.included[0].groupChat = true;
+    },
+    (p) => {
+      delete p.included[0].groupChat;
+    },
+    (p) => {
+      p.included[0]["*conversationParticipants"].push("another-member");
+    },
+    (p) => {
+      p.included[1].participantType.member.distance = "DISTANCE_1";
+    },
+    (p) => {
+      p.included[0].entityUrn = `urn:li:msg_conversation:(other,${threadId})`;
+    },
+  ]) {
+    const p = payload();
+    mutate(p);
+    assert.throws(() => verifiedReplyTarget(p, expected));
+  }
+  assert.throws(() => verifiedReplyTarget(payload(), { ...expected, recipientId: "ACoAAOther" }));
+  assert.throws(() => verifiedReplyTarget(payload(), { ...expected, selfId: "ACoAAOther" }));
+  assert.throws(() => verifiedReplyTarget(null, expected));
+});
+
+test("a reply receipt and a later snapshot use the same provider id", () => {
+  const receipt = parseReplyReceipt({ data: { value: message() } }, payload(), {
+    ...expected,
+    originToken,
+  });
+  const [mirrored] = parseThreadMessagePayloads(
+    [{ included: [...payload().included, message()] }],
+    { ...expected, limit: 20 },
+  );
+  assert.equal(receipt.message_id, mirrored.message_id);
+  assert.equal(receipt.message_id, "sent-123");
+  assert.equal(receipt.status, "sent");
+});
+
+test("receipt parsing rejects unknown, unrelated, inbound, or incomplete results", () => {
+  for (const value of [
+    {},
+    { status: "sent" },
+    message({ backendUrn: undefined }),
+    message({ originToken: "another-send" }),
+    message({ "*sender": recipient }),
+    message({ deliveredAt: null }),
+    message({ backendConversationUrn: "urn:li:messagingThread:other", "*conversation": "other" }),
+  ]) {
+    assert.throws(
+      () => parseReplyReceipt({ value }, payload(), { ...expected, originToken }),
+      /outcome is unknown/,
+    );
+  }
+});
+
+test("the browser write makes exactly one scoped POST and preserves the message", async () => {
+  const calls = [];
+  const result = await vm.runInNewContext(`(${postLinkedInReply.toString()})(...args)`, {
+    URL,
+    location: new URL(threadUrl),
+    args: ["csrf", { conversationUrn, mailboxUrn }, text, originToken, "tracking", threadUrl],
+    fetch: async (url, options) => {
+      calls.push({ url, options });
+      return { ok: true, status: 201, json: async () => ({ value: message() }) };
+    },
+  });
+  assert.ok(result.json);
+  assert.equal(calls.length, 1);
+  assert.equal(
+    calls[0].url,
+    "https://www.linkedin.com/voyager/api/voyagerMessagingDashMessengerMessages?action=createMessage",
+  );
+  assert.equal(calls[0].options.credentials, "include");
+  assert.deepEqual(JSON.parse(calls[0].options.body), {
+    message: {
+      body: { attributes: [], text },
+      renderContentUnions: [],
+      conversationUrn,
+      originToken,
+    },
+    mailboxUrn,
+    trackingId: "tracking",
+    dedupeByClientGeneratedToken: false,
+  });
+});
+
+test("navigation changes block the POST, and unknown outcomes never trigger a second POST", async () => {
+  for (const mode of ["navigation", "timeout", "server-error", "auth", "rejected"]) {
+    let calls = 0;
+    const result = await vm.runInNewContext(`(${postLinkedInReply.toString()})(...args)`, {
+      URL,
+      location: new URL(mode === "navigation" ? "https://www.linkedin.com/feed/" : threadUrl),
+      args: ["csrf", { conversationUrn, mailboxUrn }, text, originToken, "tracking", threadUrl],
+      fetch: async () => {
+        calls++;
+        if (mode === "timeout") throw new Error("timeout");
+        return { ok: false, status: mode === "auth" ? 401 : mode === "rejected" ? 422 : 503 };
+      },
+    });
+    assert.equal(calls, mode === "navigation" ? 0 : 1);
+    if (mode === "timeout" || mode === "server-error") assert.equal(result.uncertain, true);
+    if (mode === "auth") assert.equal(result.auth_required, true);
+    if (mode === "rejected" || mode === "navigation") assert.ok(result.error);
+  }
+});
+
+function fakePage({ conversation = payload(), outcome = null } = {}) {
+  const writes = [];
+  return {
+    writes,
+    goto: async () => {},
+    wait: async () => {},
+    getCookies: async () => [{ name: "JSESSIONID", value: '"csrf"' }],
+    evaluate: async (fn, ...args) => {
+      if (fn.name === "inspectLinkedInThreadPage")
+        return {
+          current_url: threadUrl,
+          initial_url: "found",
+          conversation_urls: [conversationApi],
+        };
+      if (fn.name === "fetchLinkedInConversationApi") return { json: conversation };
+      if (fn.name === "postLinkedInReply") {
+        writes.push(args);
+        return outcome ?? { json: { value: message({ originToken: args[3] }) } };
+      }
+      throw new Error(`Unexpected function ${fn.name}`);
+    },
+  };
+}
+const args = {
+  "thread-url": threadUrl,
+  "expected-recipient": recipientId,
+  "expected-self": selfId,
+  message: text,
+};
+
+test("the command defaults to verifying only and requires --send for the one write", async () => {
+  const command = getRegistry().get("linkedin/reply");
+  assert.equal(command.access, "write");
+  const page = fakePage();
+  assert.equal((await command.func(page, args))[0].status, "verified_dry_run");
+  assert.equal(page.writes.length, 0);
+  const [receipt] = await command.func(page, { ...args, send: true });
+  assert.equal(receipt.message_id, "sent-123");
+  assert.equal(page.writes.length, 1);
+  assert.equal(page.writes[0][2], text);
+  assert.equal(page.writes[0][4].length, 16);
+});
+
+test("the command refuses unverified recipients and reports uncertain outcomes without retrying", async () => {
+  const command = getRegistry().get("linkedin/reply");
+  const wrong = fakePage();
+  await assert.rejects(
+    command.func(wrong, { ...args, "expected-recipient": "ACoAAOther", send: true }),
+  );
+  assert.equal(wrong.writes.length, 0);
+  const unknown = fakePage({ outcome: { uncertain: true } });
+  await assert.rejects(command.func(unknown, { ...args, send: true }), /outcome is unknown/);
+  assert.equal(unknown.writes.length, 1);
+});

--- a/opencli-plugins/linkedin/thread-snapshot-helpers.mjs
+++ b/opencli-plugins/linkedin/thread-snapshot-helpers.mjs
@@ -558,6 +558,7 @@ export async function fetchLinkedInThreadApi(apiUrl, csrf) {
     }
     const response = await fetch(url.toString(), {
       credentials: "include",
+      cache: "no-store",
       headers: {
         "csrf-token": csrf,
         accept: "application/vnd.linkedin.normalized+json+2.1",

--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -770,13 +770,8 @@ export interface LinkedAccount {
  * - `not-connected` — no live connection for the channel. The guardian fixes
  *   this in Settings.
  * - `unsupported` — the connection is live but does not do direct messaging.
- *   LinkedIn mirrors an inbox it cannot write to; a channel Rome has not
- *   taught to send reads the same way. Why is a fact about the channel rather
- *   than about this account, so the copy is keyed on the channel name and no
- *   reason string crosses the wire — the dashboard localizes it, the same way
- *   it already localizes every channel's own label.
- * - `no-conversation` — the channel sends, but has no thread that reaches this
- *   account yet, and could not open one. Per account, and recoverable.
+ * - `no-conversation` — the channel cannot identify a direct conversation for
+ *   this account. This includes missing or ambiguous threads.
  */
 export type AccountSendState = "yes" | "not-connected" | "unsupported" | "no-conversation";
 

--- a/packages/core/src/api/routes/people-linkedin-send.test.ts
+++ b/packages/core/src/api/routes/people-linkedin-send.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, rs } from "@rstest/core";
+import { Hono } from "hono";
+import type { TalkRouter } from "@rome-os/app-runtime";
+import type {
+  OutboxMessage,
+  OutboxPage,
+  PersonResource,
+  TimelinePage,
+} from "@rome/api-types/people";
+import { createLinkedInDescriptor } from "../../connections/integrations/linkedin.js";
+import type { Credential, RuntimeKit } from "../../connections/types.js";
+import type { OpencliResult } from "../../channels/linkedin-cli.js";
+import { buildTestDeps, createTestDb, type TestDb, type TestDeps } from "../../test/helpers.js";
+import { peopleRoutes } from "./people.js";
+
+const MEMBER = "ACoAARecipient";
+const SELF = "ACoAAOwner";
+const THREAD = "2-reply==";
+const URL = `https://www.linkedin.com/messaging/thread/${THREAD}/`;
+const reply = {
+  status: "sent",
+  thread_id: THREAD,
+  message_id: "provider-reply-1",
+  sender_is_self: true,
+  sender_profile_url: `https://www.linkedin.com/in/${SELF}/`,
+  sent_at: new Date().toISOString(),
+  text: "Thanks for reaching out",
+};
+
+describe("LinkedIn replies through People", () => {
+  let db: TestDb;
+  let deps: TestDeps;
+  let app: Hono;
+  let person: string;
+  const run = rs.fn<() => Promise<OpencliResult>>();
+  let send: TalkRouter["send"];
+
+  beforeEach(async () => {
+    db = createTestDb();
+    deps = await buildTestDeps(db.db);
+    run.mockReset();
+    run.mockResolvedValue({ code: 0, stdout: JSON.stringify([reply]), stderr: "" });
+    await deps.linkedInStoreRepo.upsertThreads([
+      { threadId: THREAD, threadUrl: URL, unread: false },
+    ]);
+    await deps.linkedInStoreRepo.upsertThreadParticipants(THREAD, [
+      { participantId: MEMBER, type: "member", isSelf: false },
+      { participantId: SELF, type: "member", isSelf: true },
+    ]);
+    await deps.linkedInStoreRepo.markThreadSynced(THREAD, { isGroup: false });
+    const talker = createLinkedInDescriptor({
+      syncSink: deps.linkedInStoreRepo,
+      run,
+      minIntervalMs: 60_000,
+      maxIntervalMs: 60_000,
+    }).capabilities.talker!.build({} as Record<string, Credential>, {} as RuntimeKit);
+    send = (_connection, conversation, message) => talker.send(conversation, message);
+    deps.talkRouter = {
+      ...deps.talkRouter,
+      list: async () => [{ connectionId: "linkedin", service: "linkedin" }],
+      feature: (_id, name) => talker.feature(name),
+      send: (...args) => send(...args),
+    };
+    person = await deps.personMappingRepo.create({
+      displayName: "LinkedIn Recipient",
+      bondLevel: "acquaintance",
+      approved: true,
+      channelMappings: [{ channel: "linkedin", channelUserId: MEMBER }],
+    });
+    app = new Hono().route("/", peopleRoutes(deps));
+  });
+
+  afterEach(() => db.close());
+
+  const post = () =>
+    app.request(`/people/${person}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel: "linkedin", channelUserId: MEMBER, text: reply.text }),
+    });
+  const outbox = async () =>
+    (await (await app.request(`/people/${person}/outbox`)).json()) as OutboxPage;
+
+  it("exposes the shared composer and reconciles the provider receipt with the mirrored timeline", async () => {
+    const resource = (await (await app.request(`/people/${person}`)).json()) as PersonResource;
+    expect(resource.accounts[0].send).toBe("yes");
+    expect(run).not.toHaveBeenCalled();
+    const response = await post();
+    expect(response.status).toBe(202);
+    expect(await response.json()).toMatchObject({
+      state: "unconfirmed",
+      ref: `${THREAD}:${reply.message_id}`,
+    });
+    expect(run).toHaveBeenCalledWith(
+      [
+        "linkedin",
+        "reply",
+        "--thread-url",
+        URL,
+        "--expected-recipient",
+        MEMBER,
+        "--expected-self",
+        SELF,
+        "--message",
+        reply.text,
+        "--send",
+      ],
+      { timeoutMs: 180_000 },
+    );
+    const timeline = (await (
+      await app.request(`/people/${person}/messages`)
+    ).json()) as TimelinePage;
+    expect(timeline.entries).toHaveLength(1);
+    expect(timeline.entries[0]).toMatchObject({
+      ref: `${THREAD}:${reply.message_id}`,
+      direction: "outbound",
+      body: reply.text,
+    });
+    expect((await outbox()).messages).toEqual([]);
+  });
+
+  it("keeps a failed reply and retries the same outbox row", async () => {
+    run.mockResolvedValueOnce({ code: 1, stdout: "", stderr: "LinkedIn rejected the reply" });
+    const failed = (await (await post()).json()) as OutboxMessage;
+    expect(failed.state).toBe("failed");
+    expect((await outbox()).messages[0].id).toBe(failed.id);
+    const response = await app.request(`/people/${person}/outbox/${failed.id}/retry`, {
+      method: "POST",
+    });
+    expect(await response.json()).toMatchObject({ id: failed.id, state: "unconfirmed" });
+    expect((await outbox()).messages).toEqual([]);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps acceptance when the local mirror write fails, then clears on a provider echo by id", async () => {
+    const upsert = rs
+      .spyOn(deps.linkedInStoreRepo, "upsertMessages")
+      .mockRejectedValueOnce(new Error("disk unavailable"));
+    expect(await (await post()).json()).toMatchObject({ state: "unconfirmed" });
+    expect((await outbox()).messages).toHaveLength(1);
+    upsert.mockRestore();
+    await deps.linkedInStoreRepo.upsertMessages([
+      { threadId: THREAD, messageId: "same-text-other-id", senderIsSelf: true, text: reply.text },
+    ]);
+    expect((await outbox()).messages).toHaveLength(1);
+    await deps.linkedInStoreRepo.upsertMessages([
+      { threadId: THREAD, messageId: reply.message_id, senderIsSelf: true, text: reply.text },
+    ]);
+    expect((await outbox()).messages).toEqual([]);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a group before spawning a send", async () => {
+    await deps.linkedInStoreRepo.markThreadSynced(THREAD, { isGroup: true });
+    expect((await post()).status).toBe(409);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("does not retarget a failed reply when the direct conversation changes", async () => {
+    run.mockRejectedValueOnce(new Error("offline"));
+    const failed = (await (await post()).json()) as OutboxMessage;
+    rs.spyOn(deps.linkedInStoreRepo, "findReplyTarget").mockResolvedValue({
+      threadId: "different-thread",
+      threadUrl: "https://www.linkedin.com/messaging/thread/different-thread/",
+      participantId: MEMBER,
+      selfParticipantId: SELF,
+    });
+    await app.request(`/people/${person}/outbox/${failed.id}/retry`, { method: "POST" });
+    expect((await outbox()).messages[0]).toMatchObject({
+      state: "failed",
+      error: expect.stringContaining("conversation changed"),
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/api/routes/people-send.test.ts
+++ b/packages/core/src/api/routes/people-send.test.ts
@@ -96,9 +96,6 @@ describe("People send API", () => {
   });
 
   it("refuses a channel that does not do direct messaging, naming the state", async () => {
-    // A talker with no `directMessaging` feature is exactly LinkedIn: it
-    // mirrors an inbox it cannot write to, and says so rather than throwing
-    // when someone tries.
     const readOnly = { ...deps, talkRouter: { ...deps.talkRouter, feature: () => null } };
     const readOnlyApp = new Hono().route("/", peopleRoutes(readOnly));
 

--- a/packages/core/src/channels/linkedin-cli.test.ts
+++ b/packages/core/src/channels/linkedin-cli.test.ts
@@ -3,6 +3,7 @@ import {
   OpencliAuthError,
   OpencliCommandError,
   parseInbox,
+  parseLinkedInReply,
   parseThreadParticipants,
   parseThreadSnapshot,
   parseWhoami,
@@ -13,6 +14,47 @@ import {
 function ok(stdout: string): OpencliResult {
   return { code: 0, stdout, stderr: "" };
 }
+
+describe("parseLinkedInReply", () => {
+  const receipt = {
+    status: "sent",
+    thread_id: "thread",
+    message_id: "provider-id",
+    sender_is_self: true,
+    sent_at: "2026-09-09T12:00:00Z",
+  };
+
+  it("requires a sent message with a provider id on the requested thread", () => {
+    expect(parseLinkedInReply(ok(JSON.stringify([receipt])), "thread")).toMatchObject({
+      messageId: "provider-id",
+      threadId: "thread",
+      senderIsSelf: true,
+    });
+    for (const row of [
+      { ...receipt, status: "verified_dry_run" },
+      { ...receipt, thread_id: "other" },
+      { ...receipt, message_id: "" },
+      { ...receipt, sender_is_self: false },
+      { ...receipt, sent_at: "invalid" },
+    ]) {
+      expect(() => parseLinkedInReply(ok(JSON.stringify([row])), "thread")).toThrow(
+        "outcome is unknown",
+      );
+    }
+  });
+
+  it("reports killed commands and malformed output as unknown, while preserving auth failures", () => {
+    expect(() =>
+      parseLinkedInReply({ code: null, stdout: "", stderr: "timeout" }, "thread"),
+    ).toThrow("Check LinkedIn before retrying");
+    expect(() => parseLinkedInReply(ok("invalid JSON"), "thread")).toThrow(
+      "Check LinkedIn before retrying",
+    );
+    expect(() =>
+      parseLinkedInReply({ code: 1, stdout: "", stderr: "auth_required" }, "thread"),
+    ).toThrow(OpencliAuthError);
+  });
+});
 
 describe("parseWhoami", () => {
   it("returns the account of a signed-in session", () => {

--- a/packages/core/src/channels/linkedin-cli.ts
+++ b/packages/core/src/channels/linkedin-cli.ts
@@ -1,21 +1,15 @@
 // The opencli boundary for the LinkedIn channel: one process runner plus the
 // parsers/classifiers for the commands the channel consumes (`whoami`,
-// `inbox`, `thread-snapshot`, `thread-participants`). opencli drives Rome's
+// `inbox`, `thread-snapshot`, `thread-participants`, `reply`). opencli drives Rome's
 // server-side Chrome over CDP, and the LinkedIn session lives in that browser's
 // profile — Rome never holds a LinkedIn credential; it holds the right to use
 // the logged-in browser.
 //
-// Every command wrapped here is a read. Rome wrapped `linkedin safe-send` too,
-// for the People page's LinkedIn composer; that composer is gone and nothing
-// else sends, so the wrapper went with it. The opencli command is untouched
-// and still reachable from a shell — what Rome no longer has is a LinkedIn
-// send path a dashboard request can reach.
-//
 // Error taxonomy mirrors connections/errors.ts: an auth wall / logged-out
 // session is `OpencliAuthError` (the caller maps it to CredentialRejected);
 // everything else — CDP down, timeout, unparseable output — is
-// `OpencliCommandError` (transient; retried on the next poll, never touching
-// grant state).
+// `OpencliCommandError`. Polls retry transient failures. Replies require an
+// explicit retry, because a lost response can follow a successful send.
 
 import { execFile } from "node:child_process";
 import { z } from "zod";
@@ -303,6 +297,52 @@ export function parseThreadSnapshot(result: OpencliResult): LinkedInSnapshotMess
     subject: row.subject ?? null,
     reactionCount: row.reaction_count ?? null,
   }));
+}
+
+/** A reply receipt must carry the same provider id as the history mirror. */
+export function parseLinkedInReply(
+  result: OpencliResult,
+  threadId: string,
+): LinkedInSnapshotMessage {
+  if (result.code === null) {
+    throw new OpencliCommandError(
+      "linkedin reply",
+      "Send outcome is unknown. Check LinkedIn before retrying.",
+    );
+  }
+  let raw: unknown;
+  try {
+    raw = parseJsonOutput("linkedin reply", result);
+  } catch (error) {
+    if (error instanceof OpencliAuthError || result.code !== 0) throw error;
+    throw new OpencliCommandError(
+      "linkedin reply",
+      "Send outcome is unknown. Check LinkedIn before retrying.",
+    );
+  }
+  const parsed = z
+    .array(
+      snapshotRowSchema.extend({
+        status: z.literal("sent"),
+        sender_is_self: z.literal(true),
+      }),
+    )
+    .length(1)
+    .safeParse(raw);
+  if (!parsed.success || parsed.data[0]?.thread_id !== threadId) {
+    throw new OpencliCommandError(
+      "linkedin reply",
+      "Send outcome is unknown. Check LinkedIn before retrying.",
+    );
+  }
+  const [message] = parseThreadSnapshot(result);
+  if (!message?.sentAt) {
+    throw new OpencliCommandError(
+      "linkedin reply",
+      "Send outcome is unknown. Check LinkedIn before retrying.",
+    );
+  }
+  return message;
 }
 
 // ── thread-participants ───────────────────────────────────────────────────

--- a/packages/core/src/channels/linkedin-sync.ts
+++ b/packages/core/src/channels/linkedin-sync.ts
@@ -104,7 +104,18 @@ export interface LinkedInHistoryMessage {
   subject: string | null;
 }
 
+export interface LinkedInReplyTarget {
+  threadId: string;
+  threadUrl: string;
+  participantId: string;
+  selfParticipantId: string;
+}
+
 export interface LinkedInSyncSink {
+  /** Returns one verified direct thread, or null for absent or ambiguous membership. */
+  findReplyTarget?(
+    by: { participantId: string } | { threadId: string },
+  ): Promise<LinkedInReplyTarget | null>;
   upsertThreads(threads: LinkedInThreadInput[]): Promise<void>;
   upsertMessages(messages: LinkedInMessageInput[]): Promise<void>;
   /** Watermarks for the given threads (absent threads are omitted). */

--- a/packages/core/src/connections/integrations/linkedin.ts
+++ b/packages/core/src/connections/integrations/linkedin.ts
@@ -1,6 +1,6 @@
 // LinkedIn connection integration. Channel contract: docs/architecture/channels.md.
 //
-// LinkedIn is a read-only Talker with a single `session` grant, and the grant
+// LinkedIn has a single `session` grant, and the grant
 // is custody-external: the signed-in session lives in Rome's server-side
 // Chrome profile (the one opencli drives over CDP), so the ledger holds only a
 // custody marker plus the account identity — there is no secret Rome could
@@ -15,11 +15,8 @@
 // probe keeps the credential, and only a definite signed-out answer degrades
 // to "re-confer".
 //
-// The capability is the inbox poller (channels/linkedin.ts): jittered
-// 15–30 min ticks that mirror the inbox into linkedin_threads/
-// linkedin_messages. v1 mirrors only — no inbound delivery into the agent
-// pipeline and no send path, so `send` refuses loudly. History is served from
-// the mirror through the standard `history` talk feature.
+// The inbox poller mirrors history without delivering inbound agent turns.
+// Replies use the same browser session and the shared People outbox.
 
 import { z } from "zod";
 import type {
@@ -32,6 +29,7 @@ import {
   OpencliAuthError,
   openLinkedInBrowserTab,
   parseWhoami,
+  parseLinkedInReply,
   runOpencli,
   type LinkedInWhoami,
   type RunOpencli,
@@ -51,6 +49,9 @@ import type {
   Talker,
 } from "../types.js";
 import { historyFeature } from "./talk-features.js";
+import { createLogger } from "../../logger.js";
+
+const log = createLogger("linkedin-reply");
 
 const LINKEDIN_LOGIN_URL = "https://www.linkedin.com/login";
 const WHOAMI_TIMEOUT_MS = 90_000;
@@ -335,23 +336,85 @@ export function createLinkedInDescriptor(deps: LinkedInDescriptorDeps): Connecti
             stop(): void {
               poller.stop();
             },
-            async send(_conversationId: ConversationId, _msg) {
-              throw new Error(
-                "The LinkedIn connection is read-only: Rome mirrors your inbox but does not send LinkedIn messages.",
-              );
+            async send(conversationId: ConversationId, msg) {
+              if (
+                !msg.text?.trim() ||
+                msg.attachments?.length ||
+                msg.replyToMessageId ||
+                msg.kind === "email" ||
+                msg.parts?.length
+              ) {
+                throw new Error("LinkedIn replies support plain text only");
+              }
+              const target = await deps.syncSink.findReplyTarget?.({ threadId: conversationId });
+              if (!target)
+                throw new Error("No verified LinkedIn direct conversation for this reply");
+              if (
+                target.threadId !== conversationId ||
+                target.threadUrl !== `https://www.linkedin.com/messaging/thread/${conversationId}/`
+              ) {
+                throw new Error("LinkedIn reply target does not match the selected conversation");
+              }
+              let message;
+              try {
+                message = parseLinkedInReply(
+                  await run(
+                    [
+                      "linkedin",
+                      "reply",
+                      "--thread-url",
+                      target.threadUrl,
+                      "--expected-recipient",
+                      target.participantId,
+                      "--expected-self",
+                      target.selfParticipantId,
+                      "--message",
+                      msg.text,
+                      "--send",
+                    ],
+                    { timeoutMs: 180_000 },
+                  ),
+                  conversationId,
+                );
+              } catch (error) {
+                if (error instanceof OpencliAuthError) {
+                  throw new CredentialRejected({ grant: "session", cause: error });
+                }
+                throw error;
+              }
+              try {
+                await deps.syncSink.upsertMessages([message]);
+              } catch (error) {
+                // Provider acceptance survives a local mirror failure. The next poll repairs it.
+                log.warn("LinkedIn reply accepted but mirror write failed", {
+                  threadId: conversationId,
+                  messageId: message.messageId,
+                  error: error instanceof Error ? error.message : String(error),
+                });
+              }
+              return { conversationId, messageId: message.messageId };
             },
             feature<K extends TalkFeatureName>(name: K): TalkFeatureMap[K] | null {
               const sink = deps.syncSink;
-              if (!sink.fetchHistory) return null;
-              const features: Partial<TalkFeatureMap> = {
-                history: historyFeature({
+              const features: Partial<TalkFeatureMap> = {};
+              if (sink.findReplyTarget) {
+                features.directMessaging = {
+                  async conversationFor(address: string) {
+                    const participantId = linkedInMemberIdFromProfileUrl(address) ?? address.trim();
+                    const target = await sink.findReplyTarget?.({ participantId });
+                    return target ? (target.threadId as ConversationId) : null;
+                  },
+                };
+              }
+              if (sink.fetchHistory) {
+                features.history = historyFeature({
                   fetchHistory: async (conversationId, windowHours) => {
                     const since = new Date(Date.now() - windowHours * 3_600_000);
                     const rows = await sink.fetchHistory?.(conversationId, since);
                     return (rows ?? []).map(toHistoryNormalizedMessage);
                   },
-                }),
-              };
+                });
+              }
               return (features[name] as TalkFeatureMap[K] | undefined) ?? null;
             },
             getRuntimeDegradation(): CapabilityDegradation | null {

--- a/packages/core/src/db/repositories/linkedin-store.test.ts
+++ b/packages/core/src/db/repositories/linkedin-store.test.ts
@@ -40,6 +40,68 @@ describe("LinkedInStoreRepository", () => {
     expect(cursor?.lastSyncedAt).toBeNull();
   });
 
+  describe("reply targets", () => {
+    const recipient = { participantId: "ACoAAAda", type: "member", isSelf: false };
+    const owner = { participantId: "ACoAASelf", type: "member", isSelf: true };
+    const seed = async (id = "reply-thread") => {
+      await repo.upsertThreads([thread(id, new Date())]);
+      await repo.upsertThreadParticipants(id, [recipient, owner]);
+      await repo.markThreadSynced(id, { isGroup: false });
+    };
+
+    it("resolves a member to an existing direct thread and rechecks the same target by thread", async () => {
+      await seed();
+      const target = await repo.findReplyTarget({ participantId: recipient.participantId });
+      expect(target).toEqual({
+        threadId: "reply-thread",
+        threadUrl: thread("reply-thread", new Date()).threadUrl,
+        participantId: recipient.participantId,
+        selfParticipantId: owner.participantId,
+      });
+      expect(await repo.findReplyTarget({ threadId: "reply-thread" })).toEqual(target);
+      expect(await repo.findReplyTarget({ participantId: owner.participantId })).toBeNull();
+    });
+
+    it("does not choose between multiple direct conversations", async () => {
+      await seed("one");
+      await seed("two");
+      expect(await repo.findReplyTarget({ participantId: recipient.participantId })).toBeNull();
+    });
+
+    it("refuses groups, incomplete membership, and missing threads", async () => {
+      expect(await repo.findReplyTarget({ threadId: "missing" })).toBeNull();
+      await seed();
+      await repo.markThreadSynced("reply-thread", { isGroup: true });
+      expect(await repo.findReplyTarget({ threadId: "reply-thread" })).toBeNull();
+      await repo.markThreadSynced("reply-thread", { isGroup: false });
+      await repo.upsertThreadParticipants("reply-thread", [
+        recipient,
+        owner,
+        { ...recipient, participantId: "ACoAAThird" },
+      ]);
+      expect(await repo.findReplyTarget({ threadId: "reply-thread" })).toBeNull();
+      await repo.upsertThreadParticipants("reply-thread", [recipient]);
+      expect(await repo.findReplyTarget({ threadId: "reply-thread" })).toBeNull();
+    });
+
+    it("refuses membership inferred only from message senders", async () => {
+      await repo.upsertThreads([thread("seeded", new Date())]);
+      await repo.upsertMessages(
+        [recipient, owner].map((p) => ({
+          threadId: "seeded",
+          messageId: p.participantId,
+          senderProfileUrl: `https://www.linkedin.com/in/${p.participantId}/`,
+          senderIsSelf: p.isSelf,
+          senderType: "member",
+          text: "hello",
+        })),
+      );
+      await repo.backfillParticipantsFromMessages();
+      await repo.markThreadSynced("seeded", { isGroup: false });
+      expect(await repo.findReplyTarget({ participantId: recipient.participantId })).toBeNull();
+    });
+  });
+
   it("a re-listed thread keeps learned fields when the listing drops them", async () => {
     const at = new Date("2026-08-19T20:00:00Z");
     await repo.upsertThreads([thread("t1", at)]);

--- a/packages/core/src/db/repositories/linkedin-store.ts
+++ b/packages/core/src/db/repositories/linkedin-store.ts
@@ -12,6 +12,7 @@ import type {
   LinkedInMessageInput,
   LinkedInParticipantInput,
   LinkedInParticipantRow,
+  LinkedInReplyTarget,
   LinkedInSyncSink,
   LinkedInThreadCursor,
   LinkedInThreadInput,
@@ -121,15 +122,32 @@ function chunked<T>(items: T[], size: number): T[][] {
  * reads serve the poller's watermarks, the address book's fold over mirrored
  * accounts, and the history talk feature.
  *
- * Nothing here hands a thread or its messages to a reader as a thread. The
- * dashboard reads LinkedIn through the person contract like every other
- * channel, so every read out of this mirror is addressed by account —
- * {@link LinkedInStoreRepository.listParticipants}, scoped by
- * {@link DIRECT_THREADS}. A thread-shaped read here would have no caller but a
- * thread-shaped surface, and there is none.
+ * Reply targets require complete membership and an explicit direct-conversation verdict.
  */
 export class LinkedInStoreRepository implements LinkedInSyncSink {
   constructor(private db: DrizzleDb) {}
+
+  async findReplyTarget(
+    by: { participantId: string } | { threadId: string },
+  ): Promise<LinkedInReplyTarget | null> {
+    const scope =
+      "participantId" in by
+        ? sql`p.participant_id = ${by.participantId}`
+        : sql`t.thread_id = ${by.threadId}`;
+    const rows = await this.db.all<LinkedInReplyTarget>(sql`
+      SELECT t.thread_id AS threadId, t.thread_url AS threadUrl,
+        p.participant_id AS participantId, owner.participant_id AS selfParticipantId
+      FROM linkedin_threads t
+      JOIN linkedin_thread_participants tp ON tp.thread_id = t.thread_id
+      JOIN linkedin_participants p ON p.participant_id = tp.participant_id AND p.is_self = 0
+      JOIN linkedin_thread_participants self ON self.thread_id = t.thread_id
+      JOIN linkedin_participants owner ON owner.participant_id = self.participant_id AND owner.is_self = 1
+      WHERE ${scope} AND t.is_group = 0 AND t.participants_last_read_at IS NOT NULL
+        AND p.type = 'member' AND owner.type = 'member'
+        AND (SELECT count(*) FROM linkedin_thread_participants members WHERE members.thread_id = t.thread_id) = 2
+      LIMIT 2`);
+    return rows.length === 1 ? rows[0]! : null;
+  }
 
   async upsertThreads(threads: LinkedInThreadInput[]): Promise<void> {
     if (threads.length === 0) return;

--- a/packages/core/src/people/outbox.ts
+++ b/packages/core/src/people/outbox.ts
@@ -170,6 +170,11 @@ export async function retrySend(
     await deps.outboxRepo.refused(row.id, error);
     return wire({ ...row, state: "failed", error });
   }
+  if (resolution.target.conversationId !== row.conversationId) {
+    const error = "The account's conversation changed. Discard this reply and compose a new one.";
+    await deps.outboxRepo.refused(row.id, error);
+    return wire({ ...row, state: "failed", error });
+  }
   return attempt(deps, row, resolution.target);
 }
 
@@ -299,6 +304,7 @@ function refsFor(row: OutboxRow, addresses: readonly string[]): string[] {
   if (messageId === null) return [];
   const sessionId = channelConversationId(row.channel, row.conversationId);
   return [
+    `${row.conversationId}:${messageId}`,
     ...new Set(addresses.map((address) => `${address}:${messageId}`)),
     `agent:${conversationPlatformMessageId(sessionId, messageId)}`,
   ];

--- a/packages/core/src/people/send.ts
+++ b/packages/core/src/people/send.ts
@@ -15,8 +15,7 @@
 //
 // Whether a channel can be sent to at all is the channel's own declaration:
 // `talk.feature("directMessaging")`. A talker that does not offer it cannot be
-// written to from here, which is how LinkedIn's mirrored inbox stays readable
-// without a read-only flag threaded through anything.
+// written to from here, without a read-only flag threaded through anything.
 
 import type { ConversationId, TalkRouter } from "@rome-os/app-runtime";
 import type { AccountSendState } from "@rome/api-types/people";

--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -41,6 +41,7 @@ import {
 import { talkConnections } from "./connections-store";
 import { memoryProfilePath } from "./memory-files";
 import {
+  LI_ARVIND_MEMBER,
   accountTimeline,
   nameForAccount,
   nextPersonId,
@@ -69,23 +70,9 @@ import {
  * `accountPresentation`, and no /api/people route addresses the sentinel.
  */
 
-/**
- * Whether Rome can send on a channel, as the real read answers it.
- *
- * Production asks the live connection in two steps, and this asks the same two
- * against the fixture ledger. No connection for the channel is `not-connected`
- * — the ledger is `./connections-store.ts`, so revoking a grant on the
- * Connections page relocks talk and this read notices, the way the real one
- * does. A connection whose talker does not do direct messaging is
- * `unsupported`, which in the first cut is every channel but the two.
- *
- * `no-conversation` is unreachable here, as it is on those two channels in
- * production: their address already names the conversation. A channel that
- * keys threads separately would answer it, and the dashboard renders it —
- * `../../src/pages/people/send-copy.ts` carries the copy for all three.
- */
-function sendState(channel: string): AccountSendState {
+function sendState({ channel, channelUserId }: AccountRef): AccountSendState {
   if (talkConnections(channel).length === 0) return "not-connected";
+  if (channel === "linkedin") return channelUserId === LI_ARVIND_MEMBER ? "yes" : "no-conversation";
   return channel === "whatsapp" || channel === "telegram" ? "yes" : "unsupported";
 }
 
@@ -101,7 +88,7 @@ function personResource(person: PersonFixture): PersonResource {
       channel: a.channel,
       channelUserId: a.channelUserId,
       displayName: nameForAccount(a.channel, a.channelUserId),
-      send: sendState(a.channel),
+      send: sendState(a),
       // The account's own head, not the person's: the person's newest entry
       // names a channel and not an address, so it cannot say which of two
       // accounts on one channel was the recent one.
@@ -634,7 +621,7 @@ export const peopleHandlers = [
 
     // The same state the person read answered with, so a client that raced a
     // disconnect renders the reason it would already have shown.
-    const send = sendState(parsed.request.channel);
+    const send = sendState(parsed.request);
     if (send !== "yes") {
       return HttpResponse.json({ error: refusalMessage(send), send } satisfies SendRefusal, {
         status: 409,

--- a/packages/web/mock/handlers/people.ts
+++ b/packages/web/mock/handlers/people.ts
@@ -122,7 +122,7 @@ const HIKES_JID = "120363041948572901@g.us";
  *  it projects off the thread. */
 // LinkedIn addresses a member by its bare member id, which is the
 // `channelUserId` an inbound LinkedIn message resolves through.
-const LI_ARVIND_MEMBER = "ACoAAArvind01";
+export const LI_ARVIND_MEMBER = "ACoAAArvind01";
 const LI_CALEB_MEMBER = "ACoAACaleb02";
 
 const DEVIKA_NAME = "Devika";

--- a/packages/web/src/i18n/locales/en/people.json
+++ b/packages/web/src/i18n/locales/en/people.json
@@ -141,9 +141,8 @@
     },
     "refusal": {
       "notConnected": "{{channel}} isn't connected, so Rome can't send there. Connect it in Settings.",
-      "noConversation": "Rome has no {{channel}} conversation with them yet, so there is nowhere to send. It opens once either of you writes first.",
+      "noConversation": "Rome could not identify a direct {{channel}} conversation for this account. Open {{channel}} to reply.",
       "unsupported": {
-        "linkedin": "Rome reads {{channel}} but cannot write to it. Reply from {{channel}} itself.",
         "default": "Rome cannot send on {{channel}} yet."
       }
     }

--- a/packages/web/src/i18n/locales/zh-CN/people.json
+++ b/packages/web/src/i18n/locales/zh-CN/people.json
@@ -141,9 +141,8 @@
     },
     "refusal": {
       "notConnected": "{{channel}} 未连接，Rome 无法从这里发送。请在设置中连接。",
-      "noConversation": "Rome 与他们还没有 {{channel}} 会话，因此无处可发。任一方先开口后即可建立。",
+      "noConversation": "Rome 无法确定此账号的 {{channel}} 私聊会话。请打开 {{channel}} 回复。",
       "unsupported": {
-        "linkedin": "Rome 只能读取 {{channel}}，无法写入。请直接在 {{channel}} 上回复。",
         "default": "Rome 还不支持在 {{channel}} 上发送。"
       }
     }

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -1106,12 +1106,7 @@ describe("PersonDetailPage, sending", () => {
     renderPage("arvind");
 
     await screen.findByRole("heading", { name: "Arvind Srivastav" });
-    // The reason the server declared, in this locale's words — no sentence
-    // crossed the wire. LinkedIn's is its own: it is an inbox Rome mirrors and
-    // cannot write to, which is not the same as a channel it has yet to learn.
-    expect(
-      screen.getByText("Rome reads LinkedIn but cannot write to it. Reply from LinkedIn itself."),
-    ).toBeTruthy();
+    expect(screen.getByText("Rome cannot send on LinkedIn yet.")).toBeTruthy();
     expect(screen.queryByRole("textbox", { name: "Message text" })).toBeNull();
     // And the history stays readable.
     expect(await screen.findByText("the landlord replies fast")).toBeTruthy();

--- a/packages/web/src/pages/people/composer.tsx
+++ b/packages/web/src/pages/people/composer.tsx
@@ -180,7 +180,7 @@ function refusalText(
   send: RefusedSendState,
   channel: string,
 ): string {
-  return t(sendRefusalKey(send, channel), { channel: channelLabel(t, channel) });
+  return t(sendRefusalKey(send), { channel: channelLabel(t, channel) });
 }
 
 /** One chip's worth of target: the channel's glyph and name, and the handle.

--- a/packages/web/src/pages/people/send-copy.test.ts
+++ b/packages/web/src/pages/people/send-copy.test.ts
@@ -15,31 +15,8 @@ beforeAll(async () => {
 
 describe("sendRefusalKey", () => {
   it("answers a distinct key for each way a channel cannot be written to", () => {
-    const keys = REFUSALS.map((send) => sendRefusalKey(send, "telegram"));
+    const keys = REFUSALS.map((send) => sendRefusalKey(send));
     expect(new Set(keys).size).toBe(REFUSALS.length);
-  });
-
-  it("keys unsupported on the channel, because it means a different thing per channel", () => {
-    // LinkedIn is an inbox Rome mirrors and cannot write to; a channel Rome has
-    // not taught to send is a gap that will close. Reading them the same way
-    // would tell a guardian to wait for something that is never coming.
-    expect(sendRefusalKey("unsupported", "linkedin")).not.toBe(
-      sendRefusalKey("unsupported", "discord"),
-    );
-  });
-
-  it("falls back for a channel with no line of its own, the way the glyph lookup does", () => {
-    // The branch every channel added after this was written lands in — including
-    // one a Rome App brings, which has no entry here to add.
-    expect(sendRefusalKey("unsupported", "discord")).toBe(
-      sendRefusalKey("unsupported", "some-app-channel"),
-    );
-  });
-
-  it("does not key the other two on the channel — neither is a fact about one", () => {
-    for (const send of ["not-connected", "no-conversation"] as const) {
-      expect(sendRefusalKey(send, "linkedin")).toBe(sendRefusalKey(send, "whatsapp"));
-    }
   });
 });
 
@@ -51,9 +28,9 @@ describe("the locales behind those keys", () => {
       await i18n.changeLanguage(language);
       const t = i18n.getFixedT(language, "people") as TFunction<"people">;
       for (const send of REFUSALS) {
-        for (const channel of ["linkedin", "discord", "whatsapp"]) {
-          const key = sendRefusalKey(send, channel);
-          const line = t(key, { channel: "Discord" });
+        for (const channel of ["LinkedIn", "Discord", "WhatsApp"]) {
+          const key = sendRefusalKey(send);
+          const line = t(key, { channel });
           expect(line).not.toBe(key);
           expect(line).not.toContain("{{channel}}");
         }

--- a/packages/web/src/pages/people/send-copy.ts
+++ b/packages/web/src/pages/people/send-copy.ts
@@ -9,22 +9,10 @@ import type { AccountSendState } from "@rome/api-types/people";
  * composer would already have shown. A pure key map, like
  * `@/lib/connection-capability-copy` — the consumer owns the `t()` call.
  *
- * One of the three is not a fact about the account at all. "Unsupported" means
- * a different thing per channel — LinkedIn is an inbox Rome mirrors and cannot
- * write to, while a channel Rome has simply not taught to send is a gap that
- * will close — so its copy is keyed on the channel name, the way
- * `./channel-meta.tsx` already keys labels and glyphs. A channel with no entry
- * falls back to the general line, which is the branch every channel added after
- * this was written lands in.
  */
 
 /** Every send state that is a refusal — the four minus the one that is not. */
 export type RefusedSendState = Exclude<AccountSendState, "yes">;
-
-/** Channels whose "unsupported" has a reason of its own to give. */
-const UNSUPPORTED_COPY: Record<string, string> = {
-  linkedin: "send.refusal.unsupported.linkedin",
-};
 
 /**
  * The people-namespace key that says why this account cannot be written to.
@@ -33,13 +21,13 @@ const UNSUPPORTED_COPY: Record<string, string> = {
  * `t(key, { channel: channelLabel(t, channel) })` — the channel's own localized
  * name rather than its wire slug.
  */
-export function sendRefusalKey(send: RefusedSendState, channel: string): string {
+export function sendRefusalKey(send: RefusedSendState): string {
   switch (send) {
     case "not-connected":
       return "send.refusal.notConnected";
     case "no-conversation":
       return "send.refusal.noConversation";
     case "unsupported":
-      return UNSUPPORTED_COPY[channel] ?? "send.refusal.unsupported.default";
+      return "send.refusal.unsupported.default";
   }
 }

--- a/packages/web/src/pages/people/writes-against-mock.test.ts
+++ b/packages/web/src/pages/people/writes-against-mock.test.ts
@@ -5,7 +5,7 @@ import type { TFunction } from "i18next";
 import i18n from "@/i18n";
 import { channelMirrorHandlers } from "../../../mock/handlers/people";
 import { peopleHandlers } from "../../../mock/handlers/people-api";
-import type { OutboxPage } from "@rome/api-types/people";
+import type { OutboxPage, TimelinePage } from "@rome/api-types/people";
 import { fetchJson } from "@/lib/fetch-json";
 import {
   createPerson,
@@ -193,13 +193,14 @@ describe("Sending, against the contract's own handlers", () => {
     expect(holds(await readOutbox(RAY), sent.value.id)).toBe(false);
   });
 
-  it("refuses a channel that cannot be written to, naming which refusal it is", async () => {
-    const refused = await sendMessage("arvind-srivastav", { ...ARVIND, text: "hello" }, t);
-    expect(refused.ok).toBe(false);
-    if (refused.ok || !("conflict" in refused)) throw new Error("expected a refusal");
-    // The state, not a sentence. That is what lets the dashboard localize the
-    // reason, and say the same thing whether it read it or raced it.
-    expect(refused.conflict.send).toBe("unsupported");
+  it("sends a LinkedIn reply through the shared outbox and timeline", async () => {
+    const sent = await sendMessage("arvind-srivastav", { ...ARVIND, text: "LinkedIn reply" }, t);
+    expect(sent.ok).toBe(true);
+    if (!sent.ok) return;
+    await outboxUntil("arvind-srivastav", (page) => !holds(page, sent.value.id));
+    const response = await fetch("/api/people/arvind-srivastav/messages");
+    const timeline = (await response.json()) as TimelinePage;
+    expect(timeline.entries.some((entry) => entry.body === "LinkedIn reply")).toBe(true);
   });
 
   it("lets one of two retries of a row win, so a double click sends once", async () => {


### PR DESCRIPTION
## What this PR does

People can read LinkedIn conversations but cannot reply to them. This enables plain-text replies through the shared composer, with the recipient account visible before sending. Replies use the existing outbox for pending messages, failures, retry, and discard.

Closes #324.

## Design & Invariants

The channel resolves the selected account to one existing direct conversation using the local mirror. Missing metadata, groups, and multiple candidate conversations return `no-conversation`. Listing People makes no browser calls.

The send command reads the complete conversation membership from LinkedIn and verifies the recipient and sending account by member id. It sends one browser-authenticated request to that exact conversation. A name match cannot authorize a send. The command defaults to destination verification unless `--send` is present.

A successful response must echo the send attempt's origin token and identify the provider message using the same backend id as history. If the immediate response is incomplete or lost, Rome checks fresh thread history up to three times. Only a message with the exact origin token can confirm that attempt. Missing, null, empty, or mismatched tokens remain unconfirmed. The adapter writes that response into the mirror. If the local write fails, the receipt remains accepted and a later inbox poll can reconcile it. Outbox matching now includes the conversation id because LinkedIn member ids and thread ids differ. A retry cannot switch conversations.

Unknown outcomes are never retried automatically. Their failure text tells the guardian to check LinkedIn before retrying. This does not provide exactly-once delivery across an explicit retry after a lost response.

The shared composer and outbox preserve the [People contract](docs/concepts/people.md#outbox). The channel-specific constraints live in [Channels](docs/architecture/channels.md#linkedin-replies). The documentation pass removes stale claims that LinkedIn cannot send.

Alternatives considered:

- A separate LinkedIn composer would duplicate account selection and failure handling already owned by People.
- The installed `safe-send` command reports a Send click without a provider message id. It cannot satisfy outbox reconciliation. The reply command uses LinkedIn's browser-authenticated message creation endpoint, whose request shape is also documented in this [implementation reference](https://github.com/mguttmann/linkedin-internal-api/blob/main/docs/06-MESSAGING.md).
- Choosing the newest conversation or matching sent text could silently target or confirm the wrong message. Ambiguous destinations remain unavailable.

## Test plan

- [x] `pnpm --filter @rome/core typecheck`.
- [x] `pnpm --filter @rome/core test src/api/routes/people-linkedin-send.test.ts src/api/routes/people-send.test.ts src/db/repositories/linkedin-store.test.ts src/connections/integrations/linkedin.test.ts src/channels/linkedin-cli.test.ts` — 93 tests pass.
- [x] `pnpm --dir opencli-plugins/linkedin test` — 62 tests pass, including complete membership, wrong recipients, account changes, receipt identity, missing and invalid origin tokens, preserved request text, and recovery from partial or lost responses without resending.
- [x] `pnpm --filter rome-web test src/pages/people src/pages/PersonDetailPage.test.tsx` — 178 tests pass.
- [x] Browser check under `pnpm start:web:mock`: open the LinkedIn contact, verify the destination chip, send a synthetic reply, observe pending-to-timeline reconciliation, force a failure, and retry to one outbound entry.
- [x] Container Biome check on changed code, `git diff --check`, and `pnpm lint:prose` with Vale 3.19.0.
- [ ] Full host checks. Nix is absent, so checks used installed Node 24. `pnpm typecheck` stops on existing Rslib `autoExternal` errors. The separate web type check reports missing Storybook dependencies. `pnpm test:unit` stops on an incomplete Electron install. A broader core run passed 388 files but hit the existing Codex `paginated_threads` incompatibility and a file-browser event-stream timeout.
- [ ] Fullstack startup. `pnpm dev:all` fails because the existing Rome container occupies port 80, which Traefik needs. The temporary Traefik containers created by this attempt were removed.
- [x] Live Docker investigation: LinkedIn history confirmed that two earlier People send attempts had delivered, although Rome reported unknown outcomes. The new confirmation path identified both messages by their exact origin tokens in fresh LinkedIn history. The confirmed provider rows were mirrored through the repository, and the live People UI showed both outbound messages. No additional message was sent during diagnosis.
- [ ] A new controlled send through People with the final confirmation path. The live test above verified recovery against existing delivered messages, so this remains a draft.

## Not in this PR

- Suggested replies remain in #263.
- New conversations, group replies, attachments, and quoted replies need separate destination and content contracts.
