### PR TITLE
feat(web): add sidebar app context menu

### DIFF
--- a/packages/web/src/i18n/locales/en/apps.json
+++ b/packages/web/src/i18n/locales/en/apps.json
@@ -105,6 +105,7 @@
     "loading": "Loading apps...",
     "openLabelAria": "Open {{name}} in full view",
     "openFullTitle": "Open full view",
+    "openSplitTitle": "Open in split view",
     "openButton": "Open",
     "upgradeButton": "Upgrade → v{{version}}",
     "upgradeTitle": "Upgrade {{name}} to v{{version}}",

--- a/packages/web/src/i18n/locales/zh-CN/apps.json
+++ b/packages/web/src/i18n/locales/zh-CN/apps.json
@@ -105,6 +105,7 @@
     "loading": "正在加载应用...",
     "openLabelAria": "在完整视图中打开 {{name}}",
     "openFullTitle": "打开完整视图",
+    "openSplitTitle": "在分屏视图中打开",
     "openButton": "打开",
     "upgradeButton": "升级 → v{{version}}",
     "upgradeTitle": "将 {{name}} 升级到 v{{version}}",

--- a/packages/web/src/shell/AppGrid.context-menu.test.tsx
+++ b/packages/web/src/shell/AppGrid.context-menu.test.tsx
@@ -1,0 +1,176 @@
+// @rstest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, rs } from "@rstest/core";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import i18n from "@/i18n";
+import { AppGrid, STORAGE_KEY } from "./AppGrid";
+
+const apps = [
+  {
+    id: "recipe-box",
+    displayName: "Recipe Box",
+    status: "active",
+    hasFrontend: true,
+    href: "/apps/recipe-box",
+    iconUrl: null,
+  },
+];
+
+const fetchMock = rs.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = String(input);
+  if (url === "/api/apps") {
+    return new Response(JSON.stringify({ apps }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  if (url === "/api/apps/updates") {
+    return new Response(JSON.stringify({ upgradable: [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  if (url === "/api/settings" && (!init?.method || init.method === "GET")) {
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  if (url === "/api/settings" && init?.method === "PUT") {
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return new Response(null, { status: 404 });
+});
+
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <output data-testid="location">
+      {JSON.stringify({
+        pathname: location.pathname,
+        search: location.search,
+        state: location.state,
+      })}
+    </output>
+  );
+}
+
+function renderSidebar(collapsed: boolean, initialPath = "/apps") {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <AppGrid collapsed={collapsed} />
+        <LocationProbe />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+async function findPinnedAppLink(): Promise<HTMLAnchorElement> {
+  let link: HTMLAnchorElement | null = null;
+  await waitFor(() => {
+    link = document.querySelector('a[href="/apps/recipe-box"]');
+    expect(link).toBeTruthy();
+  });
+  return link as HTMLAnchorElement;
+}
+
+beforeAll(async () => {
+  await i18n.changeLanguage("en");
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+});
+
+beforeEach(() => {
+  fetchMock.mockClear();
+  rs.stubGlobal("fetch", fetchMock);
+  localStorage.setItem("rome-sidebar-apps", JSON.stringify(apps));
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([{ type: "app", id: "recipe-box" }]));
+});
+
+afterEach(() => {
+  cleanup();
+  rs.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe.each([
+  ["expanded sidebar", false],
+  ["collapsed rail", true],
+] as const)("pinned app context menu in the %s", (_name, collapsed) => {
+  it("offers normal, split-view, and unpin actions", async () => {
+    renderSidebar(collapsed);
+
+    fireEvent.contextMenu(await findPinnedAppLink());
+
+    const menu = await screen.findByRole("menu");
+    expect(
+      within(menu)
+        .getAllByRole("menuitem")
+        .map((item) => item.textContent),
+    ).toEqual(["Open", "Open in split view", "Unpin from sidebar"]);
+  });
+});
+
+it("opens a pinned app beside a new chat from another page", async () => {
+  const user = userEvent.setup();
+  renderSidebar(false, "/projects");
+
+  fireEvent.contextMenu(await findPinnedAppLink());
+  await user.click(await screen.findByRole("menuitem", { name: "Open in split view" }));
+
+  expect(screen.getByTestId("location").textContent).toBe(
+    JSON.stringify({
+      pathname: "/chat",
+      search: "",
+      state: { widgets: [{ type: "app", appId: "recipe-box" }] },
+    }),
+  );
+});
+
+it("keeps the active chat when opening a pinned app in split view", async () => {
+  const user = userEvent.setup();
+  renderSidebar(false, "/chat/session-1?hideSidebar=1");
+
+  fireEvent.contextMenu(await findPinnedAppLink());
+  await user.click(await screen.findByRole("menuitem", { name: "Open in split view" }));
+
+  expect(screen.getByTestId("location").textContent).toBe(
+    JSON.stringify({
+      pathname: "/chat/session-1",
+      search: "?hideSidebar=1",
+      state: { widgets: [{ type: "app", appId: "recipe-box" }] },
+    }),
+  );
+});
+
+it("unpins the app from its context menu", async () => {
+  const user = userEvent.setup();
+  renderSidebar(false);
+
+  fireEvent.contextMenu(await findPinnedAppLink());
+  await user.click(await screen.findByRole("menuitem", { name: "Unpin from sidebar" }));
+
+  expect(document.querySelector('a[href="/apps/recipe-box"]')).toBeNull();
+  expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]")).not.toContainEqual({
+    type: "app",
+    id: "recipe-box",
+  });
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/settings",
+      expect.objectContaining({
+        method: "PUT",
+        body: expect.stringContaining('"sidebarPins"'),
+      }),
+    );
+  });
+});

--- a/packages/web/src/shell/AppGrid.tsx
+++ b/packages/web/src/shell/AppGrid.tsx
@@ -8,23 +8,33 @@ import {
   Pencil2Icon,
 } from "@radix-ui/react-icons";
 import {
+  AppWindow,
   Chrome as ChromeIcon,
   Ellipsis,
   FolderKanban,
   GripVertical,
   MessagesSquare,
+  PanelRightOpen,
   Pencil,
+  PinOff,
   Plus,
   Search,
   Store,
   X,
 } from "lucide-react";
 import type { ComponentType } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import type { InstalledAppCard } from "@rome/api-types/apps";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -217,7 +227,9 @@ interface AppGridProps {
 
 export function AppGrid({ headerControlsHost, collapsed, onSearch }: AppGridProps = {}) {
   const { t } = useTranslation("common");
+  const { t: tApps } = useTranslation("apps");
   const location = useLocation();
+  const navigate = useNavigate();
   const [pins, setPins] = useState<PinnedEntry[]>(() =>
     normalizeSidebarPins(readLocalPins() ?? DEFAULT_SIDEBAR_PINS),
   );
@@ -268,9 +280,56 @@ export function AppGrid({ headerControlsHost, collapsed, onSearch }: AppGridProp
       setPins(safe);
       writeLocalPins(safe);
       void saveSetting("sidebarPins", safe).then(() => invalidateSettings());
+      window.dispatchEvent(new Event("rome-pins-changed"));
     },
     [invalidateSettings],
   );
+
+  const openAppInSplitView = useCallback(
+    (appId: string) => {
+      const currentChat = location.pathname === "/chat" || location.pathname.startsWith("/chat/");
+      const destination = currentChat
+        ? `${location.pathname}${location.search}${location.hash}`
+        : "/chat";
+      navigate(destination, {
+        state: { widgets: [{ type: "app", appId }] },
+      });
+    },
+    [location.hash, location.pathname, location.search, navigate],
+  );
+
+  const withAppContextMenu = (
+    app: InstalledAppCard | CachedApp,
+    trigger: React.ReactNode,
+  ): React.ReactNode => {
+    if (!app.href) return trigger;
+    return (
+      <ContextMenu>
+        <ContextMenuTrigger asChild>{trigger}</ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem asChild>
+            <Link to={app.href}>
+              <AppWindow aria-hidden />
+              {tApps("installed.openButton")}
+            </Link>
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => openAppInSplitView(app.id)}>
+            <PanelRightOpen aria-hidden />
+            {tApps("installed.openSplitTitle")}
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            onSelect={() =>
+              persistPins(pins.filter((pin) => !(pin.type === "app" && pin.id === app.id)))
+            }
+          >
+            <PinOff aria-hidden />
+            {tApps("installed.unpin")}
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    );
+  };
 
   const builtinMap = new Map(APP_NAV.map((b) => [b.id, b]));
 
@@ -415,22 +474,25 @@ export function AppGrid({ headerControlsHost, collapsed, onSearch }: AppGridProp
             const active = isEntryActive(location.pathname, app.href);
             return (
               <Tooltip key={`app-${pin.id}`}>
-                <TooltipTrigger asChild>
-                  <Link
-                    to={app.href}
-                    aria-label={app.displayName}
-                    className={`${RAIL_LINK_CLASS} ${active ? RAIL_ACTIVE_CLASS : RAIL_IDLE_CLASS}`}
-                  >
-                    {resolveIcon(pin)}
-                    {app.status === "disabled" ? (
-                      <span
-                        className="absolute right-2 top-2 h-1.5 w-1.5 rounded-full bg-border-strong"
-                        role="img"
-                        aria-label={t("sidebar.appDisabled")}
-                      />
-                    ) : null}
-                  </Link>
-                </TooltipTrigger>
+                {withAppContextMenu(
+                  app,
+                  <TooltipTrigger asChild>
+                    <Link
+                      to={app.href}
+                      aria-label={app.displayName}
+                      className={`${RAIL_LINK_CLASS} ${active ? RAIL_ACTIVE_CLASS : RAIL_IDLE_CLASS}`}
+                    >
+                      {resolveIcon(pin)}
+                      {app.status === "disabled" ? (
+                        <span
+                          className="absolute right-2 top-2 h-1.5 w-1.5 rounded-full bg-border-strong"
+                          role="img"
+                          aria-label={t("sidebar.appDisabled")}
+                        />
+                      ) : null}
+                    </Link>
+                  </TooltipTrigger>,
+                )}
                 <TooltipContent side="right">{app.displayName}</TooltipContent>
               </Tooltip>
             );
@@ -686,35 +748,39 @@ export function AppGrid({ headerControlsHost, collapsed, onSearch }: AppGridProp
             if (!app || !app.hasFrontend || !app.href) return null;
             const active = isEntryActive(location.pathname, app.href);
             return (
-              <Link
-                key={`app-${pin.id}`}
-                to={app.href}
-                title={app.displayName}
-                className={`${LINK_CLASS} ${active ? "bg-surface shadow-1 dark:bg-surface-hover" : "hover:bg-surface-hover dark:hover:bg-surface"}`}
-              >
-                {app.iconUrl ? (
-                  <img
-                    src={app.iconUrl}
-                    alt=""
-                    className="h-4 w-4 shrink-0 rounded-4"
-                    onError={(e) => {
-                      (e.target as HTMLImageElement).style.display = "none";
-                    }}
-                  />
-                ) : (
-                  <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-4 bg-surface-muted text-aux text-muted-foreground">
-                    {app.displayName.charAt(0).toUpperCase()}
-                  </span>
+              <Fragment key={`app-${pin.id}`}>
+                {withAppContextMenu(
+                  app,
+                  <Link
+                    to={app.href}
+                    title={app.displayName}
+                    className={`${LINK_CLASS} ${active ? "bg-surface shadow-1 dark:bg-surface-hover" : "hover:bg-surface-hover dark:hover:bg-surface"}`}
+                  >
+                    {app.iconUrl ? (
+                      <img
+                        src={app.iconUrl}
+                        alt=""
+                        className="h-4 w-4 shrink-0 rounded-4"
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).style.display = "none";
+                        }}
+                      />
+                    ) : (
+                      <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-4 bg-surface-muted text-aux text-muted-foreground">
+                        {app.displayName.charAt(0).toUpperCase()}
+                      </span>
+                    )}
+                    <span className="flex-1 truncate">{app.displayName}</span>
+                    {app.status === "disabled" ? (
+                      <span
+                        className="h-1.5 w-1.5 shrink-0 rounded-full bg-border-strong"
+                        role="img"
+                        aria-label={t("sidebar.appDisabled")}
+                      />
+                    ) : null}
+                  </Link>,
                 )}
-                <span className="flex-1 truncate">{app.displayName}</span>
-                {app.status === "disabled" ? (
-                  <span
-                    className="h-1.5 w-1.5 shrink-0 rounded-full bg-border-strong"
-                    role="img"
-                    aria-label={t("sidebar.appDisabled")}
-                  />
-                ) : null}
-              </Link>
+              </Fragment>
             );
           })}
         </nav>


### PR DESCRIPTION
## What this PR does

Apps pinned to the sidebar had no contextual actions, so opening an app alongside a chat required navigating to Chat and finding the app again. This adds a context menu to pinned apps in both the expanded sidebar and collapsed rail, with actions to open, open in split view, and unpin.

## Design & Invariants

Split view uses the existing chat workspace widget-seeding contract. When a chat is active, its route and query are preserved; from other pages, the action starts a new chat workspace. Existing left-click navigation remains unchanged, and pin changes continue to persist locally and to settings.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm --filter rome-web test`
- [x] `pnpm --filter rome-web build`
- [x] `pnpm exec biome check packages/web/src/shell/AppGrid.tsx packages/web/src/shell/AppGrid.context-menu.test.tsx packages/web/src/i18n/locales/en/apps.json packages/web/src/i18n/locales/zh-CN/apps.json`
- [ ] Browser smoke test (mock mode currently fails before app mount with existing `$RefreshReg$ is not defined` in `@rome-os/ui/sonner`)
