### PR TITLE
ci: enforce zero dead-code findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,8 @@ jobs:
 
       # Dead-code analysis. Knip resolves the import graph across every
       # workspace, so it needs the full install above and cannot move to a
-      # filtered job. The `--max-issues` count in the script is a ceiling over
-      # the findings that already exist: the step passes at today's total and
-      # fails above it. knip.jsonc explains which rules it covers, what the
-      # ceiling does not catch, and how to lower the number.
+      # filtered job. knip.jsonc documents the runtime-discovered entry points
+      # and why export-shaped rules remain warnings.
       - run: pnpm lint:deadcode
 
       - run: pnpm typecheck

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -32,19 +32,11 @@
   // here on the strength of the mobile dependency reintroduces the finding.
   "ignoreBinaries": ["tailscale", "composio", "rg", "lipo", "vale", "expo"],
 
-  // Severity decides the exit code: only `error` counts, `warn` prints and
-  // passes. The export rules are `warn` because a barrel that re-exports a
-  // package's public API for apps and SDK consumers is indistinguishable, to
-  // knip, from one nothing reads. Promote them once those barrels are pruned.
-  //
-  // `pnpm lint:deadcode` passes `--max-issues N`, where N is the count of
-  // `error` findings on the day this landed. package.json carries N and is the
-  // only place that does, so lowering it is a single edit. N is a ceiling on
-  // the aggregate, not a per-finding baseline: one finding past N fails, so
-  // dead code added on its own blocks a PR, but a PR that adds one finding and
-  // removes another still totals N and passes, and a deletion that does not
-  // lower N leaves headroom for the next one. Comparing findings by identity
-  // against a checked-in baseline is the fix, tracked separately.
+  // Severity decides the exit code: `error` fails the command, while `warn`
+  // prints and passes. The export rules are `warn` because a barrel that
+  // re-exports a package's public API for apps and SDK consumers is
+  // indistinguishable, to knip, from one nothing reads. Promote them once
+  // those barrels are pruned.
   // Nothing is suppressed: `pnpm lint:deadcode:report` prints every category
   // including the warnings.
   "rules": {
@@ -96,6 +88,7 @@
       "rstest": false,
       "entry": [
         "src/**/*.test.{ts,tsx}",
+        ".storybook/*.test.{ts,tsx}",
         "src/test/setup.ts",
         "rstest.config.mts",
         ".storybook/rsbuild.config.ts",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint:sh": "scripts/lint-shell.sh",
     "lint:prose": "node scripts/check-prose.mjs",
     "lint:agents": "tsx scripts/check-agents-symlinks.ts",
-    "lint:deadcode": "knip --no-config-hints --max-issues 20",
+    "lint:deadcode": "knip --no-config-hints",
     "lint:deadcode:report": "knip --no-exit-code",
     "typecheck:lint-agents": "tsc -p tsconfig.lint-agents.json",
     "format": "biome format --write .",


### PR DESCRIPTION
## What this PR does

The dead-code gate still allowed up to 20 `error` findings after its backlog cleared. A Storybook unit test added while the ratchet existed showed why the fixed count was unsafe: Knip reported the test as an unused file even though Rstest executes it, and CI passed.

The gate now uses Knip's default exit behavior, so its first `error` finding fails the command. Knip's manual Rstest entries also include `.storybook` tests. The configuration and CI comments now describe the active severity policy instead of the removed count. Export-shaped rules remain warnings.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint:deadcode`
- [x] Add `packages/core/src/knip-ratchet-verification.ts`, verify `pnpm lint:deadcode` fails and names it, remove it, then verify the command passes
- [x] `pnpm --filter rome-web test -- .storybook/preview-color-mode.test.tsx` (174 files, 1,420 tests)
- [x] `pnpm exec biome check --vcs-enabled=false package.json knip.jsonc`
- [x] `git diff --check`
- [ ] `pnpm lint` (the host Biome treats this manager worktree as ignored; CI runs it in a normal checkout)
- [ ] `pnpm lint:prose` (Vale is not installed on the host; CI provides it)

Closes #290
