### PR TITLE
ci: add dashboard mock deployment to Cloudflare Pages

### DIFF
--- a/.github/workflows/dashboard-mock-deploy.yml
+++ b/.github/workflows/dashboard-mock-deploy.yml
@@ -1,0 +1,61 @@
+name: Deploy Dashboard Mock
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dashboard-mock-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check Cloudflare configuration
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CLOUDFLARE_ACCOUNT_ID" ] || [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "::error::Set the CLOUDFLARE_ACCOUNT_ID repository variable and CLOUDFLARE_API_TOKEN repository secret. See docs/dashboard-mock-mode.md."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build static dashboard mock
+        run: pnpm build:web:mock
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.130.0"
+          command: pages deploy packages/web/dist-mock --project-name=rome-dashboard-mock --branch=main
+
+      - name: Report deployment
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+        run: |
+          {
+            echo "Dashboard: https://rome-dashboard-mock.pages.dev"
+            echo "Deployment: $DEPLOYMENT_URL"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/dashboard-mock-mode.md
+++ b/docs/dashboard-mock-mode.md
@@ -4,7 +4,29 @@
 
 `index.ts` holds the shell probes (`/api/health`, `/api/bootstrap`), chat, and the connection routes. It composes the per-surface modules beside it: `apps.ts`, `activity.ts`, `people.ts`, `routines.ts`, `settings.ts`. The two file browsers go through `file-browser.ts`, an in-memory filesystem the projects tree and the memory dir (`memory-files.ts`) are each served from — `/api/projects` and `/api/memory` are the same routes over a different root, so one factory answers both. The connection ledger itself lives in `connections-store.ts`, because the People page's send routes have to see a grant the Connections page revoked. Unhandled requests pass through the normal dev proxy. With a real backend running on `INTERNAL_API_PORT`, mock mode therefore doubles as an "override one endpoint" tool.
 
-Mock mode is a separate entry (`mock/rsbuild.config.ts` plus `mock/main.tsx`) rather than a dev branch in the SPA. `pnpm build` only reads the root config, so MSW and the fixtures never reach a production bundle.
+Mock mode is a separate entry (`mock/rsbuild.config.ts` plus `mock/main.tsx`) rather than a dev branch in the SPA. `pnpm build` only reads the root config, so the shipping dashboard bundle excludes MSW and the fixtures.
+
+## Static builds and Cloudflare Pages
+
+Run `pnpm build:web:mock` to build the mock dashboard into `packages/web/dist-mock`. The command rebuilds the shared kit and typechecks the dashboard before bundling.
+The static config uses production mode and omits source maps. The `/dev` galleries are excluded, while MSW and its fixtures remain in the mock entry.
+
+The output includes `mockServiceWorker.js` and a Pages `_headers` file that requires the browser to revalidate the worker script.
+Cloudflare Pages supplies the SPA fallback because the output has no top-level `404.html`.
+The static site has no backend proxy. The limitations below apply to the deployed site, and in-memory fixture writes reset on reload.
+
+The [Deploy Dashboard Mock workflow](../.github/workflows/dashboard-mock-deploy.yml) updates the `rome-dashboard-mock` Pages project through Direct Upload.
+It runs manually on `main`, serializes deployments, and reports the deployment URL in the run summary.
+
+To configure the workflow:
+
+1. Create a Cloudflare API token with **Account → Cloudflare Pages → Edit**, restricted to the account that owns `rome-dashboard-mock`.
+2. Store the token in the GitHub repository secret `CLOUDFLARE_API_TOKEN`.
+3. Set the repository variable `CLOUDFLARE_ACCOUNT_ID` to the owning Cloudflare account ID.
+4. In GitHub Actions, select **Deploy Dashboard Mock → Run workflow**, with `main` selected.
+
+The workflow must be present on the default branch before GitHub exposes its manual trigger.
+Credential setup follows [Cloudflare's Direct Upload CI guide](https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/).
 
 ## Never reimplement what core owns
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -30,7 +30,7 @@
   // exception: packages/mobile depends on it, but .github/workflows/mobile-ci.yml
   // invokes it at root scope, where that dependency is out of view. Removing it
   // here on the strength of the mobile dependency reintroduces the finding.
-  "ignoreBinaries": ["tailscale", "composio", "rg", "lipo", "vale", "expo"],
+  "ignoreBinaries": ["tailscale", "composio", "rg", "lipo", "vale", "expo", "gofmt"],
 
   // Severity decides the exit code: `error` fails the command, while `warn`
   // prints and passes. The export rules are `warn` because a barrel that
@@ -95,6 +95,7 @@
         ".storybook/*.test.ts",
         "mock/main.tsx",
         "mock/rsbuild.config.ts",
+        "mock/rsbuild.static.config.ts",
         // The desktop VNC suite reaches both of these through a string, not an
         // import: playwright.desktop-vnc.config.ts names the rsbuild config in
         // its `webServer.command`, and that config swaps @novnc/novnc for

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "pnpm build:apps && pnpm --filter @rome/core dev",
     "start:web": "pnpm --filter rome-web dev",
     "start:web:mock": "pnpm --filter rome-web dev:mock",
+    "build:web:mock": "pnpm --filter rome-web build:mock",
     "storybook": "pnpm --filter rome-web storybook",
     "build:storybook": "pnpm --filter rome-web build:storybook",
     "desktop:image:local": "pnpm --filter rome-desktop image:local",

--- a/packages/web/mock/public/_headers
+++ b/packages/web/mock/public/_headers
@@ -1,0 +1,2 @@
+/mockServiceWorker.js
+  Cache-Control: no-cache

--- a/packages/web/mock/rsbuild.static.config.ts
+++ b/packages/web/mock/rsbuild.static.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "@rsbuild/core";
+import mockConfig from "./rsbuild.config";
+
+export default defineConfig({
+  ...mockConfig,
+  mode: "production",
+  output: {
+    ...mockConfig.output,
+    sourceMap: false,
+  },
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,6 +9,7 @@
     "storybook": "storybook dev --host 127.0.0.1 --port 6006 --exact-port --no-open",
     "build:storybook": "storybook build --output-dir ../../storybook-static",
     "build:kit": "pnpm --filter \"rome-web^...\" run build",
+    "build:mock": "pnpm build:kit && tsc --noEmit && rsbuild build --config mock/rsbuild.static.config.ts",
     "build": "tsc --noEmit && rsbuild build",
     "typecheck": "tsc --noEmit",
     "preview": "rsbuild preview",

--- a/scripts/check-token-declaration-ownership.test.mjs
+++ b/scripts/check-token-declaration-ownership.test.mjs
@@ -16,7 +16,7 @@ function cssFiles(directory) {
   while (queue.length > 0) {
     const current = queue.pop();
     for (const entry of readdirSync(current, { withFileTypes: true })) {
-      if (entry.isDirectory() && !["dist", "node_modules"].includes(entry.name)) {
+      if (entry.isDirectory() && !["dist", "dist-mock", "node_modules"].includes(entry.name)) {
         queue.push(join(current, entry.name));
       } else if (entry.isFile() && entry.name.endsWith(".css")) {
         files.push(join(current, entry.name));


### PR DESCRIPTION
## What this PR does

The dashboard mock deployment requires an ad hoc local build and upload. Add a manual GitHub Actions workflow that builds `main` and updates the existing `rome-dashboard-mock` Cloudflare Pages project.

`pnpm build:web:mock` rebuilds the shared UI packages, typechecks the dashboard, and produces static assets without source maps. The output includes MSW and its cache headers. Exclude `dist-mock` from the token ownership check so generated CSS does not produce false duplicate declarations after a build.

Declare the static Rsbuild configuration as a Knip entry and `gofmt` as a host tool used by the host-helper workflow.

## Design & Invariants

- The shipping dashboard keeps its existing build entry and excludes mock fixtures.
- Deployments run manually on `main` and are serialized. Missing Cloudflare configuration fails before dependency installation.
- Setup and static hosting limitations are documented in `docs/dashboard-mock-mode.md`.
- The repository account ID variable is configured. `CLOUDFLARE_API_TOKEN` still needs a token with Cloudflare Pages Edit permission before the workflow can run.

## Test plan

- [x] `pnpm typecheck` and `pnpm test:unit` on host Node 24.
- [x] `pnpm build:web:mock`: verified the worker, cache headers, asset size limits, and absence of source maps.
- [x] `pnpm lint:deadcode` with the zero-error gate on current `main`.
- [x] Actionlint 1.7.12, `pnpm lint:prose`, Biome commit hook, and `git diff --check`.
- [x] Browser check of the new local static build's Apps page.
- [x] Existing Pages deployment: verified chat history, direct subpage refresh, and trace loading.
- [ ] `pnpm dev:all`: timed out waiting for `/api/health` while first-party apps were being installed. `Rome started` was not confirmed.
- [ ] Run the GitHub deployment workflow after merge and API token configuration.
