### PR TITLE
fix(people): align latest-message icons and previews

### DIFF
--- a/packages/web/src/pages/people/rows.tsx
+++ b/packages/web/src/pages/people/rows.tsx
@@ -43,7 +43,7 @@ export function StreamRow({ row, onOpen }: { row: PeopleRow; onOpen?: () => void
         <span className="truncate text-ui text-foreground">{row.displayName}</span>
         <span className="flex min-w-0 items-center gap-2 text-aux text-muted-foreground">
           {row.latest && (
-            <span className="text-subtle-foreground" title={row.latest.source}>
+            <span className="shrink-0 text-subtle-foreground" title={row.latest.source}>
               <ChannelGlyph channel={row.latest.source} />
             </span>
           )}
@@ -56,7 +56,7 @@ export function StreamRow({ row, onOpen }: { row: PeopleRow; onOpen?: () => void
           )}
         </span>
       </span>
-      <span className="justify-self-end font-mono text-badge tabular-nums text-subtle-foreground">
+      <span className="justify-self-end whitespace-nowrap text-right font-mono text-badge tabular-nums text-subtle-foreground sm:w-20">
         {timeAgo(t, row.latest?.timestamp ?? null)}
       </span>
     </>


### PR DESCRIPTION
## What this PR does

People → Latest shifts the message column between rows because each timestamp has a different width. This gives the source icons and previews a ragged left edge.

Reserve the same timestamp width on desktop and keep the labels right aligned on one line. Keep the channel icon from shrinking beside a long preview. The mobile name-and-preview layout stays stacked.

Closes #326.

## Test plan

- [x] `pnpm typecheck` passes after `pnpm install --frozen-lockfile` refreshed stale local dependencies.
- [x] `pnpm test:unit:web` passes: 1,413 dashboard tests and 559 UI tests.
- [x] `biome check packages/web/src/pages/people/rows.tsx` and `git diff --check` pass.
- [x] Browser check with `pnpm start:web:mock`: at 1350px, all three source icons share x=661.28px and all previews share x=685.28px. Before the fix, icon positions differed by 2.79px.
- [x] Browser checks at 390px and 320px: names and previews stay stacked, icons remain 16px wide, and long previews truncate within the row.
- [x] Search for a person and open their row.
- [ ] Full `pnpm test:unit`: stops in two desktop test files because the local Electron binary is missing.
- [ ] `pnpm dev:all` / `Rome started`: startup is blocked because the existing `rome-rome-1` container already publishes port 80.

Validation ran on macOS with Node 24.14.1, matching the repository Node major. Nix is unavailable on this host.
