### PR TITLE
fix(people): show sending messages immediately

### DIFF
--- a/docs/concepts/people.md
+++ b/docs/concepts/people.md
@@ -109,6 +109,7 @@ The outbox holds messages Rome has been asked to send and has not yet seen arriv
 - An outbox row is exactly a send whose message is not on the timeline yet. It is derived from that comparison rather than cleared by anything, so no delivery callback can be missed and the two reads cannot disagree.
 - A message is recognized as arrived by the id the channel gave back, never by its text or its timing. A channel offering direct messaging must return one.
 - A failed send stays until the guardian retries it or discards it. A retry reuses the row, so it never reads as a second message they did not write.
+- A client may name a send with a UUID before the request returns. That id joins its local sending row to the server outbox. While the row exists, repeating the same id, account, and text returns that row without sending again.
 
 **Not to be confused with:**
 

--- a/docs/concepts/people.md
+++ b/docs/concepts/people.md
@@ -109,7 +109,8 @@ The outbox holds messages Rome has been asked to send and has not yet seen arriv
 - An outbox row is exactly a send whose message is not on the timeline yet. It is derived from that comparison rather than cleared by anything, so no delivery callback can be missed and the two reads cannot disagree.
 - A message is recognized as arrived by the id the channel gave back, never by its text or its timing. A channel offering direct messaging must return one.
 - A failed send stays until the guardian retries it or discards it. A retry reuses the row, so it never reads as a second message they did not write.
-- A client may name a send with a UUID before the request returns. That id joins its local sending row to the server outbox. While the row exists, repeating the same id, account, and text returns that row without sending again.
+- A client may name a send with a UUID before the request returns. That id joins its local sending row to the server outbox. Repeating the same id, account, and text returns its recorded response without sending again.
+- Removing an outbox row saves its response in a separate receipt in the same transaction. Receipts survive restarts and expire 24 hours after delivery cleanup or explicit discard. New sends and outbox removals prune expired receipts. After expiry, the same id can start a new send.
 
 **Not to be confused with:**
 

--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -1215,8 +1215,8 @@ export function whatsAppDisplayName(contact: {
  * account, and it is a default on screen rather than a decision off it.
  */
 export interface SendMessageRequest {
-  /** Optional UUID v4 for this send. While its row exists, repeating the same
-   * id, account, and text returns that row without sending again. */
+  /** Optional UUID v4 for this send. Repeating the same id, account, and text
+   * returns its recorded response until 24 hours after outbox removal. */
   id?: string;
   channel: string;
   channelUserId: string;
@@ -1263,6 +1263,9 @@ export function matchesSendRequest(message: OutboxMessage, request: SendMessageR
     message.text === request.text
   );
 }
+
+/** Receipt lifetime after delivery cleanup or explicit discard, in milliseconds. */
+export const SEND_IDEMPOTENCY_RETENTION_MS = 24 * 60 * 60 * 1000;
 
 /** Long enough for anything a person types, short enough that no adapter has to
  *  defend itself against a megabyte. Channels with tighter limits of their own

--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -1215,6 +1215,9 @@ export function whatsAppDisplayName(contact: {
  * account, and it is a default on screen rather than a decision off it.
  */
 export interface SendMessageRequest {
+  /** Optional UUID v4 for this send. While its row exists, repeating the same
+   * id, account, and text returns that row without sending again. */
+  id?: string;
   channel: string;
   channelUserId: string;
   text: string;
@@ -1225,6 +1228,13 @@ export function parseSendMessageRequest(
 ): { request: SendMessageRequest } | { error: string } {
   if (typeof body !== "object" || body === null) return { error: "body must be an object" };
   const raw = body as Record<string, unknown>;
+  if (
+    raw.id !== undefined &&
+    (typeof raw.id !== "string" ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(raw.id))
+  ) {
+    return { error: "id must be a UUID v4" };
+  }
   const channel = typeof raw.channel === "string" ? raw.channel.trim() : "";
   const channelUserId = typeof raw.channelUserId === "string" ? raw.channelUserId.trim() : "";
   const text = typeof raw.text === "string" ? raw.text.trim() : "";
@@ -1235,7 +1245,23 @@ export function parseSendMessageRequest(
   if (text.length > SEND_MESSAGE_MAX_LENGTH) {
     return { error: `text must be at most ${SEND_MESSAGE_MAX_LENGTH} characters` };
   }
-  return { request: { channel, channelUserId, text } };
+  return {
+    request: {
+      ...(raw.id === undefined ? {} : { id: raw.id as string }),
+      channel,
+      channelUserId,
+      text,
+    },
+  };
+}
+
+/** A repeated send id may only refer to its original account and text. */
+export function matchesSendRequest(message: OutboxMessage, request: SendMessageRequest): boolean {
+  return (
+    message.channel === request.channel &&
+    message.channelUserId === request.channelUserId &&
+    message.text === request.text
+  );
 }
 
 /** Long enough for anything a person types, short enough that no adapter has to

--- a/packages/core/drizzle/system/0063_equal_tigra.sql
+++ b/packages/core/drizzle/system/0063_equal_tigra.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `outbound_send_receipts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`response` text NOT NULL,
+	`expires_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_outbound_send_receipts_expiry` ON `outbound_send_receipts` (`expires_at`);

--- a/packages/core/drizzle/system/meta/0063_snapshot.json
+++ b/packages/core/drizzle/system/meta/0063_snapshot.json
@@ -1,0 +1,3217 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6f41c9e4-0a92-47c1-89b9-431756648fd9",
+  "prevId": "8d301aa9-bb54-46c4-8e3a-24b1512b6976",
+  "tables": {
+    "action_executions": {
+      "name": "action_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initiator": {
+          "name": "initiator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_keys": {
+      "name": "app_keys",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "approvals": {
+      "name": "approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_state": {
+          "name": "execution_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_error": {
+          "name": "execution_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_mappings": {
+      "name": "channel_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_channel_mappings_identity": {
+          "name": "idx_channel_mappings_identity",
+          "columns": [
+            "channel",
+            "channel_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_mappings_person_id_persons_id_fk": {
+          "name": "channel_mappings_person_id_persons_id_fk",
+          "tableFrom": "channel_mappings",
+          "tableTo": "persons",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connection_grants": {
+      "name": "connection_grants",
+      "columns": {
+        "custody": {
+          "name": "custody",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential": {
+          "name": "credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conferred_at": {
+          "name": "conferred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_at": {
+          "name": "degraded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_reason": {
+          "name": "degraded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connection_grants_custody_name_pk": {
+          "columns": [
+            "custody",
+            "name"
+          ],
+          "name": "connection_grants_custody_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connections": {
+      "name": "connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connections_service_unique": {
+          "name": "connections_service_unique",
+          "columns": [
+            "service"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tzid": {
+          "name": "tzid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_time": {
+          "name": "local_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rrule": {
+          "name": "rrule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "execution_journal": {
+      "name": "execution_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_hash": {
+          "name": "args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expected_action_name": {
+          "name": "expected_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expected_args_hash": {
+          "name": "expected_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_action_name": {
+          "name": "actual_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_args_hash": {
+          "name": "actual_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ej_root_execution_id": {
+          "name": "idx_ej_root_execution_id",
+          "columns": [
+            "root_execution_id"
+          ],
+          "isUnique": false
+        },
+        "idx_ej_created_at": {
+          "name": "idx_ej_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardian_auth": {
+      "name": "guardian_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guardian_auth_user_id_unique": {
+          "name": "guardian_auth_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_messages": {
+      "name": "linkedin_messages",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_profile_url": {
+          "name": "sender_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_headline": {
+          "name": "sender_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_is_self": {
+          "name": "sender_is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_messages_thread_sent": {
+          "name": "idx_linkedin_messages_thread_sent",
+          "columns": [
+            "thread_id",
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_messages_thread_id_message_id_pk": {
+          "columns": [
+            "thread_id",
+            "message_id"
+          ],
+          "name": "linkedin_messages_thread_id_message_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_participants": {
+      "name": "linkedin_participants",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_self": {
+          "name": "is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_thread_participants": {
+      "name": "linkedin_thread_participants",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_thread_participants_participant": {
+          "name": "idx_linkedin_thread_participants_participant",
+          "columns": [
+            "participant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_thread_participants_thread_id_participant_id_pk": {
+          "columns": [
+            "thread_id",
+            "participant_id"
+          ],
+          "name": "linkedin_thread_participants_thread_id_participant_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_threads": {
+      "name": "linkedin_threads",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_url": {
+          "name": "thread_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_name": {
+          "name": "person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_name": {
+          "name": "conversation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread": {
+          "name": "unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "counterparty_type": {
+          "name": "counterparty_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "participants_last_read_at": {
+          "name": "participants_last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_pending_attempts": {
+      "name": "oauth_pending_attempts",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_origin": {
+          "name": "callback_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_pending_attempts_expires_at": {
+          "name": "idx_oauth_pending_attempts_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "outbound_messages": {
+      "name": "outbound_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_outbound_account": {
+          "name": "idx_outbound_account",
+          "columns": [
+            "channel",
+            "channel_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "outbound_send_receipts": {
+      "name": "outbound_send_receipts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_outbound_send_receipts_expiry": {
+          "name": "idx_outbound_send_receipts_expiry",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persons": {
+      "name": "persons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bond_level": {
+          "name": "bond_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_path": {
+          "name": "profile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_value": {
+          "name": "scope_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sync_links": {
+      "name": "project_sync_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_type": {
+          "name": "project_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_extra": {
+          "name": "project_link_extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sync_links_project_path_unique": {
+          "name": "project_sync_links_project_path_unique",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_accounts": {
+      "name": "provider_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "provider_accounts_provider_unique": {
+          "name": "provider_accounts_provider_unique",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_messages": {
+      "name": "rome_agent_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_state": {
+          "name": "input_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_platform_message_id": {
+          "name": "reply_to_platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_injected_turn_id": {
+          "name": "context_injected_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_messages_session_id": {
+          "name": "idx_rome_agent_messages_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_turn_id": {
+          "name": "idx_rome_agent_messages_turn_id",
+          "columns": [
+            "turn_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_role_created_at": {
+          "name": "idx_rome_agent_messages_role_created_at",
+          "columns": [
+            "role",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_platform_message": {
+          "name": "idx_rome_agent_messages_platform_message",
+          "columns": [
+            "session_id",
+            "platform_message_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_agent_messages\".\"platform_message_id\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_trace_blocks": {
+      "name": "rome_agent_trace_blocks",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_trace_blocks_session_id": {
+          "name": "idx_rome_agent_trace_blocks_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_trace_blocks_terminal_message": {
+          "name": "idx_rome_agent_trace_blocks_terminal_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') IN ('result', 'error')"
+        },
+        "idx_rome_agent_trace_blocks_turn_end_message": {
+          "name": "idx_rome_agent_trace_blocks_turn_end_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') = 'turn_end'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rome_agent_trace_blocks_message_id_seq_pk": {
+          "columns": [
+            "message_id",
+            "seq"
+          ],
+          "name": "rome_agent_trace_blocks_message_id_seq_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_sessions": {
+      "name": "rome_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "large_model_selection": {
+          "name": "large_model_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webchat'"
+        },
+        "source_channel": {
+          "name": "source_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_name": {
+          "name": "source_thread_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_type": {
+          "name": "source_thread_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_settings": {
+          "name": "channel_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_turn_id": {
+          "name": "parent_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handoff_spec": {
+          "name": "handoff_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_activity_at": {
+          "name": "last_seen_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_sessions_project_path": {
+          "name": "idx_rome_sessions_project_path",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_sidebar_activity": {
+          "name": "idx_rome_sessions_sidebar_activity",
+          "columns": [
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_project_activity": {
+          "name": "idx_rome_sessions_project_activity",
+          "columns": [
+            "project_path",
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_channel": {
+          "name": "idx_rome_sessions_source_channel",
+          "columns": [
+            "source_channel"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_thread": {
+          "name": "idx_rome_sessions_source_thread",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_channel_address": {
+          "name": "idx_rome_sessions_channel_address",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_sessions\".\"type\" = 'channel' AND \"rome_sessions\".\"source_channel\" IS NOT NULL AND \"rome_sessions\".\"source_thread_id\" IS NOT NULL"
+        },
+        "idx_rome_sessions_parent_session": {
+          "name": "idx_rome_sessions_parent_session",
+          "columns": [
+            "parent_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routine_runs": {
+      "name": "routine_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_routine_runs_routine_id": {
+          "name": "idx_routine_runs_routine_id",
+          "columns": [
+            "routine_id"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_fired_at": {
+          "name": "idx_routine_runs_fired_at",
+          "columns": [
+            "fired_at"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_status": {
+          "name": "idx_routine_runs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "routine_runs_routine_id_routines_id_fk": {
+          "name": "routine_runs_routine_id_routines_id_fk",
+          "tableFrom": "routine_runs",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routines": {
+      "name": "routines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed_by": {
+          "name": "managed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "routines_key_unique": {
+          "name": "routines_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sentinel_log": {
+      "name": "sentinel_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_turn_checkpoints": {
+      "name": "session_turn_checkpoints",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_turn_checkpoints_session_id_sessions_id_fk": {
+          "name": "session_turn_checkpoints_session_id_sessions_id_fk",
+          "tableFrom": "session_turn_checkpoints",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_turn_checkpoints_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "session_turn_checkpoints_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_thread_key": {
+          "name": "channel_thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shared_chats": {
+      "name": "shared_chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_shared_chats_session_id": {
+          "name": "idx_shared_chats_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_chats": {
+      "name": "wa_chats",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_contacts": {
+      "name": "wa_contacts",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify": {
+          "name": "notify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "img_url": {
+          "name": "img_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_messages": {
+      "name": "wa_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_jid": {
+          "name": "chat_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_jid": {
+          "name": "sender_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_me": {
+          "name": "from_me",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_media": {
+          "name": "has_media",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "push_name": {
+          "name": "push_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reacts_to_id": {
+          "name": "reacts_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_chat_ts": {
+          "name": "idx_wa_messages_chat_ts",
+          "columns": [
+            "chat_jid",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wa_messages_chat_jid_id_pk": {
+          "columns": [
+            "chat_jid",
+            "id"
+          ],
+          "name": "wa_messages_chat_jid_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_projects": {
+      "name": "webchat_projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webchat_projects_path_unique": {
+          "name": "webchat_projects_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_turn_feedback": {
+      "name": "webchat_turn_feedback",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webchat_turn_feedback_session_id": {
+          "name": "idx_webchat_turn_feedback_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webchat_turn_feedback_session_id_rome_sessions_id_fk": {
+          "name": "webchat_turn_feedback_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_turn_feedback",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webchat_turn_feedback_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "webchat_turn_feedback_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_workspace_layouts": {
+      "name": "webchat_workspace_layouts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webchat_workspace_layouts_session_id_rome_sessions_id_fk": {
+          "name": "webchat_workspace_layouts_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_workspace_layouts",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_invocations": {
+      "name": "webhook_invocations",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_url": {
+          "name": "callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_status": {
+          "name": "callback_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_attempted_at": {
+          "name": "callback_attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_delivered_at": {
+          "name": "callback_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_response_status": {
+          "name": "callback_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_error": {
+          "name": "callback_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webhook_invocations_created_at": {
+          "name": "idx_webhook_invocations_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_webhook_invocations_action_name": {
+          "name": "idx_webhook_invocations_action_name",
+          "columns": [
+            "action_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/system/meta/_journal.json
+++ b/packages/core/drizzle/system/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1788402301789,
       "tag": "0062_gorgeous_star_brand",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "6",
+      "when": 1789017483838,
+      "tag": "0063_equal_tigra",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/api/routes/people-send.test.ts
+++ b/packages/core/src/api/routes/people-send.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "@rstest/core";
+import { describe, it, expect, beforeEach, afterEach, rs } from "@rstest/core";
 import { Hono } from "hono";
 import { sql } from "drizzle-orm";
 import type {
@@ -12,6 +12,8 @@ import type {
 import { peopleRoutes } from "./people.js";
 import { createTestDb, buildTestDeps, type TestDb, type TestDeps } from "../../test/helpers.js";
 import { seedBaseline } from "../../test/seeds.js";
+import { OutboxRepository } from "../../db/repositories/outbox.js";
+import { SEND_IDEMPOTENCY_RETENTION_MS } from "@rome/api-types/people";
 
 // Sending to a person, and the outbox a send lives in until it arrives.
 //
@@ -28,6 +30,9 @@ describe("People send API", () => {
   let deps: TestDeps;
   let app: Hono;
   let personId: string;
+  afterEach(() => {
+    rs.useRealTimers();
+  });
 
   beforeEach(async () => {
     testDb = createTestDb();
@@ -162,6 +167,83 @@ describe("People send API", () => {
 
     // Nothing was told the send had arrived. The read noticed.
     expect(await outbox()).toEqual([]);
+  });
+
+  it("replays a delivered send after outbox cleanup and repository recreation", async () => {
+    const body = {
+      id: crypto.randomUUID(),
+      channel: "telegram",
+      channelUserId: TG,
+      text: "landed once",
+    };
+    const response = await send(body);
+    const original = await response.json();
+    const row = (await deps.outboxRepo.find(body.id))!;
+    expect(await outbox()).toEqual([]);
+    expect(await deps.outboxRepo.find(body.id)).toBeNull();
+
+    deps.outboxRepo = new OutboxRepository(testDb.db);
+    app = new Hono().route("/", peopleRoutes(deps));
+    const replayed = await send(body);
+    expect(replayed.status).toBe(202);
+    expect(await replayed.json()).toEqual(original);
+    expect(await deps.outboxRepo.openOnce({ ...body, conversationId: row.conversationId })).toEqual(
+      {
+        created: false,
+        message: original,
+      },
+    );
+    expect(await deps.outboxRepo.find(body.id)).toBeNull();
+    expect(await outbox()).toEqual([]);
+    expect(deps.channelPortMap.get("telegram")?.sentMessages).toHaveLength(1);
+    expect((await timeline()).entries.filter((entry) => entry.body === body.text)).toHaveLength(1);
+    expect((await send({ ...body, text: "different message" })).status).toBe(409);
+  });
+
+  it("retains a receipt for 24 hours after cleanup, then permits a new send", async () => {
+    rs.useFakeTimers({ toFake: ["Date"] });
+    const startedAt = Date.now();
+    rs.setSystemTime(startedAt);
+    const body = {
+      id: crypto.randomUUID(),
+      channel: "telegram",
+      channelUserId: TG,
+      text: "receipt expiry",
+    };
+    const original = await (await send(body)).json();
+    const removedAt = startedAt + 10_000;
+    rs.setSystemTime(removedAt);
+    expect(await outbox()).toEqual([]);
+
+    rs.setSystemTime(removedAt + SEND_IDEMPOTENCY_RETENTION_MS - 1);
+    expect(await (await send(body)).json()).toEqual(original);
+    expect(deps.channelPortMap.get("telegram")?.sentMessages).toHaveLength(1);
+
+    rs.setSystemTime(removedAt + SEND_IDEMPOTENCY_RETENTION_MS);
+    expect(await deps.outboxRepo.findSend(body.id)).toBeNull();
+    expect((await send(body)).status).toBe(202);
+    expect(deps.channelPortMap.get("telegram")?.sentMessages).toHaveLength(2);
+  });
+
+  it("retains a discarded send's response without retrying the provider", async () => {
+    const provider = rs
+      .spyOn(deps.channelPortMap.get("telegram")!, "sendMessage")
+      .mockRejectedValue(new Error("refused"));
+    const body = {
+      id: crypto.randomUUID(),
+      channel: "telegram",
+      channelUserId: TG,
+      text: "discarded",
+    };
+    const original = await (await send(body)).json();
+    const discarded = await app.request(`/people/${personId}/outbox/${body.id}`, {
+      method: "DELETE",
+    });
+    expect(discarded.status).toBe(204);
+    expect(await deps.outboxRepo.find(body.id)).toBeNull();
+    expect(await (await send(body)).json()).toEqual(original);
+    expect(await outbox()).toEqual([]);
+    expect(provider).toHaveBeenCalledTimes(1);
   });
 
   it("keeps a refused send in the outbox, and retries it under its own id", async () => {

--- a/packages/core/src/api/routes/people-send.test.ts
+++ b/packages/core/src/api/routes/people-send.test.ts
@@ -95,6 +95,41 @@ describe("People send API", () => {
     expect(deps.channelPortMap.get("telegram")?.sentMessages).toEqual([]);
   });
 
+  it("claims a client send id once across concurrent requests", async () => {
+    const body = { id: crypto.randomUUID(), channel: "telegram", channelUserId: TG, text: "hello" };
+    const responses = await Promise.all([send(body), send(body)]);
+    expect(responses.map((response) => response.status)).toEqual([202, 202]);
+    for (const response of responses) {
+      expect(await response.json()).toMatchObject({ id: body.id, text: "hello" });
+    }
+    expect(deps.channelPortMap.get("telegram")?.sentMessages).toHaveLength(1);
+    expect((await send(body)).status).toBe(202);
+    expect(deps.channelPortMap.get("telegram")?.sentMessages).toHaveLength(1);
+  });
+
+  it("refuses reuse of a send id for different text or another account", async () => {
+    const body = { id: crypto.randomUUID(), channel: "telegram", channelUserId: TG, text: "hello" };
+    expect((await send(body)).status).toBe(202);
+    expect((await send({ ...body, text: "different" })).status).toBe(409);
+    const anotherPerson = await deps.personMappingRepo.create({
+      displayName: "Another target",
+      bondLevel: "acquaintance",
+      approved: true,
+      channelMappings: [{ channel: "telegram", channelUserId: OTHER_TG }],
+    });
+    expect((await send({ ...body, channelUserId: OTHER_TG }, anotherPerson)).status).toBe(409);
+    expect(deps.channelPortMap.get("telegram")?.sentMessages).toHaveLength(1);
+  });
+
+  it("validates a supplied send id before contacting the provider", async () => {
+    for (const id of [null, 7, "", "not-a-uuid"]) {
+      expect(
+        (await send({ id, channel: "telegram", channelUserId: TG, text: "hello" })).status,
+      ).toBe(400);
+    }
+    expect(deps.channelPortMap.get("telegram")?.sentMessages).toEqual([]);
+  });
+
   it("refuses a channel that does not do direct messaging, naming the state", async () => {
     const readOnly = { ...deps, talkRouter: { ...deps.talkRouter, feature: () => null } };
     const readOnlyApp = new Hono().route("/", peopleRoutes(readOnly));

--- a/packages/core/src/api/routes/people.ts
+++ b/packages/core/src/api/routes/people.ts
@@ -180,7 +180,13 @@ export function peopleRoutes(deps: ApiDeps): Hono {
       return c.json({ error: "That account is not linked to this person" }, 400);
     }
 
-    const result = await sendToAccount(deps, parsed.request, parsed.request.text);
+    const result = await sendToAccount(
+      deps,
+      parsed.request,
+      parsed.request.text,
+      parsed.request.id,
+    );
+    if (!result.ok && "error" in result) return c.json({ error: result.error }, 409);
     return result.ok
       ? c.json(result.message, 202)
       : c.json(

--- a/packages/core/src/db/repositories/outbox.ts
+++ b/packages/core/src/db/repositories/outbox.ts
@@ -1,7 +1,8 @@
-import { and, eq, inArray, lt, or } from "drizzle-orm";
+import { and, eq, gt, inArray, lt, lte, or, type SQL } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
-import { outboundMessages } from "../schema.js";
-import type { DrizzleDb } from "../index.js";
+import { SEND_IDEMPOTENCY_RETENTION_MS, type OutboxMessage } from "@rome/api-types/people";
+import { outboundMessages, outboundSendReceipts } from "../schema.js";
+import type { DrizzleDb, DrizzleTx } from "../index.js";
 
 /**
  * The outbox: messages Rome has been asked to send and has not yet seen land.
@@ -47,17 +48,20 @@ export class OutboxRepository {
     conversationId: string;
     text: string;
   }): Promise<OutboxRow> {
-    return (await this.openOnce({ ...input, id: uuid() })).row;
+    const claimed = await this.openOnce({ ...input, id: uuid() });
+    if (!claimed.created) throw new Error("Generated send id already exists");
+    return claimed.row;
   }
 
-  /** The insert claims an id atomically. Only its winner may call the provider. */
+  /** Only a new claim may call the provider. Active rows and unexpired receipts
+   * both own their ids, including across concurrent cleanup and send requests. */
   async openOnce(input: {
     id: string;
     channel: string;
     channelUserId: string;
     conversationId: string;
     text: string;
-  }): Promise<{ row: OutboxRow; created: boolean }> {
+  }): Promise<{ row: OutboxRow; created: true } | { message: OutboxMessage; created: false }> {
     const now = new Date();
     const row = {
       ...input,
@@ -67,15 +71,18 @@ export class OutboxRepository {
       createdAt: now,
       updatedAt: now,
     };
-    const inserted = await this.db
-      .insert(outboundMessages)
-      .values(row)
-      .onConflictDoNothing({ target: outboundMessages.id })
-      .returning();
-    if (inserted.length > 0) return { row, created: true };
-    const existing = await this.find(input.id);
-    if (!existing) throw new Error("Outbox row disappeared after its id was claimed");
-    return { row: existing, created: false };
+    // The write lock covers both stores: cleanup cannot retire a row between
+    // checking its receipt and claiming the id in the outbox.
+    return this.db.transaction(
+      (tx) => {
+        tx.delete(outboundSendReceipts).where(lte(outboundSendReceipts.expiresAt, now)).run();
+        const existing = this.recordedSend(tx, input.id, now);
+        if (existing) return { message: existing, created: false as const };
+        tx.insert(outboundMessages).values(row).run();
+        return { row, created: true as const };
+      },
+      { behavior: "immediate" },
+    );
   }
 
   /** The channel took it and named it. Not "delivered" — that is decided by
@@ -136,21 +143,16 @@ export class OutboxRepository {
    * sent with no record of it, which is the thing this table exists to prevent.
    */
   async discard(id: string, settledBefore: Date): Promise<boolean> {
-    const deleted = await this.db
-      .delete(outboundMessages)
-      .where(
+    return this.retire(
+      id,
+      or(
+        eq(outboundMessages.state, "failed"),
         and(
-          eq(outboundMessages.id, id),
-          or(
-            eq(outboundMessages.state, "failed"),
-            and(
-              eq(outboundMessages.state, "unconfirmed"),
-              lt(outboundMessages.updatedAt, settledBefore),
-            ),
-          ),
+          eq(outboundMessages.state, "unconfirmed"),
+          lt(outboundMessages.updatedAt, settledBefore),
         ),
-      );
-    return deleted.changes > 0;
+      ),
+    );
   }
 
   /** A send whose process died before the channel answered, marked so it can
@@ -173,7 +175,49 @@ export class OutboxRepository {
   }
 
   async remove(id: string): Promise<void> {
-    await this.db.delete(outboundMessages).where(eq(outboundMessages.id, id));
+    this.retire(id);
+  }
+
+  /** A replayable response, even after delivery cleanup or discard. */
+  async findSend(id: string): Promise<OutboxMessage | null> {
+    return this.recordedSend(this.db, id, new Date());
+  }
+
+  private recordedSend(db: DrizzleDb | DrizzleTx, id: string, now: Date): OutboxMessage | null {
+    const active = db.select().from(outboundMessages).where(eq(outboundMessages.id, id)).get();
+    if (active) return outboxMessage(active);
+    const receipt = db
+      .select()
+      .from(outboundSendReceipts)
+      .where(and(eq(outboundSendReceipts.id, id), gt(outboundSendReceipts.expiresAt, now)))
+      .get();
+    return receipt?.response ?? null;
+  }
+
+  private retire(id: string, condition?: SQL): boolean {
+    const now = new Date();
+    // The response and deletion commit together. A crash or another connection
+    // can observe the active row or its receipt, never an unclaimed id.
+    return this.db.transaction(
+      (tx) => {
+        const row = tx
+          .delete(outboundMessages)
+          .where(and(eq(outboundMessages.id, id), condition))
+          .returning()
+          .get();
+        if (!row) return false;
+        tx.delete(outboundSendReceipts).where(lte(outboundSendReceipts.expiresAt, now)).run();
+        tx.insert(outboundSendReceipts)
+          .values({
+            id: row.id,
+            response: outboxMessage(row),
+            expiresAt: new Date(now.getTime() + SEND_IDEMPOTENCY_RETENTION_MS),
+          })
+          .run();
+        return true;
+      },
+      { behavior: "immediate" },
+    );
   }
 
   /** Every open row for a set of accounts, oldest first — the order they were
@@ -198,4 +242,17 @@ export class OutboxRepository {
       .filter((row) => wanted.has(`${row.channel}\n${row.channelUserId}`))
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
   }
+}
+
+export function outboxMessage(row: OutboxRow): OutboxMessage {
+  return {
+    id: row.id,
+    channel: row.channel,
+    channelUserId: row.channelUserId,
+    text: row.text,
+    timestamp: Math.floor(row.createdAt.getTime() / 1000),
+    state: row.state,
+    ref: row.providerMessageId ? `${row.conversationId}:${row.providerMessageId}` : null,
+    error: row.error,
+  };
 }

--- a/packages/core/src/db/repositories/outbox.ts
+++ b/packages/core/src/db/repositories/outbox.ts
@@ -47,9 +47,19 @@ export class OutboxRepository {
     conversationId: string;
     text: string;
   }): Promise<OutboxRow> {
+    return (await this.openOnce({ ...input, id: uuid() })).row;
+  }
+
+  /** The insert claims an id atomically. Only its winner may call the provider. */
+  async openOnce(input: {
+    id: string;
+    channel: string;
+    channelUserId: string;
+    conversationId: string;
+    text: string;
+  }): Promise<{ row: OutboxRow; created: boolean }> {
     const now = new Date();
     const row = {
-      id: uuid(),
       ...input,
       state: "sending" as const,
       providerMessageId: null,
@@ -57,8 +67,15 @@ export class OutboxRepository {
       createdAt: now,
       updatedAt: now,
     };
-    await this.db.insert(outboundMessages).values(row);
-    return row;
+    const inserted = await this.db
+      .insert(outboundMessages)
+      .values(row)
+      .onConflictDoNothing({ target: outboundMessages.id })
+      .returning();
+    if (inserted.length > 0) return { row, created: true };
+    const existing = await this.find(input.id);
+    if (!existing) throw new Error("Outbox row disappeared after its id was claimed");
+    return { row: existing, created: false };
   }
 
   /** The channel took it and named it. Not "delivered" — that is decided by

--- a/packages/core/src/db/schema/system.ts
+++ b/packages/core/src/db/schema/system.ts
@@ -9,6 +9,7 @@ import {
 } from "drizzle-orm/sqlite-core";
 import { sql } from "drizzle-orm";
 import type { AgentInputState } from "@rome-os/app-runtime";
+import type { OutboxMessage } from "@rome/api-types/people";
 import { TURN_FEEDBACK_RATINGS } from "@rome/api-types/trace-segments";
 import {
   APPROVAL_EXECUTION_STATES,
@@ -183,6 +184,17 @@ export const outboundMessages = sqliteTable(
     updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
   },
   (table) => [index("idx_outbound_account").on(table.channel, table.channelUserId)],
+);
+
+/** Outbox removal retains the response for the retry window in docs/concepts/people.md#outbox. */
+export const outboundSendReceipts = sqliteTable(
+  "outbound_send_receipts",
+  {
+    id: text("id").primaryKey(),
+    response: text("response", { mode: "json" }).$type<OutboxMessage>().notNull(),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => [index("idx_outbound_send_receipts_expiry").on(table.expiresAt)],
 );
 
 export const waChats = sqliteTable("wa_chats", {

--- a/packages/core/src/people/outbox.ts
+++ b/packages/core/src/people/outbox.ts
@@ -10,12 +10,13 @@
 // forget to call and no state the two reads can disagree about: an outbox row
 // is exactly a send whose entry is not there yet.
 
-import { matchesSendRequest, type OutboxMessage, type OutboxState } from "@rome/api-types/people";
+import { matchesSendRequest, type OutboxMessage } from "@rome/api-types/people";
 import { createLogger } from "../logger.js";
 import type { MessageAccount, Messages } from "../channels/messages.js";
 import { channelConversationId } from "../db/repositories/webchat.js";
 import { conversationPlatformMessageId } from "../db/repositories/webchat.js";
 import type { OutboxAccount, OutboxRepository, OutboxRow } from "../db/repositories/outbox.js";
+import { outboxMessage as wire } from "../db/repositories/outbox.js";
 import {
   resolveSendTarget,
   sendToTarget,
@@ -90,12 +91,12 @@ export async function sendToAccount(
   text: string,
   id?: string,
 ): Promise<SendResult> {
-  const replay = (row: OutboxRow): SendResult =>
-    matchesSendRequest(wire(row), { ...account, text })
-      ? { ok: true, message: wire(row) }
+  const replay = (message: OutboxMessage): SendResult =>
+    matchesSendRequest(message, { ...account, text })
+      ? { ok: true, message }
       : { ok: false, error: "That send id belongs to a different message" };
   if (id) {
-    const existing = await deps.outboxRepo.find(id);
+    const existing = await deps.outboxRepo.findSend(id);
     if (existing) return replay(existing);
   }
   const resolution = await resolveSendTarget(deps, account);
@@ -108,7 +109,7 @@ export async function sendToAccount(
     text,
   };
   const claimed = id ? await deps.outboxRepo.openOnce({ ...input, id }) : null;
-  if (claimed && !claimed.created) return replay(claimed.row);
+  if (claimed && !claimed.created) return replay(claimed.message);
   const row = claimed?.row ?? (await deps.outboxRepo.open(input));
 
   return { ok: true, message: await attempt(deps, row, resolution.target) };
@@ -333,17 +334,4 @@ function addressesOf(accounts: readonly MessageAccount[], row: OutboxRow): reado
       candidate.channel === row.channel && candidate.addresses.includes(row.channelUserId),
   );
   return account?.addresses ?? [row.channelUserId];
-}
-
-function wire(row: OutboxRow): OutboxMessage {
-  return {
-    id: row.id,
-    channel: row.channel,
-    channelUserId: row.channelUserId,
-    text: row.text,
-    timestamp: Math.floor(row.createdAt.getTime() / 1000),
-    state: row.state as OutboxState,
-    ref: row.providerMessageId ? `${row.conversationId}:${row.providerMessageId}` : null,
-    error: row.error,
-  };
 }

--- a/packages/core/src/people/outbox.ts
+++ b/packages/core/src/people/outbox.ts
@@ -10,7 +10,7 @@
 // forget to call and no state the two reads can disagree about: an outbox row
 // is exactly a send whose entry is not there yet.
 
-import type { OutboxMessage, OutboxState } from "@rome/api-types/people";
+import { matchesSendRequest, type OutboxMessage, type OutboxState } from "@rome/api-types/people";
 import { createLogger } from "../logger.js";
 import type { MessageAccount, Messages } from "../channels/messages.js";
 import { channelConversationId } from "../db/repositories/webchat.js";
@@ -70,7 +70,10 @@ export interface OutboxDeps extends SendDeps {
   webchatRepo: Conversations;
 }
 
-export type SendResult = { ok: true; message: OutboxMessage } | { ok: false; send: RefusedState };
+export type SendResult =
+  | { ok: true; message: OutboxMessage }
+  | { ok: false; send: RefusedState }
+  | { ok: false; error: string };
 
 /**
  * Send to one account, and answer with the outbox row it became.
@@ -85,16 +88,28 @@ export async function sendToAccount(
   deps: OutboxDeps,
   account: { channel: string; channelUserId: string },
   text: string,
+  id?: string,
 ): Promise<SendResult> {
+  const replay = (row: OutboxRow): SendResult =>
+    matchesSendRequest(wire(row), { ...account, text })
+      ? { ok: true, message: wire(row) }
+      : { ok: false, error: "That send id belongs to a different message" };
+  if (id) {
+    const existing = await deps.outboxRepo.find(id);
+    if (existing) return replay(existing);
+  }
   const resolution = await resolveSendTarget(deps, account);
   if (!resolution.ok) return { ok: false, send: resolution.send };
 
-  const row = await deps.outboxRepo.open({
+  const input = {
     channel: account.channel,
     channelUserId: account.channelUserId,
     conversationId: resolution.target.conversationId,
     text,
-  });
+  };
+  const claimed = id ? await deps.outboxRepo.openOnce({ ...input, id }) : null;
+  if (claimed && !claimed.created) return replay(claimed.row);
+  const row = claimed?.row ?? (await deps.outboxRepo.open(input));
 
   return { ok: true, message: await attempt(deps, row, resolution.target) };
 }

--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -7,6 +7,7 @@ import {
   isAssignableBondLevel,
   latestDynamic,
   matchesSendRequest,
+  SEND_IDEMPOTENCY_RETENTION_MS,
   parseAccountCursor,
   parseAccountState,
   parseStreamCursor,
@@ -243,7 +244,22 @@ interface OutboxRow extends OutboxMessage {
 }
 
 const outbox: OutboxRow[] = [];
-const sendRequests = new Map<string, OutboxRow>();
+const sendReceipts = new Map<string, { response: OutboxMessage; expiresAt: number }>();
+
+function pruneSendReceipts(now: number) {
+  for (const [id, receipt] of sendReceipts) {
+    if (receipt.expiresAt <= now) sendReceipts.delete(id);
+  }
+}
+
+function retireRow(row: OutboxRow, now: number) {
+  pruneSendReceipts(now);
+  sendReceipts.set(row.id, {
+    response: outboxMessage(row),
+    expiresAt: now + SEND_IDEMPOTENCY_RETENTION_MS,
+  });
+  outbox.splice(outbox.indexOf(row), 1);
+}
 
 /** How long the channel takes to accept a message, and how long after that it
  *  surfaces in the store the timeline reads. */
@@ -359,7 +375,6 @@ function openRow(account: AccountRef, text: string, id: string = crypto.randomUU
     attempts: 1,
   };
   outbox.push(row);
-  sendRequests.set(id, row);
   return row;
 }
 
@@ -424,7 +439,7 @@ function readOutbox(person: PersonFixture): OutboxMessage[] {
   for (let i = outbox.length - 1; i >= 0; i -= 1) {
     const row = outbox[i]!;
     if (held(row) && row.state === "unconfirmed" && row.ref !== null && arrived.has(row.ref)) {
-      outbox.splice(i, 1);
+      retireRow(row, now);
     }
   }
 
@@ -622,10 +637,14 @@ export const peopleHandlers = [
       );
     }
 
-    const existing = parsed.request.id ? sendRequests.get(parsed.request.id) : undefined;
+    pruneSendReceipts(Date.now());
+    const active = outbox.find((row) => row.id === parsed.request.id);
+    const existing = active
+      ? outboxMessage(active)
+      : sendReceipts.get(parsed.request.id ?? "")?.response;
     if (existing) {
       return matchesSendRequest(existing, parsed.request)
-        ? HttpResponse.json(outboxMessage(existing), { status: 202 })
+        ? HttpResponse.json(existing, { status: 202 })
         : HttpResponse.json(
             { error: "That send id belongs to a different message" },
             { status: 409 },
@@ -685,8 +704,7 @@ export const peopleHandlers = [
     if (!person) return notFound("person");
     const row = rowOf(person, String(params.messageId));
     if (!row || !isDismissableRow(row, Date.now())) return notTheirs();
-    outbox.splice(outbox.indexOf(row), 1);
-    sendRequests.delete(row.id);
+    retireRow(row, Date.now());
     return new HttpResponse(null, { status: 204 });
   }),
 

--- a/packages/web/mock/handlers/people-api.ts
+++ b/packages/web/mock/handlers/people-api.ts
@@ -6,6 +6,7 @@ import {
   countPeople,
   isAssignableBondLevel,
   latestDynamic,
+  matchesSendRequest,
   parseAccountCursor,
   parseAccountState,
   parseStreamCursor,
@@ -242,6 +243,7 @@ interface OutboxRow extends OutboxMessage {
 }
 
 const outbox: OutboxRow[] = [];
+const sendRequests = new Map<string, OutboxRow>();
 
 /** How long the channel takes to accept a message, and how long after that it
  *  surfaces in the store the timeline reads. */
@@ -343,9 +345,9 @@ function isDismissableRow(row: OutboxRow, now: number): boolean {
   return row.state === "unconfirmed" && now - row.attemptedAt >= STRANDED_AFTER_MS;
 }
 
-function openRow(account: AccountRef, text: string): OutboxRow {
+function openRow(account: AccountRef, text: string, id: string = crypto.randomUUID()): OutboxRow {
   const row: OutboxRow = {
-    id: crypto.randomUUID(),
+    id,
     channel: account.channel,
     channelUserId: account.channelUserId,
     text,
@@ -357,6 +359,7 @@ function openRow(account: AccountRef, text: string): OutboxRow {
     attempts: 1,
   };
   outbox.push(row);
+  sendRequests.set(id, row);
   return row;
 }
 
@@ -619,6 +622,16 @@ export const peopleHandlers = [
       );
     }
 
+    const existing = parsed.request.id ? sendRequests.get(parsed.request.id) : undefined;
+    if (existing) {
+      return matchesSendRequest(existing, parsed.request)
+        ? HttpResponse.json(outboxMessage(existing), { status: 202 })
+        : HttpResponse.json(
+            { error: "That send id belongs to a different message" },
+            { status: 409 },
+          );
+    }
+
     // The same state the person read answered with, so a client that raced a
     // disconnect renders the reason it would already have shown.
     const send = sendState(parsed.request);
@@ -628,9 +641,12 @@ export const peopleHandlers = [
       });
     }
 
-    return HttpResponse.json(outboxMessage(openRow(parsed.request, parsed.request.text)), {
-      status: 202,
-    });
+    return HttpResponse.json(
+      outboxMessage(openRow(parsed.request, parsed.request.text, parsed.request.id)),
+      {
+        status: 202,
+      },
+    );
   }),
 
   /** Every send of this person's still in flight. Unpaged — an outbox long
@@ -670,6 +686,7 @@ export const peopleHandlers = [
     const row = rowOf(person, String(params.messageId));
     if (!row || !isDismissableRow(row, Date.now())) return notTheirs();
     outbox.splice(outbox.indexOf(row), 1);
+    sendRequests.delete(row.id);
     return new HttpResponse(null, { status: 204 });
   }),
 

--- a/packages/web/src/pages/PersonDetailPage.test.tsx
+++ b/packages/web/src/pages/PersonDetailPage.test.tsx
@@ -148,6 +148,7 @@ const HELD_BY_ANOTHER: DirectoryAccount = {
 
 /** Whatever a write put on the wire, read back for assertions. */
 interface WriteBody {
+  id?: string;
   displayName?: string;
   bondLevel?: string;
   channel?: string;
@@ -179,7 +180,9 @@ function mockApi(
      * the channel taking it and rejecting it, which is the one state that
      * persists and the only one a guardian can act on.
      */
-    send?: "land" | "refuse" | "fail";
+    send?: "land" | "refuse" | "fail" | "network";
+    sendWait?: Promise<void>;
+    sendResponseWait?: Promise<void>;
     /**
      * How the retry route answers. `"refuse"` is the 404 for a row no longer
      * this reader's to send — claimed by a concurrent retry, or already
@@ -224,11 +227,13 @@ function mockApi(
       ({ ok: status < 400, status, json: async () => payload }) as Response;
 
     if (method === "POST" && path.endsWith("/messages")) {
+      await options.sendWait;
+      if (options.send === "network") throw new TypeError("Failed to fetch");
       if (options.send === "refuse") {
         return json({ error: "That channel is not connected", send: "not-connected" }, 409);
       }
       const row: OutboxMessage = {
-        id: `outbox-${outbox.length + 1}`,
+        id: body?.id ?? `outbox-${outbox.length + 1}`,
         channel: String(body?.channel),
         channelUserId: String(body?.channelUserId),
         text: String(body?.text),
@@ -239,6 +244,7 @@ function mockApi(
       };
       outbox.push(row);
       if (options.send === "land") accept(row);
+      await options.sendResponseWait;
       return json(row, 202);
     }
     if (method === "POST" && path.endsWith("/retry")) {
@@ -839,6 +845,102 @@ describe("PersonDetailPage back link consumes the dossier's history entry", () =
 // request carries the account that was on screen, and the view that already
 // names an account offers no second choice.
 describe("PersonDetailPage, sending", () => {
+  it("shows Sending before the request returns and preserves the next draft", async () => {
+    const user = userEvent.setup();
+    const gate = Promise.withResolvers<void>();
+    const calls = mockApi({ send: "land", sendWait: gate.promise });
+    renderPage();
+    const box = await screen.findByRole("textbox", { name: "Message text" });
+    await user.type(box, "on my way");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(box).toHaveProperty("value", "");
+    expect(document.activeElement).toBe(box);
+    await user.keyboard("{Enter}");
+    const pending = screen.getByRole("list", { name: "Outbox" });
+    expect(within(pending).getByText("on my way")).toBeTruthy();
+    expect(within(pending).getByRole("status").textContent).toBe("Sending");
+    expect(within(pending).queryByRole("button")).toBeNull();
+    expect(calls.filter((call) => call.method === "POST")).toHaveLength(1);
+
+    await user.type(box, "see you soon");
+    await act(async () => gate.resolve());
+    await waitFor(() => expect(screen.queryByRole("list", { name: "Outbox" })).toBeNull());
+    expect(screen.getAllByText("on my way")).toHaveLength(1);
+    expect(box).toHaveProperty("value", "see you soon");
+  });
+
+  it("joins a polled server row to its local request before the POST returns", async () => {
+    const user = userEvent.setup();
+    const gate = Promise.withResolvers<void>();
+    mockApi({ sendResponseWait: gate.promise });
+    const { queryClient } = renderPage();
+    const box = await screen.findByRole("textbox", { name: "Message text" });
+    await user.type(box, "on my way{Enter}");
+    expect(screen.getByText("Sending")).toBeTruthy();
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ["person-outbox"] });
+    });
+    expect(screen.getAllByText("on my way")).toHaveLength(1);
+    expect(await screen.findByText("Sent, not confirmed yet")).toBeTruthy();
+    expect(screen.queryByText("Sending")).toBeNull();
+    await act(async () => gate.resolve());
+    expect(screen.getAllByText("on my way")).toHaveLength(1);
+  });
+
+  it("keeps concurrent sends distinct even when their text is identical", async () => {
+    const user = userEvent.setup();
+    const gate = Promise.withResolvers<void>();
+    const calls = mockApi({ sendWait: gate.promise });
+    renderPage();
+    const box = await screen.findByRole("textbox", { name: "Message text" });
+    await user.type(box, "hello{Enter}");
+    await user.type(box, "hello{Enter}");
+
+    const posts = calls.filter((call) => call.method === "POST");
+    expect(posts).toHaveLength(2);
+    expect(posts[0]!.body!.id).not.toBe(posts[1]!.body!.id);
+    expect(screen.getAllByText("hello")).toHaveLength(2);
+    await act(async () => gate.resolve());
+    await waitFor(() => expect(screen.queryByText("Sending")).toBeNull());
+    expect(screen.getAllByText("hello")).toHaveLength(2);
+  });
+
+  it("keeps a failed request recoverable without replacing the next draft", async () => {
+    const user = userEvent.setup();
+    const gate = Promise.withResolvers<void>();
+    const options = { send: "network" as "network" | "land", sendWait: gate.promise };
+    const calls = mockApi(options);
+    renderPage();
+    const box = await screen.findByRole("textbox", { name: "Message text" });
+    await user.type(box, "on my way{Enter}");
+    await user.type(box, "see you soon");
+    await act(async () => gate.resolve());
+
+    const pending = screen.getByRole("list", { name: "Outbox" });
+    expect(within(pending).getByText("on my way")).toBeTruthy();
+    expect(within(pending).getByRole("alert")).toBeTruthy();
+    expect(box).toHaveProperty("value", "see you soon");
+    options.send = "land";
+    await user.click(within(pending).getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.queryByRole("list", { name: "Outbox" })).toBeNull());
+    const posts = calls.filter((call) => call.method === "POST");
+    expect(posts).toHaveLength(2);
+    expect(posts[1]!.body).toEqual(posts[0]!.body);
+    expect(box).toHaveProperty("value", "see you soon");
+  });
+
+  it("discards a failed local request without writing to the server", async () => {
+    const user = userEvent.setup();
+    const calls = mockApi({ send: "network" });
+    renderPage();
+    await user.type(await screen.findByRole("textbox", { name: "Message text" }), "hello{Enter}");
+    await user.click(await screen.findByRole("button", { name: "Discard this message" }));
+    expect(screen.queryByRole("list", { name: "Outbox" })).toBeNull();
+    expect(calls.filter((call) => call.method !== "GET")).toHaveLength(1);
+  });
+
   it("pins the composer so a history longer than the screen scrolls under it", async () => {
     mockApi();
     renderPage();
@@ -872,7 +974,7 @@ describe("PersonDetailPage, sending", () => {
       calls.find((call) => call.method === "POST" && call.url.endsWith("/messages")),
     );
     // The account is named, always — and it is the one the composer showed.
-    expect(sent?.body).toEqual({
+    expect(sent?.body).toMatchObject({
       channel: "whatsapp",
       channelUserId: "6591881123@s.whatsapp.net",
       text: "on my way",
@@ -934,7 +1036,8 @@ describe("PersonDetailPage, sending", () => {
     );
     // The row's own id: a retry is the same message again, not a second one the
     // guardian never wrote.
-    expect(retry?.url).toContain("/outbox/outbox-1/retry");
+    const original = calls.find((call) => call.method === "POST" && call.url.endsWith("/messages"));
+    expect(retry?.url).toContain(`/outbox/${original?.body?.id}/retry`);
     expect(
       calls.filter((call) => call.url.endsWith("/messages") && call.method === "POST"),
     ).toHaveLength(1);
@@ -999,7 +1102,7 @@ describe("PersonDetailPage, sending", () => {
     expect(screen.queryByText(/No failed message/)).toBeNull();
   });
 
-  it("retires a refusal when the target changes, so it never names the wrong channel", async () => {
+  it("keeps a refused message under its original account when the target changes", async () => {
     const user = userEvent.setup();
     mockApi({ send: "refuse" });
     renderPage();
@@ -1015,20 +1118,15 @@ describe("PersonDetailPage, sending", () => {
     );
     expect(refusal).toBeTruthy();
 
-    // Switching account retires it. A refusal names a channel, so one left
-    // standing here would be describing a channel that is no longer the one
-    // being written to.
     await user.click(screen.getByRole("button", { name: /WhatsApp · / }));
     await user.click(await screen.findByRole("menuitem", { name: /Telegram/ }));
-
-    await waitFor(() =>
-      expect(
-        screen.queryByText(
-          "WhatsApp isn't connected, so Rome can't send there. Connect it in Settings.",
-        ),
-      ).toBeNull(),
-    );
     expect(screen.getByText(/Telegram · 418820113/)).toBeTruthy();
+    expect(
+      within(screen.getByRole("list", { name: "Outbox" })).getByText("on my way"),
+    ).toBeTruthy();
+    expect(refusal).toBeTruthy();
+    await user.click(screen.getByRole("radio", { name: "Telegram" }));
+    expect(screen.queryByRole("list", { name: "Outbox" })).toBeNull();
   });
 
   it("says why a retry could not be made, and leaves the row actionable", async () => {

--- a/packages/web/src/pages/PersonDetailPage.tsx
+++ b/packages/web/src/pages/PersonDetailPage.tsx
@@ -166,7 +166,7 @@ function PersonDetailPage({ personId }: { personId: string | undefined }) {
           />
         </div>
 
-        <PersonConversation person={person} />
+        <PersonConversation key={person.id} person={person} />
       </PageBody>
     </PageShell>
   );

--- a/packages/web/src/pages/people/composer.tsx
+++ b/packages/web/src/pages/people/composer.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, SendHorizontal } from "lucide-react";
 import { canSend, type LinkedAccount, type PersonResource } from "@rome/api-types/people";
@@ -15,7 +15,6 @@ import { PAGE_FLOOR } from "@/shell/PageShell";
 import { ChannelGlyph, channelLabel } from "./channel-meta";
 import { sendRefusalKey, type RefusedSendState } from "./send-copy";
 import { accountHandle } from "./send-model";
-import { usePeopleWrites } from "./use-writes";
 
 /**
  * The composer: one message, to one account the guardian can see it is going
@@ -44,6 +43,7 @@ export function Composer({
   person,
   target,
   onChangeTarget,
+  onSend,
 }: {
   person: PersonResource;
   /** The account this composer writes to, or null when the person holds none
@@ -52,24 +52,12 @@ export function Composer({
   /** Offered where there is something to pick: the merged view. Null inside an
    *  account view, where the view already names the target. */
   onChangeTarget: ((account: LinkedAccount) => void) | null;
+  onSend: (account: LinkedAccount, text: string) => void;
 }) {
   const { t } = useTranslation("people");
-  const writes = usePeopleWrites();
   const [draft, setDraft] = useState("");
-  const [sending, setSending] = useState(false);
-  // How the last send went, and which account it was addressed to.
-  //
-  // The account is carried so the line can be shown only while it is still
-  // about the target on screen. A refusal names a channel, so one left standing
-  // after the guardian switches accounts is not merely stale — it describes a
-  // channel that is no longer the one being written to, which is worse than
-  // showing nothing. Held together and compared at render rather than cleared
-  // by an effect, so there is no ordering in which the wrong pair can be shown.
-  const [attempt, setAttempt] = useState<{
-    account: { channel: string; channelUserId: string };
-    refusal: RefusedSendState | null;
-    message: string | null;
-  } | null>(null);
+  const draftRef = useRef("");
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Nothing at all for a person Rome holds no address for. The dossier header
   // already says they have no accounts, and this slot is for a channel giving a
@@ -97,37 +85,14 @@ export function Composer({
 
   const options = person.accounts.filter(canSend);
   const text = draft.trim();
-  // Shown only while it still describes the account being written to. A switch
-  // of target retires it without anything having to remember to.
-  const failed =
-    attempt &&
-    attempt.account.channel === target.channel &&
-    attempt.account.channelUserId === target.channelUserId
-      ? attempt
-      : null;
-
-  async function submit() {
-    // `target` is narrowed above; the closure is re-created every render, so it
-    // is the account rendered beside the box and not an earlier one.
-    if (target === null || text === "" || sending) return;
-    const account = { channel: target.channel, channelUserId: target.channelUserId };
-    setSending(true);
-    setAttempt(null);
-    const outcome = await writes.say(person.id, target, text);
-    setSending(false);
-    if (outcome.ok) {
-      setDraft("");
-      return;
-    }
-    // A 409 raced a disconnect: the account was sendable when the page read it
-    // and is not now. It renders as the line the composer would have shown had
-    // the read been fresh, which is what carrying the state rather than a
-    // sentence buys.
-    setAttempt(
-      "conflict" in outcome
-        ? { account, refusal: outcome.conflict.send, message: null }
-        : { account, refusal: null, message: outcome.message },
-    );
+  function submit() {
+    const message = draftRef.current.trim();
+    if (target === null || message === "") return;
+    // Clear synchronously so repeated submit events cannot send the same draft.
+    draftRef.current = "";
+    setDraft("");
+    onSend(target, message);
+    inputRef.current?.focus();
   }
 
   return (
@@ -142,33 +107,27 @@ export function Composer({
       </p>
       <div className="flex items-center gap-2">
         <Input
+          ref={inputRef}
           size="sm"
           value={draft}
-          onChange={(event) => setDraft(event.target.value)}
+          onChange={(event) => {
+            draftRef.current = event.target.value;
+            setDraft(event.target.value);
+          }}
           onKeyDown={(event) => {
-            if (event.key === "Enter" && !event.shiftKey) {
+            if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
               event.preventDefault();
-              void submit();
+              submit();
             }
           }}
           placeholder={t("detail.composerPlaceholder", { name: person.displayName })}
           aria-label={t("detail.composerLabel")}
         />
-        <Button
-          type="button"
-          size="sm"
-          disabled={text === "" || sending}
-          onClick={() => void submit()}
-        >
+        <Button type="button" size="sm" disabled={text === ""} onClick={submit}>
           <SendHorizontal aria-hidden="true" />
           {t("send.submit")}
         </Button>
       </div>
-      {failed && (
-        <p className="mt-2 text-aux text-destructive">
-          {failed.refusal ? refusalText(t, failed.refusal, failed.account.channel) : failed.message}
-        </p>
-      )}
     </Floor>
   );
 }

--- a/packages/web/src/pages/people/conversation.tsx
+++ b/packages/web/src/pages/people/conversation.tsx
@@ -22,6 +22,7 @@ import {
   segmentOutbox,
 } from "./send-model";
 import { usePersonOutbox, usePersonTimeline } from "./use-roster";
+import { useConversationSends } from "./use-conversation-sends";
 
 /**
  * A person's conversation: what has been said, what Rome is still trying to
@@ -41,6 +42,7 @@ export function PersonConversation({ person }: { person: PersonResource }) {
   const { t } = useTranslation("people");
   const timeline = usePersonTimeline(person.id);
   const outbox = usePersonOutbox(person.id);
+  const sends = useConversationSends(person.id, outbox.messages);
 
   const segments = useMemo(() => accountSegments(person.accounts), [person.accounts]);
   const [segment, setSegment] = useState<string>(ALL_ACCOUNTS);
@@ -92,7 +94,13 @@ export function PersonConversation({ person }: { person: PersonResource }) {
         )}
       </div>
 
-      <Outbox personId={person.id} messages={segmentOutbox(outbox.messages, scoped)} />
+      <Outbox
+        personId={person.id}
+        messages={segmentOutbox(outbox.messages, scoped)}
+        localMessages={segmentOutbox(sends.messages, scoped)}
+        onRetryLocal={sends.retry}
+        onDiscardLocal={sends.discard}
+      />
 
       {timeline.isPending ? (
         <p className="py-8 text-center text-aux text-muted-foreground">{t("page.loading")}</p>
@@ -169,7 +177,12 @@ export function PersonConversation({ person }: { person: PersonResource }) {
         </div>
       )}
 
-      <Composer person={person} target={target} onChangeTarget={scoped ? null : setOverride} />
+      <Composer
+        person={person}
+        target={target}
+        onChangeTarget={scoped ? null : setOverride}
+        onSend={sends.send}
+      />
     </section>
   );
 }

--- a/packages/web/src/pages/people/outbox.tsx
+++ b/packages/web/src/pages/people/outbox.tsx
@@ -29,29 +29,42 @@ import type { WriteOutcome } from "./writes";
 export function Outbox({
   personId,
   messages,
+  localMessages = [],
+  onRetryLocal,
+  onDiscardLocal,
 }: {
   personId: string;
   messages: readonly OutboxMessage[];
+  localMessages?: readonly OutboxMessage[];
+  onRetryLocal?: (id: string) => void;
+  onDiscardLocal?: (id: string) => void;
 }) {
   const { t } = useTranslation("people");
-  if (messages.length === 0) return null;
+  const serverIds = new Set(messages.map((message) => message.id));
+  const visible = [...localMessages.filter((message) => !serverIds.has(message.id)), ...messages];
+  if (visible.length === 0) return null;
 
   return (
     <ul aria-label={t("send.outbox.label")} className="mt-3 rounded-14 border border-border p-1">
-      {messages.map((message) => (
+      {visible.map((message) => (
         <li
           key={message.id}
-          className="grid grid-cols-[auto_1fr_auto] items-center gap-3 px-2 py-2"
+          className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3 px-2 py-2 sm:grid-cols-[auto_minmax(0,1fr)_auto]"
         >
           <ChannelPill channel={message.channel} />
           <p
-            className={`min-w-0 text-ui ${
+            className={`min-w-0 break-words text-ui ${
               message.state === "failed" ? "text-foreground" : "text-muted-foreground"
             }`}
           >
             {message.text}
           </p>
-          <OutboxRowActions personId={personId} message={message} />
+          <OutboxRowActions
+            personId={personId}
+            message={message}
+            onRetryLocal={!serverIds.has(message.id) ? onRetryLocal : undefined}
+            onDiscardLocal={!serverIds.has(message.id) ? onDiscardLocal : undefined}
+          />
         </li>
       ))}
     </ul>
@@ -77,7 +90,17 @@ export function Outbox({
  * row is the one place the attempt can be made, so it has to say what happened
  * and stay usable. Silence there would be a row that looks ignored.
  */
-function OutboxRowActions({ personId, message }: { personId: string; message: OutboxMessage }) {
+function OutboxRowActions({
+  personId,
+  message,
+  onRetryLocal,
+  onDiscardLocal,
+}: {
+  personId: string;
+  message: OutboxMessage;
+  onRetryLocal?: (id: string) => void;
+  onDiscardLocal?: (id: string) => void;
+}) {
   const { t } = useTranslation("people");
   const writes = usePeopleWrites();
   const [busy, setBusy] = useState(false);
@@ -111,19 +134,19 @@ function OutboxRowActions({ personId, message }: { personId: string; message: Ou
   const dismissable = isDismissable(message, Math.floor(Date.now() / 1000));
 
   return (
-    <span className="flex items-center gap-2">
+    <span className="col-start-2 flex flex-wrap items-center gap-2 sm:col-auto">
       {failed ? (
         // `error` is what stopped it, shown as the row's detail. Usually the
         // channel's own words, which this page can neither localize nor promise
         // the shape of. One of them is not: a send whose process died before the
         // channel answered carries the server's own equivocal line, because Rome
         // genuinely does not know whether it went out.
-        <span className="flex items-center gap-1 text-badge text-destructive">
+        <span role="alert" className="flex items-center gap-1 text-badge text-destructive">
           <CircleAlert className="size-3 shrink-0" aria-hidden="true" />
           <span>{message.error ?? t("send.state.stopped")}</span>
         </span>
       ) : (
-        <span className="flex items-center gap-1 text-badge text-subtle-foreground">
+        <span role="status" className="flex items-center gap-1 text-badge text-muted-foreground">
           <Clock className="size-3" aria-hidden="true" />
           {t(message.state === "sending" ? "send.state.sending" : "send.state.unconfirmed")}
         </span>
@@ -134,7 +157,11 @@ function OutboxRowActions({ personId, message }: { personId: string; message: Ou
           variant="ghost"
           size="sm"
           disabled={busy}
-          onClick={act(() => writes.retry(personId, message.id))}
+          onClick={
+            onRetryLocal
+              ? () => onRetryLocal(message.id)
+              : act(() => writes.retry(personId, message.id))
+          }
         >
           <RotateCcw aria-hidden="true" />
           {t("send.retry")}
@@ -147,7 +174,11 @@ function OutboxRowActions({ personId, message }: { personId: string; message: Ou
           size="sm"
           aria-label={t("send.discard")}
           disabled={busy}
-          onClick={act(() => writes.discard(personId, message.id))}
+          onClick={
+            onDiscardLocal
+              ? () => onDiscardLocal(message.id)
+              : act(() => writes.discard(personId, message.id))
+          }
         >
           <X aria-hidden="true" />
         </Button>

--- a/packages/web/src/pages/people/use-conversation-sends.ts
+++ b/packages/web/src/pages/people/use-conversation-sends.ts
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { OutboxMessage } from "@rome/api-types/people";
+import { channelLabel } from "./channel-meta";
+import { sendRefusalKey } from "./send-copy";
+import { usePeopleWrites } from "./use-writes";
+import type { AccountRef } from "./writes";
+
+interface LocalSend {
+  id: string;
+  message: OutboxMessage;
+}
+
+/** Local requests join the server outbox without changing its cached rows or counts.
+ * Accepted requests retain the server id until the refreshed reads settle. */
+export function useConversationSends(personId: string, serverMessages: readonly OutboxMessage[]) {
+  const { t } = useTranslation("people");
+  const writes = usePeopleWrites();
+  const [requests, setRequests] = useState<LocalSend[]>([]);
+  const active = useRef(new Set<string>());
+
+  useEffect(() => {
+    const serverIds = new Set(serverMessages.map((message) => message.id));
+    if (serverIds.size === 0) return;
+    // Once a read observes the row, polling owns it even if the POST response
+    // is still in flight. A later delivery must not reveal its local copy again.
+    setRequests((current) => {
+      const remaining = current.filter((request) => !serverIds.has(request.id));
+      return remaining.length === current.length ? current : remaining;
+    });
+  }, [serverMessages]);
+
+  function discard(id: string) {
+    setRequests((current) => current.filter((request) => request.id !== id));
+  }
+
+  async function attempt(id: string, account: AccountRef, text: string) {
+    if (active.current.has(id)) return;
+    active.current.add(id);
+    setRequests((current) =>
+      current.map((request) =>
+        request.id === id
+          ? { ...request, message: { ...request.message, state: "sending", error: null } }
+          : request,
+      ),
+    );
+    try {
+      const outcome = await writes.say(personId, account, text, {
+        id,
+        onAccepted: (message) => {
+          // Keep the server's answer visible while the refreshed reads settle.
+          setRequests((current) =>
+            current.map((request) => (request.id === id ? { ...request, message } : request)),
+          );
+        },
+      });
+      if (outcome.ok) {
+        discard(id);
+        return;
+      }
+      const error =
+        "conflict" in outcome
+          ? t(sendRefusalKey(outcome.conflict.send), { channel: channelLabel(t, account.channel) })
+          : outcome.message;
+      setRequests((current) =>
+        current.map((request) =>
+          request.id === id
+            ? { ...request, message: { ...request.message, state: "failed", error } }
+            : request,
+        ),
+      );
+    } finally {
+      active.current.delete(id);
+    }
+  }
+
+  return {
+    messages: requests.map((request) => request.message),
+    send(account: AccountRef, text: string) {
+      const id = crypto.randomUUID();
+      const message: OutboxMessage = {
+        id,
+        channel: account.channel,
+        channelUserId: account.channelUserId,
+        text,
+        timestamp: Math.floor(Date.now() / 1000),
+        state: "sending",
+        ref: null,
+        error: null,
+      };
+      setRequests((current) => [{ id, message }, ...current]);
+      void attempt(id, account, text);
+    },
+    retry(id: string) {
+      const request = requests.find((candidate) => candidate.id === id);
+      if (request?.message.state === "failed") {
+        void attempt(id, request.message, request.message.text);
+      }
+    },
+    discard,
+  };
+}

--- a/packages/web/src/pages/people/use-writes.ts
+++ b/packages/web/src/pages/people/use-writes.ts
@@ -68,11 +68,13 @@ export interface PeopleWrites {
    * carries which of the ways the channel could not be written to, so a send
    * that raced a disconnect renders the reason the composer would already have
    * shown.
+   * `onAccepted` receives the server row before the refreshed reads settle.
    */
   say(
     personId: string,
     account: AccountRef,
     text: string,
+    options?: { id?: string; onAccepted?: (message: OutboxMessage) => void },
   ): Promise<WriteOutcome<OutboxMessage, SendRefusal>>;
   /**
    * Try a failed send again, under its own outbox id.
@@ -153,8 +155,16 @@ export function usePeopleWrites(): PeopleWrites {
       restore: (account) => settling(() => restoreAccount(ref(account), t)),
       merge: (into, from) => settling(() => mergePeople(into, from, t)),
       setBond: (personId, bondLevel) => settling(() => updatePerson(personId, { bondLevel }, t)),
-      say: (personId, account, text) =>
-        settling(() => sendMessage(personId, { ...ref(account), text }, t)),
+      say: (personId, account, text, options) =>
+        settling(async () => {
+          const outcome = await sendMessage(
+            personId,
+            { ...ref(account), text, ...(options?.id ? { id: options.id } : {}) },
+            t,
+          );
+          if (outcome.ok) options?.onAccepted?.(outcome.value);
+          return outcome;
+        }),
       retry: (personId, messageId) => resettling(() => retrySend(personId, messageId, t)),
       discard: (personId, messageId) => resettling(() => discardSend(personId, messageId, t)),
     };

--- a/packages/web/src/pages/people/writes-against-mock.test.ts
+++ b/packages/web/src/pages/people/writes-against-mock.test.ts
@@ -1,11 +1,12 @@
 // @rstest-environment jsdom
-import { afterAll, beforeAll, describe, expect, it } from "@rstest/core";
+import { afterAll, beforeAll, describe, expect, it, rs } from "@rstest/core";
 import { setupServer } from "msw/node";
 import type { TFunction } from "i18next";
 import i18n from "@/i18n";
 import { channelMirrorHandlers } from "../../../mock/handlers/people";
 import { peopleHandlers } from "../../../mock/handlers/people-api";
 import type { OutboxPage, TimelinePage } from "@rome/api-types/people";
+import { SEND_IDEMPOTENCY_RETENTION_MS } from "@rome/api-types/people";
 import { fetchJson } from "@/lib/fetch-json";
 import {
   createPerson,
@@ -140,6 +141,60 @@ async function outboxUntil(
 const holds = (page: OutboxPage, id: string) => page.messages.some((m) => m.id === id);
 
 describe("Sending, against the contract's own handlers", () => {
+  it("retains delivered send receipts through cleanup and expires them after 24 hours", async () => {
+    rs.useFakeTimers({ toFake: ["Date"] });
+    const startedAt = Date.now();
+    rs.setSystemTime(startedAt);
+    try {
+      const request = { ...RAY_TELEGRAM, id: crypto.randomUUID(), text: "mock receipt lifecycle" };
+      const sent = await sendMessage(RAY, request, t);
+      expect(sent.ok).toBe(true);
+      if (!sent.ok) return;
+      const removedAt = startedAt + 10_000;
+      rs.setSystemTime(removedAt);
+      expect(holds(await readOutbox(RAY), request.id)).toBe(false);
+      const replayed = await sendMessage(RAY, request, t);
+      expect(replayed).toMatchObject({ ok: true, value: { id: request.id, state: "unconfirmed" } });
+      expect(holds(await readOutbox(RAY), request.id)).toBe(false);
+      expect(await sendMessage(RAY, { ...request, text: "changed" }, t)).toMatchObject({
+        ok: false,
+      });
+      const timeline = await fetchJson<TimelinePage>(`/api/people/${RAY}/messages`, {
+        fallback: "timeline unavailable",
+      });
+      expect(timeline.entries.filter((entry) => entry.body === request.text)).toHaveLength(1);
+
+      rs.setSystemTime(removedAt + SEND_IDEMPOTENCY_RETENTION_MS - 1);
+      expect(await sendMessage(RAY, request, t)).toEqual(replayed);
+      rs.setSystemTime(removedAt + SEND_IDEMPOTENCY_RETENTION_MS);
+      expect(await sendMessage(RAY, request, t)).toMatchObject({
+        ok: true,
+        value: { state: "sending" },
+      });
+      expect(holds(await readOutbox(RAY), request.id)).toBe(true);
+    } finally {
+      rs.useRealTimers();
+    }
+  });
+
+  it("keeps a receipt when a failed mock send is discarded", async () => {
+    rs.useFakeTimers({ toFake: ["Date"] });
+    const startedAt = Date.now();
+    rs.setSystemTime(startedAt);
+    try {
+      const request = { ...RAY_TELEGRAM, id: crypto.randomUUID(), text: "fail discarded receipt" };
+      expect(await sendMessage(RAY, request, t)).toMatchObject({ ok: true });
+      rs.setSystemTime(startedAt + 10_000);
+      const failed = (await readOutbox(RAY)).messages.find((message) => message.id === request.id)!;
+      expect(failed.state).toBe("failed");
+      expect(await discardSend(RAY, request.id, t)).toMatchObject({ ok: true });
+      expect(await sendMessage(RAY, request, t)).toEqual({ ok: true, value: failed });
+      expect(holds(await readOutbox(RAY), request.id)).toBe(false);
+    } finally {
+      rs.useRealTimers();
+    }
+  });
+
   it("holds a send in the outbox, and lets it go once it is on the timeline", async () => {
     const sent = await sendMessage(RAY, { ...RAY_TELEGRAM, text: "on my way" }, t);
     expect(sent.ok).toBe(true);


### PR DESCRIPTION
## What this PR does

Sending a reply from People left the draft in a disabled composer until the provider call and follow-up reads finished. Send now clears and refocuses the composer immediately, with the message shown above the timeline as “Sending”.

The guardian can compose the next message while a send is in progress. Failed requests retain their text with Retry and Discard controls. At phone widths, the status sits below the message so long replies remain readable.

## Design & Invariants

- A send carries an optional UUID that joins its local row to the server outbox, including when a poll arrives before the POST response. Matching uses that id, never message text or timing.
- The database checks active outbox rows and durable receipts under one write lock before claiming an id. Delivery cleanup and explicit discard save the response and remove the row in one transaction. Receipts survive restarts and expire 24 hours after removal. Within that window, repeating the same request returns its recorded response without calling the provider. Reusing the id for another account or text is rejected. Existing clients can continue to omit the id.
- Timeline entries and message counts remain server-owned. Failed local requests stay scoped to their original recipient. The contract lives in [People: Outbox](https://github.com/rome-os/rome/blob/fix/people-immediate-sending/docs/concepts/people.md#outbox).

## Test plan

- [x] `pnpm typecheck` on host Node 24.
- [x] `pnpm test:unit`.
- [x] Focused People page tests cover delayed responses, immediate feedback, subsequent drafts, concurrent identical messages, retry, discard, and account scoping.
- [x] People send API tests cover concurrent duplicate requests, payload conflicts, invalid ids, and send → delivery cleanup → identical request. The cleanup regression also recreates the repository and verifies one provider call and one timeline entry.
- [x] Core and mock tests cover receipt retention after cleanup and discard, plus the exact 24-hour expiry boundary.
- [x] `pnpm db:check` verifies the new receipt-table migration and all committed migration sets.
- [x] Browser verification with `pnpm start:web:mock`: send by click, composer clearing and focus, Sending-to-timeline transition, and long-message layout at a 390px phone width.
- [x] Biome on changed source files, `git diff --check`, and PR title validation.
- [ ] `pnpm dev:all` runtime smoke: startup stops because host port 80 is already allocated when Traefik starts. The updated full stack could not reach the Rome startup check.
- [ ] `pnpm lint:prose`: Vale is unavailable. This host also has no Nix installation, so checks used its existing Node 24 toolchain.

