### PR TITLE
feat(system): execute root scripts through a Linux host helper

### DIFF
--- a/.github/workflows/host-helper.yml
+++ b/.github/workflows/host-helper.yml
@@ -1,0 +1,111 @@
+name: Host helper
+
+on:
+  pull_request:
+    paths:
+      - packages/host-helper/**
+      - scripts/host-helper/**
+      - .github/workflows/host-helper.yml
+  push:
+    branches: [main]
+    paths:
+      - packages/host-helper/**
+      - scripts/host-helper/**
+      - .github/workflows/host-helper.yml
+    tags: ['host-helper-v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Bare release version, such as 0.1.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: host-helper-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.7'
+          cache: false
+      - name: Check format, tests, and vet
+        working-directory: packages/host-helper
+        run: |
+          test -z "$(gofmt -l .)"
+          go test -race -count=1 ./...
+          go vet ./...
+      - name: Exercise root host and nonroot container over shared socket
+        run: bash scripts/host-helper/smoke.sh
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/host-helper-v') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.7'
+          cache: false
+      - name: Require a merged commit and validate version
+        id: release
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor HEAD origin/main
+          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            version="$INPUT_VERSION"
+          else
+            version="${REF_NAME#host-helper-v}"
+          fi
+          if ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo 'Version must be a bare major.minor.patch semver' >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Build Linux binaries and checksums
+        working-directory: packages/host-helper
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          mkdir -p dist
+          for arch in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="$arch" go build -trimpath \
+              -ldflags "-s -w -X main.version=$RELEASE_VERSION" \
+              -o "dist/rome-hostd-linux-$arch" ./cmd/rome-hostd
+          done
+          cd dist
+          sha256sum rome-hostd-linux-* > SHA256SUMS
+      - uses: actions/upload-artifact@v7
+        with:
+          name: host-helper-${{ steps.release.outputs.version }}
+          path: packages/host-helper/dist/*
+      - name: Publish immutable release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          gh release create "host-helper-v$RELEASE_VERSION" \
+            --target "$GITHUB_SHA" \
+            --title "Host helper $RELEASE_VERSION" \
+            --notes "Linux root host helper. Verify the matching SHA256SUMS before installation." \
+            packages/host-helper/dist/rome-hostd-linux-amd64 \
+            packages/host-helper/dist/rome-hostd-linux-arm64 \
+            packages/host-helper/dist/SHA256SUMS

--- a/docs/architecture/host-execution.md
+++ b/docs/architecture/host-execution.md
@@ -1,0 +1,35 @@
+# Host execution
+
+How Rome delegates scripts to a privileged Linux host service while keeping host authorization and job ownership outside the runtime.
+
+## Components
+
+- **System actions** submit, inspect, and cancel [host jobs](../concepts/host-execution.md#host-job).
+- **Core client** binds submission to the current action execution and the configured host transport.
+- **Host helper** owns authorization, job records, and privileged processes.
+- **Host installer** provisions the helper and grants access to the intended Rome runtime.
+
+```text
+system action → Core client → local socket → host helper → privileged process
+```
+
+## Invariants
+
+- Installation and permission to execute are separate. Both Rome and the host helper reject execution until explicitly enabled.
+- The helper accepts local connections through a restricted socket. It exposes no network listener.
+- The host installer controls the executable, configuration, and socket access. Agent arguments cannot choose a transport or executable path.
+- The Core client gets execution identity from runtime context. Agent arguments cannot supply an actor, an approval decision, or an execution identity.
+- The helper validates every request independently. Core validation is not the host authorization boundary.
+- Socket access delegates host authority to the trusted runtime. Action visibility and Rome approvals do not isolate other code in the same container.
+- A Linux VM and the computer running that VM are different hosts. The helper never silently changes the execution target.
+- Job acceptance is durable before process creation. A reused identity cannot start another process, including after helper recovery.
+- Job output is bounded and remains in protected job records. General audit logs carry metadata without script contents or output.
+- The installer keeps state and protocol compatibility across helper and Rome upgrades. A rollback cannot erase accepted job identities.
+
+## Limits
+
+The helper controls ordinary child processes, but unrestricted root code can change the host or create persistent services. Revoking access prevents future submissions, not earlier effects.
+
+Hosted deployment must treat every credential on a tenant VM as accessible to that tenant's root scripts. Host permissions cannot contain a fleet credential from root.
+
+Native macOS and Windows execution require their own host services. The Linux helper does not administer either operating system.

--- a/docs/architecture/host-execution.md
+++ b/docs/architecture/host-execution.md
@@ -23,6 +23,8 @@ system action → Core client → local socket → host helper → privileged pr
 - Socket access delegates host authority to the trusted runtime. Action visibility and Rome approvals do not isolate other code in the same container.
 - A Linux VM and the computer running that VM are different hosts. The helper never silently changes the execution target.
 - Job acceptance is durable before process creation. A reused identity cannot start another process, including after helper recovery.
+- The main runtime preserves host job references across action worker loss. Worker failure cannot silently become a new host submission.
+- Helper recovery waits for interrupted managed processes to stop before accepting another job. Cleanup survives the daemon process.
 - Job output is bounded and remains in protected job records. General audit logs carry metadata without script contents or output.
 - The installer keeps state and protocol compatibility across helper and Rome upgrades. A rollback cannot erase accepted job identities.
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -14,4 +14,5 @@ Browse by surface:
 - [`channels.md`](channels.md) — The server-owned setup protocol every channel connects through, and the rules that keep the connect flow generic.
 - [`notification-delivery.md`](notification-delivery.md) — How mobile push travels from an instance through the central Rome Cloud broker to the platform push service (APNs for iOS, FCM for Android), and the account-scoping, content-enforcement, and delivery invariants that hold.
 - [`desktop-runtime.md`](desktop-runtime.md) — How the macOS desktop shell hosts the Rome backend in a Linux VM, and the network/signing invariants the provider must satisfy.
+- [`host-execution.md`](host-execution.md) — How system actions delegate privileged jobs to a Linux host service and preserve its authorization boundary.
 - [`observability.md`](observability.md) — The OTEL → Collector → ClickHouse pipeline, required telemetry attributes, and the dev-vs-prod topology split.

--- a/docs/concepts/host-execution.md
+++ b/docs/concepts/host-execution.md
@@ -1,0 +1,21 @@
+# Host execution
+
+## Host job
+
+A host job is a script accepted by a privileged service on the operating system hosting Rome. Its lifetime belongs to that service.
+
+**Contracts:**
+
+- Submission reports acceptance or a terminal result. Acceptance does not mean the script succeeded.
+- A host job survives the submitting action and the Rome process. Cancelling that action does not cancel the host job.
+- Inspection and cancellation address the same host job. Cancellation and timeouts stop its managed processes without undoing completed effects.
+- A repeated request with the same identity and contents returns the existing job. Different contents under that identity are rejected.
+- Lost contact leaves the outcome unknown. Recovery inspects the existing job and never starts a replacement automatically.
+- Host recovery never resumes an interrupted script. It records an unknown outcome when completion cannot be established.
+- Root execution grants authority over the selected host, including its credentials. A job is not a sandbox for its script.
+
+**Not to be confused with:**
+
+- **[Action](actions.md)** — the Rome invocation that submits or manages a host job. Its execution record does not own the host process.
+- **Container command** — a process inside the Rome container. Host execution runs on the selected operating system outside that container.
+- **[Detached action](actions.md)** — independent work managed by Rome. A host job is managed outside Rome and retains its identity across Rome restarts.

--- a/docs/concepts/host-execution.md
+++ b/docs/concepts/host-execution.md
@@ -11,6 +11,7 @@ A host job is a script accepted by a privileged service on the operating system 
 - Inspection and cancellation address the same host job. Cancellation and timeouts stop its managed processes without undoing completed effects.
 - A repeated request with the same identity and contents returns the existing job. Different contents under that identity are rejected.
 - Lost contact leaves the outcome unknown. Recovery inspects the existing job and never starts a replacement automatically.
+- An interrupted action worker reports the original host job identities. A routine does not automatically retry that uncertain execution.
 - Host recovery never resumes an interrupted script. It records an unknown outcome when completion cannot be established.
 - Root execution grants authority over the selected host, including its credentials. A job is not a sandbox for its script.
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -12,6 +12,7 @@ Browse by domain:
 - [`messaging.md`](messaging.md) — Messages, Conversations, Channels, Policies, Sentinel, Approvals. *How messages flow in and how the system decides what to do with them.*
 - [`apps.md`](apps.md) — Rome Apps (incl. ids, SDKs, caller identity, lockfile, install sources, app store, handles, app data, hooks). *The extensibility surface.*
 - [`actions.md`](actions.md) — Actions, Action results, Suspensions, Actor. *The primary unit of executable behavior, its result envelope, and the session identity accountable for it.*
+- [`host-execution.md`](host-execution.md) — Host jobs. *Privileged scripts whose lifetime belongs to the host service outside Rome.*
 - [`skills.md`](skills.md) — Skills. *Instructional documents that teach agents how to perform tasks.*
 - [`data.md`](data.md) — Memory, Projects, Routines, Database. *Where state and knowledge live.*
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
             pkgs.nodejs_24
             pkgs.pnpm
             pkgs.git
+            pkgs.go
             # node-gyp drives the build with python3 + make + a compiler. make
             # comes from stdenv and cc from mkShell; python3 has to be asked
             # for by name, and node-gyp checks for it first, so a missing

--- a/packages/core/.env.example
+++ b/packages/core/.env.example
@@ -186,3 +186,7 @@ ROME_DOCKER_APP_CODE_MODE=compiled
 # `api.relayWebhook` (composio today), so a depositor can't redirect delivery.
 # RELAY_DRAIN_URL=
 # RELAY_DRAIN_KEY=
+
+# Host root execution requires owner opt-in here and in the host daemon policy.
+# ROME_HOST_EXECUTION_SOCKET=/run/rome-host/control.sock
+ROME_HOST_EXECUTION_ENABLED=false

--- a/packages/core/src/actions/app-actions-wiring.ts
+++ b/packages/core/src/actions/app-actions-wiring.ts
@@ -16,6 +16,7 @@ import {
   resolveModuleEntryPath,
 } from "./module-loader.js";
 import type { FavorService } from "../favors/types.js";
+import type { HostExecutionService } from "../host-execution/service.js";
 
 export interface AppActionLoadFailure {
   name: string;
@@ -85,6 +86,7 @@ interface AppActionServices {
   routinesRepo?: RoutinesRepository;
   repositories: AppRuntimeRepositories;
   favorService?: FavorService;
+  hostExecution?: HostExecutionService;
 }
 
 interface AppLookup {
@@ -113,6 +115,9 @@ function createAppActionRuntimeDeps(
 
   return {
     ...deps,
+    ...(record.metadata.ownerId === "system" && services.hostExecution
+      ? { hostExecution: services.hostExecution }
+      : {}),
     appContext: createRomeAppContext(app, {
       catalog,
       db: services.db,
@@ -231,13 +236,7 @@ export function createAppActionsSubscriber(
   actionRegistry: ActionRegistryImpl,
   catalog: AppCatalog,
   deps: Record<string, unknown>,
-  services: {
-    db: DrizzleDb;
-    actionEngine: ActionEngine;
-    routinesRepo?: RoutinesRepository;
-    repositories: AppRuntimeRepositories;
-    favorService?: FavorService;
-  },
+  services: AppActionServices,
 ): SubscriberHandler {
   return async function appActionsSubscriber(event: CatalogEvent) {
     actionRegistry.unregisterOwnedBy("app", event.appId);

--- a/packages/core/src/actions/engine.ts
+++ b/packages/core/src/actions/engine.ts
@@ -160,6 +160,12 @@ export interface ApprovalCreatedEvent {
   channelContext?: ThreadContext;
 }
 
+export interface InterruptedAction {
+  actionName: string;
+  executionId: string;
+  rootExecutionId: string;
+}
+
 interface ActionEngineOptions {
   processRole?: "main" | "worker";
   /**
@@ -191,6 +197,11 @@ interface ActionEngineOptions {
   clock?: Clock;
   /** Worker-side transport for nested cancellable actions. */
   actionSubprocessRunner?: ActionSubprocessRunner;
+  /** Main-only recovery for effects that outlive a lost worker. A returned result prevents automatic exception retries. */
+  onWorkerInterrupted?: (
+    invocation: InterruptedAction,
+    error: Error,
+  ) => Promise<ActionResult | undefined>;
   /** Main-only process factory. Worker engines intentionally receive none. */
   actionWorkerFork?: (entryPath: string, options: ForkOptions) => ChildProcess;
 }
@@ -251,6 +262,7 @@ interface ActionWorkerProcess {
   pooled: boolean;
   generation: number;
   retireAfterRun: boolean;
+  cancelRequested?: boolean;
   useCount: number;
   hasBeenReady: boolean;
   attached: boolean;
@@ -279,6 +291,7 @@ export class ActionEngine {
   private actionWorkerCoordinator: ActionWorkerCoordinator | null = null;
   private actionSubprocessRunner: ActionSubprocessRunner | null;
   private actionWorkerFork: ActionEngineOptions["actionWorkerFork"];
+  private onWorkerInterrupted: ActionEngineOptions["onWorkerInterrupted"];
   private onApprovalCreated: ActionEngineOptions["onApprovalCreated"];
   private clock: Clock;
   private workerWarmPoolSize: number;
@@ -303,6 +316,7 @@ export class ActionEngine {
     this.journalRepo = journalRepo ?? null;
     this.processRole = options?.processRole ?? "worker";
     this.onApprovalCreated = options?.onApprovalCreated;
+    this.onWorkerInterrupted = options?.onWorkerInterrupted;
     this.clock = options?.clock ?? systemClock;
     this.actionSubprocessRunner = options?.actionSubprocessRunner ?? null;
     this.actionWorkerFork = options?.actionWorkerFork;
@@ -467,6 +481,7 @@ export class ActionEngine {
       await this.executionsRepo!.markCancelRequested(rootExecutionId);
     }
 
+    active.worker.cancelRequested = true;
     this.sendCancelSignal(active.worker.child, "SIGTERM");
     this.actionWorkerCoordinator?.cancelRoot(rootExecutionId);
     if (active.cancelTimer) this.clock.clearTimeout(active.cancelTimer);
@@ -868,40 +883,74 @@ export class ActionEngine {
       }
       return result;
     } catch (err) {
-      if (err instanceof ActionCancelledError) {
-        if (this.hasExecutionCancelSupport()) {
-          await this.executionsRepo!.markRootCancelled(
+      const recovered = await this.recoverWorkerInterruption(
+        { actionName: name, executionId, rootExecutionId },
+        err,
+      );
+      const failureMessage =
+        recovered?.status === "error"
+          ? recovered.error
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      try {
+        if (err instanceof ActionCancelledError) {
+          if (this.hasExecutionCancelSupport()) {
+            await this.executionsRepo!.markRootCancelled(
+              rootExecutionId,
+              this.clock.now(),
+              err.message,
+            );
+          }
+        } else if (isRoot && mode === "subprocess" && this.hasExecutionRootErrorSupport()) {
+          await this.executionsRepo!.markRootErrored(
             rootExecutionId,
             this.clock.now(),
-            err.message,
+            failureMessage,
           );
+          await this.executionsRepo!.update(executionId, {
+            durationMs: this.clock.now().getTime() - startedAt.getTime(),
+          });
+        } else {
+          await this.recordExecutionCompletion({
+            executionId,
+            rootExecutionId,
+            actionName: name,
+            actionType: action.config.type,
+            status: "error",
+            args,
+            error: failureMessage,
+            initiator,
+            actor,
+            parentId,
+            startedAt,
+          });
         }
-      } else if (isRoot && mode === "subprocess" && this.hasExecutionRootErrorSupport()) {
-        await this.executionsRepo!.markRootErrored(
-          rootExecutionId,
-          this.clock.now(),
-          err instanceof Error ? err.message : String(err),
-        );
-        await this.executionsRepo!.update(executionId, {
-          durationMs: this.clock.now().getTime() - startedAt.getTime(),
-        });
-      } else {
-        await this.recordExecutionCompletion({
+      } catch (persistenceError) {
+        if (!recovered) throw persistenceError;
+        // Losing the execution log must not turn an uncertain external effect into a retry.
+        log.error("failed to persist interrupted action", {
           executionId,
-          rootExecutionId,
-          actionName: name,
-          actionType: action.config.type,
-          status: "error",
-          args,
-          error: err instanceof Error ? err.message : String(err),
-          initiator,
-          actor,
-          parentId,
-          startedAt,
+          error: String(persistenceError),
         });
       }
+      if (recovered) return recovered;
       throw err;
     }
+  }
+
+  private async recoverWorkerInterruption(
+    invocation: InterruptedAction,
+    error: unknown,
+  ): Promise<ActionResult | undefined> {
+    if (
+      this.processRole !== "main" ||
+      !(error instanceof Error) ||
+      error.name !== "ActionWorkerExitError"
+    ) {
+      return undefined;
+    }
+    return this.onWorkerInterrupted?.(invocation, error);
   }
 
   private async executeInCurrentProcess(
@@ -1037,13 +1086,23 @@ export class ActionEngine {
       { executionId, rootExecutionId, isRoot: false },
       payload,
       observer,
-    ).finally(() => {
-      if (cancelTimer) this.clock.clearTimeout(cancelTimer);
-    });
+    )
+      .catch(async (error: unknown) => {
+        const recovered = await this.recoverWorkerInterruption(
+          { actionName: payload.actionName, executionId, rootExecutionId },
+          error,
+        );
+        if (recovered) return recovered;
+        throw error;
+      })
+      .finally(() => {
+        if (cancelTimer) this.clock.clearTimeout(cancelTimer);
+      });
 
     return {
       result,
       cancel: () => {
+        worker.cancelRequested = true;
         this.sendCancelSignal(worker.child, "SIGTERM");
         if (cancelTimer) this.clock.clearTimeout(cancelTimer);
         cancelTimer = this.clock.setTimeout(() => {
@@ -1146,6 +1205,7 @@ export class ActionEngine {
     observer?: ActionRunObserver,
     actionEventObserver?: ActionInvocationObserver,
   ): Promise<ActionResult> {
+    worker.cancelRequested = false;
     return new Promise<ActionResult>((resolve, reject) => {
       const finish = (options: { reusable: boolean }) => {
         if (invocation.isRoot && this.processRole === "main") {
@@ -1205,7 +1265,7 @@ export class ActionEngine {
         settled = true;
         cleanupListeners();
         finish({ reusable: false });
-        if (signal || code === 130 || code === 143) {
+        if (worker.cancelRequested && (signal || code === 130 || code === 143)) {
           reject(new ActionCancelledError("Cancelled by user"));
           return;
         }

--- a/packages/core/src/actions/worker-runtime.ts
+++ b/packages/core/src/actions/worker-runtime.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from "../config.js";
+import { HostExecutionService } from "../host-execution/service.js";
 import { getDb } from "../db/index.js";
 import { AgentLoader } from "../core/agent-loader.js";
 import { ActionRegistryImpl } from "./registry.js";
@@ -208,7 +209,16 @@ export async function createWorkerActionEngine(): Promise<ActionEngine> {
         providers: [createCodexImageGenerationProvider({ agentRunner })],
       }),
     },
-    { db, actionEngine, routinesRepo, repositories: appRuntimeRepositories },
+    {
+      db,
+      actionEngine,
+      routinesRepo,
+      repositories: appRuntimeRepositories,
+      hostExecution: new HostExecutionService({
+        socketPath: config.hostExecutionSocket,
+        enabled: config.hostExecutionEnabled,
+      }),
+    },
   );
   if (agentLoader.getRegistryLoadFailures().length > 0) {
     log.warn("some app agents failed to load", {

--- a/packages/core/src/apps/context.test.ts
+++ b/packages/core/src/apps/context.test.ts
@@ -21,6 +21,7 @@ import {
   getCurrentActionContext,
 } from "@rome-os/app-runtime";
 import { registerAppActions, registerLazyAppActions } from "../actions/app-actions-wiring.js";
+import { HostExecutionService } from "../host-execution/service.js";
 import { bumpModuleEnvEpoch } from "../actions/module-loader.js";
 import type { SettingsRepository } from "../db/repositories/settings.js";
 import type { WebChatRepository } from "../db/repositories/webchat.js";
@@ -39,6 +40,64 @@ type RuntimeContextGlobal = typeof globalThis & {
 
 describe("app runtime context", () => {
   const tempDirs: string[] = [];
+
+  it("injects host execution only into system actions in both main and worker loaders", async () => {
+    for (const register of [registerAppActions, registerLazyAppActions]) {
+      for (const appId of ["system", "ordinary-app"]) {
+        const app = resolvedApp(appId);
+        const actionDir = await tempDir();
+        await writeFile(
+          join(actionDir, "index.js"),
+          `
+export function createAction(config, deps) {
+  return {
+    config,
+    execute: async () => ({ status: "ok", data: { hasHostExecution: Boolean(deps.hostExecution) } }),
+  };
+}
+`,
+        );
+        const loader = {
+          getAllRecords: () =>
+            new Map([
+              [
+                "host_probe",
+                {
+                  config: actionConfig("host_probe"),
+                  directory: actionDir,
+                  metadata: {
+                    kind: "action",
+                    ownerType: "app",
+                    ownerId: appId,
+                    publicName: "host_probe",
+                    aliases: [],
+                    sourcePath: actionDir,
+                  },
+                },
+              ],
+            ]),
+        } as unknown as ActionLoader;
+        const registry = new ActionRegistryImpl([]);
+        const loaded = await register(
+          loader,
+          registry,
+          catalogFor(app),
+          {},
+          {
+            db: {} as RomeAppRuntimeServices["db"],
+            actionEngine: {} as ActionEngine,
+            repositories: createRepositories(),
+            hostExecution: new HostExecutionService({ enabled: false }),
+          },
+        );
+        expect(loaded.failed).toEqual([]);
+        expect(await registry.get("host_probe")?.execute({})).toEqual({
+          status: "ok",
+          data: { hasHostExecution: appId === "system" },
+        });
+      }
+    }
+  });
 
   afterEach(async () => {
     delete (globalThis as RuntimeContextGlobal).__romeAppRuntimeContexts;

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -15,6 +15,8 @@ const CONFIG_ENV_KEYS = [
   "POSTGRES_CONNECTION_STRING",
   "SENTINEL_REVIEW_INTERVAL_MINUTES",
   "ROME_ACTION_MAX_WORKERS",
+  "ROME_HOST_EXECUTION_SOCKET",
+  "ROME_HOST_EXECUTION_ENABLED",
   "WEB_PORT",
   "WEB_HOST",
   "INTERNAL_API_PORT",
@@ -33,6 +35,24 @@ beforeEach(() => {
 });
 
 describe("loadConfig()", () => {
+  it("disables host execution and leaves its socket unset by default", () => {
+    expect(loadConfig()).toMatchObject({ hostExecutionEnabled: false });
+    expect(loadConfig().hostExecutionSocket).toBeUndefined();
+  });
+
+  it("requires explicit host execution enablement and an absolute socket path", () => {
+    rs.stubEnv("ROME_HOST_EXECUTION_ENABLED", "true");
+    rs.stubEnv("ROME_HOST_EXECUTION_SOCKET", "/run/rome-host/control.sock");
+    expect(loadConfig()).toMatchObject({
+      hostExecutionEnabled: true,
+      hostExecutionSocket: "/run/rome-host/control.sock",
+    });
+    rs.stubEnv("ROME_HOST_EXECUTION_ENABLED", "yes");
+    expect(() => loadConfig()).toThrow("Invalid configuration");
+    rs.stubEnv("ROME_HOST_EXECUTION_ENABLED", "false");
+    rs.stubEnv("ROME_HOST_EXECUTION_SOCKET", "https://host.example");
+    expect(() => loadConfig()).toThrow("Invalid configuration");
+  });
   it("parses valid env and returns typed config", () => {
     rs.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test-key");
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -43,6 +43,12 @@ const configSchema = z.object({
   // silence. Fits inside the reserved 3:00–3:30am nightly window.
   systemUpgradeCountdownMinutes: z.coerce.number().int().positive().default(10),
 
+  hostExecutionSocket: z.string().startsWith("/").optional(),
+  hostExecutionEnabled: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform((value) => value === "true"),
+
   // Every root, delegated, and warm action worker counts against this bound.
   // A bounded default keeps burst traffic from forking unbounded workers;
   // operators can tune it to measured worker RSS.
@@ -134,6 +140,12 @@ function envToRawConfig(env: NodeJS.ProcessEnv): Record<string, unknown> {
   }
   if (env.SYSTEM_UPGRADE_COUNTDOWN_MINUTES) {
     raw.systemUpgradeCountdownMinutes = env.SYSTEM_UPGRADE_COUNTDOWN_MINUTES;
+  }
+  if (env.ROME_HOST_EXECUTION_SOCKET) {
+    raw.hostExecutionSocket = env.ROME_HOST_EXECUTION_SOCKET;
+  }
+  if (env.ROME_HOST_EXECUTION_ENABLED !== undefined) {
+    raw.hostExecutionEnabled = env.ROME_HOST_EXECUTION_ENABLED;
   }
   if (env.LINKEDIN_POLL_MIN_MINUTES) {
     raw.linkedinPollMinMinutes = env.LINKEDIN_POLL_MIN_MINUTES;

--- a/packages/core/src/host-execution/service.test.ts
+++ b/packages/core/src/host-execution/service.test.ts
@@ -1,0 +1,295 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "@rstest/core";
+import { actionExecutionContext } from "../actions/context.js";
+import { HostExecutionService, type HostJob, type RootScriptInput } from "./service.js";
+import { createAction } from "../../../../rome_apps/system/src/actions/execute-root-script/index.js";
+
+const input: RootScriptInput = {
+  target: "hosting-vm",
+  interpreter: "sh",
+  script: "printf hello",
+  reason: "Verify the host helper",
+  timeoutSeconds: 60,
+};
+const jobId = createHash("sha256").update("execution-1").digest("hex");
+const completed: HostJob = {
+  id: jobId,
+  requestId: jobId,
+  hostId: "host-1",
+  scriptSha256: createHash("sha256").update(input.script).digest("hex"),
+  status: "succeeded",
+  exitCode: 0,
+  stdout: "hello",
+  stderr: "",
+  truncated: false,
+  startedAt: "2026-01-01T00:00:00Z",
+  finishedAt: "2026-01-01T00:00:01Z",
+};
+const capabilities = {
+  protocolVersion: 1,
+  version: "0.1.0",
+  hostId: "host-1",
+  platform: "linux",
+  enabled: true,
+  interpreters: ["sh", "bash"],
+  maxTimeoutSeconds: 600,
+  maxOutputBytes: 131_072,
+};
+
+const resources: Array<{ server: Server; directory: string }> = [];
+
+async function helper(handler: (request: IncomingMessage, response: ServerResponse) => void) {
+  const directory = await mkdtemp("/tmp/rome-host-test-");
+  const socketPath = join(directory, "control.sock");
+  const server = createServer(handler);
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+  resources.push({ server, directory });
+  return { service: new HostExecutionService({ socketPath, enabled: true }), socketPath };
+}
+
+function json(response: ServerResponse, value: unknown, status = 200) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(value));
+}
+
+async function readBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return JSON.parse(Buffer.concat(chunks).toString());
+}
+
+function start(service: HostExecutionService, value = input) {
+  return actionExecutionContext.run(
+    {
+      executionId: "execution-1",
+      rootExecutionId: "root-1",
+      initiator: "test",
+    },
+    () => service.start(value),
+  );
+}
+
+afterEach(async () => {
+  for (const { server, directory } of resources.splice(0)) {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe("HostExecutionService over HTTP Unix socket", () => {
+  it("carries action execution context across the system action boundary", async () => {
+    let submission: unknown;
+    const { service } = await helper((request, response) => {
+      if (request.url === "/v1/capabilities") return json(response, capabilities);
+      void readBody(request).then((body) => {
+        submission = body;
+        json(response, completed);
+      });
+    });
+    const action = createAction(
+      {
+        name: "execute_root_script",
+        type: "system",
+        description: "Host execution",
+        complexity: "complex",
+        speed: "moderate",
+        reliability: "medium",
+        sideEffects: "write",
+      },
+      { hostExecution: service },
+    );
+    const result = await actionExecutionContext.run(
+      {
+        executionId: "execution-1",
+        rootExecutionId: "root-1",
+        initiator: "test",
+      },
+      () => action.execute(input),
+    );
+    expect(result).toMatchObject({ status: "ok", data: { stdout: "hello", completed: true } });
+    expect(submission).toMatchObject({
+      requestId: jobId,
+      executionId: "execution-1",
+      rootExecutionId: "root-1",
+    });
+  });
+  it("submits trusted execution metadata and reuses the same deterministic ID on retry", async () => {
+    const submissions: unknown[] = [];
+    const { service } = await helper((request, response) => {
+      if (request.url === "/v1/capabilities") return json(response, capabilities);
+      void readBody(request).then((body) => {
+        submissions.push(body);
+        json(response, completed, submissions.length === 1 ? 202 : 200);
+      });
+    });
+    expect(await start(service)).toEqual(completed);
+    expect(await start(service)).toEqual(completed);
+    expect(submissions).toEqual(
+      [0, 1].map(() => ({
+        interpreter: "sh",
+        script: input.script,
+        reason: input.reason,
+        timeoutSeconds: 60,
+        requestId: jobId,
+        hostId: "host-1",
+        executionId: "execution-1",
+        rootExecutionId: "root-1",
+      })),
+    );
+  });
+
+  it("requires both Core opt-in and a configured socket", async () => {
+    await expect(start(new HostExecutionService({ enabled: false }))).rejects.toThrow(
+      "disabled in Rome",
+    );
+    await expect(start(new HostExecutionService({ enabled: true }))).rejects.toThrow(
+      "not configured",
+    );
+  });
+
+  it("fails readably when the helper is missing", async () => {
+    await expect(
+      start(
+        new HostExecutionService({
+          enabled: true,
+          socketPath: "/tmp/rome-host-nonexistent/control.sock",
+        }),
+      ),
+    ).rejects.toThrow("Host helper is unavailable");
+  });
+
+  it("honors host disablement and timeout policy without submitting", async () => {
+    let requests = 0;
+    const { service } = await helper((_request, response) => {
+      requests++;
+      json(response, { ...capabilities, enabled: false });
+    });
+    await expect(start(service)).rejects.toThrow("disabled by the hosting VM owner");
+    expect(requests).toBe(1);
+    const limited = await helper((_request, response) =>
+      json(response, { ...capabilities, maxTimeoutSeconds: 10 }),
+    );
+    await expect(start(limited.service)).rejects.toThrow("Host timeout limit is 10 seconds");
+  });
+
+  it("rejects missing trusted context, caller metadata, arbitrary targets, and oversized UTF-8 before transport", async () => {
+    const service = new HostExecutionService({ enabled: true, socketPath: "/missing" });
+    await expect(service.start(input)).rejects.toThrow("trusted Rome action execution context");
+    await expect(
+      start(service, { ...input, executionId: "forged" } as RootScriptInput),
+    ).rejects.toThrow();
+    await expect(
+      start(service, { ...input, target: "other" } as unknown as RootScriptInput),
+    ).rejects.toThrow();
+    await expect(start(service, { ...input, script: "é".repeat(40_000) })).rejects.toThrow();
+  });
+
+  it("reconciles a lost submission response with GET and never automatically resubmits", async () => {
+    const requests: string[] = [];
+    const { service } = await helper((request, response) => {
+      requests.push(`${request.method} ${request.url}`);
+      if (request.url === "/v1/capabilities") return json(response, capabilities);
+      if (request.method === "POST") return request.socket.destroy();
+      json(response, completed);
+    });
+    expect(await start(service)).toEqual(completed);
+    expect(requests).toEqual(["GET /v1/capabilities", "POST /v1/jobs", `GET /v1/jobs/${jobId}`]);
+  });
+
+  it("returns the lookup ID when both submission and reconciliation are uncertain", async () => {
+    let posts = 0;
+    const { service } = await helper((request, response) => {
+      if (request.url === "/v1/capabilities") return json(response, capabilities);
+      if (request.method === "POST") {
+        posts++;
+        return request.socket.destroy();
+      }
+      json(response, { error: "not_found", message: "Job not found" }, 404);
+    });
+    await expect(start(service)).rejects.toMatchObject({
+      jobId,
+      message: expect.stringContaining("outcome is unknown"),
+    });
+    expect(posts).toBe(1);
+  });
+
+  it("preserves an unknown restart outcome without resubmission", async () => {
+    let posts = 0;
+    const { service } = await helper((request, response) => {
+      if (request.url === "/v1/capabilities") return json(response, capabilities);
+      posts++;
+      json(response, { ...completed, status: "unknown", exitCode: null });
+    });
+    expect(await start(service)).toMatchObject({ status: "unknown" });
+    expect(posts).toBe(1);
+  });
+
+  it("does not report an old script as success when a conflicting submission response is lost", async () => {
+    let posts = 0;
+    const { service } = await helper((request, response) => {
+      if (request.url === "/v1/capabilities") return json(response, capabilities);
+      if (request.method === "POST") {
+        posts++;
+        return request.socket.destroy();
+      }
+      json(response, { ...completed, scriptSha256: "f".repeat(64) });
+    });
+    await expect(start(service)).rejects.toMatchObject({
+      jobId,
+      message: expect.stringContaining("outcome is unknown"),
+    });
+    expect(posts).toBe(1);
+  });
+
+  it("reports payload conflicts without retrying or returning the existing job as success", async () => {
+    const requests: string[] = [];
+    const { service } = await helper((request, response) => {
+      requests.push(request.method!);
+      if (request.url === "/v1/capabilities") return json(response, capabilities);
+      json(response, { error: "conflict", message: "Different payload" }, 409);
+    });
+    await expect(start(service)).rejects.toThrow("Different payload");
+    expect(requests).toEqual(["GET", "POST"]);
+  });
+
+  it("polls accepted jobs briefly and returns the running snapshot", async () => {
+    let polls = 0;
+    const { service } = await helper((request, response) => {
+      if (request.url === "/v1/capabilities") return json(response, capabilities);
+      if (request.method === "GET") polls++;
+      json(response, { ...completed, status: "running", exitCode: null, finishedAt: null });
+    });
+    expect(await start(service)).toMatchObject({ status: "running" });
+    expect(polls).toBe(4);
+  });
+
+  it("inspects and cancels accepted jobs after Core enablement is switched off", async () => {
+    const requests: string[] = [];
+    const { socketPath } = await helper((request, response) => {
+      requests.push(`${request.method} ${request.url}`);
+      json(response, { ...completed, status: "cancelled", exitCode: null });
+    });
+    const service = new HostExecutionService({ socketPath, enabled: false });
+    await expect(service.inspect(jobId)).resolves.toMatchObject({ status: "cancelled" });
+    await expect(service.cancel(jobId)).resolves.toMatchObject({ status: "cancelled" });
+    expect(requests).toEqual([`GET /v1/jobs/${jobId}`, `POST /v1/jobs/${jobId}/cancel`]);
+    await expect(service.inspect("../other")).rejects.toThrow();
+  });
+
+  it("validates response identity and bounds response bytes", async () => {
+    const mismatched = await helper((_request, response) =>
+      json(response, { ...completed, id: "wrong" }),
+    );
+    await expect(mismatched.service.inspect(jobId)).rejects.toThrow("mismatched identity");
+    const oversized = await helper((_request, response) =>
+      json(response, { ...completed, stdout: "x".repeat(2 * 1024 * 1024) }),
+    );
+    await expect(oversized.service.inspect(jobId)).rejects.toThrow();
+  });
+});

--- a/packages/core/src/host-execution/service.test.ts
+++ b/packages/core/src/host-execution/service.test.ts
@@ -202,6 +202,46 @@ describe("HostExecutionService over HTTP Unix socket", () => {
     expect(requests).toEqual(["GET /v1/capabilities", "POST /v1/jobs", `GET /v1/jobs/${jobId}`]);
   });
 
+  it.each([
+    "busy",
+    "retention_limit",
+    "unavailable",
+  ])("preserves the explicit %s rejection without reconciling an unaccepted job", async (code) => {
+    const requests: string[] = [];
+    const { service } = await helper((request, response) => {
+      requests.push(`${request.method} ${request.url}`);
+      if (request.url === "/v1/capabilities") return json(response, capabilities);
+      if (request.method === "POST") {
+        return json(response, { error: code, message: "Request was not accepted" }, 503);
+      }
+      json(response, { error: "not_found", message: "Job not found" }, 404);
+    });
+    await expect(start(service)).rejects.toMatchObject({
+      message: `Host helper ${code}: Request was not accepted`,
+      code,
+      jobId: undefined,
+    });
+    expect(requests).toEqual(["GET /v1/capabilities", "POST /v1/jobs"]);
+  });
+
+  it("reconciles a persistence failure that may have reserved the request ID", async () => {
+    const requests: string[] = [];
+    const { service } = await helper((request, response) => {
+      requests.push(`${request.method} ${request.url}`);
+      if (request.url === "/v1/capabilities") return json(response, capabilities);
+      if (request.method === "POST") {
+        return json(
+          response,
+          { error: "state_unavailable", message: "Directory sync failed" },
+          503,
+        );
+      }
+      json(response, { ...completed, status: "unknown", exitCode: null });
+    });
+    await expect(start(service)).resolves.toMatchObject({ id: jobId, status: "unknown" });
+    expect(requests).toEqual(["GET /v1/capabilities", "POST /v1/jobs", `GET /v1/jobs/${jobId}`]);
+  });
+
   it("returns the lookup ID when both submission and reconciliation are uncertain", async () => {
     let posts = 0;
     const { service } = await helper((request, response) => {

--- a/packages/core/src/host-execution/service.ts
+++ b/packages/core/src/host-execution/service.ts
@@ -1,0 +1,267 @@
+import { createHash } from "node:crypto";
+import { request } from "node:http";
+import { setTimeout as delay } from "node:timers/promises";
+import { z } from "zod";
+import { actionExecutionContext } from "../actions/context.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("host-execution");
+const jobIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9_-]+$/);
+const inputSchema = z.strictObject({
+  target: z.literal("hosting-vm"),
+  interpreter: z.enum(["sh", "bash"]),
+  script: z
+    .string()
+    .min(1)
+    .refine((value) => Buffer.byteLength(value) <= 65_536),
+  reason: z.string().trim().min(1).max(2_000),
+  timeoutSeconds: z.number().int().min(1).max(600).default(60),
+});
+const capabilitiesSchema = z.object({
+  protocolVersion: z.literal(1),
+  version: z.string(),
+  hostId: z.string().min(1),
+  platform: z.literal("linux"),
+  enabled: z.boolean(),
+  interpreters: z.array(z.enum(["sh", "bash"])),
+  maxTimeoutSeconds: z.number().int().positive(),
+  maxOutputBytes: z.number().int().positive(),
+});
+const jobSchema = z.object({
+  id: jobIdSchema,
+  requestId: jobIdSchema,
+  hostId: z.string().min(1),
+  scriptSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  status: z.enum(["queued", "running", "succeeded", "failed", "cancelled", "timed_out", "unknown"]),
+  exitCode: z.number().int().nullable(),
+  stdout: z.string(),
+  stderr: z.string(),
+  truncated: z.boolean(),
+  startedAt: z.string().nullable(),
+  finishedAt: z.string().nullable(),
+});
+
+export type RootScriptInput = z.input<typeof inputSchema>;
+export type HostJob = z.infer<typeof jobSchema>;
+
+export class HostExecutionError extends Error {
+  constructor(
+    message: string,
+    readonly jobId?: string,
+  ) {
+    super(message);
+    this.name = "HostExecutionError";
+  }
+}
+
+class HostResponseError extends HostExecutionError {
+  constructor(
+    message: string,
+    readonly statusCode: number,
+  ) {
+    super(message);
+  }
+}
+
+export class HostExecutionService {
+  constructor(private readonly config: { socketPath?: string; enabled: boolean }) {}
+
+  /** Accepted jobs outlive Rome actions. Reconcile by job ID after a lost response, never submit a replacement automatically. */
+  async start(rawInput: RootScriptInput): Promise<HostJob> {
+    this.requireEnabled();
+    const input = inputSchema.parse(rawInput);
+    const context = actionExecutionContext.getStore();
+    if (!context?.executionId || !context.rootExecutionId) {
+      throw new HostExecutionError(
+        "Root execution requires trusted Rome action execution context.",
+      );
+    }
+    const jobId = createHash("sha256").update(context.executionId).digest("hex");
+    const scriptSha256 = createHash("sha256").update(input.script).digest("hex");
+    const capabilities = capabilitiesSchema.parse(await this.send("GET", "/v1/capabilities"));
+    if (!capabilities.enabled) {
+      throw new HostExecutionError("Root execution is disabled by the hosting VM owner.");
+    }
+    if (!capabilities.interpreters.includes(input.interpreter)) {
+      throw new HostExecutionError(`The hosting VM does not support ${input.interpreter}.`);
+    }
+    if (input.timeoutSeconds > capabilities.maxTimeoutSeconds) {
+      throw new HostExecutionError(
+        `Host timeout limit is ${capabilities.maxTimeoutSeconds} seconds.`,
+      );
+    }
+    const { target: _target, ...scriptInput } = input;
+    const payload = {
+      ...scriptInput,
+      requestId: jobId,
+      hostId: capabilities.hostId,
+      executionId: context.executionId,
+      rootExecutionId: context.rootExecutionId,
+    };
+    let snapshot: HostJob;
+    try {
+      snapshot = this.parseJob(
+        await this.send("POST", "/v1/jobs", payload),
+        jobId,
+        capabilities.hostId,
+        scriptSha256,
+      );
+    } catch (error) {
+      if (error instanceof HostResponseError && error.statusCode < 500) throw error;
+      // A dropped POST response can follow durable acceptance. GET is the only automatic recovery request.
+      try {
+        snapshot = this.parseJob(
+          await this.send("GET", `/v1/jobs/${jobId}`),
+          jobId,
+          capabilities.hostId,
+          scriptSha256,
+        );
+      } catch {
+        throw new HostExecutionError(
+          `Host submission outcome is unknown. Inspect job ${jobId} with system:manage_root_script before considering another execution.`,
+          jobId,
+        );
+      }
+    }
+    log.info("host job accepted", {
+      jobId,
+      hostId: snapshot.hostId,
+      executionId: context.executionId,
+      rootExecutionId: context.rootExecutionId,
+      scriptSha256: snapshot.scriptSha256,
+    });
+    for (let attempt = 0; attempt < 4 && this.isPending(snapshot); attempt++) {
+      await delay(250);
+      try {
+        snapshot = this.parseJob(
+          await this.send("GET", `/v1/jobs/${jobId}`, undefined, 250),
+          jobId,
+          capabilities.hostId,
+          scriptSha256,
+        );
+      } catch {
+        // Acceptance is already known. A failed poll leaves the durable job available for explicit inspection.
+        break;
+      }
+    }
+    return snapshot;
+  }
+
+  async inspect(jobId: string): Promise<HostJob> {
+    this.requireSocket();
+    jobIdSchema.parse(jobId);
+    return this.parseJob(await this.send("GET", `/v1/jobs/${jobId}`), jobId);
+  }
+
+  /** Cancellation is best effort for a managed process group. Unrestricted root scripts can escape it. */
+  async cancel(jobId: string): Promise<HostJob> {
+    this.requireSocket();
+    jobIdSchema.parse(jobId);
+    return this.parseJob(await this.send("POST", `/v1/jobs/${jobId}/cancel`), jobId);
+  }
+
+  private isPending(job: HostJob): boolean {
+    return job.status === "queued" || job.status === "running";
+  }
+
+  private parseJob(value: unknown, jobId: string, hostId?: string, scriptSha256?: string): HostJob {
+    const job = jobSchema.parse(value);
+    if (job.id !== jobId || job.requestId !== jobId || (hostId && job.hostId !== hostId)) {
+      throw new HostExecutionError("Host helper returned a job with mismatched identity.", jobId);
+    }
+    if (scriptSha256 && job.scriptSha256 !== scriptSha256) {
+      throw new HostExecutionError(
+        "Host helper returned a job with a different script hash.",
+        jobId,
+      );
+    }
+    return job;
+  }
+
+  private requireSocket(): string {
+    if (!this.config.socketPath) {
+      throw new HostExecutionError(
+        "Host helper is not configured. Set ROME_HOST_EXECUTION_SOCKET to the mounted host control socket.",
+      );
+    }
+    return this.config.socketPath;
+  }
+
+  private requireEnabled(): void {
+    if (!this.config.enabled) {
+      throw new HostExecutionError(
+        "Root execution is disabled in Rome. The owner must explicitly set ROME_HOST_EXECUTION_ENABLED=true and enable the host policy.",
+      );
+    }
+    this.requireSocket();
+  }
+
+  private async send(
+    method: string,
+    path: string,
+    body?: unknown,
+    timeoutMs = 5_000,
+  ): Promise<unknown> {
+    const socketPath = this.requireSocket();
+    const data = body === undefined ? undefined : JSON.stringify(body);
+    return new Promise((resolve, reject) => {
+      const req = request(
+        {
+          socketPath,
+          method,
+          path,
+          headers:
+            data === undefined
+              ? {}
+              : {
+                  "content-type": "application/json",
+                  "content-length": Buffer.byteLength(data),
+                },
+        },
+        (response) => {
+          const chunks: Buffer[] = [];
+          let size = 0;
+          response.on("data", (chunk: Buffer) => {
+            size += chunk.length;
+            if (size > 2 * 1024 * 1024) {
+              req.destroy(new HostExecutionError("Host helper response exceeded 2 MiB."));
+              return;
+            }
+            chunks.push(chunk);
+          });
+          response.on("error", reject);
+          response.on("end", () => {
+            try {
+              const parsed: unknown = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+              const status = response.statusCode ?? 500;
+              if (status < 200 || status >= 300) {
+                const error = z.object({ error: z.string(), message: z.string() }).parse(parsed);
+                reject(
+                  new HostResponseError(`Host helper ${error.error}: ${error.message}`, status),
+                );
+              } else {
+                resolve(parsed);
+              }
+            } catch {
+              reject(new HostExecutionError("Host helper returned an invalid JSON response."));
+            }
+          });
+        },
+      );
+      // A wall-clock deadline bounds trickling responses as well as idle connections.
+      const timer = setTimeout(
+        () => req.destroy(new HostExecutionError("Host helper request timed out.")),
+        timeoutMs,
+      );
+      req.on("close", () => clearTimeout(timer));
+      req.on("error", (error) =>
+        reject(new HostExecutionError(`Host helper is unavailable: ${error.message}`)),
+      );
+      req.end(data);
+    });
+  }
+}

--- a/packages/core/src/host-execution/service.ts
+++ b/packages/core/src/host-execution/service.ts
@@ -6,6 +6,7 @@ import { actionExecutionContext } from "../actions/context.js";
 import { createLogger } from "../logger.js";
 
 const log = createLogger("host-execution");
+const admissionRejections = new Set(["busy", "retention_limit", "unavailable"]);
 const jobIdSchema = z
   .string()
   .min(1)
@@ -62,6 +63,7 @@ class HostResponseError extends HostExecutionError {
   constructor(
     message: string,
     readonly statusCode: number,
+    readonly code: string,
   ) {
     super(message);
   }
@@ -111,8 +113,14 @@ export class HostExecutionService {
         scriptSha256,
       );
     } catch (error) {
-      if (error instanceof HostResponseError && error.statusCode < 500) throw error;
-      // A dropped POST response can follow durable acceptance. GET is the only automatic recovery request.
+      if (
+        error instanceof HostResponseError &&
+        (error.statusCode < 500 ||
+          (error.statusCode === 503 && admissionRejections.has(error.code)))
+      ) {
+        throw error;
+      }
+      // A transport or persistence failure can follow durable acceptance. GET is the only recovery request.
       try {
         snapshot = this.parseJob(
           await this.send("GET", `/v1/jobs/${jobId}`),
@@ -241,7 +249,11 @@ export class HostExecutionService {
               if (status < 200 || status >= 300) {
                 const error = z.object({ error: z.string(), message: z.string() }).parse(parsed);
                 reject(
-                  new HostResponseError(`Host helper ${error.error}: ${error.message}`, status),
+                  new HostResponseError(
+                    `Host helper ${error.error}: ${error.message}`,
+                    status,
+                    error.error,
+                  ),
                 );
               } else {
                 resolve(parsed);

--- a/packages/core/src/host-execution/worker-recovery.test.ts
+++ b/packages/core/src/host-execution/worker-recovery.test.ts
@@ -1,0 +1,321 @@
+import { AsyncResource } from "node:async_hooks";
+import type { ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, rs } from "@rstest/core";
+import { createAction } from "../../../../rome_apps/system/src/actions/execute-root-script/index.js";
+import { ActionCancelledError } from "../actions/action-errors.js";
+import { ActionEngine } from "../actions/engine.js";
+import { ActionRegistryImpl } from "../actions/registry.js";
+import type { ActionResult } from "../actions/types.js";
+import { isActionWorkerPayload } from "../actions/worker-protocol.js";
+import { ActionExecutionsRepository } from "../db/repositories/action-executions.js";
+import { RoutineRunsRepository } from "../db/repositories/routine-runs.js";
+import { RoutinesRepository, toRoutine } from "../db/repositories/routines.js";
+import { RoutineEngine } from "../routines/engine.js";
+import { createTestDb } from "../test/helpers.js";
+import { buildAction, FakeClock } from "../test/kit/index.js";
+import { HostExecutionService } from "./service.js";
+import { createHostWorkerRecovery } from "./worker-recovery.js";
+
+const input = { target: "hosting-vm", interpreter: "sh", script: "printf hello", reason: "test" };
+const actionName = "system:execute_root_script";
+const jobId = (executionId: string) => createHash("sha256").update(executionId).digest("hex");
+const cleanup: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  for (const close of cleanup.splice(0).reverse()) await close();
+});
+
+async function setup(nested = false, signal: NodeJS.Signals | null = null, cancel = false) {
+  const testDb = createTestDb();
+  cleanup.push(() => testDb.close());
+  const repo = new ActionExecutionsRepository(testDb.db);
+  const clock = new FakeClock();
+  const submissions: Array<Record<string, string>> = [];
+  const directory = await mkdtemp("/tmp/rome-worker-job-");
+  const socketPath = join(directory, "control.sock");
+  const server = createServer(async (request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/v1/capabilities") {
+      response.end(
+        JSON.stringify({
+          protocolVersion: 1,
+          version: "1",
+          hostId: "host-1",
+          platform: "linux",
+          enabled: true,
+          interpreters: ["sh"],
+          maxTimeoutSeconds: 600,
+          maxOutputBytes: 4096,
+        }),
+      );
+      return;
+    }
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.from(chunk));
+    const body = JSON.parse(Buffer.concat(chunks).toString());
+    submissions.push(body);
+    response.end(
+      JSON.stringify({
+        id: body.requestId,
+        requestId: body.requestId,
+        hostId: "host-1",
+        scriptSha256: createHash("sha256").update(body.script).digest("hex"),
+        status: "succeeded",
+        exitCode: 0,
+        stdout: "hello",
+        stderr: "",
+        truncated: false,
+        startedAt: "2026-01-01T00:00:00Z",
+        finishedAt: "2026-01-01T00:00:01Z",
+      }),
+    );
+  });
+  await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+  cleanup.push(async () => {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await rm(directory, { recursive: true, force: true });
+  });
+  const registry = new ActionRegistryImpl([]);
+  const hostAction = createAction(buildAction(actionName, { cancellable: false }).config, {
+    hostExecution: new HostExecutionService({ enabled: true, socketPath }),
+  });
+  let child: EventEmitter & {
+    connected: boolean;
+    exitCode: number | null;
+    signalCode: NodeJS.Signals | null;
+  };
+  let engine: ActionEngine;
+  async function loseWorker(): Promise<ActionResult> {
+    if (cancel) {
+      Object.assign(child, { pid: 999999 });
+      const kill = rs.spyOn(process, "kill").mockReturnValue(true);
+      cleanup.push(() => {
+        kill.mockRestore();
+      });
+      await engine.cancel("root-1");
+    }
+    child.connected = false;
+    child.exitCode = signal ? null : 1;
+    child.signalCode = signal;
+    child.emit("exit", child.exitCode, signal);
+    return new Promise(() => {});
+  }
+  registry.register(
+    nested
+      ? hostAction
+      : {
+          ...hostAction,
+          execute: async (args, context) => {
+            const result = await hostAction.execute(args, context);
+            if (result.status === "error") return result;
+            return loseWorker();
+          },
+        },
+  );
+  const workerEngine = new ActionEngine(registry, undefined, repo);
+  if (nested)
+    registry.register(
+      buildAction("app:parent", {
+        execute: async () => {
+          await workerEngine.run(actionName, input);
+          return loseWorker();
+        },
+      }),
+    );
+  const isolatedWorker = new AsyncResource("host-worker-test");
+  cleanup.push(() => {
+    isolatedWorker.emitDestroy();
+  });
+  const fork = rs.fn(() => {
+    child = Object.assign(new EventEmitter(), {
+      connected: true,
+      exitCode: null,
+      signalCode: null,
+    });
+    Object.assign(child, {
+      send(message: unknown, callback?: (error: Error | null) => void) {
+        callback?.(null);
+        if (isActionWorkerPayload(message)) {
+          isolatedWorker.runInAsyncScope(() => {
+            void workerEngine.run(message.actionName, message.args, message.context).then(
+              (result) => child.emit("message", { type: "result", result }),
+              (error) =>
+                child.emit("message", {
+                  type: "error",
+                  error: { name: error.name, message: error.message },
+                }),
+            );
+          });
+        }
+        return true;
+      },
+    });
+    return child as unknown as ChildProcess;
+  });
+  engine = new ActionEngine(registry, undefined, repo, undefined, undefined, {
+    processRole: "main",
+    workerWarmPoolSize: 0,
+    clock,
+    actionWorkerFork: fork,
+    onWorkerInterrupted: createHostWorkerRecovery(repo),
+  });
+  return {
+    engine,
+    repo,
+    clock,
+    submissions,
+    fork,
+    db: testDb.db,
+    name: nested ? "app:parent" : actionName,
+  };
+}
+
+describe("host jobs after action worker loss", () => {
+  it.each([
+    null,
+    "SIGKILL",
+  ] as const)("returns the original receipt after acceptance and worker exit (%s)", async (signal) => {
+    const { engine, repo, submissions, name } = await setup(false, signal);
+    const result = await engine.run(name, input, {
+      executionId: "execution-1",
+      rootExecutionId: "root-1",
+    });
+    expect(result).toMatchObject({
+      status: "error",
+      error: expect.stringContaining(jobId("execution-1")),
+    });
+    expect(result).toMatchObject({ error: expect.stringContaining("system:manage_root_script") });
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0]).toMatchObject({
+      requestId: jobId("execution-1"),
+      executionId: "execution-1",
+      rootExecutionId: "root-1",
+    });
+    expect(await repo.findById("execution-1")).toMatchObject({ status: "error" });
+  });
+
+  it("retains a completed inline child's receipt when its parent worker dies", async () => {
+    const { engine, repo, submissions, name } = await setup(true);
+    const result = await engine.run(
+      name,
+      {},
+      { executionId: "parent-1", rootExecutionId: "root-1" },
+    );
+    expect(submissions).toHaveLength(1);
+    expect(result).toMatchObject({
+      status: "error",
+      error: expect.stringContaining(submissions[0]!.requestId),
+    });
+    expect(await repo.findById(submissions[0]!.executionId)).toMatchObject({
+      status: "success",
+      parentId: "parent-1",
+    });
+  });
+
+  it("returns receipts through the delegated worker boundary", async () => {
+    const { engine, submissions, name } = await setup(true);
+    const delegated = engine.startDelegatedAction({
+      actionName: name,
+      args: {},
+      context: {
+        executionId: "delegated-parent",
+        rootExecutionId: "root",
+        parentExecutionId: "owner",
+      },
+    });
+    expect(await delegated.result).toMatchObject({
+      status: "error",
+      error: expect.stringContaining(submissions[0]!.requestId),
+    });
+    expect(submissions).toHaveLength(1);
+  });
+
+  it.each([
+    false,
+    true,
+  ])("does not automatically retry a triggered host routine after worker loss (persistence failure: %s)", async (persistenceFailure) => {
+    const { engine, repo, clock, submissions, fork, db } = await setup();
+    if (persistenceFailure)
+      rs.spyOn(repo, "markRootErrored").mockRejectedValue(new Error("database unavailable"));
+    const routines = new RoutinesRepository(db);
+    const runs = new RoutineRunsRepository(db);
+    const routineEngine = new RoutineEngine(routines, runs, engine, 100, clock);
+    cleanup.push(() => routineEngine.stop());
+    let fire!: (payload: Record<string, unknown>) => Promise<void>;
+    routineEngine.registerProvider("event-bus", {
+      type: "event-bus",
+      activate: async (_routine, callback) => {
+        fire = callback;
+      },
+      deactivate() {},
+      isActive: () => true,
+      stop() {},
+    });
+    const id = await routines.create({
+      name: "host-maintenance",
+      trigger: { type: "event-bus", eventName: "test" },
+      actionName,
+      args: input,
+      enabled: true,
+    });
+    await routineEngine.activate(toRoutine((await routines.findById(id))!));
+    await fire({ source: "trigger" });
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0]).not.toHaveProperty("__triggerPayload");
+    expect((await runs.findByRoutineId(id))[0]).toMatchObject({
+      status: "error",
+      error: expect.stringContaining(submissions[0]!.requestId),
+    });
+    expect(clock.pendingTimerCount()).toBe(0);
+    await clock.advance(1000);
+    expect(fork).toHaveBeenCalledTimes(1);
+    expect(submissions).toHaveLength(1);
+  });
+
+  it("preserves requested cancellation instead of returning a recovery result", async () => {
+    const { engine, name } = await setup(false, "SIGTERM", true);
+    await expect(engine.run(name, input, { executionId: "root-1" })).rejects.toBeInstanceOf(
+      ActionCancelledError,
+    );
+  });
+
+  it("restricts receipts to the interrupted subtree and preserves IDs if lookup fails", async () => {
+    const { repo } = await setup();
+    await repo.create({
+      id: "host-child",
+      rootExecutionId: "root",
+      parentId: "parent",
+      actionName,
+      status: "success",
+    });
+    await repo.create({
+      id: "sibling",
+      rootExecutionId: "root",
+      parentId: "root",
+      actionName,
+      status: "running",
+    });
+    await repo.create({ id: "unrelated", rootExecutionId: "other", actionName, status: "running" });
+    const recover = createHostWorkerRecovery(repo);
+    const invocation = { actionName: "app:parent", executionId: "parent", rootExecutionId: "root" };
+    const error = new Error("worker lost");
+    const result = await recover(invocation, error);
+    expect(result).toMatchObject({ error: expect.stringContaining(jobId("host-child")) });
+    expect(JSON.stringify(result)).not.toContain(jobId("sibling"));
+    expect(JSON.stringify(result)).not.toContain(jobId("unrelated"));
+    rs.spyOn(repo, "findByRootExecutionIds").mockRejectedValue(new Error("database unavailable"));
+    expect(await recover({ ...invocation, actionName }, error)).toMatchObject({
+      status: "error",
+      error: expect.stringContaining(jobId("parent")),
+    });
+    expect(await recover(invocation, error)).toMatchObject({
+      status: "error",
+      error: expect.stringContaining("database unavailable"),
+    });
+  });
+});

--- a/packages/core/src/host-execution/worker-recovery.ts
+++ b/packages/core/src/host-execution/worker-recovery.ts
@@ -1,0 +1,49 @@
+import { createHash } from "node:crypto";
+import type { InterruptedAction } from "../actions/engine.js";
+import type { ActionResult } from "../actions/types.js";
+import type { ActionExecutionsRepository } from "../db/repositories/action-executions.js";
+
+const HOST_ACTION = "system:execute_root_script";
+
+/** Lost workers cannot establish host completion. Preserve receipts without submitting replacement jobs. */
+export function createHostWorkerRecovery(repo: ActionExecutionsRepository) {
+  return async (invocation: InterruptedAction, error: Error): Promise<ActionResult | undefined> => {
+    let executions = [{ id: invocation.executionId, rootExecutionId: invocation.rootExecutionId }];
+    if (invocation.actionName !== HOST_ACTION) {
+      try {
+        const rows = await repo.findByRootExecutionIds([invocation.rootExecutionId]);
+        const descendants = new Set([invocation.executionId]);
+        // Include completed children: their result may never have reached the root caller.
+        for (let previousSize = -1; previousSize !== descendants.size; ) {
+          previousSize = descendants.size;
+          for (const row of rows) {
+            if (row.parentId && descendants.has(row.parentId)) descendants.add(row.id);
+          }
+        }
+        executions = rows.filter(
+          (row) =>
+            descendants.has(row.id) &&
+            row.actionName === HOST_ACTION &&
+            row.status !== "pending_approval",
+        );
+      } catch (lookupError) {
+        return {
+          status: "error",
+          error: `${error.message}. Cannot inspect the interrupted execution tree: ${String(lookupError)}. Host jobs may still be running. Inspect execution ${invocation.executionId} (root ${invocation.rootExecutionId}) before retrying.`,
+        };
+      }
+    }
+    if (executions.length === 0) return undefined;
+    const jobs = executions.map((execution) => ({
+      jobId: createHash("sha256").update(execution.id).digest("hex"),
+      executionId: execution.id,
+      rootExecutionId: execution.rootExecutionId,
+      target: "hosting-vm",
+      completed: false,
+    }));
+    return {
+      status: "error",
+      error: `${error.message}. Host submission outcome is unknown. Inspect each original job with system:manage_root_script before considering another execution.\n${JSON.stringify({ jobs })}`,
+    };
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,7 @@ import { mapGuardianToChannel } from "./channels/guardian-mapping.js";
 import type { EmailInboundResult } from "./channels/email-control.js";
 import { startApi, type ApiHandle, type ApiDeps } from "./api/index.js";
 import { SystemUpgradeService } from "./system-upgrade/service.js";
+import { HostExecutionService } from "./host-execution/service.js";
 import { resolveAutoUpgradeEnabled } from "./lib/auto-upgrade-gate.js";
 import { PublicAccessState } from "./lib/public-access-state.js";
 import { reconcilePublicAccessAtStartup } from "./lib/public-access.js";
@@ -790,12 +791,23 @@ async function main() {
       ],
     }),
   };
+  const hostExecution = new HostExecutionService({
+    socketPath: config.hostExecutionSocket,
+    enabled: config.hostExecutionEnabled,
+  });
   const appActionReload = await registerAppActions(
     actionLoader,
     actionRegistry,
     appCatalog,
     appActionDeps,
-    { db, actionEngine, routinesRepo, repositories: appRuntimeRepositories, favorService },
+    {
+      db,
+      actionEngine,
+      routinesRepo,
+      repositories: appRuntimeRepositories,
+      favorService,
+      hostExecution,
+    },
   );
 
   appCatalog.subscribe(
@@ -805,6 +817,7 @@ async function main() {
       routinesRepo,
       repositories: appRuntimeRepositories,
       favorService,
+      hostExecution,
     }),
   );
   appCatalog.subscribe(async function favorActionRequirementsSubscriber(event) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,6 +113,7 @@ import type { EmailInboundResult } from "./channels/email-control.js";
 import { startApi, type ApiHandle, type ApiDeps } from "./api/index.js";
 import { SystemUpgradeService } from "./system-upgrade/service.js";
 import { HostExecutionService } from "./host-execution/service.js";
+import { createHostWorkerRecovery } from "./host-execution/worker-recovery.js";
 import { resolveAutoUpgradeEnabled } from "./lib/auto-upgrade-gate.js";
 import { PublicAccessState } from "./lib/public-access-state.js";
 import { reconcilePublicAccessAtStartup } from "./lib/public-access.js";
@@ -459,6 +460,7 @@ async function main() {
     executionJournalRepo,
     {
       processRole: "main",
+      onWorkerInterrupted: createHostWorkerRecovery(actionExecutionsRepo),
       maxWorkerProcesses: config.actionWorkerMaxProcesses,
       actionWorkerFork: (entryPath, options) => fork(entryPath, [], options),
       onApprovalCreated: async ({ approvalId, actionName, preview, channelContext }) => {

--- a/packages/host-helper/README.md
+++ b/packages/host-helper/README.md
@@ -1,0 +1,103 @@
+# Rome host helper
+
+`rome-hostd` runs on a dedicated Linux host and accepts root script jobs from
+Rome through a Unix socket. It has no TCP listener or third-party runtime
+dependencies. The [host execution contracts](../../docs/architecture/host-execution.md)
+define its trust boundary and job lifetime.
+
+The helper is optional. Both its host policy and
+`ROME_HOST_EXECUTION_ENABLED=true` in Rome must permit new submissions.
+Inspection and cancellation remain available when submission is disabled.
+Socket access grants the trusted container authority over the host. Root can
+read host credentials and change host services, including the helper itself.
+
+## Build and verify
+
+From this directory in the Nix development shell on Linux:
+
+```sh
+go test -race ./...
+go vet ./...
+CGO_ENABLED=0 GOOS=linux go build -o dist/rome-hostd ./cmd/rome-hostd
+```
+
+On macOS, use the container integration check below. It runs a root helper and a nonroot client in separate
+isolated Linux containers. It mounts only a test socket volume between them.
+It never mounts the Docker daemon socket or the real host root filesystem.
+From the repository root:
+
+```sh
+bash scripts/host-helper/smoke.sh
+```
+
+## Host configuration
+
+The CLI accepts `--config`, which defaults to `/etc/rome-host/config.json`.
+The config file and its directory must be protected from unprivileged writers.
+The CLI requires Linux root. Example configuration:
+
+```json
+{
+  "hostId": "my-vm",
+  "enabled": false,
+  "socketPath": "/run/rome-host/control.sock",
+  "stateDir": "/var/lib/rome-host",
+  "socketGid": 10001,
+  "maxTimeoutSeconds": 600,
+  "maxOutputBytes": 131072
+}
+```
+
+Choose `socketGid` from the actual Rome backend user's primary group in the
+runtime image. The sample value is not an image default. Mount the socket
+directory into the Rome container and set `ROME_HOST_EXECUTION_SOCKET` to
+the socket's container path. Keep the source directory stable during service
+restarts and create it before Docker restores containers on VM boot.
+
+Rome Cloud manages the binary, systemd unit, socket mount, and instance policy
+through its deployment bundle. The helper release and the Rome image can
+upgrade independently. The host must contain only credentials whose authority
+the operator intends to delegate to its root scripts.
+
+## Job protocol
+
+| Request | Result |
+| --- | --- |
+| `GET /v1/capabilities` | Protocol version, host identity, policy, interpreters, and limits |
+| `POST /v1/jobs` | Durable acceptance, or the existing identical job |
+| `GET /v1/jobs/<id>` | Job state and bounded output |
+| `POST /v1/jobs/<id>/cancel` | Idempotent cancellation of the managed job |
+
+Rome submits through `system:execute_root_script` and manages the returned ID
+through `system:manage_root_script`. A job ID is the SHA256 of the submitting
+Rome execution ID. A new action execution creates a new job. When a response is
+lost, inspect the known job before starting another execution.
+
+The helper runs `/bin/sh -s` or `/bin/bash -s` with the script on stdin. Its
+working directory is private to the job, and it receives a minimal environment.
+Container paths and environment variables are not inherited. A successful
+submission can report a job that is still running. Terminal failures in Rome
+include the job snapshot as JSON in the action's error string.
+
+One job runs at a time. At most 10,000 job identities are retained. At capacity,
+new submissions fail while inspection and cancellation continue. The helper
+never evicts an accepted identity or recursively removes work directories.
+Operators must monitor disk use and archive work with awareness of files and
+mounts a root script can create. Do not delete job records to recover capacity:
+doing so discards deduplication history. Replace the host identity and retire
+the old target when provisioning a fresh job store.
+
+An interrupted nonterminal job becomes `unknown` after helper recovery. The
+helper never restarts its script. Root scripts can escape ordinary process
+cleanup or create persistent services, so cancellation is not rollback.
+
+## Releases
+
+The Host helper workflow runs Go tests and the container integration check.
+After the source is merged, run the workflow on `main` with a bare semver, or
+push a `host-helper-v<version>` tag that points to a merged commit.
+
+Each release contains `rome-hostd-linux-amd64`, `rome-hostd-linux-arm64`, and
+`SHA256SUMS`. `rome-hostd --version` prints the embedded version. Configure
+Rome Cloud with the exact artifact URL, digest, and version. A mutable image
+tag or a GitHub repository credential is not required on the VM.

--- a/packages/host-helper/README.md
+++ b/packages/host-helper/README.md
@@ -87,8 +87,9 @@ mounts a root script can create. Do not delete job records to recover capacity:
 doing so discards deduplication history. Replace the host identity and retire
 the old target when provisioning a fresh job store.
 
-An interrupted nonterminal job becomes `unknown` after helper recovery. The
-helper never restarts its script. Root scripts can escape ordinary process
+A job supervisor kills and reaps ordinary process-group descendants when the
+helper dies. Recovery waits for that cleanup before accepting jobs. An interrupted
+nonterminal job becomes `unknown`, and the helper never restarts its script. Root scripts can escape ordinary process
 cleanup or create persistent services, so cancellation is not rollback.
 
 ## Releases

--- a/packages/host-helper/cmd/rome-hostd/main.go
+++ b/packages/host-helper/cmd/rome-hostd/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+
+	"github.com/rome-os/rome/packages/host-helper/internal/hosthelper"
+)
+
+var version = "dev"
+
+func main() {
+	configPath := flag.String("config", "/etc/rome-host/config.json", "protected host config file")
+	showVersion := flag.Bool("version", false, "print version")
+	flag.Parse()
+	if *showVersion {
+		fmt.Println(version)
+		return
+	}
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	if flag.NArg() != 0 {
+		logger.Error("unexpected arguments")
+		os.Exit(2)
+	}
+	if runtime.GOOS != "linux" || os.Geteuid() != 0 {
+		logger.Error("rome-hostd requires Linux root")
+		os.Exit(1)
+	}
+	syscall.Umask(0077)
+	config, err := hosthelper.LoadConfig(*configPath)
+	if err != nil {
+		logger.Error("invalid host config", "error", err)
+		os.Exit(1)
+	}
+	server, err := hosthelper.New(config, version, logger)
+	if err != nil {
+		logger.Error("cannot start host helper", "error", err)
+		os.Exit(1)
+	}
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT)
+	done := make(chan error, 1)
+	go func() { done <- server.Serve() }()
+	logger.Info("rome-hostd started", "version", version, "hostId", config.HostID, "enabled", config.Enabled)
+	exitCode := 0
+	select {
+	case <-signals:
+	case err = <-done:
+		if err != nil {
+			logger.Error("host helper listener stopped", "error", err)
+			exitCode = 1
+		}
+	}
+	server.Close()
+	signal.Stop(signals)
+	os.Exit(exitCode)
+}

--- a/packages/host-helper/cmd/rome-hostd/main.go
+++ b/packages/host-helper/cmd/rome-hostd/main.go
@@ -15,6 +15,7 @@ import (
 var version = "dev"
 
 func main() {
+	hosthelper.RunSupervisor()
 	configPath := flag.String("config", "/etc/rome-host/config.json", "protected host config file")
 	showVersion := flag.Bool("version", false, "print version")
 	flag.Parse()

--- a/packages/host-helper/go.mod
+++ b/packages/host-helper/go.mod
@@ -1,0 +1,3 @@
+module github.com/rome-os/rome/packages/host-helper
+
+go 1.26.0

--- a/packages/host-helper/internal/hosthelper/config.go
+++ b/packages/host-helper/internal/hosthelper/config.go
@@ -1,0 +1,189 @@
+package hosthelper
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"syscall"
+	"unicode/utf8"
+)
+
+const maxBodyBytes = 512 * 1024
+const maxJobs = 10000
+
+var identifier = regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`)
+
+type Config struct {
+	HostID            string `json:"hostId"`
+	Enabled           bool   `json:"enabled"`
+	SocketPath        string `json:"socketPath"`
+	StateDir          string `json:"stateDir"`
+	SocketGID         int    `json:"socketGid"`
+	MaxTimeoutSeconds int    `json:"maxTimeoutSeconds"`
+	MaxOutputBytes    int    `json:"maxOutputBytes"`
+}
+
+func (c *Config) defaults() {
+	if c.SocketPath == "" {
+		c.SocketPath = "/run/rome-host/control.sock"
+	}
+	if c.StateDir == "" {
+		c.StateDir = "/var/lib/rome-host"
+	}
+	if c.MaxTimeoutSeconds == 0 {
+		c.MaxTimeoutSeconds = 600
+	}
+	if c.MaxOutputBytes == 0 {
+		c.MaxOutputBytes = 128 * 1024
+	}
+}
+
+func (c Config) validate() error {
+	if !identifier.MatchString(c.HostID) {
+		return errors.New("hostId must be a 1..128 character identifier")
+	}
+	if c.SocketGID < 0 || uint64(c.SocketGID) > 4294967294 {
+		return errors.New("invalid socketGid")
+	}
+	if c.MaxTimeoutSeconds < 1 || c.MaxTimeoutSeconds > 600 {
+		return errors.New("maxTimeoutSeconds must be 1..600")
+	}
+	if c.MaxOutputBytes < 1 || c.MaxOutputBytes > 128*1024 {
+		return errors.New("maxOutputBytes must be 1..131072")
+	}
+	if !filepath.IsAbs(c.SocketPath) || filepath.Clean(c.SocketPath) != c.SocketPath || len(c.SocketPath) > 100 {
+		return errors.New("socketPath must be a clean absolute path of at most 100 bytes")
+	}
+	if !filepath.IsAbs(c.StateDir) || filepath.Clean(c.StateDir) != c.StateDir || c.StateDir == "/" {
+		return errors.New("stateDir must be a clean absolute directory path")
+	}
+	return nil
+}
+
+// LoadConfig requires a regular file owned by this UID with no unprivileged writers.
+func LoadConfig(path string) (Config, error) {
+	c := Config{}
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return c, errors.New("config path must be clean and absolute")
+	}
+	if err := protectedPath(filepath.Dir(path)); err != nil {
+		return c, err
+	}
+	if err := protectedFile(path); err != nil {
+		return c, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return c, err
+	}
+	defer f.Close()
+	b, err := io.ReadAll(io.LimitReader(f, maxBodyBytes+1))
+	if err != nil {
+		return c, err
+	}
+	if len(b) > maxBodyBytes {
+		return c, errors.New("config is too large")
+	}
+	if err = strictJSON(b, &c, []string{"hostId", "socketGid"}); err != nil {
+		return c, err
+	}
+	var fields map[string]json.RawMessage
+	json.Unmarshal(b, &fields)
+	if _, ok := fields["maxTimeoutSeconds"]; ok && c.MaxTimeoutSeconds == 0 {
+		return c, errors.New("maxTimeoutSeconds must be positive")
+	}
+	if _, ok := fields["maxOutputBytes"]; ok && c.MaxOutputBytes == 0 {
+		return c, errors.New("maxOutputBytes must be positive")
+	}
+	c.defaults()
+	return c, c.validate()
+}
+
+func strictJSON(data []byte, target any, required []string) error {
+	if !utf8.Valid(data) {
+		return errors.New("JSON must be UTF-8")
+	}
+	t := reflect.TypeOf(target).Elem()
+	allowed := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		allowed[t.Field(i).Tag.Get("json")] = true
+	}
+	d := json.NewDecoder(bytes.NewReader(data))
+	token, err := d.Token()
+	if err != nil || token != json.Delim('{') {
+		return errors.New("expected a JSON object")
+	}
+	seen := map[string]bool{}
+	for d.More() {
+		token, err = d.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := token.(string)
+		if !ok || !allowed[key] || seen[key] {
+			return errors.New("unknown or duplicate JSON field")
+		}
+		seen[key] = true
+		var value json.RawMessage
+		if err = d.Decode(&value); err != nil {
+			return err
+		}
+		if bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+			return errors.New("null fields are not allowed")
+		}
+	}
+	if _, err = d.Token(); err != nil {
+		return err
+	}
+	if _, err = d.Token(); err != io.EOF {
+		return errors.New("unexpected trailing JSON")
+	}
+	for _, key := range required {
+		if !seen[key] {
+			return fmt.Errorf("missing %s", key)
+		}
+	}
+	return json.Unmarshal(data, target)
+}
+
+func protectedFile(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || !info.Mode().IsRegular() || int(stat.Uid) != os.Geteuid() || info.Mode().Perm()&0022 != 0 {
+		return fmt.Errorf("unprotected file: %s", path)
+	}
+	return nil
+}
+
+func protectedPath(path string) error {
+	if !filepath.IsAbs(path) {
+		return errors.New("protected paths must be absolute")
+	}
+	for {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok || !info.IsDir() || (int(stat.Uid) != os.Geteuid() && stat.Uid != 0) {
+			return fmt.Errorf("unprotected directory: %s", path)
+		}
+		// A sticky ancestor cannot replace a protected child owned by this UID.
+		if info.Mode().Perm()&0022 != 0 && info.Mode()&os.ModeSticky == 0 {
+			return fmt.Errorf("writable directory: %s", path)
+		}
+		if path == "/" {
+			return nil
+		}
+		path = filepath.Dir(path)
+	}
+}

--- a/packages/host-helper/internal/hosthelper/execute.go
+++ b/packages/host-helper/internal/hosthelper/execute.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -71,28 +70,46 @@ func (s *Server) execute(ctx context.Context, job *activeJob) {
 	}
 	o := &output{remaining: s.config.MaxOutputBytes}
 	job.output = o
-	cmd := exec.CommandContext(ctx, "/bin/"+r.Request.Interpreter, "-s")
+	alive, lifetime, err := os.Pipe()
+	if err != nil {
+		s.finishLocked(job, ctx, err, nil, o)
+		s.mu.Unlock()
+		return
+	}
+	defer lifetime.Close()
+	cmd := exec.Command("/proc/self/exe", "--supervise", r.Request.Interpreter)
+	cmd.ExtraFiles = []*os.File{alive, s.executionLease}
 	cmd.Dir = work
 	cmd.Env = []string{"PATH=/usr/sbin:/usr/bin:/sbin:/bin", "HOME=" + work, "TMPDIR=" + work, "LANG=C.UTF-8", "LC_ALL=C.UTF-8"}
 	cmd.Stdin = strings.NewReader(r.Request.Script)
 	cmd.Stdout = stream{output: o}
 	cmd.Stderr = stream{output: o, stderr: true}
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		if errors.Is(err, syscall.ESRCH) {
-			return os.ErrProcessDone
-		}
-		return err
-	}
-	// Descendants can inherit output pipes after the shell exits. Bound their
-	// drain time independently of the script deadline.
+	// With no CommandContext, WaitDelay bounds output drain only after supervisor
+	// exit. A deadline must close liveness, never kill the supervisor during cleanup.
 	cmd.WaitDelay = 250 * time.Millisecond
-	err = cmd.Start()
+	err = ctx.Err()
+	if err == nil {
+		err = cmd.Start()
+	}
+	alive.Close()
 	s.mu.Unlock()
 	if err == nil {
+		finished := make(chan struct{})
+		go func() {
+			select {
+			case <-ctx.Done():
+				lifetime.Close()
+			case <-finished:
+			}
+		}()
 		err = cmd.Wait()
-		syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		close(finished)
+		if errors.Is(err, exec.ErrWaitDelay) {
+			o.mu.Lock()
+			o.truncated = true
+			o.mu.Unlock()
+			err = nil
+		}
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/packages/host-helper/internal/hosthelper/execute.go
+++ b/packages/host-helper/internal/hosthelper/execute.go
@@ -1,0 +1,138 @@
+package hosthelper
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type output struct {
+	// Both exec copy goroutines share the combined byte budget under mu.
+	mu        sync.Mutex
+	remaining int
+	stdout    bytes.Buffer
+	stderr    bytes.Buffer
+	truncated bool
+}
+
+type stream struct {
+	output *output
+	stderr bool
+}
+
+func (w stream) Write(p []byte) (int, error) {
+	o := w.output
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	n := min(len(p), o.remaining)
+	if n < len(p) {
+		o.truncated = true
+	}
+	if w.stderr {
+		o.stderr.Write(p[:n])
+	} else {
+		o.stdout.Write(p[:n])
+	}
+	o.remaining -= n
+	return len(p), nil
+}
+
+func (s *Server) execute(ctx context.Context, job *activeJob) {
+	defer s.workers.Done()
+	defer job.cancel()
+	s.mu.Lock()
+	r := job.record
+	work, err := os.MkdirTemp(filepath.Join(s.config.StateDir, "work"), r.Request.RequestID+"-")
+	if err != nil {
+		s.finishLocked(job, ctx, err, nil, nil)
+		s.mu.Unlock()
+		return
+	}
+	// Work is private and retained for inspection. Root scripts may put arbitrary
+	// files or mounts there, so the daemon never recursively deletes it.
+	now := time.Now().UTC()
+	r.Snapshot.Status = "running"
+	r.Snapshot.StartedAt = &now
+	if err = s.save(r); err != nil {
+		r.Snapshot.Status = "unknown"
+		r.Snapshot.FinishedAt = &now
+		s.uncertain = r
+		s.storageFault()
+		s.active = nil
+		s.mu.Unlock()
+		return
+	}
+	o := &output{remaining: s.config.MaxOutputBytes}
+	job.output = o
+	cmd := exec.CommandContext(ctx, "/bin/"+r.Request.Interpreter, "-s")
+	cmd.Dir = work
+	cmd.Env = []string{"PATH=/usr/sbin:/usr/bin:/sbin:/bin", "HOME=" + work, "TMPDIR=" + work, "LANG=C.UTF-8", "LC_ALL=C.UTF-8"}
+	cmd.Stdin = strings.NewReader(r.Request.Script)
+	cmd.Stdout = stream{output: o}
+	cmd.Stderr = stream{output: o, stderr: true}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	// Descendants can inherit output pipes after the shell exits. Bound their
+	// drain time independently of the script deadline.
+	cmd.WaitDelay = 250 * time.Millisecond
+	err = cmd.Start()
+	s.mu.Unlock()
+	if err == nil {
+		err = cmd.Wait()
+		syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.finishLocked(job, ctx, err, cmd, o)
+}
+
+func (s *Server) finishLocked(job *activeJob, ctx context.Context, err error, cmd *exec.Cmd, o *output) {
+	r := job.record
+	now := time.Now().UTC()
+	r.Snapshot.FinishedAt = &now
+	r.Snapshot.Status = "succeeded"
+	if err != nil {
+		r.Snapshot.Status = "failed"
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		r.Snapshot.Status = "timed_out"
+	} else if job.cancelled {
+		r.Snapshot.Status = "cancelled"
+	}
+	if cmd != nil && cmd.ProcessState != nil {
+		exit := cmd.ProcessState.ExitCode()
+		r.Snapshot.ExitCode = &exit
+	}
+	if o != nil {
+		o.copyTo(&r.Snapshot)
+	}
+	if err := s.save(r); err != nil {
+		r.Snapshot.Status = "unknown"
+		r.Snapshot.ExitCode = nil
+		s.uncertain = r
+		s.storageFault()
+	}
+	s.audit("finished", r)
+	s.active = nil
+}
+
+func (o *output) copyTo(snapshot *Snapshot) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	snapshot.Stdout = strings.ToValidUTF8(o.stdout.String(), "?")
+	snapshot.Stderr = strings.ToValidUTF8(o.stderr.String(), "?")
+	snapshot.Truncated = o.truncated
+}

--- a/packages/host-helper/internal/hosthelper/listener.go
+++ b/packages/host-helper/internal/hosthelper/listener.go
@@ -1,0 +1,39 @@
+package hosthelper
+
+import (
+	"net"
+	"sync"
+)
+
+type limitedListener struct {
+	net.Listener
+	slots chan struct{}
+}
+
+type limitedConn struct {
+	net.Conn
+	once  sync.Once
+	slots chan struct{}
+}
+
+func (l *limitedListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		select {
+		case l.slots <- struct{}{}:
+			return &limitedConn{Conn: conn, slots: l.slots}, nil
+		default:
+			conn.Close()
+		}
+	}
+}
+
+func (c *limitedConn) Close() error {
+	err := c.Conn.Close()
+	// HTTP may close a connection on several concurrent shutdown paths.
+	c.once.Do(func() { <-c.slots })
+	return err
+}

--- a/packages/host-helper/internal/hosthelper/server.go
+++ b/packages/host-helper/internal/hosthelper/server.go
@@ -24,26 +24,29 @@ type activeJob struct {
 }
 
 type Server struct {
-	config  Config
-	version string
-	logger  *slog.Logger
+	syncStateDir func(string) error
+	config       Config
+	version      string
+	logger       *slog.Logger
 	// mu guards jobs, active, closing, and fault. Persistence and process launch
 	// share this lock so cancellation and duplicate submission cannot cross intent.
 	// Snapshot reads take output.mu after mu. Output writers never take mu.
-	mu        sync.Mutex
-	jobs      map[string]struct{}
-	active    *activeJob
-	uncertain *record
-	closing   bool
-	fault     bool
-	workers   sync.WaitGroup
-	locks     []*os.File
-	listener  *net.UnixListener
-	http      *http.Server
-	closeOnce sync.Once
+	mu             sync.Mutex
+	jobs           map[string]struct{}
+	active         *activeJob
+	uncertain      *record
+	closing        bool
+	fault          bool
+	workers        sync.WaitGroup
+	locks          []*os.File
+	executionLease *os.File
+	listener       *net.UnixListener
+	http           *http.Server
+	closeOnce      sync.Once
 }
 
-// New locks durable state and the socket directory until Close. Call Serve once.
+// New holds state and socket locks until Close. It waits for surviving job
+// cleanup before recovery. Call Serve once.
 func New(config Config, version string, logger *slog.Logger) (_ *Server, err error) {
 	config.defaults()
 	if err = config.validate(); err != nil {
@@ -52,7 +55,7 @@ func New(config Config, version string, logger *slog.Logger) (_ *Server, err err
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 	}
-	s := &Server{config: config, version: version, logger: logger, jobs: map[string]struct{}{}}
+	s := &Server{syncStateDir: syncDir, config: config, version: version, logger: logger, jobs: map[string]struct{}{}}
 	defer func() {
 		if err != nil {
 			for _, lock := range s.locks {
@@ -68,6 +71,13 @@ func New(config Config, version string, logger *slog.Logger) (_ *Server, err err
 		return nil, err
 	}
 	s.locks = append(s.locks, lock)
+	// The daemon lock excludes another live server. A surviving supervisor keeps
+	// executionLease until its process group is killed and reaped, before recovery.
+	s.executionLease, err = lockFileMode(filepath.Join(config.StateDir, ".execution.lock"), syscall.LOCK_EX)
+	if err != nil {
+		return nil, err
+	}
+	s.locks = append(s.locks, s.executionLease)
 	if err = privateDir(filepath.Join(config.StateDir, "jobs"), 0700); err != nil {
 		return nil, err
 	}
@@ -292,6 +302,10 @@ func (s *Server) submit(w http.ResponseWriter, req *http.Request) {
 	// Reserve the ID even if fsync fails after rename. No uncertain intent may run.
 	s.jobs[request.RequestID] = struct{}{}
 	if err = s.save(r); err != nil {
+		now := time.Now().UTC()
+		r.Snapshot.Status = "unknown"
+		r.Snapshot.FinishedAt = &now
+		s.uncertain = r
 		s.storageFault()
 		apiError(w, 503, "state_unavailable", "could not persist job intent")
 		return

--- a/packages/host-helper/internal/hosthelper/server.go
+++ b/packages/host-helper/internal/hosthelper/server.go
@@ -1,0 +1,322 @@
+package hosthelper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type activeJob struct {
+	record    *record
+	output    *output
+	cancel    context.CancelFunc
+	cancelled bool
+}
+
+type Server struct {
+	config  Config
+	version string
+	logger  *slog.Logger
+	// mu guards jobs, active, closing, and fault. Persistence and process launch
+	// share this lock so cancellation and duplicate submission cannot cross intent.
+	// Snapshot reads take output.mu after mu. Output writers never take mu.
+	mu        sync.Mutex
+	jobs      map[string]struct{}
+	active    *activeJob
+	uncertain *record
+	closing   bool
+	fault     bool
+	workers   sync.WaitGroup
+	locks     []*os.File
+	listener  *net.UnixListener
+	http      *http.Server
+	closeOnce sync.Once
+}
+
+// New locks durable state and the socket directory until Close. Call Serve once.
+func New(config Config, version string, logger *slog.Logger) (_ *Server, err error) {
+	config.defaults()
+	if err = config.validate(); err != nil {
+		return nil, err
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	}
+	s := &Server{config: config, version: version, logger: logger, jobs: map[string]struct{}{}}
+	defer func() {
+		if err != nil {
+			for _, lock := range s.locks {
+				lock.Close()
+			}
+		}
+	}()
+	if err = privateDir(config.StateDir, 0700); err != nil {
+		return nil, err
+	}
+	lock, err := lockFile(filepath.Join(config.StateDir, ".lock"))
+	if err != nil {
+		return nil, err
+	}
+	s.locks = append(s.locks, lock)
+	if err = privateDir(filepath.Join(config.StateDir, "jobs"), 0700); err != nil {
+		return nil, err
+	}
+	if err = privateDir(filepath.Join(config.StateDir, "work"), 0700); err != nil {
+		return nil, err
+	}
+	if err = syncDir(config.StateDir); err != nil {
+		return nil, err
+	}
+	if err = s.recover(); err != nil {
+		return nil, err
+	}
+	socketDir := filepath.Dir(config.SocketPath)
+	if err = privateDir(socketDir, 0755); err != nil {
+		return nil, err
+	}
+	lock, err = lockFile(filepath.Join(socketDir, ".rome-host.lock"))
+	if err != nil {
+		return nil, err
+	}
+	s.locks = append(s.locks, lock)
+	if info, statErr := os.Lstat(config.SocketPath); statErr == nil {
+		if info.Mode()&os.ModeSocket == 0 {
+			return nil, errors.New("socket path exists and is not a socket")
+		}
+		connection, dialErr := net.DialTimeout("unix", config.SocketPath, 200*time.Millisecond)
+		if dialErr == nil {
+			connection.Close()
+			return nil, errors.New("socket has a live listener")
+		}
+		if !errors.Is(dialErr, syscall.ECONNREFUSED) {
+			return nil, errors.New("cannot establish whether socket is stale")
+		}
+		if err = os.Remove(config.SocketPath); err != nil {
+			return nil, err
+		}
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return nil, statErr
+	}
+	s.listener, err = net.ListenUnix("unix", &net.UnixAddr{Name: config.SocketPath, Net: "unix"})
+	if err != nil {
+		return nil, err
+	}
+	s.listener.SetUnlinkOnClose(false)
+	defer func() {
+		if err != nil {
+			s.listener.Close()
+			os.Remove(config.SocketPath)
+		}
+	}()
+	if err = os.Chmod(config.SocketPath, 0660); err != nil {
+		return nil, err
+	}
+	if err = os.Chown(config.SocketPath, os.Geteuid(), config.SocketGID); err != nil {
+		return nil, err
+	}
+	s.http = &http.Server{Handler: s, ReadHeaderTimeout: 2 * time.Second, ReadTimeout: 5 * time.Second, WriteTimeout: 5 * time.Second, IdleTimeout: 10 * time.Second, MaxHeaderBytes: 8192}
+	return s, nil
+}
+
+func (s *Server) Serve() error {
+	err := s.http.Serve(&limitedListener{Listener: s.listener, slots: make(chan struct{}, 64)})
+	if errors.Is(err, http.ErrServerClosed) || errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
+// Close rejects new jobs, cancels the managed process group, and persists its
+// outcome before releasing locks. Root scripts can escape the process group.
+func (s *Server) Close() {
+	s.closeOnce.Do(func() {
+		s.mu.Lock()
+		s.closing = true
+		if s.active != nil {
+			s.active.cancelled = true
+			s.active.cancel()
+		}
+		s.mu.Unlock()
+		s.http.Close()
+		s.listener.Close()
+		s.workers.Wait()
+		os.Remove(s.config.SocketPath)
+		for _, lock := range s.locks {
+			lock.Close()
+		}
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(value)
+}
+
+func apiError(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, map[string]string{"error": code, "message": message})
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.URL.RawQuery != "" {
+		apiError(w, 400, "invalid_request", "query parameters are not supported")
+		return
+	}
+	if req.Method == "GET" && req.URL.Path == "/v1/capabilities" {
+		writeJSON(w, 200, map[string]any{"protocolVersion": 1, "version": s.version, "hostId": s.config.HostID, "platform": "linux", "enabled": s.config.Enabled, "interpreters": []string{"sh", "bash"}, "maxTimeoutSeconds": s.config.MaxTimeoutSeconds, "maxOutputBytes": s.config.MaxOutputBytes})
+		return
+	}
+	if req.Method == "POST" && req.URL.Path == "/v1/jobs" {
+		s.submit(w, req)
+		return
+	}
+	parts := strings.Split(strings.TrimPrefix(req.URL.Path, "/v1/jobs/"), "/")
+	if !strings.HasPrefix(req.URL.Path, "/v1/jobs/") || !identifier.MatchString(parts[0]) {
+		apiError(w, 404, "not_found", "unknown endpoint")
+		return
+	}
+	cancel := len(parts) == 2 && parts[1] == "cancel" && req.Method == "POST"
+	if !cancel && !(len(parts) == 1 && req.Method == "GET") {
+		apiError(w, 404, "not_found", "unknown endpoint")
+		return
+	}
+	if cancel {
+		body, err := io.ReadAll(http.MaxBytesReader(w, req.Body, 1))
+		if err != nil || len(body) != 0 {
+			apiError(w, 400, "invalid_request", "cancel requires an empty body")
+			return
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := parts[0]
+	if _, ok := s.jobs[id]; !ok {
+		apiError(w, 404, "not_found", "unknown job")
+		return
+	}
+	if s.active != nil && s.active.record.Request.RequestID == id {
+		if cancel {
+			s.active.cancelled = true
+			s.active.cancel()
+		}
+		writeJSON(w, 200, s.snapshot(s.active.record))
+		return
+	}
+	if s.uncertain != nil && s.uncertain.Request.RequestID == id {
+		writeJSON(w, 200, s.uncertain.Snapshot)
+		return
+	}
+	r, err := s.read(id)
+	if err != nil {
+		s.storageFault()
+		apiError(w, 503, "state_unavailable", "durable job state unavailable")
+		return
+	}
+	writeJSON(w, 200, r.Snapshot)
+}
+
+func (s *Server) submit(w http.ResponseWriter, req *http.Request) {
+	if !s.config.Enabled {
+		apiError(w, 403, "disabled", "host execution is disabled")
+		return
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, req.Body, maxBodyBytes))
+	if err != nil {
+		apiError(w, 400, "invalid_request", "request body exceeds the host limit")
+		return
+	}
+	var request Request
+	if err = strictJSON(body, &request, requestFields); err != nil {
+		apiError(w, 400, "invalid_request", err.Error())
+		return
+	}
+	if err = request.validate(); err != nil {
+		apiError(w, 400, "invalid_request", err.Error())
+		return
+	}
+	if request.HostID != s.config.HostID {
+		apiError(w, 409, "host_mismatch", "hostId does not match this host")
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.jobs[request.RequestID]; ok {
+		var r *record
+		if s.active != nil && s.active.record.Request.RequestID == request.RequestID {
+			r = s.active.record
+		} else if s.uncertain != nil && s.uncertain.Request.RequestID == request.RequestID {
+			r = s.uncertain
+		} else {
+			r, err = s.read(request.RequestID)
+		}
+		if err != nil {
+			s.storageFault()
+			apiError(w, 503, "state_unavailable", "durable job state unavailable")
+			return
+		}
+		if r.Request != request {
+			apiError(w, 409, "request_conflict", "requestId already belongs to a different request")
+			return
+		}
+		writeJSON(w, 200, s.snapshot(r))
+		return
+	}
+	if request.TimeoutSeconds > s.config.MaxTimeoutSeconds {
+		apiError(w, 400, "invalid_request", "timeoutSeconds is outside the host limit")
+		return
+	}
+	if s.closing || s.fault {
+		apiError(w, 503, "unavailable", "daemon is stopping or durable state is unavailable")
+		return
+	}
+	if s.active != nil {
+		apiError(w, 503, "busy", "another host job is active")
+		return
+	}
+	if len(s.jobs) >= maxJobs {
+		apiError(w, 503, "retention_limit", "10000 durable job IDs retained; preserve records to retain deduplication")
+		return
+	}
+	r := newRecord(request)
+	// Reserve the ID even if fsync fails after rename. No uncertain intent may run.
+	s.jobs[request.RequestID] = struct{}{}
+	if err = s.save(r); err != nil {
+		s.storageFault()
+		apiError(w, 503, "state_unavailable", "could not persist job intent")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(request.TimeoutSeconds)*time.Second)
+	s.active = &activeJob{record: r, cancel: cancel}
+	s.workers.Add(1)
+	s.audit("accepted", r)
+	go s.execute(ctx, s.active)
+	writeJSON(w, 202, r.Snapshot)
+}
+
+func (s *Server) storageFault() {
+	s.fault = true
+	s.logger.Error("host helper durable state unavailable")
+}
+
+func (s *Server) snapshot(r *record) Snapshot {
+	snapshot := r.Snapshot
+	if s.active != nil && s.active.record == r && s.active.output != nil {
+		s.active.output.copyTo(&snapshot)
+	}
+	return snapshot
+}
+
+func (s *Server) audit(event string, r *record) {
+	s.logger.Info("host execution", "event", event, "requestId", r.Request.RequestID, "hostId", r.Request.HostID, "executionId", r.Request.ExecutionID, "rootExecutionId", r.Request.RootExecutionID, "scriptSha256", r.Snapshot.ScriptSHA256, "status", r.Snapshot.Status)
+}

--- a/packages/host-helper/internal/hosthelper/server_test.go
+++ b/packages/host-helper/internal/hosthelper/server_test.go
@@ -1,0 +1,572 @@
+package hosthelper
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func testConfig(t *testing.T) Config {
+	t.Helper()
+	dir := t.TempDir()
+	return Config{HostID: "host-1", Enabled: true, SocketPath: filepath.Join(dir, "run", "control.sock"), StateDir: filepath.Join(dir, "state"), SocketGID: os.Getegid(), MaxTimeoutSeconds: 3, MaxOutputBytes: 1024}
+}
+
+func startServer(t *testing.T, c Config) (*Server, *http.Client) {
+	t.Helper()
+	s, err := New(c, "0.1.0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		if err := s.Serve(); err != nil {
+			t.Error(err)
+		}
+	}()
+	transport := &http.Transport{DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "unix", c.SocketPath)
+	}}
+	client := &http.Client{Transport: transport, Timeout: 8 * time.Second}
+	t.Cleanup(func() { transport.CloseIdleConnections(); s.Close() })
+	return s, client
+}
+
+func request(id, script string) Request {
+	return Request{RequestID: id, HostID: "host-1", Interpreter: "sh", Script: script, Reason: "test", TimeoutSeconds: 3, ExecutionID: "execution-1", RootExecutionID: "root-1"}
+}
+
+func call(t *testing.T, c *http.Client, method, path string, body any) (int, []byte) {
+	t.Helper()
+	var data []byte
+	if body != nil {
+		var err error
+		data, err = json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return rawCall(t, c, method, path, data)
+}
+
+func rawCall(t *testing.T, c *http.Client, method, path string, data []byte) (int, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(method, "http://unix"+path, bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res.StatusCode, b
+}
+
+func waitJob(t *testing.T, c *http.Client, id string) Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(6 * time.Second)
+	for time.Now().Before(deadline) {
+		status, data := call(t, c, "GET", "/v1/jobs/"+id, nil)
+		if status != 200 {
+			t.Fatalf("GET: %d %s", status, data)
+		}
+		var snapshot Snapshot
+		if err := json.Unmarshal(data, &snapshot); err != nil {
+			t.Fatal(err)
+		}
+		if snapshot.Status != "running" && snapshot.Status != "queued" {
+			return snapshot
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("job did not finish")
+	return Snapshot{}
+}
+
+func submit(t *testing.T, c *http.Client, r Request) {
+	t.Helper()
+	status, data := call(t, c, "POST", "/v1/jobs", r)
+	if status != 202 {
+		t.Fatalf("submit: %d %s", status, data)
+	}
+}
+
+func TestUDSExecutionAndPersistence(t *testing.T) {
+	c := testConfig(t)
+	s, client := startServer(t, c)
+	t.Setenv("HOST_HELPER_SECRET", "secret")
+	info, err := os.Stat(c.SocketPath)
+	if err != nil || info.Mode().Perm() != 0660 {
+		t.Fatalf("socket permissions: %v %v", info, err)
+	}
+	status, body := call(t, client, "GET", "/v1/capabilities", nil)
+	if status != 200 || !bytes.Contains(body, []byte(`"version":"0.1.0"`)) {
+		t.Fatalf("capabilities %d %s", status, body)
+	}
+	r := request("first", "printf 'hello'; printf 'error' >&2; test -z \"${HOST_HELPER_SECRET:-}\"; exit 7")
+	submit(t, client, r)
+	got := waitJob(t, client, r.RequestID)
+	if got.Status != "failed" || got.ExitCode == nil || *got.ExitCode != 7 || got.Stdout != "hello" || got.Stderr != "error" || got.StartedAt == nil || got.FinishedAt == nil {
+		t.Fatalf("snapshot: %+v", got)
+	}
+	s.Close()
+	_, client2 := startServer(t, c)
+	status, body = call(t, client2, "POST", "/v1/jobs", r)
+	if status != 200 {
+		t.Fatalf("duplicate after restart: %d %s", status, body)
+	}
+	if restored := waitJob(t, client2, r.RequestID); restored.ScriptSHA256 != got.ScriptSHA256 || restored.Stdout != got.Stdout || restored.Status != got.Status {
+		t.Fatalf("recovered snapshot: %+v", restored)
+	}
+	submit(t, client2, request("environment", "test -z \"${HOST_HELPER_SECRET:-}\" && printf clean"))
+	if got := waitJob(t, client2, "environment"); got.Status != "succeeded" || got.Stdout != "clean" {
+		t.Fatalf("environment: %+v", got)
+	}
+}
+
+func TestStrictRequestsAndDisabled(t *testing.T) {
+	c := testConfig(t)
+	_, client := startServer(t, c)
+	r := request("invalid", "true")
+	b, _ := json.Marshal(r)
+	tests := [][]byte{
+		[]byte(`null`), []byte(`{}`), []byte(`[]`), append(append([]byte{}, b...), []byte(` {}`)...),
+		bytes.Replace(b, []byte(`"requestId":"invalid"`), []byte(`"requestId":"invalid","requestId":"invalid"`), 1),
+		bytes.Replace(b, []byte(`"requestId"`), []byte(`"RequestId"`), 1),
+		bytes.Replace(b, []byte(`"script":"true"`), []byte(`"script":null`), 1),
+		bytes.Replace(b, []byte(`"script":"true"`), []byte(`"script":"true","cwd":"/"`), 1),
+		bytes.Repeat([]byte("x"), maxBodyBytes+1),
+	}
+	for i, b := range tests {
+		if status, data := rawCall(t, client, "POST", "/v1/jobs", b); status != 400 {
+			t.Fatalf("case %d: %d %s", i, status, data)
+		}
+	}
+	for _, modify := range []func(*Request){
+		func(r *Request) { r.RequestID = "../escape" }, func(r *Request) { r.Interpreter = "python" }, func(r *Request) { r.TimeoutSeconds = 0 },
+		func(r *Request) { r.TimeoutSeconds = 4 }, func(r *Request) { r.Script = strings.Repeat("x", 65537) }, func(r *Request) { r.Reason = strings.Repeat("x", 2001) },
+		func(r *Request) { r.Script = "\x00" }, func(r *Request) { r.ExecutionID = "" },
+	} {
+		r := request("invalid", "true")
+		modify(&r)
+		if status, data := call(t, client, "POST", "/v1/jobs", r); status != 400 {
+			t.Fatalf("invalid input: %d %s", status, data)
+		}
+	}
+	r.HostID = "other"
+	if status, _ := call(t, client, "POST", "/v1/jobs", r); status != 409 {
+		t.Fatal(status)
+	}
+	c2 := testConfig(t)
+	c2.Enabled = false
+	_, disabled := startServer(t, c2)
+	if status, _ := call(t, disabled, "POST", "/v1/jobs", request("denied", "true")); status != 403 {
+		t.Fatal(status)
+	}
+}
+
+func TestConcurrentDuplicatesBusyAndConflict(t *testing.T) {
+	_, client := startServer(t, testConfig(t))
+	r := request("duplicate", "sleep 0.4; printf once")
+	var wg sync.WaitGroup
+	statuses := make(chan int, 20)
+	for range 20 {
+		wg.Add(1)
+		go func() { defer wg.Done(); status, _ := call(t, client, "POST", "/v1/jobs", r); statuses <- status }()
+	}
+	wg.Wait()
+	close(statuses)
+	accepted := 0
+	for status := range statuses {
+		if status == 202 {
+			accepted++
+		} else if status != 200 {
+			t.Fatal(status)
+		}
+	}
+	if accepted != 1 {
+		t.Fatalf("launched %d jobs", accepted)
+	}
+	if status, _ := call(t, client, "POST", "/v1/jobs", request("busy", "true")); status != 503 {
+		t.Fatal(status)
+	}
+	r.Reason = "different"
+	if status, _ := call(t, client, "POST", "/v1/jobs", r); status != 409 {
+		t.Fatal(status)
+	}
+	if got := waitJob(t, client, r.RequestID); got.Stdout != "once" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestTimeoutCancellationOutputAndOrphanPipes(t *testing.T) {
+	_, client := startServer(t, testConfig(t))
+	r := request("timeout", "sleep 20 & wait")
+	r.TimeoutSeconds = 1
+	submit(t, client, r)
+	if got := waitJob(t, client, r.RequestID); got.Status != "timed_out" {
+		t.Fatalf("%+v", got)
+	}
+	submit(t, client, request("cancel", "sleep 20 & wait"))
+	for range 2 {
+		if status, _ := call(t, client, "POST", "/v1/jobs/cancel/cancel", nil); status != 200 {
+			t.Fatal(status)
+		}
+	}
+	if got := waitJob(t, client, "cancel"); got.Status != "cancelled" {
+		t.Fatalf("%+v", got)
+	}
+	submit(t, client, request("flood", "head -c 1048576 /dev/zero; head -c 1048576 /dev/zero >&2"))
+	if got := waitJob(t, client, "flood"); got.Status != "succeeded" || !got.Truncated || len(got.Stdout)+len(got.Stderr) != 1024 {
+		t.Fatalf("flood status=%s truncated=%v bytes=%d", got.Status, got.Truncated, len(got.Stdout)+len(got.Stderr))
+	}
+	start := time.Now()
+	submit(t, client, request("orphan", "sleep 20 & printf done"))
+	if got := waitJob(t, client, "orphan"); got.Stdout != "done" || time.Since(start) > 2*time.Second {
+		t.Fatalf("orphan: %+v", got)
+	}
+	submit(t, client, request("after-orphan", "printf next"))
+	if got := waitJob(t, client, "after-orphan"); got.Status != "succeeded" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestRunningSnapshotIncludesBoundedOutput(t *testing.T) {
+	_, client := startServer(t, testConfig(t))
+	r := request("live", "printf progress; printf warning >&2; sleep 20")
+	submit(t, client, r)
+	deadline := time.Now().Add(time.Second)
+	for {
+		_, data := call(t, client, "GET", "/v1/jobs/live", nil)
+		var snapshot Snapshot
+		if err := json.Unmarshal(data, &snapshot); err != nil {
+			t.Fatal(err)
+		}
+		if snapshot.Stdout == "progress" && snapshot.Stderr == "warning" {
+			if snapshot.Status != "running" {
+				t.Fatalf("%+v", snapshot)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("live output absent: %+v", snapshot)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	status, data := call(t, client, "POST", "/v1/jobs", r)
+	if status != 200 || !bytes.Contains(data, []byte(`"stdout":"progress"`)) {
+		t.Fatalf("duplicate snapshot: %d %s", status, data)
+	}
+	call(t, client, "POST", "/v1/jobs/live/cancel", nil)
+	waitJob(t, client, r.RequestID)
+}
+
+func TestRecoveryNeverRelaunchesIntent(t *testing.T) {
+	c := testConfig(t)
+	s, client := startServer(t, c)
+	r := request("interrupted", "printf should-not-run")
+	record := newRecord(r)
+	record.Snapshot.Status = "running"
+	if err := s.save(record); err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+	_, client = startServer(t, c)
+	if got := waitJob(t, client, r.RequestID); got.Status != "unknown" || got.Stdout != "" || got.ExitCode != nil {
+		t.Fatalf("%+v", got)
+	}
+	if status, _ := call(t, client, "POST", "/v1/jobs", r); status != 200 {
+		t.Fatal(status)
+	}
+	if got := waitJob(t, client, r.RequestID); got.Status != "unknown" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestShutdownAndSingleDaemonLock(t *testing.T) {
+	c := testConfig(t)
+	s, client := startServer(t, c)
+	if other, err := New(c, "test", nil); err == nil {
+		other.Close()
+		t.Fatal("second daemon acquired state lock")
+	}
+	otherConfig := c
+	otherConfig.StateDir = filepath.Join(t.TempDir(), "state")
+	if other, err := New(otherConfig, "test", nil); err == nil {
+		other.Close()
+		t.Fatal("second daemon acquired socket lock")
+	}
+	submit(t, client, request("shutdown", "sleep 30 & wait"))
+	start := time.Now()
+	s.Close()
+	if time.Since(start) > 2*time.Second {
+		t.Fatal("shutdown hung")
+	}
+	if info, err := os.Stat(filepath.Dir(c.SocketPath)); err != nil || !info.IsDir() {
+		t.Fatal("socket directory removed")
+	}
+	c.Enabled = false
+	_, client = startServer(t, c)
+	if got := waitJob(t, client, "shutdown"); got.Status != "cancelled" {
+		t.Fatalf("%+v", got)
+	}
+	if status, _ := call(t, client, "POST", "/v1/jobs/shutdown/cancel", nil); status != 200 {
+		t.Fatal(status)
+	}
+}
+
+func TestLiveForeignListenerIsNotRemoved(t *testing.T) {
+	c := testConfig(t)
+	if err := os.MkdirAll(filepath.Dir(c.SocketPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	l, err := net.Listen("unix", c.SocketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	if s, err := New(c, "test", nil); err == nil {
+		s.Close()
+		t.Fatal("replaced live listener")
+	}
+	conn, err := net.Dial("unix", c.SocketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+}
+
+func TestConfigProtectionAndStrictDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	write := func(body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(`{"hostId":"host","socketGid":0}`)
+	c, err := LoadConfig(path)
+	if err != nil || c.Enabled || c.MaxOutputBytes != 131072 || c.MaxTimeoutSeconds != 600 {
+		t.Fatalf("%+v %v", c, err)
+	}
+	for _, body := range []string{`{"hostId":"host"}`, `{"hostId":"host","socketGid":null}`, `{"hostId":"host","socketGid":0,"enabled":true,"enabled":false}`, `{"hostId":"host","socketGid":0,"maxOutputBytes":0}`, `{"hostId":"host","socketGid":0,"maxOutputBytes":131073}`} {
+		write(body)
+		if _, err := LoadConfig(path); err == nil {
+			t.Fatal("accepted invalid config", body)
+		}
+	}
+	write(`{"hostId":"host","socketGid":0}`)
+	if err := os.Chmod(path, 0666); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("accepted writable config")
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "symlink.json")
+	if err := os.Symlink(path, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadConfig(link); err == nil {
+		t.Fatal("accepted symlink config")
+	}
+	if _, err := LoadConfig(dir + "/./config.json"); err == nil {
+		t.Fatal("accepted noncanonical config path")
+	}
+}
+
+func TestDuplicateSurvivesTighterTimeoutPolicy(t *testing.T) {
+	c := testConfig(t)
+	s, client := startServer(t, c)
+	r := request("policy-change", "true")
+	submit(t, client, r)
+	waitJob(t, client, r.RequestID)
+	s.Close()
+	c.MaxTimeoutSeconds = 1
+	_, client = startServer(t, c)
+	if status, data := call(t, client, "POST", "/v1/jobs", r); status != 200 {
+		t.Fatalf("%d %s", status, data)
+	}
+	r.RequestID = "new-job"
+	if status, _ := call(t, client, "POST", "/v1/jobs", r); status != 400 {
+		t.Fatal(status)
+	}
+}
+
+func TestRetentionLimitKeepsDuplicateIdentity(t *testing.T) {
+	s, client := startServer(t, testConfig(t))
+	r := request("retained", "true")
+	submit(t, client, r)
+	waitJob(t, client, r.RequestID)
+	s.mu.Lock()
+	for i := 1; i < maxJobs; i++ {
+		s.jobs["reserved-"+strconv.Itoa(i)] = struct{}{}
+	}
+	s.mu.Unlock()
+	if status, data := call(t, client, "POST", "/v1/jobs", request("overflow", "true")); status != 503 || !bytes.Contains(data, []byte("retention_limit")) {
+		t.Fatalf("%d %s", status, data)
+	}
+	if status, data := call(t, client, "POST", "/v1/jobs", r); status != 200 {
+		t.Fatalf("%d %s", status, data)
+	}
+	r.Script = "printf different"
+	if status, _ := call(t, client, "POST", "/v1/jobs", r); status != 409 {
+		t.Fatal(status)
+	}
+}
+
+func TestFailedTerminalPersistenceReturnsUnknownAndStopsAdmission(t *testing.T) {
+	c := testConfig(t)
+	s, client := startServer(t, c)
+	marker := filepath.Join(t.TempDir(), "release")
+	r := request("disk-failure", "while [ ! -f '"+marker+"' ]; do sleep 0.01; done; printf complete")
+	submit(t, client, r)
+	deadline := time.Now().Add(time.Second)
+	for {
+		_, data := call(t, client, "GET", "/v1/jobs/"+r.RequestID, nil)
+		if bytes.Contains(data, []byte(`"status":"running"`)) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("job did not start")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	jobs := filepath.Join(c.StateDir, "jobs")
+	if err := os.Rename(jobs, jobs+"-backup"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(jobs, []byte("blocked"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(marker, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	got := waitJob(t, client, r.RequestID)
+	if got.Status != "unknown" || got.Stdout != "complete" {
+		t.Fatalf("%+v", got)
+	}
+	if status, _ := call(t, client, "POST", "/v1/jobs", r); status != 200 {
+		t.Fatal(status)
+	}
+	if status, _ := call(t, client, "POST", "/v1/jobs", request("next", "true")); status != 503 {
+		t.Fatal(status)
+	}
+	s.Close()
+	if err := os.Remove(jobs); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(jobs+"-backup", jobs); err != nil {
+		t.Fatal(err)
+	}
+	_, client = startServer(t, c)
+	if got := waitJob(t, client, r.RequestID); got.Status != "unknown" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestCrashDaemonProcess(t *testing.T) {
+	path := os.Getenv("ROME_HELPER_CRASH_TEST_CONFIG")
+	if path == "" {
+		return
+	}
+	c, err := LoadConfig(path)
+	if err != nil {
+		panic(err)
+	}
+	s, err := New(c, "test", nil)
+	if err != nil {
+		panic(err)
+	}
+	if err := s.Serve(); err != nil {
+		panic(err)
+	}
+	os.Exit(0)
+}
+
+func TestAbruptDaemonDeathRecoversUnknown(t *testing.T) {
+	c := testConfig(t)
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	b, _ := json.Marshal(c)
+	if err := os.WriteFile(configPath, b, 0600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCrashDaemonProcess$")
+	cmd.Env = append(os.Environ(), "ROME_HELPER_CRASH_TEST_CONFIG="+configPath)
+	var log bytes.Buffer
+	cmd.Stdout = &log
+	cmd.Stderr = &log
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if conn, err := net.Dial("unix", c.SocketPath); err == nil {
+			conn.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("child daemon did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	transport := &http.Transport{DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "unix", c.SocketPath)
+	}}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+	pidFile := filepath.Join(t.TempDir(), "pid")
+	r := request("crash", "printf '%s' $$ > '"+pidFile+"'; sleep 20")
+	submit(t, client, r)
+	var pid int
+	for {
+		if data, err := os.ReadFile(pidFile); err == nil {
+			pid, _ = strconv.Atoi(string(data))
+			if pid > 0 {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("job did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	defer syscall.Kill(-pid, syscall.SIGKILL)
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	cmd.Wait()
+	// A crashed daemon cannot attest the root script stopped. The test owns and
+	// kills this process group independently before inspecting durable recovery.
+	syscall.Kill(-pid, syscall.SIGKILL)
+	_, restarted := startServer(t, c)
+	if got := waitJob(t, restarted, r.RequestID); got.Status != "unknown" {
+		t.Fatalf("%+v", got)
+	}
+	if status, _ := call(t, restarted, "POST", "/v1/jobs", r); status != 200 {
+		t.Fatal(status)
+	}
+	if got := waitJob(t, restarted, r.RequestID); got.Status != "unknown" {
+		t.Fatalf("%+v", got)
+	}
+}

--- a/packages/host-helper/internal/hosthelper/server_test.go
+++ b/packages/host-helper/internal/hosthelper/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -17,6 +18,11 @@ import (
 	"testing"
 	"time"
 )
+
+func TestMain(m *testing.M) {
+	RunSupervisor()
+	os.Exit(m.Run())
+}
 
 func testConfig(t *testing.T) Config {
 	t.Helper()
@@ -504,6 +510,11 @@ func TestCrashDaemonProcess(t *testing.T) {
 }
 
 func TestAbruptDaemonDeathRecoversUnknown(t *testing.T) {
+	t.Run("cleanup without restart", func(t *testing.T) { testAbruptDaemonDeath(t, false) })
+	t.Run("recovery waits for cleanup", func(t *testing.T) { testAbruptDaemonDeath(t, true) })
+}
+
+func testAbruptDaemonDeath(t *testing.T, pauseSupervisor bool) {
 	c := testConfig(t)
 	configPath := filepath.Join(t.TempDir(), "config.json")
 	b, _ := json.Marshal(c)
@@ -512,9 +523,8 @@ func TestAbruptDaemonDeathRecoversUnknown(t *testing.T) {
 	}
 	cmd := exec.Command(os.Args[0], "-test.run=^TestCrashDaemonProcess$")
 	cmd.Env = append(os.Environ(), "ROME_HELPER_CRASH_TEST_CONFIG="+configPath)
-	var log bytes.Buffer
-	cmd.Stdout = &log
-	cmd.Stderr = &log
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -536,12 +546,16 @@ func TestAbruptDaemonDeathRecoversUnknown(t *testing.T) {
 	defer transport.CloseIdleConnections()
 	client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
 	pidFile := filepath.Join(t.TempDir(), "pid")
-	r := request("crash", "printf '%s' $$ > '"+pidFile+"'; sleep 20")
+	r := request("crash", "sleep 20 & printf '%s %s' $$ $! > '"+pidFile+"'; wait")
 	submit(t, client, r)
-	var pid int
+	var pid, childPID int
 	for {
 		if data, err := os.ReadFile(pidFile); err == nil {
-			pid, _ = strconv.Atoi(string(data))
+			pids := strings.Fields(string(data))
+			if len(pids) == 2 {
+				pid, _ = strconv.Atoi(pids[0])
+				childPID, _ = strconv.Atoi(pids[1])
+			}
 			if pid > 0 {
 				break
 			}
@@ -552,14 +566,71 @@ func TestAbruptDaemonDeathRecoversUnknown(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	defer syscall.Kill(-pid, syscall.SIGKILL)
+	var supervisorPID int
+	if pauseSupervisor {
+		data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+		if err != nil {
+			t.Fatal(err)
+		}
+		supervisorPID, err = strconv.Atoi(strings.Fields(string(data))[3])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := syscall.Kill(supervisorPID, syscall.SIGSTOP); err != nil {
+			t.Fatal(err)
+		}
+		defer syscall.Kill(supervisorPID, syscall.SIGCONT)
+	}
 	if err := cmd.Process.Kill(); err != nil {
 		t.Fatal(err)
 	}
 	cmd.Wait()
-	// A crashed daemon cannot attest the root script stopped. The test owns and
-	// kills this process group independently before inspecting durable recovery.
-	syscall.Kill(-pid, syscall.SIGKILL)
+	if pauseSupervisor {
+		type result struct {
+			server *Server
+			err    error
+		}
+		recovered := make(chan result, 1)
+		go func() { server, err := New(c, "test", nil); recovered <- result{server, err} }()
+		var got result
+		returned := false
+		select {
+		case got = <-recovered:
+			returned = true
+			t.Error("recovery returned before supervisor cleanup")
+		case <-time.After(100 * time.Millisecond):
+		}
+		syscall.Kill(supervisorPID, syscall.SIGCONT)
+		if !returned {
+			select {
+			case got = <-recovered:
+			case <-time.After(3 * time.Second):
+				t.Fatal("recovery remained blocked after cleanup")
+			}
+		}
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		got.server.Close()
+	} else {
+		deadline := time.Now().Add(2 * time.Second)
+		for syscall.Kill(pid, 0) == nil || syscall.Kill(childPID, 0) == nil {
+			if time.Now().After(deadline) {
+				t.Fatal("ordinary children survive daemon death without restart")
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
 	_, restarted := startServer(t, c)
+	for _, process := range []int{pid, childPID} {
+		if err := syscall.Kill(process, 0); err == nil {
+			t.Fatalf("job process %d survives daemon death and recovery", process)
+		}
+	}
+	submit(t, restarted, request("after-crash", "true"))
+	if got := waitJob(t, restarted, "after-crash"); got.Status != "succeeded" {
+		t.Fatalf("%+v", got)
+	}
 	if got := waitJob(t, restarted, r.RequestID); got.Status != "unknown" {
 		t.Fatalf("%+v", got)
 	}
@@ -568,5 +639,96 @@ func TestAbruptDaemonDeathRecoversUnknown(t *testing.T) {
 	}
 	if got := waitJob(t, restarted, r.RequestID); got.Status != "unknown" {
 		t.Fatalf("%+v", got)
+	}
+}
+
+func TestFailedInitialDirectorySyncReturnsUnknown(t *testing.T) {
+	c := testConfig(t)
+	s, client := startServer(t, c)
+	s.mu.Lock()
+	s.syncStateDir = func(string) error { return errors.New("injected post-rename fsync failure") }
+	s.mu.Unlock()
+	marker := filepath.Join(t.TempDir(), "executed")
+	r := request("uncertain-intent", "touch '"+marker+"'")
+	if status, _ := call(t, client, "POST", "/v1/jobs", r); status != 503 {
+		t.Fatal(status)
+	}
+	persisted, err := s.read(r.RequestID)
+	if err != nil || persisted.Snapshot.Status != "queued" {
+		t.Fatalf("post-rename record: %+v %v", persisted, err)
+	}
+	for _, method := range []string{"GET", "POST"} {
+		path := "/v1/jobs/" + r.RequestID
+		var body any
+		if method == "POST" {
+			path = "/v1/jobs"
+			body = r
+		}
+		status, data := call(t, client, method, path, body)
+		var got Snapshot
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatal(err)
+		}
+		if status != 200 || got.Status != "unknown" || got.FinishedAt == nil {
+			t.Fatalf("%s: %d %s", method, status, data)
+		}
+	}
+	if status, _ := call(t, client, "POST", "/v1/jobs", request("next", "true")); status != 503 {
+		t.Fatal(status)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("uncertain intent executed: %v", err)
+	}
+	s.Close()
+	_, client = startServer(t, c)
+	if got := waitJob(t, client, r.RequestID); got.Status != "unknown" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestEscapedServiceDoesNotBlockJobs(t *testing.T) {
+	for _, redirected := range []bool{true, false} {
+		for _, exitCode := range []int{0, 17} {
+			t.Run(strconv.FormatBool(redirected)+"/exit-"+strconv.Itoa(exitCode), func(t *testing.T) {
+				_, client := startServer(t, testConfig(t))
+				pidFile := filepath.Join(t.TempDir(), "service-pid")
+				redirect := ""
+				if redirected {
+					redirect = " >/dev/null 2>&1"
+				}
+				script := "setsid sh -c 'echo $$ > " + pidFile + "; exec sleep 20'" + redirect + " & while [ ! -s " + pidFile + " ]; do sleep 0.01; done; printf done; exit " + strconv.Itoa(exitCode)
+				submit(t, client, request("service", script))
+				deadline := time.Now().Add(2 * time.Second)
+				var pid int
+				for pid == 0 {
+					if data, err := os.ReadFile(pidFile); err == nil {
+						pid, _ = strconv.Atoi(strings.TrimSpace(string(data)))
+					}
+					if time.Now().After(deadline) {
+						t.Fatal("escaped service did not start")
+					}
+					time.Sleep(time.Millisecond)
+				}
+				defer syscall.Kill(-pid, syscall.SIGKILL)
+				got := waitJob(t, client, "service")
+				status := "succeeded"
+				if exitCode != 0 {
+					status = "failed"
+				}
+				if got.Stdout != "done" || got.Status != status || got.ExitCode == nil || *got.ExitCode != exitCode {
+					t.Fatalf("%+v", got)
+				}
+				if !redirected && exitCode == 0 && !got.Truncated {
+					t.Fatalf("forced output drain not reported: %+v", got)
+				}
+				submit(t, client, request("next-service", "true"))
+				if got := waitJob(t, client, "next-service"); got.Status != "succeeded" {
+					t.Fatalf("%+v", got)
+				}
+				if err := syscall.Kill(pid, 0); err != nil {
+					t.Fatalf("escaped service was killed: %v", err)
+				}
+			})
+		}
 	}
 }

--- a/packages/host-helper/internal/hosthelper/state.go
+++ b/packages/host-helper/internal/hosthelper/state.go
@@ -1,0 +1,250 @@
+package hosthelper
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+	"unicode/utf8"
+)
+
+type Request struct {
+	RequestID       string `json:"requestId"`
+	HostID          string `json:"hostId"`
+	Interpreter     string `json:"interpreter"`
+	Script          string `json:"script"`
+	Reason          string `json:"reason"`
+	TimeoutSeconds  int    `json:"timeoutSeconds"`
+	ExecutionID     string `json:"executionId"`
+	RootExecutionID string `json:"rootExecutionId"`
+}
+
+var requestFields = []string{"requestId", "hostId", "interpreter", "script", "reason", "timeoutSeconds", "executionId", "rootExecutionId"}
+
+func (r Request) validate() error {
+	if !identifier.MatchString(r.RequestID) {
+		return errors.New("invalid requestId")
+	}
+	if r.Interpreter != "sh" && r.Interpreter != "bash" {
+		return errors.New("interpreter must be sh or bash")
+	}
+	if len(r.Script) == 0 || len(r.Script) > 64*1024 || strings.ContainsRune(r.Script, 0) || !utf8.ValidString(r.Script) {
+		return errors.New("script must be 1..65536 UTF-8 bytes without NUL")
+	}
+	if strings.TrimSpace(r.Reason) == "" || utf8.RuneCountInString(r.Reason) > 2000 {
+		return errors.New("reason must be 1..2000 characters")
+	}
+	if len(r.ExecutionID) == 0 || len(r.ExecutionID) > 256 || len(r.RootExecutionID) == 0 || len(r.RootExecutionID) > 256 {
+		return errors.New("execution IDs must be 1..256 bytes")
+	}
+	if r.TimeoutSeconds < 1 || r.TimeoutSeconds > 600 {
+		return errors.New("timeoutSeconds must be 1..600")
+	}
+	return nil
+}
+
+type Snapshot struct {
+	ID           string     `json:"id"`
+	RequestID    string     `json:"requestId"`
+	HostID       string     `json:"hostId"`
+	ScriptSHA256 string     `json:"scriptSha256"`
+	Status       string     `json:"status"`
+	ExitCode     *int       `json:"exitCode"`
+	Stdout       string     `json:"stdout"`
+	Stderr       string     `json:"stderr"`
+	Truncated    bool       `json:"truncated"`
+	StartedAt    *time.Time `json:"startedAt"`
+	FinishedAt   *time.Time `json:"finishedAt"`
+}
+
+type record struct {
+	Request  Request  `json:"request"`
+	Snapshot Snapshot `json:"snapshot"`
+}
+
+func newRecord(r Request) *record {
+	hash := sha256.Sum256([]byte(r.Script))
+	return &record{Request: r, Snapshot: Snapshot{ID: r.RequestID, RequestID: r.RequestID, HostID: r.HostID, ScriptSHA256: hex.EncodeToString(hash[:]), Status: "queued"}}
+}
+
+func lockFile(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err = protectedFile(path); err == nil {
+		err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	}
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("cannot lock %s: %w", path, err)
+	}
+	return f, nil
+}
+
+func privateDir(path string, mode os.FileMode) error {
+	var created []string
+	for parent := path; ; parent = filepath.Dir(parent) {
+		_, err := os.Lstat(parent)
+		if err == nil {
+			if err := protectedPath(parent); err != nil {
+				return err
+			}
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		created = append(created, parent)
+	}
+	if err := os.MkdirAll(path, mode); err != nil {
+		return err
+	}
+	if err := protectedPath(path); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	stat := info.Sys().(*syscall.Stat_t)
+	if int(stat.Uid) != os.Geteuid() || info.Mode().Perm()&0022 != 0 {
+		return fmt.Errorf("directory must be owned by daemon UID without group/world write: %s", path)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		return err
+	}
+	// Persist every new ancestor entry before any job intent can depend on it.
+	for _, directory := range created {
+		if err := syncDir(directory); err != nil {
+			return err
+		}
+		if err := syncDir(filepath.Dir(directory)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) recordPath(id string) string {
+	return filepath.Join(s.config.StateDir, "jobs", id+".json")
+}
+
+func (s *Server) save(r *record) error {
+	dir := filepath.Dir(s.recordPath(r.Request.RequestID))
+	f, err := os.CreateTemp(dir, ".intent-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+	if err = json.NewEncoder(f).Encode(r); err != nil {
+		return err
+	}
+	if err = f.Sync(); err != nil {
+		return err
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	if err = os.Rename(f.Name(), s.recordPath(r.Request.RequestID)); err != nil {
+		return err
+	}
+	return syncDir(dir)
+}
+
+func syncDir(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}
+
+func (s *Server) read(id string) (*record, error) {
+	path := s.recordPath(id)
+	if err := protectedFile(path); err != nil {
+		return nil, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var r record
+	d := json.NewDecoder(io.LimitReader(f, 8*1024*1024))
+	d.DisallowUnknownFields()
+	if err = d.Decode(&r); err != nil {
+		return nil, err
+	}
+	if err = d.Decode(new(any)); err != io.EOF {
+		return nil, errors.New("trailing state data")
+	}
+	expected := newRecord(r.Request).Snapshot
+	if r.Request.RequestID != id || r.Snapshot.ID != id || r.Snapshot.RequestID != id || r.Snapshot.HostID != r.Request.HostID || r.Snapshot.ScriptSHA256 != expected.ScriptSHA256 {
+		return nil, errors.New("inconsistent state record")
+	}
+	switch r.Snapshot.Status {
+	case "queued", "running", "succeeded", "failed", "cancelled", "timed_out", "unknown":
+	default:
+		return nil, errors.New("invalid persisted status")
+	}
+	return &r, nil
+}
+
+func (s *Server) recover() error {
+	dir := filepath.Join(s.config.StateDir, "jobs")
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for {
+		entries, err := f.ReadDir(100)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if strings.HasPrefix(name, ".intent-") {
+				if err := os.Remove(filepath.Join(dir, name)); err != nil {
+					return err
+				}
+				continue
+			}
+			id := strings.TrimSuffix(name, ".json")
+			if name != id+".json" || !identifier.MatchString(id) {
+				return errors.New("unexpected state entry")
+			}
+			if len(s.jobs) >= maxJobs {
+				return errors.New("state exceeds retained job limit")
+			}
+			r, err := s.read(id)
+			if err != nil {
+				return fmt.Errorf("recover %s: %w", id, err)
+			}
+			if r.Snapshot.Status == "queued" || r.Snapshot.Status == "running" {
+				now := time.Now().UTC()
+				r.Snapshot.Status = "unknown"
+				r.Snapshot.FinishedAt = &now
+				r.Snapshot.ExitCode = nil
+				if err = s.save(r); err != nil {
+					return err
+				}
+				s.audit("recovered", r)
+			}
+			s.jobs[id] = struct{}{}
+		}
+		if err == io.EOF {
+			return nil
+		}
+	}
+}

--- a/packages/host-helper/internal/hosthelper/state.go
+++ b/packages/host-helper/internal/hosthelper/state.go
@@ -75,12 +75,16 @@ func newRecord(r Request) *record {
 }
 
 func lockFile(path string) (*os.File, error) {
+	return lockFileMode(path, syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func lockFileMode(path string, mode int) (*os.File, error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0600)
 	if err != nil {
 		return nil, err
 	}
 	if err = protectedFile(path); err == nil {
-		err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		err = syscall.Flock(int(f.Fd()), mode)
 	}
 	if err != nil {
 		f.Close()
@@ -157,7 +161,7 @@ func (s *Server) save(r *record) error {
 	if err = os.Rename(f.Name(), s.recordPath(r.Request.RequestID)); err != nil {
 		return err
 	}
-	return syncDir(dir)
+	return s.syncStateDir(dir)
 }
 
 func syncDir(path string) error {

--- a/packages/host-helper/internal/hosthelper/supervisor.go
+++ b/packages/host-helper/internal/hosthelper/supervisor.go
@@ -1,0 +1,73 @@
+package hosthelper
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// RunSupervisor handles the internal --supervise invocation and exits. Call it
+// before parsing daemon flags. Other invocations return without side effects.
+func RunSupervisor() {
+	if len(os.Args) != 3 || os.Args[1] != "--supervise" {
+		return
+	}
+	os.Exit(supervise(os.Args[2]))
+}
+
+func supervise(interpreter string) int {
+	if interpreter != "sh" && interpreter != "bash" {
+		return 1
+	}
+	alive := os.NewFile(3, "daemon-liveness")
+	lease := os.NewFile(4, "execution-lease")
+	defer alive.Close()
+	defer lease.Close()
+	// Only the supervisor retains these descriptors. The shell cannot keep the
+	// liveness pipe or startup barrier open by inheriting them.
+	syscall.CloseOnExec(3)
+	syscall.CloseOnExec(4)
+	// PR_SET_CHILD_SUBREAPER makes orphaned grandchildren waitable here, including
+	// when the shell exits before its background children. No host service is needed.
+	if _, _, errno := syscall.Syscall6(syscall.SYS_PRCTL, 36, 1, 0, 0, 0, 0); errno != 0 {
+		return 1
+	}
+	dead := make(chan struct{})
+	go func() { io.Copy(io.Discard, alive); close(dead) }()
+	cmd := exec.Command("/bin/"+interpreter, "-s")
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		return 1
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	var err error
+	select {
+	case err = <-done:
+	case <-dead:
+		syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		err = <-done
+	}
+	syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	// Reap before releasing lease so recovery cannot admit work while ordinary
+	// descendants still run. Root code can escape this group or kill its supervisor.
+	for {
+		_, waitErr := syscall.Wait4(-cmd.Process.Pid, nil, 0, nil)
+		if errors.Is(waitErr, syscall.EINTR) {
+			continue
+		}
+		if waitErr != nil {
+			break
+		}
+	}
+	if err != nil {
+		if code := cmd.ProcessState.ExitCode(); code >= 0 {
+			return code
+		}
+		return 1
+	}
+	return 0
+}

--- a/rome_apps/system/app.yaml
+++ b/rome_apps/system/app.yaml
@@ -22,8 +22,10 @@ actions:
   - actions/delete-routine
   - actions/conversation-settings-manage
   - actions/email-inbound
+  - actions/execute-root-script
   - actions/fetch-channel-history
   - actions/generate-image
+  - actions/manage-root-script
   - actions/publish-event
   - actions/search-event-catalog
   - actions/search-routine

--- a/rome_apps/system/docs/2026-09-09-host-root-execution.md
+++ b/rome_apps/system/docs/2026-09-09-host-root-execution.md
@@ -1,0 +1,25 @@
+# Host root execution
+
+The system app submits Linux root scripts through `execute_root_script` and
+inspects or cancels accepted jobs through `manage_root_script`. The helper is
+optional and execution requires explicit enablement in both Rome and host
+policy.
+
+Accepted jobs belong to the host service and survive the submitting action.
+The result distinguishes acceptance from completion. Failed scripts return
+their bounded output and job identity in the action error. A lost response
+triggers inspection of the known job instead of another submission.
+
+Core provides the host client only to system actions and derives job identity
+from execution context. This wiring is an API boundary within the trusted
+runtime, not isolation from other container code with access to the socket.
+
+Validation covers the action envelopes, Core's Unix-socket protocol, trusted
+execution identity, system-only injection in main and worker loaders, and the
+system app build. The Linux integration check uses separate root-helper and
+nonroot-client containers to verify execution, output limits, cancellation,
+timeouts, duplicate requests, and recovery after helper restart.
+
+Native macOS and Windows helpers use different host installation mechanisms
+and are outside this Linux delivery. Host jobs follow the
+[host execution contracts](../../../docs/concepts/host-execution.md).

--- a/rome_apps/system/docs/2026-09-10-host-execution-recovery.md
+++ b/rome_apps/system/docs/2026-09-10-host-execution-recovery.md
@@ -1,0 +1,14 @@
+# Host execution recovery
+
+Root script actions accept the routine engine's reserved trigger field and strip
+it before calling Core. The helper receives only the validated script request.
+
+If an action worker disappears after submission, the main runtime reports the
+original host job identities. Routine dispatch records that uncertain outcome
+without scheduling another execution. This includes host jobs submitted by
+nested actions whose parent worker exits before returning its result.
+
+Validation exercises the real main and worker action engines with the host
+client over a Unix socket. The regression submits one job, loses the worker
+result, and checks that the caller receives its lookup ID without a second
+submission. A routine regression covers reserved trigger input and retry policy.

--- a/rome_apps/system/src/actions/execute-root-script/action.yaml
+++ b/rome_apps/system/src/actions/execute-root-script/action.yaml
@@ -1,0 +1,14 @@
+name: execute_root_script
+type: system
+description: >-
+  Submit an unrestricted root shell script on the Linux VM hosting Rome.
+  Requires explicit owner enablement in Rome and host policy. Target must be hosting-vm.
+  Returns bounded output if complete, or an accepted job ID if still running.
+  Accepted host jobs survive Rome action or agent cancellation. Use system:manage_root_script
+  to inspect or cancel a job. A new invocation creates a new job, so inspect an uncertain
+  submission before repeating it. Scripts can change or destroy the entire host.
+complexity: complex
+speed: moderate
+reliability: medium
+sideEffects: write
+cancellable: false

--- a/rome_apps/system/src/actions/execute-root-script/index.test.ts
+++ b/rome_apps/system/src/actions/execute-root-script/index.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, rs } from "@rstest/core";
+import type { ActionConfig } from "@rome-os/app-runtime";
+import { createAction } from "./index.js";
+import { createAction as createManageAction } from "../manage-root-script/index.js";
+import type { HostExecutionDeps, HostJob } from "../root-script.js";
+
+const config: ActionConfig = {
+  name: "execute_root_script",
+  type: "system",
+  description: "Execute a host script",
+  complexity: "complex",
+  speed: "moderate",
+  reliability: "medium",
+  sideEffects: "write",
+};
+const input = {
+  target: "hosting-vm",
+  interpreter: "sh",
+  script: "printf hello",
+  reason: "Check host execution",
+};
+const job: HostJob = {
+  id: "job-1",
+  requestId: "job-1",
+  hostId: "host-1",
+  scriptSha256: "a".repeat(64),
+  status: "succeeded",
+  exitCode: 0,
+  stdout: "hello",
+  stderr: "",
+  truncated: false,
+  startedAt: "2026-01-01T00:00:00Z",
+  finishedAt: "2026-01-01T00:00:01Z",
+};
+
+function dependencies(snapshot = job) {
+  return {
+    hostExecution: {
+      start: rs.fn(async () => snapshot),
+      inspect: rs.fn(async () => snapshot),
+      cancel: rs.fn(async () => snapshot),
+    },
+  } satisfies HostExecutionDeps;
+}
+
+describe("host root script actions", () => {
+  it("passes script inputs with the default timeout and reports successful output", async () => {
+    const deps = dependencies();
+    const result = await createAction(config, deps).execute(input);
+    expect(deps.hostExecution.start).toHaveBeenCalledWith({ ...input, timeoutSeconds: 60 });
+    expect(result).toMatchObject({
+      status: "ok",
+      data: { ...job, completed: true, target: "hosting-vm" },
+    });
+  });
+
+  it("rejects caller-supplied audit IDs, host URLs, non-shell interpreters, and excessive UTF-8 scripts", async () => {
+    const deps = dependencies();
+    const action = createAction(config, deps);
+    for (const patch of [
+      { executionId: "forged" },
+      { rootExecutionId: "forged" },
+      { requestId: "forged" },
+      { hostId: "host-other" },
+      { url: "https://other" },
+      { target: "other" },
+      { interpreter: "python" },
+      { timeoutSeconds: 601 },
+      { script: "é".repeat(40_000) },
+    ]) {
+      expect(await action.execute({ ...input, ...patch })).toMatchObject({ status: "error" });
+    }
+    expect(deps.hostExecution.start).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes accepted remote work from completion and names the cancellation path", async () => {
+    const result = await createAction(
+      config,
+      dependencies({ ...job, status: "running", exitCode: null, finishedAt: null }),
+    ).execute(input);
+    expect(result).toMatchObject({
+      status: "ok",
+      data: {
+        id: job.id,
+        status: "running",
+        completed: false,
+        message: expect.stringContaining(
+          "Stopping the Rome action or agent does not cancel this job",
+        ),
+      },
+    });
+  });
+
+  it("maps terminal script failures and unknown outcomes to action errors with output", async () => {
+    for (const status of ["failed", "timed_out", "cancelled", "unknown"] as const) {
+      const result = await createAction(
+        config,
+        dependencies({ ...job, status, exitCode: 7, stderr: "failure", truncated: true }),
+      ).execute(input);
+      expect(result).toMatchObject({
+        status: "error",
+      });
+      if (result.status !== "error") throw new Error("Expected an action error");
+      expect(JSON.parse(result.error.split("\n")[1]!)).toMatchObject({
+        status,
+        exitCode: 7,
+        stdout: "hello",
+        stderr: "failure",
+        truncated: true,
+      });
+    }
+  });
+
+  it("preserves the lookup ID after an uncertain submission", async () => {
+    const deps = dependencies();
+    deps.hostExecution.start.mockRejectedValueOnce(
+      Object.assign(new Error("Submission outcome is unknown"), { jobId: "lookup-1" }),
+    );
+    const result = await createAction(config, deps).execute(input);
+    expect(result.status).toBe("error");
+    if (result.status !== "error") throw new Error("Expected an action error");
+    expect(JSON.parse(result.error.split("\n")[1]!)).toEqual({
+      jobId: "lookup-1",
+      target: "hosting-vm",
+      completed: false,
+    });
+  });
+
+  it("returns a readable error when the runtime does not supply host execution", async () => {
+    expect(await createAction(config, {}).execute(input)).toMatchObject({
+      status: "error",
+      error: expect.stringContaining("unavailable"),
+    });
+  });
+
+  it("routes explicit inspection and cancellation to the same durable job", async () => {
+    const deps = dependencies();
+    const action = createManageAction({ ...config, name: "manage_root_script" }, deps);
+    expect(
+      await action.execute({ target: "hosting-vm", operation: "inspect", jobId: job.id }),
+    ).toMatchObject({ status: "ok", data: { id: job.id } });
+    expect(
+      await action.execute({ target: "hosting-vm", operation: "cancel", jobId: job.id }),
+    ).toMatchObject({ status: "ok", data: { id: job.id } });
+    expect(deps.hostExecution.inspect).toHaveBeenCalledWith(job.id);
+    expect(deps.hostExecution.cancel).toHaveBeenCalledWith(job.id);
+    expect(deps.hostExecution.start).not.toHaveBeenCalled();
+  });
+});

--- a/rome_apps/system/src/actions/execute-root-script/index.ts
+++ b/rome_apps/system/src/actions/execute-root-script/index.ts
@@ -1,0 +1,38 @@
+import { defineAction, z, type Action, type ActionConfig } from "@rome-os/app-runtime";
+import { hostExecutionError, hostJobResult, type HostExecutionDeps } from "../root-script.js";
+
+export const executeRootScriptInputSchema = z.strictObject({
+  target: z
+    .literal("hosting-vm")
+    .describe("The Linux VM hosting this Rome container. Runs as host root."),
+  interpreter: z.enum(["sh", "bash"]),
+  script: z
+    .string()
+    .min(1)
+    .max(65_536)
+    .describe(
+      "Noninteractive shell script, at most 64 KiB UTF-8. Runs with a minimal host environment.",
+    ),
+  reason: z.string().trim().min(1).max(2_000).describe("Why this host-root operation is needed."),
+  timeoutSeconds: z.number().int().min(1).max(600).default(60),
+});
+
+export function createAction(config: ActionConfig, deps: HostExecutionDeps): Action {
+  return defineAction({
+    config,
+    schema: executeRootScriptInputSchema,
+    execute: async (input) => {
+      if (!deps.hostExecution) {
+        return { status: "error", error: "Host execution is unavailable in this Rome runtime." };
+      }
+      if (Buffer.byteLength(input.script) > 65_536) {
+        return { status: "error", error: "The script exceeds the 64 KiB UTF-8 limit." };
+      }
+      try {
+        return hostJobResult(await deps.hostExecution.start(input));
+      } catch (error) {
+        return hostExecutionError(error);
+      }
+    },
+  });
+}

--- a/rome_apps/system/src/actions/execute-root-script/index.ts
+++ b/rome_apps/system/src/actions/execute-root-script/index.ts
@@ -15,13 +15,14 @@ export const executeRootScriptInputSchema = z.strictObject({
     ),
   reason: z.string().trim().min(1).max(2_000).describe("Why this host-root operation is needed."),
   timeoutSeconds: z.number().int().min(1).max(600).default(60),
+  __triggerPayload: z.unknown().optional(),
 });
 
 export function createAction(config: ActionConfig, deps: HostExecutionDeps): Action {
   return defineAction({
     config,
     schema: executeRootScriptInputSchema,
-    execute: async (input) => {
+    execute: async ({ __triggerPayload: _triggerPayload, ...input }) => {
       if (!deps.hostExecution) {
         return { status: "error", error: "Host execution is unavailable in this Rome runtime." };
       }

--- a/rome_apps/system/src/actions/manage-root-script/action.yaml
+++ b/rome_apps/system/src/actions/manage-root-script/action.yaml
@@ -1,0 +1,13 @@
+name: manage_root_script
+type: system
+description: >-
+  Inspect the durable status and bounded output of a hosting-vm root script job, or request
+  cancellation of its managed process group. Use the job ID returned by execute_root_script.
+  Works after the originating Rome action exits or root execution is disabled.
+  Cancellation is best effort because unrestricted root scripts can escape the process group.
+  An unknown outcome requires inspection of host state before another submission.
+complexity: simple
+speed: fast
+reliability: high
+sideEffects: write
+cancellable: false

--- a/rome_apps/system/src/actions/manage-root-script/index.ts
+++ b/rome_apps/system/src/actions/manage-root-script/index.ts
@@ -1,0 +1,27 @@
+import { defineAction, z, type Action, type ActionConfig } from "@rome-os/app-runtime";
+import { hostExecutionError, hostJobResult, type HostExecutionDeps } from "../root-script.js";
+
+export function createAction(config: ActionConfig, deps: HostExecutionDeps): Action {
+  return defineAction({
+    config,
+    schema: z.strictObject({
+      target: z.literal("hosting-vm"),
+      operation: z.enum(["inspect", "cancel"]),
+      jobId: z
+        .string()
+        .min(1)
+        .max(128)
+        .regex(/^[A-Za-z0-9_-]+$/),
+    }),
+    execute: async ({ operation, jobId }) => {
+      if (!deps.hostExecution) {
+        return { status: "error", error: "Host execution is unavailable in this Rome runtime." };
+      }
+      try {
+        return hostJobResult(await deps.hostExecution[operation](jobId));
+      } catch (error) {
+        return hostExecutionError(error);
+      }
+    },
+  });
+}

--- a/rome_apps/system/src/actions/root-script.ts
+++ b/rome_apps/system/src/actions/root-script.ts
@@ -1,0 +1,69 @@
+import type { ActionResult } from "@rome-os/app-runtime";
+
+export interface RootScriptInput {
+  target: "hosting-vm";
+  interpreter: "sh" | "bash";
+  script: string;
+  reason: string;
+  timeoutSeconds: number;
+}
+
+export interface HostJob {
+  id: string;
+  requestId: string;
+  hostId: string;
+  scriptSha256: string;
+  status: "queued" | "running" | "succeeded" | "failed" | "cancelled" | "timed_out" | "unknown";
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  truncated: boolean;
+  startedAt: string | null;
+  finishedAt: string | null;
+}
+
+export interface HostExecutionDeps {
+  hostExecution?: {
+    start(input: RootScriptInput): Promise<HostJob>;
+    inspect(jobId: string): Promise<HostJob>;
+    cancel(jobId: string): Promise<HostJob>;
+  };
+}
+
+export function hostJobResult(job: HostJob): ActionResult {
+  const pending = job.status === "queued" || job.status === "running";
+  const data = {
+    ...job,
+    target: "hosting-vm",
+    completed: !pending && job.status !== "unknown",
+    ...(pending && {
+      message:
+        "Accepted by the hosting VM. The script is still running. Inspect or cancel this job with system:manage_root_script. Stopping the Rome action or agent does not cancel this job.",
+    }),
+  };
+  if (!pending && (job.status !== "succeeded" || job.exitCode !== 0)) {
+    const message =
+      job.status === "unknown"
+        ? `Host job ${job.id} has an unknown outcome. Inspect host state before starting another script.`
+        : `Host job ${job.id} ${job.status} (exit code ${job.exitCode ?? "unavailable"}).`;
+    return {
+      status: "error",
+      error: `${message}\n${JSON.stringify(data)}`,
+    };
+  }
+  return { status: "ok", data };
+}
+
+export function hostExecutionError(error: unknown): ActionResult {
+  const message = error instanceof Error ? error.message : String(error);
+  const jobId =
+    error instanceof Error && "jobId" in error && typeof error.jobId === "string"
+      ? error.jobId
+      : undefined;
+  return {
+    status: "error",
+    error: jobId
+      ? `${message}\n${JSON.stringify({ jobId, target: "hosting-vm", completed: false })}`
+      : message,
+  };
+}

--- a/scripts/host-helper/smoke-client.mjs
+++ b/scripts/host-helper/smoke-client.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { request } from "node:http";
+import { setTimeout as delay } from "node:timers/promises";
+
+const socketPath = "/run/rome-host/control.sock";
+
+function rpc(method, path, body) {
+  return new Promise((resolve, reject) => {
+    const bytes = body === undefined ? undefined : JSON.stringify(body);
+    const req = request(
+      {
+        socketPath,
+        path,
+        method,
+        headers: bytes
+          ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(bytes) }
+          : {},
+      },
+      (response) => {
+        let data = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          data += chunk;
+        });
+        response.on("end", () => {
+          try {
+            resolve({ status: response.statusCode, body: JSON.parse(data) });
+          } catch (error) {
+            reject(error);
+          }
+        });
+        response.on("error", reject);
+      },
+    );
+    req.setTimeout(5000, () => req.destroy(new Error("Host RPC timeout")));
+    req.on("error", reject);
+    req.end(bytes);
+  });
+}
+
+async function ready() {
+  let lastError;
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      const result = await rpc("GET", "/v1/capabilities");
+      assert.equal(result.status, 200);
+      assert.equal(result.body.hostId, "smoke-vm");
+      assert.equal(result.body.enabled, true);
+      assert.equal(result.body.protocolVersion, 1);
+      return;
+    } catch (error) {
+      lastError = error;
+      await delay(100);
+    }
+  }
+  throw lastError;
+}
+
+function submission(requestId, script, timeoutSeconds = 3) {
+  return {
+    requestId,
+    hostId: "smoke-vm",
+    interpreter: "sh",
+    script,
+    reason: "Isolated host execution integration check",
+    timeoutSeconds,
+    executionId: requestId,
+    rootExecutionId: requestId,
+  };
+}
+
+async function terminal(id) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const result = await rpc("GET", `/v1/jobs/${id}`);
+    assert.equal(result.status, 200);
+    if (!["queued", "running"].includes(result.body.status)) return result.body;
+    await delay(100);
+  }
+  throw new Error(`Job ${id} did not finish`);
+}
+
+async function submit(body) {
+  const result = await rpc("POST", "/v1/jobs", body);
+  assert.ok([200, 202].includes(result.status), JSON.stringify(result));
+  assert.equal(result.body.id, body.requestId);
+  return result.body;
+}
+
+const rootJob = submission(
+  "smoke-root",
+  'id -u; printf "host-only" > /var/lib/rome-host/smoke-root-proof; printf "%s" "${HOST_EXECUTION_TEST_SECRET:-clean}"',
+);
+
+assert.equal(process.getuid(), 10001);
+await ready();
+
+if (process.argv[2] === "verify-restart") {
+  const prior = await terminal(rootJob.requestId);
+  const duplicate = await submit(rootJob);
+  assert.equal(duplicate.status, "succeeded");
+  assert.equal(duplicate.startedAt, prior.startedAt);
+  assert.equal(duplicate.finishedAt, prior.finishedAt);
+  console.log("Host job identity and result survived helper restart.");
+} else {
+  const wrongHost = await rpc("POST", "/v1/jobs", { ...rootJob, hostId: "another-vm" });
+  assert.ok([400, 403, 409].includes(wrongHost.status));
+
+  await submit(rootJob);
+  const rootResult = await terminal(rootJob.requestId);
+  assert.equal(rootResult.status, "succeeded");
+  assert.equal(rootResult.stdout, "0\nclean");
+  assert.equal(rootResult.exitCode, 0);
+
+  const duplicate = await submit(rootJob);
+  assert.equal(duplicate.startedAt, rootResult.startedAt);
+  const collision = await rpc("POST", "/v1/jobs", { ...rootJob, script: "exit 1" });
+  assert.equal(collision.status, 409);
+
+  await submit(submission("smoke-failure", "printf failure >&2; exit 17"));
+  const failed = await terminal("smoke-failure");
+  assert.equal(failed.status, "failed");
+  assert.equal(failed.exitCode, 17);
+  assert.equal(failed.stderr, "failure");
+
+  await submit(submission("smoke-timeout", "sleep 20", 1));
+  assert.equal((await terminal("smoke-timeout")).status, "timed_out");
+
+  await submit(submission("smoke-cancel", "sleep 20"));
+  assert.equal((await rpc("POST", "/v1/jobs/smoke-cancel/cancel")).status, 200);
+  assert.equal((await terminal("smoke-cancel")).status, "cancelled");
+
+  await submit(submission("smoke-output", "head -c 10000 /dev/zero | tr '\\0' x"));
+  const output = await terminal("smoke-output");
+  assert.equal(output.status, "succeeded");
+  assert.equal(output.truncated, true);
+  assert.ok(Buffer.byteLength(output.stdout) + Buffer.byteLength(output.stderr) <= 1024);
+  console.log("Nonroot client executed and managed bounded root jobs on the isolated host.");
+}

--- a/scripts/host-helper/smoke.sh
+++ b/scripts/host-helper/smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+smoke_dir="$(mktemp -d)"
+smoke_name="rome-host-smoke-$$"
+socket_volume="${smoke_name}-socket"
+state_volume="${smoke_name}-state"
+go_image="${ROME_HOST_TEST_GO_IMAGE:-golang:1.26.7-bookworm}"
+node_image="${ROME_HOST_TEST_NODE_IMAGE:-node:24-bookworm-slim}"
+
+cleanup() {
+  docker rm -f "$smoke_name" >/dev/null 2>&1 || true
+  docker volume rm "$socket_volume" "$state_volume" >/dev/null 2>&1 || true
+  rm -rf "$smoke_dir"
+}
+trap cleanup EXIT
+
+docker run --rm \
+  --mount "type=bind,src=$repo_root/packages/host-helper,dst=/src,readonly" \
+  --mount "type=bind,src=$smoke_dir,dst=/out" \
+  --workdir /src "$go_image" \
+  sh -c 'CGO_ENABLED=0 go build -o /out/rome-hostd ./cmd/rome-hostd'
+
+cat >"$smoke_dir/config.json" <<'JSON'
+{"hostId":"smoke-vm","enabled":true,"socketPath":"/run/rome-host/control.sock","stateDir":"/var/lib/rome-host","socketGid":10001,"maxTimeoutSeconds":3,"maxOutputBytes":1024}
+JSON
+
+docker volume create "$socket_volume" >/dev/null
+docker volume create "$state_volume" >/dev/null
+docker run -d --name "$smoke_name" --network none \
+  --mount "type=bind,src=$smoke_dir,dst=/fixtures,readonly" \
+  --mount "type=volume,src=$socket_volume,dst=/run/rome-host" \
+  --mount "type=volume,src=$state_volume,dst=/var/lib/rome-host" \
+  --env HOST_EXECUTION_TEST_SECRET=not-for-children \
+  "$node_image" sh -c \
+  'mkdir -p /etc/rome-host && chmod 700 /var/lib/rome-host && cp /fixtures/config.json /etc/rome-host/config.json && chmod 600 /etc/rome-host/config.json && exec /fixtures/rome-hostd --config /etc/rome-host/config.json' >/dev/null
+
+run_client() {
+  docker run --rm --network none --user 10001:10001 \
+    --mount "type=volume,src=$socket_volume,dst=/run/rome-host,readonly" \
+    --mount "type=bind,src=$repo_root/scripts/host-helper,dst=/tests,readonly" \
+    "$node_image" node /tests/smoke-client.mjs "$1"
+}
+
+run_client exercise
+docker restart "$smoke_name" >/dev/null
+run_client verify-restart
+docker exec "$smoke_name" test -f /var/lib/rome-host/smoke-root-proof
+echo 'Host execution smoke passed: nonroot client, root host job, durable deduplication, timeout and cancellation.'


### PR DESCRIPTION
## What this PR does

Rome agents cannot run scripts on the Linux VM hosting their container. The system app now submits root scripts to an optional host helper and exposes a second action to inspect or cancel accepted jobs. Both Rome and the host policy require explicit enablement.

The companion Rome Cloud PR installs the pinned helper and socket mount through provisioning, warm-pool claims, maintenance, and upgrades: https://github.com/amantru/rome-cloud/pull/97.

## Design & Invariants

- A local Unix socket connects Core to a small Go helper. No Docker control socket, host TCP listener, or SSH credential reaches the agent.
- Core derives request identity from the current action execution. Durable job IDs prevent duplicate execution. A lost submission response triggers inspection, never automatic resubmission. Script hashes must match during reconciliation.
- Unexpected worker loss preserves original job references, including nested submissions. Routine dispatch records an uncertain outcome without automatically retrying. Receipt recovery survives execution-log write failures.
- Host jobs outlive the submitting action. Inspection and explicit cancellation remain available after new submissions are disabled. Output, request size, execution time, and concurrency are bounded. Interrupted jobs become unknown after helper recovery.
- A job supervisor survives daemon failure and cleans up its managed process group. A lease blocks helper recovery until cleanup finishes. Deliberately separate services remain outside that group, with bounded output draining after supervisor exit.
- Explicit admission rejections retain their helper error codes. A failed initial state write reports an unknown outcome, including a failure after file replacement.
- The helper owns configuration and job state outside the container. Socket access delegates authority to the trusted container; action visibility is not isolation from other code in that container. Root scripts can read host credentials and create persistent effects.
- Protocol and lifetime contracts live in `docs/concepts/host-execution.md` and `docs/architecture/host-execution.md`. Reviewed adjacent action/desktop contracts for removal; none qualify. The helper README documents release artifacts, capacity, and retained job history.

The helper workflow verifies Linux behavior and publishes versioned amd64/arm64 binaries with checksums only from a merged commit. The default configuration remains disabled.

## Test plan

- [x] `pnpm typecheck`.
- [x] `pnpm test:unit`: all 4,421 Core tests passed, alongside the remaining workspace, web, and UI suites.
- [x] System app build, focused action/config/injection/UDS tests, `pnpm lint`, and `pnpm lint:prose`.
- [x] Go race tests, vet, Linux amd64/arm64 builds, version output, and rejection of a nonroot daemon process.
- [x] Regression tests failed before the fixes and passed afterward: explicit 503 rejections, worker loss after host acceptance, routine retry and metadata, failed execution-log writes, daemon death and recovery barriers, initial directory-sync failure, and separate services retaining output pipes.
- [x] `bash scripts/host-helper/smoke.sh`: separate root-helper/nonroot-client Linux containers verify execution, minimal environment, failures, cancellation, timeout, bounded output, duplicate requests, and helper restart.
- [x] Independent code/security review approved; architecture review clear.
- [ ] Full `pnpm dev:all` startup: attempted, but the existing `rome-rome-1` container owns host port 80. Traefik cannot attach its network/published ports, so the observability readiness gate times out before this worktree starts. The existing container was left running. The task-local diagnostic proxy was removed.

Nix is unavailable on this host. Host checks used Node 24.14.1, matching the devShell major. Helper checks used isolated Linux Go 1.26.7 containers.

## Not in this PR

- Native macOS and Windows host helpers: this delivery targets Linux hosting VMs.
- Production publication or fleet activation: publish the merged helper release, scope credentials on tenant VMs, and apply explicit owner grants before enabling execution.
