### PR TITLE
ci: publish weekday Docker patch releases at 08:30 Pacific

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,13 +4,44 @@ on:
   push:
     tags:
       - "v*"
+  schedule:
+    - cron: "30 8 * * 1-5"
+      timezone: America/Los_Angeles
+
+# Version allocation and latest updates share one lock across all release runs.
+concurrency:
+  group: docker-hub-publish
+  cancel-in-progress: false
 
 env:
   IMAGE_NAME: yunfanye/rome
 
 jobs:
+  release:
+    if: github.repository == 'rome-os/rome'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      actions: read
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      sha: ${{ steps.release.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Prepare release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/docker/prepare-release.sh
+
   build:
+    needs: release
     runs-on: ${{ matrix.runner }}
+    env:
+      RELEASE_TAG: ${{ needs.release.outputs.tag }}
     permissions:
       contents: read
     strategy:
@@ -27,6 +58,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: true
+          ref: ${{ needs.release.outputs.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -51,7 +83,7 @@ jobs:
           # Tag rules here only feed the OCI labels on the per-arch digest
           # pushes; the publish job owns the real tag set (including latest).
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},value=${{ env.RELEASE_TAG }}
           flavor: |
             latest=false
 
@@ -69,10 +101,10 @@ jobs:
           # isn't strict semver (vMAJOR.MINOR.PATCH with optional -prerelease;
           # +buildmeta is rejected because docker tags can't contain "+") fails
           # the publish before any image exists.
-          version="${GITHUB_REF#refs/tags/v}"
+          version="${RELEASE_TAG#v}"
           semver='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?$'
           if [[ ! "$version" =~ $semver ]]; then
-            echo "::error::Tag '${GITHUB_REF#refs/tags/}' is not strict semver; refusing to publish."
+            echo "::error::Tag '${RELEASE_TAG}' is not strict semver; refusing to publish."
             exit 1
           fi
           # Enforce tag immutability: refuse to republish a semver tag that
@@ -143,7 +175,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs:
+      - release
       - build
+    env:
+      RELEASE_TAG: ${{ needs.release.outputs.tag }}
     permissions:
       contents: read
 
@@ -172,7 +207,7 @@ jobs:
           # back. Compare this release against every stable semver tag already
           # in the registry; prereleases never move latest. curl -f fails the
           # job on registry errors rather than guessing.
-          version="${GITHUB_REF#refs/tags/v}"
+          version="${RELEASE_TAG#v}"
           move=false
           if [[ "$version" != *-* ]]; then
             url="https://hub.docker.com/v2/repositories/${IMAGE_NAME}/tags?page_size=100"
@@ -198,7 +233,7 @@ jobs:
           # semver tags. `latest` is owned entirely by the latest_check step
           # (flavor latest=false disables the action's own auto behavior).
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},value=${{ env.RELEASE_TAG }}
             type=raw,value=latest,enable=${{ steps.latest_check.outputs.move_latest }}
           flavor: |
             latest=false

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,9 +4,23 @@ Rome ships two kinds of release artifacts: the **runtime Docker image** (the pro
 
 ## Rome runtime image (Docker Hub)
 
-The runtime image is released by pushing a git tag — there is no manual image publish path. [`.github/workflows/docker-publish.yml`](../.github/workflows/docker-publish.yml) triggers on `v*` tags, builds multi-arch (amd64 + arm64) images, and publishes to the repository named by `IMAGE_NAME` in that workflow. A stable release uses `vMAJOR.MINOR.PATCH`, and a prerelease appends `-rc.N`.
+The runtime image is released through [`.github/workflows/docker-publish.yml`](../.github/workflows/docker-publish.yml), on a `v*` tag push or a weekday schedule. It builds multi-arch (amd64 + arm64) images and publishes to the repository named by `IMAGE_NAME` in that workflow. A stable release uses `vMAJOR.MINOR.PATCH`, and a prerelease appends `-rc.N`.
 
-The steps for cutting a release — preflight, version choice, the confirmed push, and verification — live in the [`release-rome-image`](../.claude/skills/release-rome-image/SKILL.md) skill. Follow it rather than running the helper directly.
+### Scheduled patch releases
+
+The workflow starts every Monday through Friday at 08:30 in `America/Los_Angeles`, including during daylight saving time. GitHub can delay scheduled runs when its runners are busy.
+
+Each scheduled run increments the patch component of the highest stable git tag, even when `main` has no new commits. For example, `v1.1.9` becomes `v1.1.10`. Prerelease and package tags do not affect that choice.
+
+The release uses the `main` commit that triggered the schedule. Its latest push CI run must have succeeded before the workflow creates a tag. Missing, failed, cancelled, or unfinished CI stops the release without creating a tag.
+
+The scheduled run creates an annotated tag with `GITHUB_TOKEN` and publishes it in the same run. No additional token or repository secret is required. All production Docker publish runs share one concurrency group, so version allocation and `latest` updates run serially.
+
+Rerunning a scheduled run reuses its original tag. To retry a failed build or publish, rerun the failed jobs. The [tagging contract](#tagging-contract) rejects any attempt to overwrite an image version that already exists.
+
+### Manual releases
+
+The steps for cutting a manual release — preflight, version choice, the confirmed push, and verification — live in the [`release-rome-image`](../.claude/skills/release-rome-image/SKILL.md) skill. Follow it rather than running the helper directly.
 
 `scripts/dev/create-patch-release-tag.sh` is a planning aid the skill calls with `--dry-run` to compute the next patch version, not a release command. It accepts `--remote`, `--branch`, `--prefix`, and the matching `ROME_RELEASE_*` environment variables. **A bare invocation creates the annotated tag and pushes it**, which starts the publish with nothing between it and Docker Hub. Pass `--dry-run` to see the version and target commit without releasing.
 
@@ -32,7 +46,7 @@ The workflow freezes `ROME_VERSION` (tag with `v` stripped — always equal to t
 
 ### Rehearsing the pipeline
 
-`.github/workflows/docker-publish-test.yml` is a manually-dispatched mirror that publishes to `zoolsher/rome` with separate `TEST_DOCKERHUB_*` secrets, so the full multi-arch flow can be exercised without touching the production repository. It is a copy, not a shared workflow — when changing the release pipeline, update both or note the drift.
+`.github/workflows/docker-publish-test.yml` publishes to `zoolsher/rome` with separate `TEST_DOCKERHUB_*` secrets on manual dispatch and twice-daily schedules. It exercises the multi-arch build and manifest publish without creating production release tags. It does not use the production weekday schedule, CI gate, or version allocation. It is a copy, not a shared workflow — when changing the release pipeline, update both or note the drift.
 
 ## npm packages (via release-please)
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "obs:dashboards": "node infra/observability/dashboards/apply.mjs",
     "test:ci:areas": "scripts/test-env.sh node --test scripts/ci-changed-areas.test.mjs",
     "test:docker-runtime": "scripts/test-env.sh node --test scripts/bundle-docker-core.test.mjs",
-    "test:release:targets": "scripts/test-env.sh node --test scripts/check-publish-targets.test.mjs",
+    "test:release:targets": "scripts/test-env.sh node --test scripts/check-publish-targets.test.mjs scripts/docker/prepare-release.test.mjs",
     "test:obs:dashboards": "scripts/test-env.sh node --test infra/observability/dashboards/*.test.mjs",
     "test:ui:padding": "scripts/test-env.sh node --test scripts/check-padding-scale.test.mjs",
     "test:ui:tokens": "scripts/test-env.sh node --test scripts/check-utility-tokens.test.mjs scripts/tailwind-policy.test.mjs scripts/tailwind-rules/spacing.test.mjs scripts/tailwind-rules/radius.test.mjs",

--- a/scripts/docker/prepare-release.sh
+++ b/scripts/docker/prepare-release.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target_sha="$(git rev-parse HEAD)"
+
+case "$GITHUB_EVENT_NAME" in
+  push)
+    if [[ "$GITHUB_REF" != refs/tags/v* ]]; then
+      echo "::error::Docker releases require a v* tag."
+      exit 1
+    fi
+    tag="${GITHUB_REF#refs/tags/}"
+    ;;
+  schedule)
+    if [[ "$GITHUB_REF" != refs/heads/main || "$target_sha" != "$GITHUB_SHA" ]]; then
+      echo "::error::Scheduled releases must use the triggering main commit."
+      exit 1
+    fi
+
+    # A rerun keeps its original version even if another release has since landed.
+    marker="rome-scheduled-release:${GITHUB_RUN_ID}"
+    tag="$(git for-each-ref --format='%(refname:strip=2) %(contents:subject)' refs/tags/ |
+      awk -v marker="$marker" '$2 == marker { print $1 }')"
+    if [[ -n "$tag" ]]; then
+      if [[ "$(git rev-parse "${tag}^{commit}")" != "$target_sha" ]]; then
+        echo "::error::The scheduled release tag points at a different commit."
+        exit 1
+      fi
+    else
+      ci="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=main&event=push&head_sha=${target_sha}&per_page=1" \
+        --jq '.workflow_runs[0] | "\(.status):\(.conclusion)"')"
+      if [[ "$ci" != completed:success ]]; then
+        echo "::error::CI for ${target_sha} is ${ci}. No release tag was created."
+        exit 1
+      fi
+
+      latest_tag="$(git tag --list --sort=-version:refname |
+        awk '/^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/ && !found { print; found = 1 }')"
+      if [[ -z "$latest_tag" ]]; then
+        echo "::error::No stable vMAJOR.MINOR.PATCH tag exists."
+        exit 1
+      fi
+      IFS='.' read -r major minor patch <<<"${latest_tag#v}"
+      tag="v${major}.${minor}.$((patch + 1))"
+
+      git -c user.name='github-actions[bot]' \
+        -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+        tag -a "$tag" "$target_sha" -m "$marker"
+      # GITHUB_TOKEN does not trigger another push workflow. This run publishes it.
+      git push origin "refs/tags/${tag}"
+    fi
+    ;;
+  *)
+    echo "::error::Unsupported release event: ${GITHUB_EVENT_NAME}"
+    exit 1
+    ;;
+esac
+
+{
+  echo "tag=${tag}"
+  echo "sha=${target_sha}"
+} >>"$GITHUB_OUTPUT"
+
+echo "Release ${tag} from ${target_sha}"

--- a/scripts/docker/prepare-release.test.mjs
+++ b/scripts/docker/prepare-release.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(new URL("./prepare-release.sh", import.meta.url));
+
+function fixture(t) {
+  const root = mkdtempSync(join(tmpdir(), "rome-release-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const cwd = join(root, "checkout");
+  const remote = join(root, "remote.git");
+  const bin = join(root, "bin");
+  mkdirSync(cwd);
+  mkdirSync(bin);
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GITHUB_EVENT_NAME: "schedule",
+    GITHUB_REF: "refs/heads/main",
+    GITHUB_RUN_ID: "100",
+    GITHUB_REPOSITORY: "rome-os/rome",
+    GITHUB_OUTPUT: join(root, "output"),
+    CI_RESULT: "completed:success",
+    GH_CALLS: join(root, "gh-calls"),
+  };
+  const git = (...args) =>
+    execFileSync("git", args, {
+      cwd,
+      env,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  git("init", "--bare", remote);
+  git("init", "-b", "main");
+  git("config", "user.name", "Release test");
+  git("config", "user.email", "release@example.invalid");
+  git("commit", "--allow-empty", "-m", "Initial commit");
+  const sha = git("rev-parse", "HEAD");
+  env.GITHUB_SHA = sha;
+  git("remote", "add", "origin", remote);
+  git("tag", "v1.1.9");
+  git("push", "origin", "main", "--tags");
+  writeFileSync(
+    join(bin, "gh"),
+    '#!/bin/sh\nprintf "%s\\n" "$*" >> "$GH_CALLS"\nif [ "$CI_RESULT" = api-error ]; then exit 1; fi\nprintf "%s\\n" "$CI_RESULT"\n',
+    { mode: 0o755 },
+  );
+
+  const run = (overrides = {}) => {
+    writeFileSync(env.GITHUB_OUTPUT, "");
+    return spawnSync("bash", [script], { cwd, env: { ...env, ...overrides }, encoding: "utf8" });
+  };
+  const output = () => readFileSync(env.GITHUB_OUTPUT, "utf8");
+  return { git, run, output, sha, env, remote };
+}
+
+test("a weekday release increments the stable patch and pins the checked CI commit", (t) => {
+  const f = fixture(t);
+  for (const tag of ["v1.1.8", "v1.2.0-rc.1", "desktop-v9.0.0", "v01.99.0"]) {
+    f.git("tag", tag);
+  }
+  f.git("commit", "--allow-empty", "-m", "A newer main commit");
+  f.git("push", "origin", "main");
+  f.git("checkout", "--detach", f.sha);
+
+  const result = f.run();
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(f.output(), `tag=v1.1.10\nsha=${f.sha}\n`);
+  assert.equal(f.git("--git-dir", f.remote, "rev-parse", "v1.1.10^{commit}"), f.sha);
+  assert.match(
+    readFileSync(f.env.GH_CALLS, "utf8"),
+    new RegExp(`branch=main&event=push&head_sha=${f.sha}&per_page=1`),
+  );
+});
+
+test("stable versions sort numerically across minor and major versions", (t) => {
+  const f = fixture(t);
+  for (const tag of ["v2.9.9", "v2.10.12", "v1.99.99", "v3.0.0-rc.1"]) f.git("tag", tag);
+  assert.equal(f.run().status, 0);
+  assert.match(f.output(), /^tag=v2\.10\.13\n/);
+});
+
+for (const ci of [
+  "null:null",
+  "completed:failure",
+  "completed:cancelled",
+  "in_progress:null",
+  "queued:null",
+  "api-error",
+]) {
+  test(`CI ${ci} creates no release tag`, (t) => {
+    const f = fixture(t);
+    assert.notEqual(f.run({ CI_RESULT: ci }).status, 0);
+    assert.equal(f.git("tag", "--list"), "v1.1.9");
+    assert.equal(f.git("ls-remote", "--tags", "origin", "v1.1.10"), "");
+    assert.equal(f.output(), "");
+  });
+}
+
+test("a rerun reuses its tag after another release, and a new run still increments without new commits", (t) => {
+  const f = fixture(t);
+  assert.equal(f.run().status, 0);
+  f.git("tag", "v1.1.11");
+  f.git("push", "origin", "v1.1.11");
+  assert.equal(f.run().status, 0);
+  assert.match(f.output(), /^tag=v1\.1\.10\n/);
+  assert.equal(f.git("tag", "--list", "v1.1.12"), "");
+
+  assert.equal(f.run({ GITHUB_RUN_ID: "101" }).status, 0);
+  assert.match(f.output(), /^tag=v1\.1\.12\n/);
+});
+
+test("tag pushes retain their version without allocating a patch or querying CI", (t) => {
+  const f = fixture(t);
+  const result = f.run({
+    GITHUB_EVENT_NAME: "push",
+    GITHUB_REF: "refs/tags/v2.0.0-rc.1",
+    CI_RESULT: "api-error",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(f.output(), `tag=v2.0.0-rc.1\nsha=${f.sha}\n`);
+  assert.equal(f.git("tag", "--list"), "v1.1.9");
+});
+
+test("a remote tag collision fails without overwriting the existing tag", (t) => {
+  const f = fixture(t);
+  f.git("tag", "v1.1.10");
+  f.git("push", "origin", "v1.1.10");
+  f.git("tag", "-d", "v1.1.10");
+  assert.notEqual(f.run().status, 0);
+  assert.equal(f.git("--git-dir", f.remote, "rev-parse", "v1.1.10"), f.sha);
+  assert.equal(f.output(), "");
+});
+
+test("missing stable versions fail without inventing an initial version", (t) => {
+  const f = fixture(t);
+  f.git("tag", "-d", "v1.1.9");
+  assert.notEqual(f.run().status, 0);
+  assert.equal(f.git("tag", "--list"), "");
+});
+
+test("unexpected events, branches, and checkout commits cannot allocate a version", (t) => {
+  const f = fixture(t);
+  for (const overrides of [
+    { GITHUB_EVENT_NAME: "workflow_dispatch" },
+    { GITHUB_EVENT_NAME: "push" },
+    { GITHUB_REF: "refs/heads/feature" },
+    { GITHUB_SHA: "0".repeat(40) },
+  ]) {
+    assert.notEqual(f.run(overrides).status, 0);
+    assert.equal(f.git("tag", "--list"), "v1.1.9");
+    assert.equal(f.output(), "");
+  }
+});


### PR DESCRIPTION
## What this PR does

Rome has no automatic production patch release schedule. Run Docker Hub Publish every Monday through Friday at 08:30 in `America/Los_Angeles`, with daylight saving time handled by GitHub.

Each run increments the highest stable git tag, such as `v1.1.9` to `v1.1.10`, even without new commits. The schedule starts after this workflow reaches `main`.

## Design & Invariants

- The scheduled run tags its triggering `main` commit only after that commit's latest push CI run succeeds. Missing, failed, cancelled, or unfinished CI creates no tag.
- The same workflow creates the tag and publishes both architectures. `GITHUB_TOKEN` tag pushes do not trigger another workflow, so this needs no additional credentials.
- All production publish runs share a concurrency group. A scheduled rerun reuses its original tag, and a conflicting remote tag is never overwritten.
- Manual tag pushes, immutable image versions, and the rule that `latest` follows the highest stable version remain supported. The test publisher retains its separate schedule and version rules.

The contract lives in [docs/releases.md](docs/releases.md#scheduled-patch-releases). GitHub documents [timezone schedules](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onschedule) and [GITHUB_TOKEN event behavior](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs).

## Test plan

- [x] `pnpm typecheck` and `pnpm test:unit` passed on Node 24.14.1. Nix is unavailable on this host.
- [x] Thirteen release tests use temporary local Git remotes to cover numeric version ordering, CI failures, commit pinning, reruns, unchanged commits, and tag collisions.
- [x] Actionlint 1.7.12, ShellCheck 0.11.0, shfmt 3.12.0, Biome 2.3.6, `pnpm lint:prose`, and `git diff --check` passed for the changed files.
- [ ] `pnpm dev:all` stopped because an existing container occupies port 80. Restored the shared Traefik service with its existing port override.
- [ ] Verify the first scheduled production publish after merge.
