### PR TITLE
docs(people): define send idempotency contract

### DIFF
--- a/docs/concepts/people.md
+++ b/docs/concepts/people.md
@@ -109,7 +109,7 @@ The outbox holds messages Rome has been asked to send and has not yet seen arriv
 - An outbox row is exactly a send whose message is not on the timeline yet. It is derived from that comparison rather than cleared by anything, so no delivery callback can be missed and the two reads cannot disagree.
 - A message is recognized as arrived by the id the channel gave back, never by its text or its timing. A channel offering direct messaging must return one.
 - A failed send stays until the guardian retries it or discards it. A retry reuses the row, so it never reads as a second message they did not write.
-- The optional `SendMessageRequest.id` is a UUID v4 idempotency key. A client creates one for each composed message and reuses it only when repeating that request. The id joins a local sending row to the server outbox. Repeating the same id, account, and text returns its recorded response without sending again. Reusing an id with another account or text is refused.
+- A client may name a send with an optional UUID v4 idempotency key. It creates one key for each composed message and reuses it only when repeating that request. The key joins a local sending row to the server outbox. Repeating the same key, account, and text returns its recorded response without sending again. Reusing a key with another account or text is refused.
 - Removing an outbox row saves its response in a separate receipt in the same transaction. Receipts survive restarts and expire 24 hours after delivery cleanup or explicit discard. New sends and outbox removals prune expired receipts. After expiry, the same id can start a new send.
 
 **Not to be confused with:**

--- a/docs/concepts/people.md
+++ b/docs/concepts/people.md
@@ -109,7 +109,7 @@ The outbox holds messages Rome has been asked to send and has not yet seen arriv
 - An outbox row is exactly a send whose message is not on the timeline yet. It is derived from that comparison rather than cleared by anything, so no delivery callback can be missed and the two reads cannot disagree.
 - A message is recognized as arrived by the id the channel gave back, never by its text or its timing. A channel offering direct messaging must return one.
 - A failed send stays until the guardian retries it or discards it. A retry reuses the row, so it never reads as a second message they did not write.
-- A client may name a send with a UUID before the request returns. That id joins its local sending row to the server outbox. Repeating the same id, account, and text returns its recorded response without sending again.
+- The optional `SendMessageRequest.id` is a UUID v4 idempotency key. A client creates one for each composed message and reuses it only when repeating that request. The id joins a local sending row to the server outbox. Repeating the same id, account, and text returns its recorded response without sending again. Reusing an id with another account or text is refused.
 - Removing an outbox row saves its response in a separate receipt in the same transaction. Receipts survive restarts and expire 24 hours after delivery cleanup or explicit discard. New sends and outbox removals prune expired receipts. After expiry, the same id can start a new send.
 
 **Not to be confused with:**

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -30,7 +30,7 @@
   // exception: packages/mobile depends on it, but .github/workflows/mobile-ci.yml
   // invokes it at root scope, where that dependency is out of view. Removing it
   // here on the strength of the mobile dependency reintroduces the finding.
-  "ignoreBinaries": ["tailscale", "composio", "rg", "lipo", "vale", "expo"],
+  "ignoreBinaries": ["tailscale", "composio", "rg", "lipo", "vale", "expo", "gofmt"],
 
   // Severity decides the exit code: `error` fails the command, while `warn`
   // prints and passes. The export rules are `warn` because a barrel that

--- a/packages/api-types/src/people.ts
+++ b/packages/api-types/src/people.ts
@@ -1215,8 +1215,10 @@ export function whatsAppDisplayName(contact: {
  * account, and it is a default on screen rather than a decision off it.
  */
 export interface SendMessageRequest {
-  /** Optional UUID v4 for this send. Repeating the same id, account, and text
-   * returns its recorded response until 24 hours after outbox removal. */
+  /** Optional UUID v4 idempotency key. A client creates one for each composed
+   * message and reuses it only when repeating that request. The same id,
+   * account, and text returns its recorded response until 24 hours after
+   * outbox removal. */
   id?: string;
   channel: string;
   channelUserId: string;

--- a/packages/core/src/api/routes/people-send.test.ts
+++ b/packages/core/src/api/routes/people-send.test.ts
@@ -112,6 +112,17 @@ describe("People send API", () => {
     expect(deps.channelPortMap.get("telegram")?.sentMessages).toHaveLength(1);
   });
 
+  it("delivers identical messages when they have distinct send ids", async () => {
+    const body = { channel: "telegram", channelUserId: TG, text: "ok" };
+    const responses = await Promise.all([
+      send({ ...body, id: crypto.randomUUID() }),
+      send({ ...body, id: crypto.randomUUID() }),
+    ]);
+
+    expect(responses.map((response) => response.status)).toEqual([202, 202]);
+    expect(deps.channelPortMap.get("telegram")?.sentMessages).toHaveLength(2);
+  });
+
   it("refuses reuse of a send id for different text or another account", async () => {
     const body = { id: crypto.randomUUID(), channel: "telegram", channelUserId: TG, text: "hello" };
     expect((await send(body)).status).toBe(202);


### PR DESCRIPTION
## What this PR does

The People send contract identifies `SendMessageRequest.id` only as a send UUID. This leaves its idempotency role and client lifecycle implicit.

The contract now names the UUID as an idempotency key. It tells clients to create one key per composed message and reuse it only when repeating that request. A server regression test also confirms that identical text with distinct keys still delivers twice.

Current `main` also fails its zero-dead-code gate because the host-helper workflow invokes `gofmt` without registering that host binary. This PR adds the missing Knip declaration so the required lint check can evaluate the People change.

## Design & Invariants

- A repeated request uses the same UUID, account, and text. It returns the recorded `OutboxMessage` without another provider call.
- A new composed message gets a new UUID, even when its text matches another message. The server never deduplicates by content.
- Reusing a UUID with another account or text is refused. A receipt keeps the successful request replayable for 24 hours after outbox removal.
- The Outbox concept remains distinct from Timeline and Link across the API, repository, and UI. No concept entry qualifies for removal.

The durable contract lives in [People: Outbox](https://github.com/rome-os/rome/blob/docs/people-send-idempotency-contract/docs/concepts/people.md#outbox).

## Test plan

- [x] `pnpm --filter @rome/core exec rstest run src/api/routes/people-send.test.ts` (25 tests)
- [x] `pnpm typecheck`
- [x] `pnpm test:unit` (all workspace unit suites)
- [x] `pnpm lint:deadcode`
- [x] `pnpm exec biome check packages/api-types/src/people.ts packages/core/src/api/routes/people-send.test.ts`
- [x] `pnpm exec biome check --vcs-enabled=false knip.jsonc`
- [x] `git diff --check`
- [ ] `pnpm lint:prose` requires Vale, which is not installed on this host. CI runs it with the repository toolchain.

Closes #211

