### PR TITLE
feat(core): allow exact model IDs in app agent configs

### DIFF
--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -1,14 +1,42 @@
 # Agents
 
-An agent is an LLM-backed runtime entity: a named configuration that sets a model tier, a set of builtin tools and callable [actions](actions.md), a system prompt, and optionally the subagents it may delegate to. The runtime assembles the system prompt from the shared agent charter, the agent's own identity, and runtime context.
+An agent is an LLM-backed runtime entity: a named configuration that sets a model tier or an exact model ID, a set of builtin tools and callable [actions](actions.md), a system prompt, and optionally the subagents it may delegate to. The runtime assembles the system prompt from the shared agent charter, the agent's own identity, and runtime context.
 
 **Contracts:**
 
 - An agent definition declares a [local artifact name](apps.md#artifact-names-and-references). The name cannot contain `:`, and `main` is reserved for Rome Core. Its `actions` and `allowedSubagents` references use canonical `<app-id>:<local-name>` ids for both same-app and cross-app references.
-- The agent abstraction is provider-agnostic. An agent names a model *tier*, never a concrete model. The runtime maps each tier to a concrete model, and swapping the model provider does not change the agent contract.
-- An agent whose behavior depends on a provider-specific capability may pin a provider. The pin is fail-closed: a pinned agent's sessions resolve only on that provider, and fail with a clear error rather than silently falling back to a provider that lacks the capability.
-- Every agent conversation happens within a [session](sessions.md). There is no session-less agent turn.
+- An agent can remain provider-agnostic by declaring `tier: large|medium|small`. The runtime maps the tier to an available provider and concrete model.
+- An agent whose behavior depends on a provider-specific capability may pin a provider. A provider-pinned tier resolves only on that provider and fails rather than falling back to another provider.
+- An agent that needs a specific model may declare `provider` with `modelId` instead of a tier. Rome requests that exact ID without tier mapping or automatic substitution. The provider and connected account must support the requested model.
+- Every agent conversation happens within a [session](sessions.md). There is no session-less agent turn. Explicit guardian selections and saved session pins take precedence over the agent's configured model.
 - Each subagent has a restricted capability set appropriate to its role. Delegation never widens capabilities.
+
+## Model selection
+
+Use a tier when the app should run across providers. Add `provider: openai` or `provider: anthropic` to restrict tier resolution to one provider. Use `modelId` when a particular provider model is required:
+
+```yaml
+name: fast_coding_agent
+description: Completes coding tasks with a specific model.
+provider: openai
+modelId: gpt-5.3-codex-spark
+reasoningEffort: high
+permissionMode: default
+tools:
+  - Read
+systemPromptPrefix: Complete the requested coding task.
+```
+
+`modelId` is the provider's model ID, not a WebChat selector slug. For example, `gpt-5.6-terra` is a provider ID while `gpt-5-6-terra` is a selector slug. IDs do not need to appear in Rome's WebChat catalog. Rome checks provider availability and known entitlements, and the provider validates IDs it receives. Declaring an ID does not grant access to that model.
+
+**Validation:**
+
+- `modelId` requires `provider: openai|anthropic` and a nonempty string containing no whitespace. Rome preserves the ID rather than trimming or rewriting it.
+- `modelId` cannot be combined with `tier`, legacy `model`, or `codeBacked: true`.
+- Without `modelId`, a tier is required. Legacy `model: opus|sonnet|haiku` remains accepted and normalizes to `large|medium|small`.
+- The same schema validates runtime agent loading and packed-app installation. Older Rome versions that do not recognize `modelId` reject it rather than silently ignoring the pin.
+
+An agent model pin supplies the default for a new session, not an instruction to migrate existing history. Changing the YAML affects new sessions. Existing sessions retain their [session model pin](sessions.md#model-pin) unless the guardian explicitly selects another model.
 
 ## Structured output
 

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -24,15 +24,17 @@ A session remembers the concrete model that produced its history — the **sessi
 
 **Contracts:**
 
-- A successful turn establishes or updates the pin. A pinned session never drifts to another model on its own. A session with no pin resolves by tier until its next successful turn records one.
-- Resolution precedence for a turn is **explicit guardian selection → session pin → agent tier**. An explicit model selection (the webchat model selector) wins over the pin, and the successful turn then re-pins the session to the model that actually ran. Choosing a model is therefore the rescue path for a session stranded by a pin whose model cannot run.
-- A pinned model is **fail-closed**: if it cannot run (logged out, quota-exhausted, or entitlement lost), the turn fails with a structured resolution error rather than silently substituting another model. Recovery is an explicit selection or a new session.
-- Forks inherit the live session's model and never write pins. A new session — including a summoned or subagent session on a shared thread — resolves from its own tier, because session lookup is agent-scoped.
+- A successful turn establishes or updates the pin. A pinned session never drifts to another model on its own. A session with no pin resolves from the agent's exact `modelId`, when configured, or its tier until its next successful turn records a pin.
+- Resolution precedence for a turn is **explicit guardian selection → session pin → agent modelId → agent tier**. An explicit model selection (the webchat model selector) wins over both pins, and the successful turn then re-pins the session to the model that actually ran. Choosing a model is therefore the rescue path for a session stranded by a pin whose model cannot run.
+- A pinned model is **fail-closed**: if it cannot run (logged out, quota-exhausted, or entitlement lost), the turn fails with a structured resolution error rather than silently substituting another model. Recovery is an explicit selection, or a new session whose configured model is available.
+- A new session — including a summoned or subagent session on a shared thread — resolves from its own agent's exact model or tier, because session lookup is agent-scoped. A fork inherits the live session's model unless its caller supplies a tier override, and never updates its source session's pin.
+- Changing an agent's configured `modelId` does not rewrite a saved session pin. The changed default applies to new or unpinned sessions.
 
 **Not to be confused with:**
 
-- **Provider pin** — an [agent](agents.md) may pin a *provider* for capability reasons. The session model pin records the concrete *model* a session's history was produced by.
-- **Model tier** — the tier is the agent-level default the pin overrides once a turn has run.
+- **Provider pin** — an [agent](agents.md) may pin a *provider* while still letting a tier select the concrete model.
+- **Agent model pin** — `provider` with `modelId` supplies an exact default for a new or unpinned session. The session model pin records the model that produced existing history and takes precedence over that default.
+- **Model tier** — the portable agent-level default the session pin overrides once a turn has run.
 
 ## Agent run
 
@@ -94,7 +96,7 @@ The caller creating the fork chooses one of two modes:
 The caller also chooses how long the fork's provider branch lives:
 
 - **One-shot** (the default) — the provider branch is disposable. It closes when the single turn completes, and nothing can resume it. Recap and turn-feedback forks run this way.
-- **Continuable** — the caller asks for a provider thread of its own and Rome pins an agent session to it when the turn completes. Later turns resume that thread, so the fork becomes a conversation the guardian can keep talking to. A side chat runs this way.
+- **Continuable** — the caller asks for a provider thread of its own and Rome pins an agent session to it when the turn completes. Later turns resume that thread, so the fork becomes a conversation the guardian can keep talking to.
 
 **Contracts:**
 

--- a/packages/core/src/apps/packaging/agent-model-config.test.ts
+++ b/packages/core/src/apps/packaging/agent-model-config.test.ts
@@ -32,12 +32,19 @@ describe("agent exact model configuration", () => {
     expect(issuePaths({ modelId: "gpt-5.3-codex-spark" })).toContain("provider");
   });
 
-  it.each(["", " ", " model", "model ", "two models", "model\n", "model\tid", null, 42])(
-    "rejects invalid model ID %j",
-    (modelId) => {
-      expect(issuePaths({ provider: "openai", modelId })).toContain("modelId");
-    },
-  );
+  it.each([
+    "",
+    " ",
+    " model",
+    "model ",
+    "two models",
+    "model\n",
+    "model\tid",
+    null,
+    42,
+  ])("rejects invalid model ID %j", (modelId) => {
+    expect(issuePaths({ provider: "openai", modelId })).toContain("modelId");
+  });
 
   it.each(["mock", "unknown", "", null])("rejects invalid provider %j", (provider) => {
     expect(issuePaths({ provider, modelId: "exact-model" })).toContain("provider");
@@ -48,13 +55,15 @@ describe("agent exact model configuration", () => {
   });
 
   it.each(["opus", "sonnet", "haiku"])("rejects modelId combined with legacy model %s", (model) => {
-    expect(issuePaths({ provider: "anthropic", modelId: "exact-model", model })).toContain("modelId");
+    expect(issuePaths({ provider: "anthropic", modelId: "exact-model", model })).toContain(
+      "modelId",
+    );
   });
 
   it("rejects a meaningless pin on a code-backed agent", () => {
-    expect(
-      issuePaths({ provider: "openai", modelId: "exact-model", codeBacked: true }),
-    ).toContain("modelId");
+    expect(issuePaths({ provider: "openai", modelId: "exact-model", codeBacked: true })).toContain(
+      "modelId",
+    );
   });
 
   it("requires a selection rather than silently defaulting", () => {

--- a/packages/core/src/apps/packaging/agent-model-config.test.ts
+++ b/packages/core/src/apps/packaging/agent-model-config.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "@rstest/core";
+import { AgentConfigSchema } from "./artifact-config.js";
+
+const base = {
+  name: "pinned_agent",
+  description: "An agent with explicit model requirements",
+  systemPromptPrefix: "Complete the requested task.",
+  tools: [],
+  permissionMode: "default",
+};
+
+function issuePaths(input: Record<string, unknown>): string[] {
+  const result = AgentConfigSchema.safeParse({ ...base, ...input });
+  expect(result.success).toBe(false);
+  return result.success ? [] : result.error.issues.map((issue) => issue.path.join("."));
+}
+
+describe("agent exact model configuration", () => {
+  it.each([
+    ["openai", "gpt-5.3-codex-spark"],
+    ["anthropic", "claude-opus-4-6[1m]"],
+    ["openai", "future-model-not-in-the-webchat-catalog"],
+  ])("preserves %s model ID %s without inventing a tier", (provider, modelId) => {
+    const config = AgentConfigSchema.parse({ ...base, provider, modelId });
+    expect(config).toMatchObject({ providerId: provider, modelId, reasoningEffort: "high" });
+    expect(config).not.toHaveProperty("tier");
+    expect(config).not.toHaveProperty("provider");
+    expect(config).not.toHaveProperty("model");
+  });
+
+  it("requires an explicit provider instead of guessing from the ID", () => {
+    expect(issuePaths({ modelId: "gpt-5.3-codex-spark" })).toContain("provider");
+  });
+
+  it.each(["", " ", " model", "model ", "two models", "model\n", "model\tid", null, 42])(
+    "rejects invalid model ID %j",
+    (modelId) => {
+      expect(issuePaths({ provider: "openai", modelId })).toContain("modelId");
+    },
+  );
+
+  it.each(["mock", "unknown", "", null])("rejects invalid provider %j", (provider) => {
+    expect(issuePaths({ provider, modelId: "exact-model" })).toContain("provider");
+  });
+
+  it.each(["large", "medium", "small"])("rejects modelId combined with tier %s", (tier) => {
+    expect(issuePaths({ provider: "openai", modelId: "exact-model", tier })).toContain("modelId");
+  });
+
+  it.each(["opus", "sonnet", "haiku"])("rejects modelId combined with legacy model %s", (model) => {
+    expect(issuePaths({ provider: "anthropic", modelId: "exact-model", model })).toContain("modelId");
+  });
+
+  it("rejects a meaningless pin on a code-backed agent", () => {
+    expect(
+      issuePaths({ provider: "openai", modelId: "exact-model", codeBacked: true }),
+    ).toContain("modelId");
+  });
+
+  it("requires a selection rather than silently defaulting", () => {
+    expect(issuePaths({})).toContain("tier");
+    expect(issuePaths({ provider: "openai" })).toContain("tier");
+  });
+
+  it("preserves strict unknown-field validation", () => {
+    const result = AgentConfigSchema.safeParse({
+      ...base,
+      provider: "openai",
+      modelId: "exact-model",
+      modelID: "misspelled-field",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it.each(["large", "medium", "small"])("preserves portable tier %s", (tier) => {
+    const config = AgentConfigSchema.parse({ ...base, tier });
+    expect(config.tier).toBe(tier);
+    expect(config).not.toHaveProperty("modelId");
+    expect(config).not.toHaveProperty("providerId");
+  });
+
+  it.each([
+    ["opus", "large"],
+    ["sonnet", "medium"],
+    ["haiku", "small"],
+  ])("preserves legacy model %s as tier %s", (model, tier) => {
+    const config = AgentConfigSchema.parse({ ...base, model });
+    expect(config.tier).toBe(tier);
+    expect(config).not.toHaveProperty("model");
+    expect(config).not.toHaveProperty("modelId");
+  });
+
+  it("preserves provider-pinned tiers and existing tier-over-legacy precedence", () => {
+    const config = AgentConfigSchema.parse({
+      ...base,
+      provider: "openai",
+      tier: "small",
+      model: "opus",
+    });
+    expect(config).toMatchObject({ providerId: "openai", tier: "small" });
+  });
+
+  it("preserves reasoning effort and structured-output validation with an exact pin", () => {
+    const outputSchema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+      required: ["answer"],
+      additionalProperties: false,
+    };
+    const config = AgentConfigSchema.parse({
+      ...base,
+      provider: "openai",
+      modelId: "exact-model",
+      reasoningEffort: "low",
+      outputSchema,
+    });
+    expect(config.reasoningEffort).toBe("low");
+    expect(config.outputSchema).toEqual(outputSchema);
+    expect(
+      issuePaths({
+        provider: "openai",
+        modelId: "exact-model",
+        outputSchema: { type: "object", properties: { answer: { type: "not-a-type" } } },
+      }),
+    ).toContain("outputSchema");
+  });
+});

--- a/packages/core/src/apps/packaging/artifact-config.ts
+++ b/packages/core/src/apps/packaging/artifact-config.ts
@@ -7,7 +7,7 @@ const FavorRequirementSchema = z
   .object({
     amount: z.number().int().positive(),
     title: z.string().min(1),
-    summary: z.string().min(1).optional(),
+    summary: z.string().min(1),
     displayFields: z
       .array(
         z
@@ -85,7 +85,11 @@ export const AgentConfigSchema = z
     description: z.string().min(1),
     tier: z.enum(TIER_VALUES).optional(),
     model: z.enum(["opus", "sonnet", "haiku"]).optional(),
-    modelId: z.string().min(1).regex(/^\S+$/u, "Model ID must not contain whitespace").optional(),
+    modelId: z
+      .string()
+      .min(1)
+      .refine((value) => !/\s/u.test(value), "Model ID must not contain whitespace")
+      .optional(),
     reasoningEffort: z.enum(REASONING_EFFORT_VALUES).default(DEFAULT_REASONING_EFFORT),
     provider: z.enum(PROVIDER_VALUES).optional(),
     systemPromptPrefix: z.string().min(1),

--- a/packages/core/src/apps/packaging/artifact-config.ts
+++ b/packages/core/src/apps/packaging/artifact-config.ts
@@ -7,7 +7,7 @@ const FavorRequirementSchema = z
   .object({
     amount: z.number().int().positive(),
     title: z.string().min(1),
-    summary: z.string().min(1),
+    summary: z.string().min(1).optional(),
     displayFields: z
       .array(
         z

--- a/packages/core/src/apps/packaging/artifact-config.ts
+++ b/packages/core/src/apps/packaging/artifact-config.ts
@@ -85,6 +85,7 @@ export const AgentConfigSchema = z
     description: z.string().min(1),
     tier: z.enum(TIER_VALUES).optional(),
     model: z.enum(["opus", "sonnet", "haiku"]).optional(),
+    modelId: z.string().min(1).regex(/^\S+$/u, "Model ID must not contain whitespace").optional(),
     reasoningEffort: z.enum(REASONING_EFFORT_VALUES).default(DEFAULT_REASONING_EFFORT),
     provider: z.enum(PROVIDER_VALUES).optional(),
     systemPromptPrefix: z.string().min(1),
@@ -112,6 +113,29 @@ export const AgentConfigSchema = z
   })
   .strict()
   .superRefine((raw, ctx) => {
+    if (raw.modelId !== undefined) {
+      if (!raw.provider) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["provider"],
+          message: "Required when modelId is set",
+        });
+      }
+      if (raw.tier !== undefined || raw.model !== undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["modelId"],
+          message: "modelId cannot be combined with tier or legacy model",
+        });
+      }
+      if (raw.codeBacked) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["modelId"],
+          message: "Code-backed agents do not use a modelId",
+        });
+      }
+    }
     if (!raw.outputSchema) return;
     const portabilityIssues = validatePortableOutputSchema(raw.outputSchema);
     for (const issue of portabilityIssues) {
@@ -130,15 +154,15 @@ export const AgentConfigSchema = z
   })
   .transform((raw, ctx) => {
     const tier = raw.tier ?? (raw.model ? LEGACY_MODEL_TO_TIER[raw.model] : undefined);
-    if (!tier) {
+    if (!tier && raw.modelId === undefined) {
       ctx.addIssue({
         code: "custom",
         path: ["tier"],
         message:
-          "Required (either `tier: large|medium|small` or legacy `model: opus|sonnet|haiku`)",
+          "Required (either `tier: large|medium|small`, legacy `model: opus|sonnet|haiku`, or `provider` with `modelId`)",
       });
       return z.NEVER;
     }
     const { model: _legacy, tier: _tier, provider, ...rest } = raw;
-    return { ...rest, tier, ...(provider ? { providerId: provider } : {}) };
+    return { ...rest, ...(tier ? { tier } : {}), ...(provider ? { providerId: provider } : {}) };
   });

--- a/packages/core/src/core/agent-model-selection.test.ts
+++ b/packages/core/src/core/agent-model-selection.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "@rstest/core";
+import { resolveAgentModelRequest } from "./agent-model-selection.js";
+import {
+  WEBCHAT_LARGE_MODEL_SELECTIONS,
+  type ModelSelectionId,
+} from "./model-selector.js";
+
+const config = { providerId: "openai" as const, modelId: "gpt-5.3-codex-spark" };
+const sessionPin = { providerId: "anthropic" as const, model: "saved-model[1m]" };
+
+describe("resolveAgentModelRequest", () => {
+  it("resolves a no-tier config to an exact provider/model pair", () => {
+    expect(resolveAgentModelRequest(config)).toEqual({
+      exact: { providerId: "openai", model: "gpt-5.3-codex-spark" },
+    });
+  });
+
+  it("does not require exact IDs to appear in the WebChat catalog", () => {
+    expect(
+      resolveAgentModelRequest({ providerId: "anthropic", modelId: "future-model[1m]" }),
+    ).toEqual({ exact: { providerId: "anthropic", model: "future-model[1m]" } });
+  });
+
+  it("preserves the saved session provider and model over a changed agent config", () => {
+    expect(resolveAgentModelRequest(config, undefined, sessionPin)).toEqual({ exact: sessionPin });
+  });
+
+  it("preserves the saved model over a tier default", () => {
+    expect(resolveAgentModelRequest({ tier: "small" }, undefined, sessionPin)).toEqual({
+      exact: sessionPin,
+    });
+  });
+
+  it.each(Object.keys(WEBCHAT_LARGE_MODEL_SELECTIONS) as ModelSelectionId[])(
+    "lets explicit selection %s override both the saved and agent pins without a tier",
+    (selectionId) => {
+      const { providerId, model } = WEBCHAT_LARGE_MODEL_SELECTIONS[selectionId];
+      expect(resolveAgentModelRequest(config, selectionId, sessionPin)).toEqual({
+        exact: { providerId, model },
+      });
+    },
+  );
+
+  it("uses the provider's model ID rather than the WebChat selection slug", () => {
+    expect(resolveAgentModelRequest(config, "gpt-5-6-terra")).toEqual({
+      exact: { providerId: "openai", model: "gpt-5.6-terra" },
+    });
+  });
+
+  it.each(["large", "medium", "small"] as const)("preserves tier %s", (tier) => {
+    expect(resolveAgentModelRequest({ tier })).toEqual({ tier, providerId: undefined });
+    expect(resolveAgentModelRequest({ tier, providerId: "anthropic" })).toEqual({
+      tier,
+      providerId: "anthropic",
+    });
+  });
+
+  it("rejects a missing selection instead of adding an implicit tier", () => {
+    expect(() => resolveAgentModelRequest({})).toThrow("requires a tier");
+    expect(() => resolveAgentModelRequest({ providerId: "openai" })).toThrow("requires a tier");
+  });
+
+  it("rejects invalid programmatic exact configs instead of falling back", () => {
+    expect(() => resolveAgentModelRequest({ modelId: "exact-model" })).toThrow("requires a provider");
+    expect(() => resolveAgentModelRequest({ providerId: "openai", modelId: "" })).toThrow(
+      "requires a provider",
+    );
+    expect(() => resolveAgentModelRequest({ ...config, tier: "large" })).toThrow(
+      "cannot be combined with tier",
+    );
+  });
+});

--- a/packages/core/src/core/agent-model-selection.test.ts
+++ b/packages/core/src/core/agent-model-selection.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "@rstest/core";
 import { resolveAgentModelRequest } from "./agent-model-selection.js";
-import {
-  WEBCHAT_LARGE_MODEL_SELECTIONS,
-  type ModelSelectionId,
-} from "./model-selector.js";
+import { WEBCHAT_LARGE_MODEL_SELECTIONS, type ModelSelectionId } from "./model-selector.js";
 
 const config = { providerId: "openai" as const, modelId: "gpt-5.3-codex-spark" };
 const sessionPin = { providerId: "anthropic" as const, model: "saved-model[1m]" };
@@ -31,15 +28,14 @@ describe("resolveAgentModelRequest", () => {
     });
   });
 
-  it.each(Object.keys(WEBCHAT_LARGE_MODEL_SELECTIONS) as ModelSelectionId[])(
-    "lets explicit selection %s override both the saved and agent pins without a tier",
-    (selectionId) => {
-      const { providerId, model } = WEBCHAT_LARGE_MODEL_SELECTIONS[selectionId];
-      expect(resolveAgentModelRequest(config, selectionId, sessionPin)).toEqual({
-        exact: { providerId, model },
-      });
-    },
-  );
+  it.each(
+    Object.keys(WEBCHAT_LARGE_MODEL_SELECTIONS) as ModelSelectionId[],
+  )("lets explicit selection %s override both the saved and agent pins without a tier", (selectionId) => {
+    const { providerId, model } = WEBCHAT_LARGE_MODEL_SELECTIONS[selectionId];
+    expect(resolveAgentModelRequest(config, selectionId, sessionPin)).toEqual({
+      exact: { providerId, model },
+    });
+  });
 
   it("uses the provider's model ID rather than the WebChat selection slug", () => {
     expect(resolveAgentModelRequest(config, "gpt-5-6-terra")).toEqual({
@@ -61,7 +57,9 @@ describe("resolveAgentModelRequest", () => {
   });
 
   it("rejects invalid programmatic exact configs instead of falling back", () => {
-    expect(() => resolveAgentModelRequest({ modelId: "exact-model" })).toThrow("requires a provider");
+    expect(() => resolveAgentModelRequest({ modelId: "exact-model" })).toThrow(
+      "requires a provider",
+    );
     expect(() => resolveAgentModelRequest({ providerId: "openai", modelId: "" })).toThrow(
       "requires a provider",
     );

--- a/packages/core/src/core/agent-model-selection.ts
+++ b/packages/core/src/core/agent-model-selection.ts
@@ -1,4 +1,4 @@
-// Model selection contract: docs/architecture/agent-model-selection.md.
+// Model selection contract: docs/concepts/sessions.md#model-pin.
 
 import type { AgentConfig } from "../types.js";
 import type { ExactModelResolutionRequest, ModelResolutionRequest } from "./model-resolver.js";

--- a/packages/core/src/core/agent-model-selection.ts
+++ b/packages/core/src/core/agent-model-selection.ts
@@ -1,0 +1,28 @@
+// Model selection contract: docs/architecture/agent-model-selection.md.
+
+import type { AgentConfig } from "../types.js";
+import type { ExactModelResolutionRequest, ModelResolutionRequest } from "./model-resolver.js";
+import { WEBCHAT_LARGE_MODEL_SELECTIONS, type ModelSelectionId } from "./model-selector.js";
+
+/** Shared by session open and turn-boundary resolution. Never supplies an implicit tier. */
+export function resolveAgentModelRequest(
+  config: Pick<AgentConfig, "tier" | "providerId" | "modelId">,
+  selectionId?: ModelSelectionId,
+  sessionPin?: ExactModelResolutionRequest["exact"],
+): ModelResolutionRequest {
+  if (selectionId) {
+    const { providerId, model } = WEBCHAT_LARGE_MODEL_SELECTIONS[selectionId];
+    return { exact: { providerId, model } };
+  }
+  if (sessionPin) return { exact: sessionPin };
+  if (config.modelId !== undefined) {
+    if (!config.providerId || !config.modelId || config.tier !== undefined) {
+      throw new Error("An agent modelId requires a provider and cannot be combined with tier");
+    }
+    return { exact: { providerId: config.providerId, model: config.modelId } };
+  }
+  if (!config.tier) {
+    throw new Error("Agent config requires a tier or a provider with modelId");
+  }
+  return { tier: config.tier, providerId: config.providerId };
+}

--- a/packages/core/src/core/agent-session-model-pin.test.ts
+++ b/packages/core/src/core/agent-session-model-pin.test.ts
@@ -38,16 +38,18 @@ const key = { agentName: AGENT, channelThreadKey: "webchat:model-pin-test" };
 
 function createProvider(id: ProviderId) {
   const calls: ModelRunParams[] = [];
-  const openSession = rs.fn(async (params: ModelSessionParams) =>
-    createSessionFromRun(
+  const openSession = rs.fn(async (params: ModelSessionParams) => {
+    const session = createSessionFromRun(
       id,
       async function* (input): AsyncIterable<AgentMessage> {
         calls.push(input);
         yield { type: "result", content: "done" };
       },
-      { ...params, providerThreadId: params.providerThreadId ?? `native-${params.sessionId}` },
-    ),
-  );
+      params,
+    );
+    session.providerThreadId = params.providerThreadId ?? `native-${params.sessionId}`;
+    return session;
+  });
   const provider: ModelProvider = {
     id,
     displayName: id,

--- a/packages/core/src/core/agent-session-model-pin.test.ts
+++ b/packages/core/src/core/agent-session-model-pin.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, rs } from "@rstest/core";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ActionEngine } from "../actions/engine.js";
+import { ActionRegistryImpl } from "../actions/registry.js";
+import { SessionsRepository } from "../db/repositories/sessions.js";
+import { createTestDb, type TestDb } from "../test/helpers.js";
+import type { AgentMessage } from "../types.js";
+import { AgentLoader } from "./agent-loader.js";
+import { createAgentLifecycleDispatcher } from "./agent-lifecycle.js";
+import {
+  createSessionFromRun,
+  type ModelProvider,
+  type ModelRunParams,
+  type ModelSessionParams,
+  type ProviderId,
+} from "./agent-runner.js";
+import { createAgentSessionManager, type AgentSessionManager } from "./agent-session.js";
+import { CapabilityDiscovery } from "./capability-discovery.js";
+import { createModelResolver } from "./model-resolver.js";
+import { PromptBuilder } from "./prompt-builder.js";
+import { SessionManager } from "./session-manager.js";
+import { SkillCatalog } from "./skill-catalog.js";
+
+const AGENT = "pinned_agent";
+const MODEL = "gpt-5.3-codex-spark";
+const baseConfig = {
+  name: AGENT,
+  description: "Model pin regression fixture",
+  provider: "openai",
+  modelId: MODEL,
+  systemPromptPrefix: "Complete the task.",
+  tools: [],
+  permissionMode: "default",
+};
+const key = { agentName: AGENT, channelThreadKey: "webchat:model-pin-test" };
+
+function createProvider(id: ProviderId) {
+  const calls: ModelRunParams[] = [];
+  const openSession = rs.fn(async (params: ModelSessionParams) =>
+    createSessionFromRun(
+      id,
+      async function* (input): AsyncIterable<AgentMessage> {
+        calls.push(input);
+        yield { type: "result", content: "done" };
+      },
+      { ...params, providerThreadId: params.providerThreadId ?? `native-${params.sessionId}` },
+    ),
+  );
+  const provider: ModelProvider = {
+    id,
+    displayName: id,
+    builtinTools: new Set<string>(),
+    openSession,
+  };
+  return { provider, openSession, calls };
+}
+
+function healthyState() {
+  return {
+    codex: { loggedIn: true, quotaExhausted: false, solAccess: true, lunaAccess: true },
+    claude: { loggedIn: true, quotaExhausted: false },
+  };
+}
+
+async function collect(events: AsyncIterable<AgentMessage>): Promise<AgentMessage[]> {
+  const messages: AgentMessage[] = [];
+  for await (const message of events) messages.push(message);
+  return messages;
+}
+
+describe("agent model pins through AgentSessionManager", () => {
+  let directory: string;
+  let testDb: TestDb;
+  let loader: AgentLoader;
+  let sessionManager: SessionManager;
+  let openai: ReturnType<typeof createProvider>;
+  let anthropic: ReturnType<typeof createProvider>;
+  let state: ReturnType<typeof healthyState>;
+  const managers: AgentSessionManager[] = [];
+
+  async function writeConfig(overrides: Record<string, unknown> = {}): Promise<void> {
+    const config = { ...baseConfig, ...overrides };
+    // JSON is valid YAML. Keeping the serializer here avoids quoting model IDs by hand.
+    await writeFile(join(directory, `${config.name}.yaml`), JSON.stringify(config));
+    await loader.loadAll(directory);
+  }
+
+  function createManager(isSubagent = false): AgentSessionManager {
+    const actionRegistry = new ActionRegistryImpl([]);
+    const promptBuilder = new PromptBuilder();
+    rs.spyOn(promptBuilder, "build").mockReturnValue("Model pin test prompt");
+    const manager = createAgentSessionManager(
+      {
+        agentLoader: loader,
+        sessionManager,
+        promptBuilder,
+        actionRegistry,
+        actionEngine: new ActionEngine(actionRegistry),
+        modelResolver: createModelResolver({
+          providers: [openai.provider, anthropic.provider],
+          aiToolState: { get: () => state, refresh: async () => state },
+        }),
+        capabilityDiscovery: new CapabilityDiscovery(),
+        skillCatalog: new SkillCatalog(),
+        lifecycleDispatcher: createAgentLifecycleDispatcher(),
+      },
+      { keepAliveAcrossTurns: true, isSubagent },
+    );
+    managers.push(manager);
+    return manager;
+  }
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), "rome-agent-model-pin-"));
+    testDb = createTestDb();
+    loader = new AgentLoader();
+    sessionManager = new SessionManager(new SessionsRepository(testDb.db));
+    openai = createProvider("openai");
+    anthropic = createProvider("anthropic");
+    state = healthyState();
+    await writeConfig();
+  });
+
+  afterEach(async () => {
+    for (const manager of managers.splice(0)) await manager.shutdown();
+    testDb?.close();
+    if (directory) await rm(directory, { recursive: true, force: true });
+    rs.restoreAllMocks();
+  });
+
+  it("loads a no-tier YAML pin and uses it on the first and later turns", async () => {
+    expect(loader.get(AGENT)).toMatchObject({ providerId: "openai", modelId: MODEL });
+    expect(loader.get(AGENT).tier).toBeUndefined();
+    const session = await createManager().acquire(key, { workingDir: directory });
+    await collect(session.sendTurn({ prompt: "first" }).events);
+    await collect(session.sendTurn({ prompt: "second" }).events);
+
+    expect(openai.openSession).toHaveBeenCalledTimes(1);
+    expect(openai.calls.map((call) => call.model)).toEqual([MODEL, MODEL]);
+    expect(anthropic.openSession).not.toHaveBeenCalled();
+    expect(await sessionManager.findResumableSessionById(session.sessionId, AGENT)).toMatchObject({
+      provider: "openai",
+      model: MODEL,
+      providerThreadId: `native-${session.sessionId}`,
+    });
+  });
+
+  it("resumes the saved pin after a manifest change, but uses the new pin for a new session", async () => {
+    const firstManager = createManager();
+    const first = await firstManager.acquire(key, { workingDir: directory });
+    await collect(first.sendTurn({ prompt: "establish pin" }).events);
+    await firstManager.shutdown();
+
+    await writeConfig({ provider: "anthropic", modelId: "future-model[1m]" });
+    const secondManager = createManager();
+    const resumed = await secondManager.acquire(key, { workingDir: directory });
+    expect(resumed.sessionId).toBe(first.sessionId);
+    await collect(resumed.sendTurn({ prompt: "resume" }).events);
+    expect(openai.calls.map((call) => call.model)).toEqual([MODEL, MODEL]);
+    expect(anthropic.openSession).not.toHaveBeenCalled();
+
+    const fresh = await secondManager.acquire(
+      { ...key, channelThreadKey: "webchat:new-model-pin-test" },
+      { workingDir: directory },
+    );
+    await collect(fresh.sendTurn({ prompt: "new conversation" }).events);
+    expect(anthropic.calls.map((call) => call.model)).toEqual(["future-model[1m]"]);
+  });
+
+  it("allows a guardian override without a tier and persists the override on cold resume", async () => {
+    const firstManager = createManager();
+    const first = await firstManager.acquire(key, {
+      workingDir: directory,
+      selectionId: "claude-sonnet",
+    });
+    await collect(first.sendTurn({ prompt: "use selected model" }).events);
+    await firstManager.shutdown();
+
+    const resumed = await createManager().acquire(key, {
+      workingDir: directory,
+      resumeSessionId: first.sessionId,
+    });
+    await collect(resumed.sendTurn({ prompt: "continue" }).events);
+    expect(anthropic.calls.map((call) => call.model)).toEqual([
+      "claude-sonnet-5",
+      "claude-sonnet-5",
+    ]);
+    expect(openai.openSession).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on a disconnected pinned provider even when another provider is healthy", async () => {
+    state.codex.loggedIn = false;
+    await expect(createManager().acquire(key, { workingDir: directory })).rejects.toMatchObject({
+      code: "model_provider_unavailable",
+      provider: "openai",
+      reason: "not_logged_in",
+    });
+    expect(openai.openSession).not.toHaveBeenCalled();
+    expect(anthropic.openSession).not.toHaveBeenCalled();
+  });
+
+  it("fails a later turn on quota exhaustion and recovers on the same model", async () => {
+    const session = await createManager().acquire(key, { workingDir: directory });
+    await collect(session.sendTurn({ prompt: "first" }).events);
+    state.codex.quotaExhausted = true;
+    const failed = await collect(session.sendTurn({ prompt: "blocked" }).events);
+    expect(failed).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        code: "model_provider_unavailable",
+        provider: "openai",
+        reason: "quota_exhausted",
+      }),
+    );
+    expect(openai.calls).toHaveLength(1);
+    expect(anthropic.openSession).not.toHaveBeenCalled();
+
+    state.codex.quotaExhausted = false;
+    await collect(session.sendTurn({ prompt: "retry" }).events);
+    expect(openai.calls.map((call) => call.model)).toEqual([MODEL, MODEL]);
+  });
+
+  it("enforces known model entitlements instead of substituting a tier model", async () => {
+    await writeConfig({ modelId: "gpt-6-astra" });
+    state.codex.solAccess = false;
+    await expect(createManager().acquire(key, { workingDir: directory })).rejects.toMatchObject({
+      code: "model_unavailable",
+      provider: "openai",
+      reason: "model_access_denied",
+    });
+    expect(openai.openSession).not.toHaveBeenCalled();
+    expect(anthropic.openSession).not.toHaveBeenCalled();
+  });
+
+  it("keeps a child's tier selection independent of a parent's pin on a shared thread", async () => {
+    const parent = await createManager().acquire(key, { workingDir: directory });
+    await collect(parent.sendTurn({ prompt: "parent" }).events);
+    await writeConfig({ name: "worker", modelId: undefined, tier: "medium" });
+    const child = await createManager(true).acquire(
+      { ...key, agentName: "worker" },
+      { workingDir: directory },
+    );
+    await collect(child.sendTurn({ prompt: "child" }).events);
+    expect(child.sessionId).not.toBe(parent.sessionId);
+    expect(openai.calls.map((call) => call.model)).toEqual([MODEL, "gpt-5.6-terra"]);
+  });
+});

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -281,7 +281,10 @@ export interface AgentTurnHandle {
 
 export interface SendTurnOptions {
   /**
-   * OTel span links to attach a turn back to its originating request.
+   * OTel span links to attach to the per-turn `agent:*` root span. Used by
+   * the webchat HTTP handler to tie a turn back to its originating POST
+   * request without making the POST a parent (the POST span ends long
+   * before the turn does).
    */
   links?: Link[];
   /** Turn-scoped parent ref used when this turn is launched as a subagent. */
@@ -800,7 +803,7 @@ async function openSession(
   const isNewSession = !resumeResult;
   const providerThreadId = resumeResult?.providerThreadId ?? undefined;
   // The session model pin records the model that produced this history.
-  // Precedence: docs/architecture/agent-model-selection.md.
+  // Precedence: docs/concepts/sessions.md#model-pin.
   const sessionPin =
     resumeResult?.provider && resumeResult.model
       ? { providerId: resumeResult.provider as ProviderId, model: resumeResult.model }
@@ -896,7 +899,7 @@ async function openSession(
   const allowList = config.actions ?? [];
   const findPermittedAction = (name: string): Action | undefined => {
     const requestedAction = deps.actionRegistry.get(name);
-    if (!requestedAction) return undefined;
+    if (!requestedAction) throw new Error(`Unknown action: ${name}`);
     return deps.actionRegistry
       .getForAgent(allowList)
       .find((action) => action.config.name === requestedAction.config.name);
@@ -940,8 +943,8 @@ async function openSession(
 
   // Re-bind into the current turn's OTel context so `action:*` spans land
   // under the agent span even when the SDK invokes this callback async.
-  // The original `context.with(turnCtx, sendUserInput)` block has long
-  // since returned by the time MCP tool callbacks fire.
+  // The original `context.with(turnCtx, sendUserInput)` block is no longer
+  // active by the time MCP tool callbacks fire.
   const inCurrentTurnCtx = <T>(fn: () => T): T => {
     const ctx = impl.currentTurnCtxRef ?? context.active();
     return context.with(ctx, fn);
@@ -1017,7 +1020,7 @@ async function openSession(
             };
           }
           // Webchat: the chat client mounts the component off this tool_result
-          // (the drain loop snapshots a pending_interaction card keyed by
+          // (the drain loop persists a pending_interaction card keyed by
           // toolUseId). The guardian's outcome arrives as a new turn, so tell the
           // agent to stop here rather than treating the directive as data.
           return {
@@ -1044,7 +1047,7 @@ async function openSession(
                 `anything else:\n\n${promptText}`,
             };
           }
-          // Webchat: the drain loop snapshots a handoff card keyed by toolUseId and
+          // Webchat: the drain loop persists a handoff card keyed by toolUseId and
           // mints the child session. The handoff mounts no surface itself — the
           // summoned agent brings one up via `show_app`. handback/handbackHint ride
           // on the tool_result so the drain loop can stamp the child session's
@@ -1121,7 +1124,7 @@ async function openSession(
           },
           createRoutine: async (createArgs) => {
             const result = await deps.actionEngine.run("create_routine", createArgs, {
-              initiator: "system:handback-validate",
+              initiator: `agent:${key.agentName}`,
               sessionId: refs.sessionId,
               agentName: key.agentName,
               channelThreadKey: key.channelThreadKey,
@@ -1617,7 +1620,6 @@ interface ImplArgs {
   /** Whether the underlying SDK session was freshly minted (vs resumed). */
   isNewSession: boolean;
   /** Subagent sessions get no thread-context block (they get no contextSuffix today either). */
-  isNewSession: boolean;
   isSubagent: boolean;
   selectionId?: ModelSelectionId;
   /** Session model pin from the resumed row, when one exists. */
@@ -1649,7 +1651,7 @@ interface TurnSink {
    * it at. Drained at terminal time by `translateTurnSpans` to emit
    * `tool` spans + thinking/text events under `model.turn`. Includes blocks
    * the sink itself drops (e.g. subagent tool_results) so per-tool spans
-   * are still reconstructed for subagent dispatch from the parent's view.
+   * are reconstructed for subagent dispatch from the parent's view.
    */
   blocks: CapturedBlock[];
   /** Captured at turn start; used as the floor for tool startedAt values. */
@@ -1702,7 +1704,7 @@ function toolResultSuspendsTurn(output: unknown): boolean {
   if (Array.isArray(value)) {
     const textBlock = value.find(
       (block): block is { type: "text"; text: string } =>
-        isRecord(block) && block.type === "text" && typeof block.content === "string",
+        isRecord(block) && block.type === "text" && typeof block.text === "string",
     );
     value = textBlock?.text;
   }
@@ -2017,7 +2019,7 @@ class AgentSessionImpl implements AgentSession {
         const sink = this.currentSink;
         if (!sink) {
           // No active turn — log and drop. Should not happen because
-          // sendTurn allocates the sink before the drain loop starts.
+          // sendTurn allocates the sink before sendUserInput.
           log.warn("agent session received event with no active turn", {
             type: msg.type,
             sessionId: this.sessionId,
@@ -2075,7 +2077,7 @@ class AgentSessionImpl implements AgentSession {
         await this.deps.sessionManager.touchSession(this.sessionId);
 
         if (msg.type === "tool_use" && this.subagentToolNames.has(msg.tool)) {
-          sink.pendingSubagentUses.set(msg.id, msg);
+          sink.pendingSubagentToolUses.set(msg.id, msg);
           this.maybePublishSubagentStart(sink, msg.id);
           continue;
         }
@@ -3461,7 +3463,7 @@ function buildSubagentTools(
 function buildLifecycleOutput(
   terminal: StreamAgentMessage | undefined,
   status: AgentTurnStatus,
-  stopReason: string | undefined,
+  stopReason?: string,
 ): AgentTurnOutput {
   if (terminal?.type === "result") {
     return {

--- a/packages/core/src/core/agent-session.ts
+++ b/packages/core/src/core/agent-session.ts
@@ -56,6 +56,7 @@ import {
   type ModelResolutionErrorPayload,
   type ModelResolver,
 } from "./model-resolver.js";
+import { resolveAgentModelRequest } from "./agent-model-selection.js";
 import {
   resolveWebchatLargeModelSelection,
   type ModelSelectionId,
@@ -280,10 +281,7 @@ export interface AgentTurnHandle {
 
 export interface SendTurnOptions {
   /**
-   * OTel span links to attach to the per-turn `agent:*` root span. Used by
-   * the webchat HTTP handler to tie a turn back to its originating POST
-   * request without making the POST a parent (the POST span ends long
-   * before the turn does).
+   * OTel span links to attach a turn back to its originating request.
    */
   links?: Link[];
   /** Turn-scoped parent ref used when this turn is launched as a subagent. */
@@ -801,10 +799,8 @@ async function openSession(
   const romeSessionId = requestedRomeSessionId;
   const isNewSession = !resumeResult;
   const providerThreadId = resumeResult?.providerThreadId ?? undefined;
-  // The session model pin: the concrete model that produced this
-  // session's history. Authoritative for resume and every later turn —
-  // resolution precedence is explicit guardian selection → pin → agent tier.
-  // Legacy rows (model NULL) have no pin and resolve by tier.
+  // The session model pin records the model that produced this history.
+  // Precedence: docs/architecture/agent-model-selection.md.
   const sessionPin =
     resumeResult?.provider && resumeResult.model
       ? { providerId: resumeResult.provider as ProviderId, model: resumeResult.model }
@@ -816,11 +812,6 @@ async function openSession(
     init.resumeSessionId && !sessionPin
       ? resolveSelectionFromChannelThreadKey(key.channelThreadKey)
       : undefined;
-  // Resolution precedence: explicit guardian selection → pin → tier.
-  // A restored selection is an explicit selection, so it always wins — the old
-  // provider-mismatch guard that dropped it on resume is gone: a
-  // legacy row that switches providers via its selection now follows the single
-  // precedence rule instead of being pinned back to the stored provider's tier.
   const selectionId = init.selectionId ?? persistedSelection?.id;
 
   if (isNewSession && !init.preparedSessionId) {
@@ -1130,7 +1121,7 @@ async function openSession(
           },
           createRoutine: async (createArgs) => {
             const result = await deps.actionEngine.run("create_routine", createArgs, {
-              initiator: `agent:${key.agentName}`,
+              initiator: "system:handback-validate",
               sessionId: refs.sessionId,
               agentName: key.agentName,
               channelThreadKey: key.channelThreadKey,
@@ -1559,13 +1550,8 @@ async function openSession(
       isNewSession: true,
     });
   } else {
-    // Precedence: explicit guardian selection → session pin → agent
-    // tier. A pinned resume requests exactly the pinned model and fails closed
-    // (structured ModelResolutionError) when it cannot run — no substitution.
     initialResolution = await deps.modelResolver.getModelProvider(
-      !selectionId && sessionPin
-        ? { exact: sessionPin }
-        : { tier: config.tier, selectionId, providerId: config.providerId },
+      resolveAgentModelRequest(config, selectionId, sessionPin),
     );
     modelSession = await openModelSession(
       initialResolution,
@@ -1631,6 +1617,7 @@ interface ImplArgs {
   /** Whether the underlying SDK session was freshly minted (vs resumed). */
   isNewSession: boolean;
   /** Subagent sessions get no thread-context block (they get no contextSuffix today either). */
+  isNewSession: boolean;
   isSubagent: boolean;
   selectionId?: ModelSelectionId;
   /** Session model pin from the resumed row, when one exists. */
@@ -1715,7 +1702,7 @@ function toolResultSuspendsTurn(output: unknown): boolean {
   if (Array.isArray(value)) {
     const textBlock = value.find(
       (block): block is { type: "text"; text: string } =>
-        isRecord(block) && block.type === "text" && typeof block.text === "string",
+        isRecord(block) && block.type === "text" && typeof block.content === "string",
     );
     value = textBlock?.text;
   }
@@ -1983,19 +1970,8 @@ class AgentSessionImpl implements AgentSession {
 
   private async ensureModelSessionForTurn(): Promise<void> {
     if (this.config.codeBacked) return;
-    // Precedence: explicit guardian selection → session pin → agent
-    // tier. Once a pin exists, every turn requests exactly the pinned model:
-    // entitlement/setting changes no longer swap an ongoing session's backend,
-    // and a pin that cannot run fails the turn with the structured
-    // ModelResolutionError instead of silently substituting a model.
     const resolution = await this.deps.modelResolver.getModelProvider(
-      !this.selectionId && this.sessionPin
-        ? { exact: this.sessionPin }
-        : {
-            tier: this.config.tier,
-            selectionId: this.selectionId,
-            providerId: this.config.providerId,
-          },
+      resolveAgentModelRequest(this.config, this.selectionId, this.sessionPin),
     );
     if (
       this.modelSessionAvailable &&
@@ -2041,7 +2017,7 @@ class AgentSessionImpl implements AgentSession {
         const sink = this.currentSink;
         if (!sink) {
           // No active turn — log and drop. Should not happen because
-          // sendTurn allocates the sink before sendUserInput.
+          // sendTurn allocates the sink before the drain loop starts.
           log.warn("agent session received event with no active turn", {
             type: msg.type,
             sessionId: this.sessionId,
@@ -2099,7 +2075,7 @@ class AgentSessionImpl implements AgentSession {
         await this.deps.sessionManager.touchSession(this.sessionId);
 
         if (msg.type === "tool_use" && this.subagentToolNames.has(msg.tool)) {
-          sink.pendingSubagentToolUses.set(msg.id, msg);
+          sink.pendingSubagentUses.set(msg.id, msg);
           this.maybePublishSubagentStart(sink, msg.id);
           continue;
         }

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -97,7 +97,7 @@ export interface ForkRunParams {
 }
 
 /** Maps tier names to full model IDs (Anthropic provider defaults). */
-export const MODEL_MAP: Record<AgentConfig["tier"], string> = {
+export const MODEL_MAP: Record<NonNullable<AgentConfig["tier"]>, string> = {
   large: "claude-opus-4-8[1m]",
   medium: "claude-sonnet-5",
   small: "claude-haiku-4-5-20251001",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,22 +33,22 @@ export interface AgentConfig {
   name: string;
   description: string;
   /**
-   * Provider-agnostic capability tier. ModelResolver maps this to a provider
-   * and concrete model. The legacy `model:
-   * opus|sonnet|haiku` YAML field is accepted by the loader and normalized to
-   * `large|medium|small` for back-compat.
+   * Provider-agnostic capability tier. Required unless modelId is set.
+   * The loader normalizes legacy model: opus|sonnet|haiku to this field.
    */
-  tier: "large" | "medium" | "small";
+  tier?: "large" | "medium" | "small";
+  /**
+   * Exact provider model ID. Requires providerId and excludes tier.
+   * Resolution uses this ID without tier mapping or automatic substitution.
+   */
+  modelId?: string;
   /** Provider-agnostic reasoning effort. Defaults to `high` when omitted in YAML. */
   reasoningEffort: ReasoningEffort;
   /**
-   * Optional provider pin (yaml `provider: anthropic|openai`). When set,
-   * ModelResolver only considers this provider for the agent's sessions —
-   * `tier` still picks the concrete model within it — and resolution fails
-   * with ModelResolutionError instead of falling back to another provider
-   * when the pinned one is disconnected or out of quota. For agents whose
-   * behavior depends on a provider-specific capability (e.g. Codex's
-   * embedded image generation).
+   * Optional provider pin (yaml `provider: anthropic|openai`). Required for
+   * modelId. With tier, restricts model resolution to this provider.
+   * An unavailable pinned provider fails with ModelResolutionError instead
+   * of falling back to another provider.
    */
   providerId?: "anthropic" | "openai";
   systemPromptPrefix: string;


### PR DESCRIPTION
## What this PR does

App agents can select a capability tier or pin a provider, but cannot request a specific provider model ID. This adds `provider` plus `modelId` to agent YAML and routes exact selections through the existing fail-closed model resolver.

```yaml
name: fast_coding_agent
description: Completes coding tasks with a specific model.
provider: openai
modelId: gpt-5.3-codex-spark
reasoningEffort: high
permissionMode: default
tools:
  - Read
systemPromptPrefix: Complete the requested coding task.
```

Ports [yunfanye/rome-personal#1](https://github.com/yunfanye/rome-personal/pull/1) to upstream `main`. The follow-up fixes test formatting, supplies the mock provider thread ID on its session handle, and excludes absent tiers from the model-map key type.

## Design & Invariants

- An [agent definition](https://github.com/rome-os/rome/blob/codex/agent-exact-model-pins/docs/concepts/agents.md#model-selection) uses an exact `provider`/`modelId` pair or a tier. Exact IDs cannot be combined with `tier`, legacy `model`, or `codeBacked: true`.
- The [session model contract](https://github.com/rome-os/rome/blob/codex/agent-exact-model-pins/docs/concepts/sessions.md#model-pin) defines precedence: explicit guardian selection, saved session pin, agent exact model, then agent tier.
- Existing sessions retain the model that produced their history after an agent configuration change. New or unpinned sessions use the configured default.
- Unavailable pins fail without substitution. Existing provider availability and entitlement checks remain in the resolver. The provider validates model IDs outside Rome's catalog.
- Portable tiers, provider-pinned tiers, legacy configurations, subagent isolation, and fork tier overrides remain supported.

## Test plan

- [x] Run `git diff --check origin/main...HEAD` and validate the Conventional Commit PR title.
- [x] Run `pnpm typecheck` on the host.
- [x] Run all 4,489 core unit tests, including the exact-model configuration, selection-precedence, and session lifecycle cases.
- [x] Run `pnpm lint`, `pnpm lint:prose`, `pnpm lint:deadcode`, `pnpm check:ui:tailwind`, `pnpm lint:agents`, and `pnpm typecheck:lint-agents`.
- [x] Run the full `pnpm test:unit` suite as a non-root user in the container.
- [ ] Run `pnpm dev:all` through `Rome started` in the container logs. Startup is waiting for the local observability endpoint at `http://clickhouse.rome.localhost:3000/ping`, which refuses connections.

The source PR is a draft, and this PR preserves that status. Nix is unavailable on this host. Host type checking uses Node 24, and the test and lint commands run in an isolated Node 24 container with pnpm 11.6.0 and Vale 3.19.0.

## Not in this PR

- Per-invocation model overrides in the app runtime SDK are deferred to keep this change scoped to agent definitions.
- A dynamic model-catalog UI is deferred because exact selection is configured through agent YAML.

