### PR TITLE
feat(core): render per-app social meta for app document routes

### DIFF
--- a/packages/core/src/api/app-document-routes.e2e.test.ts
+++ b/packages/core/src/api/app-document-routes.e2e.test.ts
@@ -134,5 +134,6 @@ describe("app document routes through buildApp", () => {
     const app = await buildTestHost();
     const res = await app.request("/icon.svg", { headers: HEADERS });
     expect(res.status).toBe(200);
+    expect(await res.text()).toBe("<svg></svg>");
   });
 });

--- a/packages/core/src/api/app-document-routes.e2e.test.ts
+++ b/packages/core/src/api/app-document-routes.e2e.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Black-box regression: `buildApp` mounts the SPA shell (`mountSpa` in
+ * `api/index.ts`) with per-app social meta on `/apps/*` and `/full/apps/*`
+ * document routes, swapped via `buildAppSocialCard` +
+ * `renderSocialMeta` (`api/app-social-card.ts`, `lib/social-meta.ts`).
+ * Everything else — unknown apps, non-app SPA routes, static assets — must
+ * keep serving the shell/asset unchanged.
+ *
+ * The fixture drives the real production `buildApp` against a temp
+ * `webRoot` so a future regression in the mount order, the social-meta
+ * swap, or the static-vs-fallback precedence breaks this test without it
+ * needing to mirror that wiring itself.
+ */
+import { afterAll, describe, expect, it } from "@rstest/core";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { buildApp } from "./index.js";
+import type { ApiConfig, ApiDeps } from "./deps.js";
+import type { AppCatalog } from "../apps/catalog.js";
+import type { AppView, ResolvedApp } from "../apps/state.js";
+import { buildTestDeps, createTestDb } from "../test/helpers.js";
+
+const INDEX_HTML = `<html><head>
+<title>Rome</title>
+<!-- rome:social:start -->
+<meta property="og:title" content="Rome OS - Enjoy your life with Rome" />
+<meta property="og:image" content="https://romeos.cc/public-og-20260825.jpg" />
+<!-- rome:social:end -->
+</head><body></body></html>`;
+
+const webRoot = mkdtempSync(path.join(os.tmpdir(), "rome-app-document-routes-"));
+writeFileSync(path.join(webRoot, "index.html"), INDEX_HTML, "utf8");
+writeFileSync(path.join(webRoot, "icon.svg"), "<svg></svg>", "utf8");
+
+const testDb = createTestDb();
+afterAll(() => {
+  testDb.close();
+  rmSync(webRoot, { recursive: true, force: true });
+});
+
+function buildRedditFixture(): ResolvedApp {
+  return {
+    appId: "reddit",
+    state: "installed",
+    enabled: true,
+    firstParty: false,
+    source: { mode: "bundle", path: "/tmp/unused" },
+    installedHash: "0".repeat(64),
+    installedVersion: "0.0.1",
+    lastError: null,
+    updatedAt: new Date(0).toISOString(),
+    manifest: {
+      id: "reddit",
+      version: "0.0.1",
+      description: 'Watches <subreddits> & "more"',
+      agents: [],
+      actions: [],
+      skills: [],
+      hooks: [],
+    },
+    rootPath: "/tmp/unused",
+    resolveRoot: "/tmp/unused",
+    displayName: "Reddit Radar",
+    iconAbsolutePath: undefined,
+    artifacts: { agent: [], action: [], skill: [], hook: [] },
+    web: {
+      assetVersion: "abcdef123456",
+      distPath: "/tmp/unused",
+      entry: "index.js",
+      styles: [],
+      displayName: "Reddit Radar",
+    } as unknown as ResolvedApp["web"],
+    api: null,
+    db: null,
+  };
+}
+
+async function buildTestHost() {
+  const map = new Map<string, ResolvedApp>([["reddit", buildRedditFixture()]]);
+  const catalog = {
+    get: (appId: string): AppView | ResolvedApp | null => map.get(appId) ?? null,
+    list: () => Array.from(map.values()),
+    subscribe: () => () => {},
+  } as unknown as AppCatalog;
+  const deps: ApiDeps = { ...(await buildTestDeps(testDb.db)), appCatalog: catalog };
+  const config: ApiConfig = { port: 0, host: "127.0.0.1", webRoot };
+  return buildApp(deps, config).app;
+}
+
+const HEADERS = { host: "jessie.romeos.cc", "x-forwarded-proto": "https" };
+
+describe("app document routes through buildApp", () => {
+  it("swaps the shell's social meta for a routed app on /full/apps/:id", async () => {
+    const app = await buildTestHost();
+    const res = await app.request("/full/apps/reddit", { headers: HEADERS });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-cache");
+    const body = await res.text();
+    expect(body).toContain("<title>Reddit Radar</title>");
+    expect(body).toContain('<meta property="og:title" content="Reddit Radar" />');
+    expect(body).toContain(
+      '<meta property="og:description" content="Watches &lt;subreddits&gt; &amp; &quot;more&quot;" />',
+    );
+    expect(body).toContain(
+      '<meta property="og:url" content="https://jessie.romeos.cc/full/apps/reddit" />',
+    );
+    expect(body).not.toContain("Rome OS - Enjoy your life with Rome");
+  });
+
+  it("swaps meta for embedded /apps/:id sub-paths too", async () => {
+    const app = await buildTestHost();
+    const res = await app.request("/apps/reddit/posts/1", { headers: HEADERS });
+    const body = await res.text();
+    expect(body).toContain(
+      '<meta property="og:url" content="https://jessie.romeos.cc/apps/reddit/posts/1" />',
+    );
+  });
+
+  it("keeps the static shell for an unknown app and for non-app SPA routes", async () => {
+    const app = await buildTestHost();
+    for (const routePath of ["/full/apps/nope", "/dashboard"]) {
+      const res = await app.request(routePath, { headers: HEADERS });
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("<title>Rome</title>");
+      expect(body).toContain(
+        '<meta property="og:title" content="Rome OS - Enjoy your life with Rome" />',
+      );
+    }
+  });
+
+  it("still serves static assets ahead of the SPA fallback", async () => {
+    const app = await buildTestHost();
+    const res = await app.request("/icon.svg", { headers: HEADERS });
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/core/src/api/app-social-card.test.ts
+++ b/packages/core/src/api/app-social-card.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "@rstest/core";
+import { DEFAULT_SOCIAL_IMAGE_URL } from "../lib/social-meta.js";
+import { buildAppSocialCard, getRoutedAppId } from "./app-social-card.js";
+
+function catalogWith(views: Record<string, unknown>) {
+  return { get: (appId: string) => (views[appId] as never) ?? null };
+}
+
+const reddit = {
+  appId: "reddit",
+  state: "installed",
+  enabled: true,
+  displayName: "Reddit Radar",
+  manifest: { id: "reddit", description: "Watches subreddits" },
+  web: { displayName: "Reddit Radar" },
+};
+
+function req(path: string): Request {
+  return new Request(`http://127.0.0.1:4141${path}`, {
+    headers: { host: "jessie.romeos.cc", "x-forwarded-proto": "https" },
+  });
+}
+
+describe("getRoutedAppId", () => {
+  it("extracts the app id from embedded and full routes", () => {
+    expect(getRoutedAppId("/apps/reddit")).toBe("reddit");
+    expect(getRoutedAppId("/apps/reddit/")).toBe("reddit");
+    expect(getRoutedAppId("/apps/reddit/posts/1")).toBe("reddit");
+    expect(getRoutedAppId("/full/apps/reddit")).toBe("reddit");
+    expect(getRoutedAppId("/full/apps/%40acme%2Fradar")).toBe("@acme/radar");
+  });
+
+  it("returns null for other paths and malformed ids", () => {
+    expect(getRoutedAppId("/")).toBeNull();
+    expect(getRoutedAppId("/apps")).toBeNull();
+    expect(getRoutedAppId("/dashboard")).toBeNull();
+    expect(getRoutedAppId("/apps/Not%20Valid")).toBeNull();
+  });
+});
+
+describe("buildAppSocialCard", () => {
+  it("builds a card for an installed app with a web bundle", () => {
+    const card = buildAppSocialCard(
+      { appCatalog: catalogWith({ reddit }) },
+      req("/full/apps/reddit"),
+    );
+    expect(card).toEqual({
+      title: "Reddit Radar",
+      description: "Watches subreddits",
+      url: "https://jessie.romeos.cc/full/apps/reddit",
+      imageUrl: DEFAULT_SOCIAL_IMAGE_URL,
+    });
+  });
+
+  it("returns null for unknown apps, non-app paths, and apps without a frontend", () => {
+    const deps = {
+      appCatalog: catalogWith({ reddit, headless: { ...reddit, appId: "headless", web: null } }),
+    };
+    expect(buildAppSocialCard(deps, req("/apps/nope"))).toBeNull();
+    expect(buildAppSocialCard(deps, req("/dashboard"))).toBeNull();
+    expect(buildAppSocialCard(deps, req("/apps/headless"))).toBeNull();
+  });
+});

--- a/packages/core/src/api/app-social-card.test.ts
+++ b/packages/core/src/api/app-social-card.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "@rstest/core";
-import { DEFAULT_SOCIAL_IMAGE_URL } from "../lib/social-meta.js";
 import { buildAppSocialCard, getRoutedAppId } from "./app-social-card.js";
 
 function catalogWith(views: Record<string, unknown>) {
@@ -48,7 +47,6 @@ describe("buildAppSocialCard", () => {
       title: "Reddit Radar",
       description: "Watches subreddits",
       url: "https://jessie.romeos.cc/full/apps/reddit",
-      imageUrl: DEFAULT_SOCIAL_IMAGE_URL,
     });
   });
 

--- a/packages/core/src/api/app-social-card.ts
+++ b/packages/core/src/api/app-social-card.ts
@@ -36,7 +36,9 @@ function isResolvedWebApp(
 /**
  * The social card for an app document request, or null when the request is
  * not for an installed app with a frontend (the shell then keeps its static
- * card). Mirrors the SPA's own `getRoutedAppId` in packages/web.
+ * card). Mirrors the SPA's own `getRoutedAppId` in packages/web, minus its
+ * reserved-id guard (`store`, `inbox`, …), which only affects client
+ * routing — an unmatched id here just keeps the static card.
  */
 export function buildAppSocialCard(deps: AppSocialCardDeps, request: Request): SocialCard | null {
   const pathname = new URL(request.url).pathname;
@@ -45,6 +47,8 @@ export function buildAppSocialCard(deps: AppSocialCardDeps, request: Request): S
   const view = deps.appCatalog.get(appId);
   if (!isResolvedWebApp(view)) return null;
 
+  // Echoes the requested host on purpose: the crawler already holds this
+  // URL; getInstanceOrigin would break loopback/tailnet previews.
   const { origin } = getExternalRequestOrigin(request);
   return {
     title: view.displayName,

--- a/packages/core/src/api/app-social-card.ts
+++ b/packages/core/src/api/app-social-card.ts
@@ -1,7 +1,7 @@
 import type { AppCatalog } from "../apps/catalog.js";
 import type { ResolvedApp } from "../apps/state.js";
 import { getExternalRequestOrigin } from "../lib/request-origin.js";
-import { DEFAULT_SOCIAL_IMAGE_URL, type SocialCard } from "../lib/social-meta.js";
+import type { SocialCard } from "../lib/social-meta.js";
 import { decodeAppIdPathSegment, InvalidAppApiPathError } from "./helpers.js";
 
 const APP_ROUTE_RE = /^\/(?:full\/)?apps\/([^/]+)(?:\/|$)/;
@@ -38,7 +38,8 @@ function isResolvedWebApp(
  * not for an installed app with a frontend (the shell then keeps its static
  * card). Mirrors the SPA's own `getRoutedAppId` in packages/web, minus its
  * reserved-id guard (`store`, `inbox`, …), which only affects client
- * routing — an unmatched id here just keeps the static card.
+ * routing — an unmatched id here just keeps the static card. Leaves
+ * `imageUrl` unset, so the render keeps the shell's own og:image.
  */
 export function buildAppSocialCard(deps: AppSocialCardDeps, request: Request): SocialCard | null {
   const pathname = new URL(request.url).pathname;
@@ -54,6 +55,5 @@ export function buildAppSocialCard(deps: AppSocialCardDeps, request: Request): S
     title: view.displayName,
     description: view.manifest.description,
     url: `${origin}${pathname}`,
-    imageUrl: DEFAULT_SOCIAL_IMAGE_URL,
   };
 }

--- a/packages/core/src/api/app-social-card.ts
+++ b/packages/core/src/api/app-social-card.ts
@@ -1,0 +1,55 @@
+import type { AppCatalog } from "../apps/catalog.js";
+import type { ResolvedApp } from "../apps/state.js";
+import { getExternalRequestOrigin } from "../lib/request-origin.js";
+import { DEFAULT_SOCIAL_IMAGE_URL, type SocialCard } from "../lib/social-meta.js";
+import { decodeAppIdPathSegment, InvalidAppApiPathError } from "./helpers.js";
+
+const APP_ROUTE_RE = /^\/(?:full\/)?apps\/([^/]+)(?:\/|$)/;
+
+/** App id named by an `/apps/<id>` or `/full/apps/<id>` document path, else null. */
+export function getRoutedAppId(pathname: string): string | null {
+  const match = pathname.match(APP_ROUTE_RE);
+  if (!match) return null;
+  try {
+    return decodeAppIdPathSegment(match[1]);
+  } catch (err) {
+    if (err instanceof InvalidAppApiPathError) return null;
+    throw err;
+  }
+}
+
+export interface AppSocialCardDeps {
+  appCatalog: Pick<AppCatalog, "get">;
+}
+
+function isResolvedWebApp(
+  view: unknown,
+): view is ResolvedApp & { web: NonNullable<ResolvedApp["web"]> } {
+  return (
+    !!view &&
+    typeof view === "object" &&
+    (view as ResolvedApp).manifest !== undefined &&
+    (view as ResolvedApp).web != null
+  );
+}
+
+/**
+ * The social card for an app document request, or null when the request is
+ * not for an installed app with a frontend (the shell then keeps its static
+ * card). Mirrors the SPA's own `getRoutedAppId` in packages/web.
+ */
+export function buildAppSocialCard(deps: AppSocialCardDeps, request: Request): SocialCard | null {
+  const pathname = new URL(request.url).pathname;
+  const appId = getRoutedAppId(pathname);
+  if (appId === null) return null;
+  const view = deps.appCatalog.get(appId);
+  if (!isResolvedWebApp(view)) return null;
+
+  const { origin } = getExternalRequestOrigin(request);
+  return {
+    title: view.displayName,
+    description: view.manifest.description,
+    url: `${origin}${pathname}`,
+    imageUrl: DEFAULT_SOCIAL_IMAGE_URL,
+  };
+}

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -1,10 +1,12 @@
 import type { Server } from "node:http";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { serve, type ServerType } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { createLogger } from "../logger.js";
+import { renderSocialMeta } from "../lib/social-meta.js";
+import { buildAppSocialCard } from "./app-social-card.js";
 import { attachTerminalServer } from "../terminal-server.js";
 import { attachDesktopProxy } from "../desktop-proxy-server.js";
 import { attachAppWebSocket } from "../apps/websocket-server.js";
@@ -186,21 +188,35 @@ export function buildApp(
 
   // SPA shell. Hono owns it so loopback callers inside the container
   // (`localhost:4141/dashboard`, in-process Chrome CDP, etc.) can reach
-  // the dashboard without going through Caddy. External traffic does NOT
-  // arrive here: the generated Caddyfile serves the shell + assets straight
-  // from disk via `file_server` and only proxies /api, webhooks, app assets,
-  // and WebSocket upgrades (see lib/caddyfile-generator.ts). Anything that
-  // must reach production browsers therefore has to exist as a file under
-  // webRoot (e.g. the boot-written runtime-config.js); Hono-side
-  // response rewriting here would be invisible outside the container.
+  // the dashboard without going through Caddy. External traffic mostly does
+  // NOT arrive here: the generated Caddyfile serves the shell + assets
+  // straight from disk via `file_server` and proxies only /api, webhooks, app
+  // assets, WebSocket upgrades — and the `/apps/*` + `/full/apps/*` document
+  // paths, which come here so the social meta can be swapped per app (see
+  // lib/caddyfile-generator.ts). Anything else that must reach production
+  // browsers has to exist as a file under webRoot (e.g. the boot-written
+  // runtime-config.js).
   if (config.webRoot && existsSync(join(config.webRoot, "index.html"))) {
-    mountSpa(app, config.webRoot);
+    mountSpa(app, config.webRoot, deps);
   }
 
   return { app, webchatRuntime };
 }
 
-function mountSpa(app: Hono, webRoot: string): void {
+function mountSpa(app: Hono, webRoot: string, deps: Pick<ApiDeps, "appCatalog">): void {
+  // App document routes get the shell with per-app social meta. Registered
+  // before `serveStatic` so the static handler never answers them, and
+  // `no-cache` because Caddy set that on the shell before this path existed —
+  // a cached shell points at bundle hashes the next image upgrade removes.
+  const appDocument = (c: Context) => {
+    const card = buildAppSocialCard(deps, c.req.raw);
+    return c.html(renderSocialMeta(readIndexHtml(webRoot), card), 200, {
+      "Cache-Control": "no-cache",
+    });
+  };
+  app.get("/apps/*", appDocument);
+  app.get("/full/apps/*", appDocument);
+
   // Serve hashed assets + public files. `serveStatic` calls next() on
   // miss, so unknown paths fall through to the SPA fallback below.
   app.use(
@@ -211,7 +227,7 @@ function mountSpa(app: Hono, webRoot: string): void {
     }),
   );
   // Any non-API, non-static path returns index.html so the SPA router
-  // can handle the route (`/dashboard`, `/login`, `/apps/foo`, …).
+  // can handle the route (`/dashboard`, `/login`, …).
   app.get("/*", (c) => c.html(readIndexHtml(webRoot)));
 }
 

--- a/packages/core/src/lib/caddyfile-generator.test.ts
+++ b/packages/core/src/lib/caddyfile-generator.test.ts
@@ -88,6 +88,7 @@ describe("generateCaddyfile app document routes", () => {
     expect(appDocsAt).toBeLessThan(fallbackAt);
     const body = caddyfile.split("handle @appDocs {")[1].split("}")[0];
     expect(body).toContain("reverse_proxy 127.0.0.1:");
+    expect(body).toContain("encode zstd gzip");
     expect(body).not.toContain("forward_auth");
   });
 
@@ -95,6 +96,7 @@ describe("generateCaddyfile app document routes", () => {
     const caddyfile = generateCaddyfile(publicConfig);
     const block = caddyfile.split("handle /full/apps/morning-brief/* {")[1].split("}")[0];
     expect(block).toContain("reverse_proxy 127.0.0.1:");
+    expect(block).toContain("encode zstd gzip");
     expect(block).not.toContain("rewrite * /index.html");
     // Cloud-email apps share the same shell delivery.
     const cloudEmail = generateCaddyfile({

--- a/packages/core/src/lib/caddyfile-generator.test.ts
+++ b/packages/core/src/lib/caddyfile-generator.test.ts
@@ -76,3 +76,33 @@ describe("generateCaddyfile runtime-config.js delivery", () => {
     expect(caddyfile).toContain("root * /custom/web/dist");
   });
 });
+
+describe("generateCaddyfile app document routes", () => {
+  it("proxies /apps and /full/apps documents to Hono in open mode, after the asset handlers", () => {
+    const caddyfile = generateCaddyfile(openConfig);
+    expect(caddyfile).toContain("@appDocs path /apps /apps/* /full/apps /full/apps/*");
+    const appDocsAt = caddyfile.indexOf("handle @appDocs {");
+    const missingAssetsAt = caddyfile.indexOf("handle @missingSpaAssets {");
+    const fallbackAt = caddyfile.lastIndexOf("try_files {path} /index.html");
+    expect(appDocsAt).toBeGreaterThan(missingAssetsAt);
+    expect(appDocsAt).toBeLessThan(fallbackAt);
+    const body = caddyfile.split("handle @appDocs {")[1].split("}")[0];
+    expect(body).toContain("reverse_proxy 127.0.0.1:");
+    expect(body).not.toContain("forward_auth");
+  });
+
+  it("proxies allowlisted app documents to Hono in public-access mode", () => {
+    const caddyfile = generateCaddyfile(publicConfig);
+    const block = caddyfile.split("handle /full/apps/morning-brief/* {")[1].split("}")[0];
+    expect(block).toContain("reverse_proxy 127.0.0.1:");
+    expect(block).not.toContain("rewrite * /index.html");
+    // Cloud-email apps share the same shell delivery.
+    const cloudEmail = generateCaddyfile({
+      enableAccessControl: true,
+      allowedApps: [],
+      cloudEmailAccess: { "night-brief": ["a@b.co"] },
+    });
+    const emailBlock = cloudEmail.split("handle /apps/night-brief {")[1].split("}")[0];
+    expect(emailBlock).toContain("reverse_proxy 127.0.0.1:");
+  });
+});

--- a/packages/core/src/lib/caddyfile-generator.ts
+++ b/packages/core/src/lib/caddyfile-generator.ts
@@ -48,13 +48,6 @@ export function generateCaddyfile(config: PublicAccessConfig): string {
 \t# reverse_proxy still upgrades the original request) lets the upgrade through.
 \theader_up -Connection
 }`;
-  const spaShell = `
-root * ${webRoot}
-rewrite * /index.html
-encode zstd gzip
-header Cache-Control "no-cache"
-file_server
-`.trim();
   // Boot-written runtime browser config. An explicit handle in
   // BOTH modes: the content changes across container boots so it must never get
   // the immutable-asset cache header, and in public-access mode the fallback
@@ -86,6 +79,9 @@ handle /${RUNTIME_CONFIG_FILENAME} {
     //     Unknown paths fall back to `index.html` for the client router.
     //     Hono keeps its own copy for loopback/tailnet callers that reach
     //     `:4141` without going via Caddy.
+    //   - `@appDocs` (`/apps/*`, `/full/apps/*`) is the shell too, but served
+    //     by Hono so the social meta can be swapped per app. Public, no
+    //     forward_auth: the shell was public from disk already.
     //
     // WebSocket-bearing paths (`/ws/*`, `/desktop-proxy*`) are split out
     // because \`forward_auth\` forwards Upgrade/Connection headers verbatim
@@ -122,6 +118,10 @@ handle @spaAssets {
 handle @missingSpaAssets {
 \trespond 404
 }
+@appDocs path /apps /apps/* /full/apps /full/apps/*
+handle @appDocs {
+\t${proxy}
+}
 handle {
 \troot * ${webRoot}
 \ttry_files {path} /index.html
@@ -132,8 +132,8 @@ handle {
 `.trim();
   } else {
     // Public-access mode: the public edge exposes only an allowlisted set
-    // of apps + a gateway landing page. Allowlisted app shells are served from
-    // the same SPA `dist` bundle; their `/api/*` paths are proxied to Hono.
+    // of apps + a gateway landing page. Allowlisted app shells are proxied to
+    // Hono for per-app social meta, same as their `/api/*` paths.
     const publicAppBlocks = normalized.allowedApps
       .map((appId) => {
         const appIdSegment = encodeURIComponent(appId);
@@ -154,16 +154,16 @@ handle /app-assets/${appIdSegment}/* {
 \t${proxy}
 }
 handle ${getEmbeddedAppHref(appId)} {
-${indent(spaShell, 1)}
+\t${proxy}
 }
 handle ${getEmbeddedAppHref(appId)}/* {
-${indent(spaShell, 1)}
+\t${proxy}
 }
 handle ${getFullAppHref(appId)} {
-${indent(spaShell, 1)}
+\t${proxy}
 }
 handle ${getFullAppHref(appId)}/* {
-${indent(spaShell, 1)}
+\t${proxy}
 }
 `.trim();
       })
@@ -198,16 +198,16 @@ ${indent(forwardAuth, 1)}
 \t${proxy}
 }
 handle ${getEmbeddedAppHref(appId)} {
-${indent(spaShell, 1)}
+\t${proxy}
 }
 handle ${getEmbeddedAppHref(appId)}/* {
-${indent(spaShell, 1)}
+\t${proxy}
 }
 handle ${getFullAppHref(appId)} {
-${indent(spaShell, 1)}
+\t${proxy}
 }
 handle ${getFullAppHref(appId)}/* {
-${indent(spaShell, 1)}
+\t${proxy}
 }
 `.trim();
       })

--- a/packages/core/src/lib/caddyfile-generator.ts
+++ b/packages/core/src/lib/caddyfile-generator.ts
@@ -120,6 +120,7 @@ handle @missingSpaAssets {
 }
 @appDocs path /apps /apps/* /full/apps /full/apps/*
 handle @appDocs {
+\tencode zstd gzip
 \t${proxy}
 }
 handle {
@@ -154,15 +155,19 @@ handle /app-assets/${appIdSegment}/* {
 \t${proxy}
 }
 handle ${getEmbeddedAppHref(appId)} {
+\tencode zstd gzip
 \t${proxy}
 }
 handle ${getEmbeddedAppHref(appId)}/* {
+\tencode zstd gzip
 \t${proxy}
 }
 handle ${getFullAppHref(appId)} {
+\tencode zstd gzip
 \t${proxy}
 }
 handle ${getFullAppHref(appId)}/* {
+\tencode zstd gzip
 \t${proxy}
 }
 `.trim();
@@ -198,15 +203,19 @@ ${indent(forwardAuth, 1)}
 \t${proxy}
 }
 handle ${getEmbeddedAppHref(appId)} {
+\tencode zstd gzip
 \t${proxy}
 }
 handle ${getEmbeddedAppHref(appId)}/* {
+\tencode zstd gzip
 \t${proxy}
 }
 handle ${getFullAppHref(appId)} {
+\tencode zstd gzip
 \t${proxy}
 }
 handle ${getFullAppHref(appId)}/* {
+\tencode zstd gzip
 \t${proxy}
 }
 `.trim();

--- a/packages/core/src/lib/public-access.test.ts
+++ b/packages/core/src/lib/public-access.test.ts
@@ -136,10 +136,8 @@ describe("generateCaddyfile", () => {
     expect(inboxShellStart).toBeGreaterThan(-1);
     expect(inboxShellEnd).toBeGreaterThan(inboxShellStart);
     const inboxShell = out.slice(inboxShellStart, inboxShellEnd);
-    expect(inboxShell).toContain("rewrite * /index.html");
-    expect(inboxShell).toContain("encode zstd gzip");
-    expect(inboxShell).toContain('header Cache-Control "no-cache"');
-    expect(inboxShell).toContain("file_server");
+    expect(inboxShell).toContain("reverse_proxy 127.0.0.1:");
+    expect(inboxShell).not.toContain("rewrite * /index.html");
   });
 
   it("emits signed-in visitor routes for cloud-email apps", () => {

--- a/packages/core/src/lib/social-meta.test.ts
+++ b/packages/core/src/lib/social-meta.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "@rstest/core";
+import { DEFAULT_SOCIAL_IMAGE_URL, renderSocialMeta, type SocialCard } from "./social-meta.js";
+
+const SHELL = [
+  "<html><head>",
+  "    <title>Rome</title>",
+  "    <!-- explainer -->",
+  "    <!-- rome:social:start -->",
+  '    <meta property="og:type" content="website" />',
+  '    <meta property="og:title" content="Rome OS - Enjoy your life with Rome" />',
+  `    <meta property="og:image" content="${DEFAULT_SOCIAL_IMAGE_URL}" />`,
+  "    <!-- rome:social:end -->",
+  '    <script src="/runtime-config.js"></script>',
+  "</head><body></body></html>",
+].join("\n");
+
+const card: SocialCard = {
+  title: "Reddit Radar",
+  description: 'AI agent <radar> & "dashboard"',
+  url: "https://jessie.romeos.cc/full/apps/reddit",
+  imageUrl: "https://jessie.romeos.cc/app-og/reddit.png?v=1",
+};
+
+describe("renderSocialMeta", () => {
+  it("returns the shell untouched when there is no card", () => {
+    expect(renderSocialMeta(SHELL, null)).toBe(SHELL);
+  });
+
+  it("replaces the title and the marked block, escaping attribute values", () => {
+    const html = renderSocialMeta(SHELL, card);
+    expect(html).toContain("<title>Reddit Radar</title>");
+    expect(html).not.toContain("Rome OS - Enjoy your life with Rome");
+    expect(html).toContain('<meta property="og:title" content="Reddit Radar" />');
+    expect(html).toContain(
+      '<meta property="og:description" content="AI agent &lt;radar&gt; &amp; &quot;dashboard&quot;" />',
+    );
+    expect(html).toContain(
+      '<meta property="og:url" content="https://jessie.romeos.cc/full/apps/reddit" />',
+    );
+    expect(html).toContain(
+      '<meta property="og:image" content="https://jessie.romeos.cc/app-og/reddit.png?v=1" />',
+    );
+    expect(html).toContain('<meta name="twitter:card" content="summary_large_image" />');
+    expect(html).toContain(
+      '<meta name="twitter:image" content="https://jessie.romeos.cc/app-og/reddit.png?v=1" />',
+    );
+    // Everything outside the block survives.
+    expect(html).toContain("<!-- explainer -->");
+    expect(html).toContain('<script src="/runtime-config.js"></script>');
+    expect(html).toContain("<!-- rome:social:start -->");
+    expect(html).toContain("<!-- rome:social:end -->");
+  });
+
+  it("keeps every emitted meta tag on its own single line", () => {
+    const html = renderSocialMeta(SHELL, card);
+    const block = html.split("<!-- rome:social:start -->")[1].split("<!-- rome:social:end -->")[0];
+    for (const line of block.trim().split("\n")) {
+      expect(line.trim()).toMatch(/^<meta [^\n]*\/>$/);
+    }
+  });
+
+  it("returns the shell untouched when the markers are missing", () => {
+    const noMarkers = "<html><head><title>Rome</title></head></html>";
+    expect(renderSocialMeta(noMarkers, card)).toBe(noMarkers);
+  });
+});

--- a/packages/core/src/lib/social-meta.test.ts
+++ b/packages/core/src/lib/social-meta.test.ts
@@ -63,4 +63,9 @@ describe("renderSocialMeta", () => {
     const noMarkers = "<html><head><title>Rome</title></head></html>";
     expect(renderSocialMeta(noMarkers, card)).toBe(noMarkers);
   });
+
+  it("treats a title containing $-patterns as literal text, not a replacement pattern", () => {
+    const html = renderSocialMeta(SHELL, { ...card, title: "Cost $& Co" });
+    expect(html).toContain("<title>Cost $&amp; Co</title>");
+  });
 });

--- a/packages/core/src/lib/social-meta.test.ts
+++ b/packages/core/src/lib/social-meta.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@rstest/core";
-import { DEFAULT_SOCIAL_IMAGE_URL, renderSocialMeta, type SocialCard } from "./social-meta.js";
+import { renderSocialMeta, type SocialCard } from "./social-meta.js";
 
 const SHELL = [
   "<html><head>",
@@ -8,7 +8,7 @@ const SHELL = [
   "    <!-- rome:social:start -->",
   '    <meta property="og:type" content="website" />',
   '    <meta property="og:title" content="Rome OS - Enjoy your life with Rome" />',
-  `    <meta property="og:image" content="${DEFAULT_SOCIAL_IMAGE_URL}" />`,
+  '    <meta property="og:image" content="https://romeos.cc/public-og-20260825.jpg" />',
   "    <!-- rome:social:end -->",
   '    <script src="/runtime-config.js"></script>',
   "</head><body></body></html>",
@@ -67,5 +67,32 @@ describe("renderSocialMeta", () => {
   it("treats a title containing $-patterns as literal text, not a replacement pattern", () => {
     const html = renderSocialMeta(SHELL, { ...card, title: "Cost $& Co" });
     expect(html).toContain("<title>Cost $&amp; Co</title>");
+  });
+
+  it("keeps the shell's own og:image when the card has no imageUrl", () => {
+    const html = renderSocialMeta(SHELL, { ...card, imageUrl: undefined });
+    expect(html).toContain(
+      '<meta property="og:image" content="https://romeos.cc/public-og-20260825.jpg" />',
+    );
+    expect(html).toContain(
+      '<meta name="twitter:image" content="https://romeos.cc/public-og-20260825.jpg" />',
+    );
+    expect(html).toContain('<meta property="og:title" content="Reddit Radar" />');
+  });
+
+  it("omits image tags when neither the card nor the shell has one", () => {
+    const shellWithoutImage = [
+      "<html><head>",
+      "    <title>Rome</title>",
+      "    <!-- rome:social:start -->",
+      '    <meta property="og:type" content="website" />',
+      '    <meta property="og:title" content="Rome OS - Enjoy your life with Rome" />',
+      "    <!-- rome:social:end -->",
+      "</head><body></body></html>",
+    ].join("\n");
+    const html = renderSocialMeta(shellWithoutImage, { ...card, imageUrl: undefined });
+    expect(html).not.toContain("og:image");
+    expect(html).not.toContain("twitter:image");
+    expect(html).toContain('<meta property="og:title" content="Reddit Radar" />');
   });
 });

--- a/packages/core/src/lib/social-meta.ts
+++ b/packages/core/src/lib/social-meta.ts
@@ -64,5 +64,5 @@ export function renderSocialMeta(indexHtml: string, card: SocialCard | null): st
   const before = indexHtml.slice(0, start + START_MARKER.length);
   const after = indexHtml.slice(end);
   const withBlock = `${before}\n${socialTags(card)}\n    ${after}`;
-  return withBlock.replace(TITLE_RE, `<title>${escapeHtml(card.title)}</title>`);
+  return withBlock.replace(TITLE_RE, () => `<title>${escapeHtml(card.title)}</title>`);
 }

--- a/packages/core/src/lib/social-meta.ts
+++ b/packages/core/src/lib/social-meta.ts
@@ -1,21 +1,22 @@
 // Per-route social card for the SPA shell. Pure string work: the caller
 // decides whether a request maps to an app (api/app-social-card.ts) and
 // whether the response reaches a browser (Caddy proxies /apps/* documents to
-// Hono precisely so this replacement is visible outside the container).
-
-export const DEFAULT_SOCIAL_IMAGE_URL = "https://romeos.cc/public-og-20260825.jpg";
+// Hono precisely so this replacement is visible outside the container). The
+// fallback image lives only in packages/web/index.html; a card without one
+// keeps whatever og:image the shell already has.
 
 const START_MARKER = "<!-- rome:social:start -->";
 const END_MARKER = "<!-- rome:social:end -->";
 const TITLE_RE = /<title>[^<]*<\/title>/;
+const SHELL_OG_IMAGE_RE = /<meta property="og:image" content="([^"]*)"/;
 
 export interface SocialCard {
   title: string;
   description: string;
   /** Absolute URL of the page being shared. */
   url: string;
-  /** Absolute URL of a 1200x630 image. */
-  imageUrl: string;
+  /** Absolute URL of a 1200x630 image; omitted → the shell's own og:image is kept. */
+  imageUrl?: string;
 }
 
 function escapeHtml(value: string): string {
@@ -26,28 +27,46 @@ function escapeHtml(value: string): string {
     .replace(/"/g, "&quot;");
 }
 
-function socialTags(card: SocialCard): string {
+/**
+ * The og:image/twitter:image attribute value to emit, or null to omit those
+ * tags entirely. `card.imageUrl` wins when present (freshly escaped); else
+ * the shell's own og:image, read out of its existing marked block, is
+ * reused as-is — it is already an escaped HTML attribute value.
+ */
+function resolveImageValue(card: SocialCard, existingBlock: string): string | null {
+  if (card.imageUrl !== undefined) return escapeHtml(card.imageUrl);
+  const match = existingBlock.match(SHELL_OG_IMAGE_RE);
+  return match ? match[1] : null;
+}
+
+function socialTags(card: SocialCard, imageValue: string | null): string {
   const t = escapeHtml(card.title);
   const d = escapeHtml(card.description);
   const u = escapeHtml(card.url);
-  const i = escapeHtml(card.imageUrl);
-  // One tag per line, never wrapped: Rsbuild drops multi-line <meta> tags.
-  return [
+  const lines = [
     '<meta property="og:type" content="website" />',
     '<meta property="og:site_name" content="Rome" />',
     `<meta property="og:title" content="${t}" />`,
     `<meta property="og:description" content="${d}" />`,
     `<meta property="og:url" content="${u}" />`,
-    `<meta property="og:image" content="${i}" />`,
-    '<meta property="og:image:width" content="1200" />',
-    '<meta property="og:image:height" content="630" />',
+  ];
+  if (imageValue !== null) {
+    lines.push(
+      `<meta property="og:image" content="${imageValue}" />`,
+      '<meta property="og:image:width" content="1200" />',
+      '<meta property="og:image:height" content="630" />',
+    );
+  }
+  lines.push(
     '<meta name="twitter:card" content="summary_large_image" />',
     `<meta name="twitter:title" content="${t}" />`,
     `<meta name="twitter:description" content="${d}" />`,
-    `<meta name="twitter:image" content="${i}" />`,
-  ]
-    .map((line) => `    ${line}`)
-    .join("\n");
+  );
+  if (imageValue !== null) {
+    lines.push(`<meta name="twitter:image" content="${imageValue}" />`);
+  }
+  // One tag per line, never wrapped: Rsbuild drops multi-line <meta> tags.
+  return lines.map((line) => `    ${line}`).join("\n");
 }
 
 /**
@@ -61,8 +80,11 @@ export function renderSocialMeta(indexHtml: string, card: SocialCard | null): st
   const end = indexHtml.indexOf(END_MARKER);
   if (start === -1 || end === -1 || end < start) return indexHtml;
 
+  const existingBlock = indexHtml.slice(start + START_MARKER.length, end);
+  const imageValue = resolveImageValue(card, existingBlock);
+
   const before = indexHtml.slice(0, start + START_MARKER.length);
   const after = indexHtml.slice(end);
-  const withBlock = `${before}\n${socialTags(card)}\n    ${after}`;
+  const withBlock = `${before}\n${socialTags(card, imageValue)}\n    ${after}`;
   return withBlock.replace(TITLE_RE, () => `<title>${escapeHtml(card.title)}</title>`);
 }

--- a/packages/core/src/lib/social-meta.ts
+++ b/packages/core/src/lib/social-meta.ts
@@ -1,0 +1,68 @@
+// Per-route social card for the SPA shell. Pure string work: the caller
+// decides whether a request maps to an app (api/app-social-card.ts) and
+// whether the response reaches a browser (Caddy proxies /apps/* documents to
+// Hono precisely so this replacement is visible outside the container).
+
+export const DEFAULT_SOCIAL_IMAGE_URL = "https://romeos.cc/public-og-20260825.jpg";
+
+const START_MARKER = "<!-- rome:social:start -->";
+const END_MARKER = "<!-- rome:social:end -->";
+const TITLE_RE = /<title>[^<]*<\/title>/;
+
+export interface SocialCard {
+  title: string;
+  description: string;
+  /** Absolute URL of the page being shared. */
+  url: string;
+  /** Absolute URL of a 1200x630 image. */
+  imageUrl: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function socialTags(card: SocialCard): string {
+  const t = escapeHtml(card.title);
+  const d = escapeHtml(card.description);
+  const u = escapeHtml(card.url);
+  const i = escapeHtml(card.imageUrl);
+  // One tag per line, never wrapped: Rsbuild drops multi-line <meta> tags.
+  return [
+    '<meta property="og:type" content="website" />',
+    '<meta property="og:site_name" content="Rome" />',
+    `<meta property="og:title" content="${t}" />`,
+    `<meta property="og:description" content="${d}" />`,
+    `<meta property="og:url" content="${u}" />`,
+    `<meta property="og:image" content="${i}" />`,
+    '<meta property="og:image:width" content="1200" />',
+    '<meta property="og:image:height" content="630" />',
+    '<meta name="twitter:card" content="summary_large_image" />',
+    `<meta name="twitter:title" content="${t}" />`,
+    `<meta name="twitter:description" content="${d}" />`,
+    `<meta name="twitter:image" content="${i}" />`,
+  ]
+    .map((line) => `    ${line}`)
+    .join("\n");
+}
+
+/**
+ * Swap the shell's `<title>` and the marked social block for `card`. Returns
+ * the input unchanged when there is no card or the markers are absent, so a
+ * shell built without them still serves.
+ */
+export function renderSocialMeta(indexHtml: string, card: SocialCard | null): string {
+  if (card === null) return indexHtml;
+  const start = indexHtml.indexOf(START_MARKER);
+  const end = indexHtml.indexOf(END_MARKER);
+  if (start === -1 || end === -1 || end < start) return indexHtml;
+
+  const before = indexHtml.slice(0, start + START_MARKER.length);
+  const after = indexHtml.slice(end);
+  const withBlock = `${before}\n${socialTags(card)}\n    ${after}`;
+  return withBlock.replace(TITLE_RE, `<title>${escapeHtml(card.title)}</title>`);
+}

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -55,11 +55,13 @@
          chat app or a timeline is a link to `<slug>.romeos.cc`, which without
          these renders as bare text.
 
-         Static, and identical on every instance: crawlers do not run the SPA, so
-         nothing React sets here would ever be seen, and per-chat titles would
-         have to be rendered server-side. The card carries Rome's own name and
-         nothing about the instance or its contents. The host is not repeated in
-         the title because every platform already renders it beside the card.
+         Static defaults for every route. For `/apps/<id>` and `/full/apps/<id>`
+         document requests the server swaps the block between the two
+         rome:social markers below, and the <title> above, for the routed app
+         (packages/core/src/lib/social-meta.ts; Caddy proxies those paths to
+         Hono for exactly this reason). Keep the markers: the replacer looks
+         for them. The host is not repeated in the title because every
+         platform already renders it beside the card.
 
          The image is the marketing site's, by absolute URL — instances have no
          1200x630 asset of their own and copying one here would be a second
@@ -71,6 +73,7 @@
          `<meta>` split across lines from the emitted HTML — the two description
          tags vanished from dist/index.html that way, and nothing failed. Biome
          ignores this file, so no formatter will rewrap them; a person might. -->
+    <!-- rome:social:start -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Rome" />
     <meta property="og:title" content="Rome OS - Enjoy your life with Rome" />
@@ -82,6 +85,7 @@
     <meta name="twitter:title" content="Rome OS - Enjoy your life with Rome" />
     <meta name="twitter:description" content="Enjoy your life, work, business, and creativity with Rome OS, the private agentic operating system." />
     <meta name="twitter:image" content="https://romeos.cc/public-og-20260825.jpg" />
+    <!-- rome:social:end -->
     <!-- Per-deployment browser config. Referenced unconditionally:
          the committed public/ copy is an empty stub for dev servers and host
          runs; the container-boot script overwrites it in the web root, which is

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -67,7 +67,9 @@
          1200x630 asset of their own and copying one here would be a second
          place to forget. It is datestamped, and rome-cloud renames it on every
          swap so caches refetch, which makes this a link that a swap over there
-         breaks. A dead image costs the picture, not the card.
+         breaks. A dead image costs the picture, not the card. The same URL is
+         DEFAULT_SOCIAL_IMAGE_URL in packages/core/src/lib/social-meta.ts;
+         change both.
 
          Each tag stays on ONE line even where that runs long. Rsbuild drops a
          `<meta>` split across lines from the emitted HTML — the two description

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -67,9 +67,9 @@
          1200x630 asset of their own and copying one here would be a second
          place to forget. It is datestamped, and rome-cloud renames it on every
          swap so caches refetch, which makes this a link that a swap over there
-         breaks. A dead image costs the picture, not the card. The same URL is
-         DEFAULT_SOCIAL_IMAGE_URL in packages/core/src/lib/social-meta.ts;
-         change both.
+         breaks. A dead image costs the picture, not the card. This is the
+         only place the URL lives; social-meta.ts reads it back out of this
+         block when a card has no image of its own.
 
          Each tag stays on ONE line even where that runs long. Rsbuild drops a
          `<meta>` split across lines from the emitted HTML — the two description


### PR DESCRIPTION
## What this PR does

Every link to an app inside an instance — `https://<slug>.romeos.cc/apps/<id>` or `/full/apps/<id>` — previews as the generic Rome card when pasted into Slack, Discord, X, or WeChat. The SPA shell is one static `index.html` that Caddy serves from disk, crawlers do not run the bundle, and nothing React sets is ever seen.

This PR makes the server answer those two document paths itself: Caddy proxies `/apps/*` and `/full/apps/*` to Hono, and Hono returns the same shell with `<title>` and the `og:*` / `twitter:*` block swapped for the routed app's name and description. The image stays the marketing site's static card for now; a follow-up PR generates one per app (see "Not in this PR").

Refs #202.

## Design & Invariants

- The shell stays a static file with one marked block. `packages/core/src/lib/social-meta.ts` is pure string replacement between `<!-- rome:social:start -->` and `<!-- rome:social:end -->`; without a card or without markers it returns the input untouched, so a shell built without them still serves.
- The fallback image has one source: `index.html`. A card without an image of its own keeps whatever `og:image` the shell already carries, so a marketing-card swap is a one-file edit.
- Only app document paths (`/apps`, `/apps/*`, `/full/apps`, `/full/apps/*`) reach Hono. Every other route, hashed asset, and `runtime-config.js` is still delivered from disk by Caddy. In public-access mode the per-app blocks that used to serve the shell from disk now proxy; their auth posture is unchanged (they never had `forward_auth`) and they keep `encode zstd gzip`, as does the open-mode `@appDocs` block.
- Visibility: an app's `displayName` and `description` become readable by anyone holding its URL — for every installed app with a frontend, public or private. Spec decision (owner, 2026-09-09): the card is generated for all apps; these are the manifest fields the author wrote for display, never runtime data.
- The swapped response carries `Cache-Control: no-cache`, the same header Caddy set on the disk-served shell, so a browser never holds a shell whose bundle hashes the next image upgrade removes.
- Unknown apps and apps without a `web` block fall back to the static card.
- `packages/web/index.html` line rule holds: each emitted `<meta>` is a single line (Rsbuild drops multi-line tags).

## Test plan

- [x] `pnpm typecheck` (0 errors)
- [x] `pnpm test:unit` (core 4401, web 1420, rest 559 — all green)
- [x] New tests: `lib/social-meta.test.ts`, `api/app-social-card.test.ts`, `api/app-document-routes.e2e.test.ts` (real `buildApp` + temp webRoot: swapped meta, `no-cache`, sub-path in `og:url`, static shell for unknown apps and `/dashboard`, assets still served), `lib/caddyfile-generator.test.ts` (open + public-access, incl. `encode`); `lib/public-access.test.ts` updated to expect proxied app shells
- [x] `pnpm --filter rome-web build` → `dist/index.html` keeps both markers and `<title>`
- [x] Same black-box run once against the real built `dist/index.html`
- [ ] On a cloud dev instance: `curl -A Twitterbot https://<slug>.romeos.cc/full/apps/<id>` and paste the link into Slack / Discord (the local `pnpm dev:all` loop serves the shell from the Rsbuild dev server without Caddy, so it cannot exercise this path)

## Not in this PR

- Per-app generated card image (`/app-og/<id>.png`, resvg-rendered at install time) — follow-up PR; this PR keeps `og:image` on the static card.

