### PR TITLE
feat(opencli): add United cash and award flight search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+      - name: Test United OpenCLI plugin
+        run: scripts/test-env.sh node --test opencli-plugins/united/*.test.mjs
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm lint:prose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,9 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-      - name: Test United OpenCLI plugin
-        run: scripts/test-env.sh node --test opencli-plugins/united/*.test.mjs
       - run: pnpm install --frozen-lockfile
+      - name: Test United OpenCLI plugin
+        run: pnpm -C opencli-plugins/united test
       - run: pnpm lint
       - run: pnpm lint:prose
       - run: pnpm check:ui:tailwind

--- a/opencli-plugins/README.md
+++ b/opencli-plugins/README.md
@@ -53,6 +53,10 @@ Agents pick up new/changed commands automatically: the `browser-automation` skil
 
 ## Rome-owned commands
 
+- `opencli united flights FROM TO DEPART [--return DATE] [--miles]` — searches United cash fares or
+  MileagePlus awards with separate taxes, cabin and stop filters, and per-person price scope.
+  See the [United command reference](united/README.md) for examples and browser requirements.
+
 - `opencli chatgpt memory` — opens Personalization > Memory summary in the signed-in ChatGPT
   browser session and returns each learned-memory section with its last-updated label.
 - `opencli chase accept-offers -f json` — accepts every available Chase Offer across all credit

--- a/opencli-plugins/united/README.md
+++ b/opencli-plugins/united/README.md
@@ -1,0 +1,105 @@
+# United flight prices
+
+`united flights` reads United flight search results in money or MileagePlus miles.
+It returns one row per flight and displayed fare column. It never selects a fare or books travel.
+
+## Install
+
+```bash
+opencli plugin install /path/to/rome/opencli-plugins/united
+opencli united flights --help
+```
+
+Rome installs this directory through its [OpenCLI plugin install loop](../README.md#install-points-all-idempotent).
+The plugin has no runtime dependencies beyond OpenCLI and the browser.
+
+## Search
+
+```bash
+# Cash, one-way, nonstop flights sorted by the displayed fare
+opencli united flights SFO IAH 2026-11-13 --stops nonstop --sort price -f json
+
+# Award miles with cash taxes and the signed-in account's displayed discounts
+opencli united flights SFO IAH 2026-11-13 --miles --max-miles 20000 -f json
+
+# Round-trip search for two adults, returning outbound flight choices
+opencli united flights SFO IAH 2026-11-13 --return 2026-11-15 --adults 2 -f json
+
+# Compare all displayed cabin columns, excluding mixed-cabin itineraries
+opencli united flights SFO NRT 2026-11-13 --miles --cabin all --exclude-mixed-cabin -f json
+
+# Direct CDP instead of Browser Bridge. Target a tab in the signed-in browser context.
+opencli --cdp-endpoint http://127.0.0.1:9222 --cdp-target united.com \
+  united flights SFO IAH 2026-11-13 --miles -f json
+```
+
+Replace the example dates with future travel dates. Use three-letter airport codes, not city names or URLs.
+
+| Option | Meaning |
+| --- | --- |
+| `--return YYYY-MM-DD` | Round-trip search. Omit for one-way. |
+| `--miles` | Award search. Omit for money. |
+| `--adults 1..9` | Adult traveler count. Defaults to 1. |
+| `--cabin` | `economy` (default), `economy-plus`, `premium-economy`, `business`, `first`, `business-or-first`, or `all`. |
+| `--stops` | `any` (default), `nonstop`, `one-or-fewer`, or `two-or-fewer`. |
+| `--max-price` | Maximum displayed USD cash price. Invalid with `--miles`. |
+| `--max-miles` | Maximum displayed award miles. Requires `--miles`. |
+| `--max-duration` | Maximum outbound duration in minutes. |
+| `--exclude-mixed-cabin` | Exclude fares labeled mixed cabin or showing several cabins. |
+| `--sort` | `best` (United order), `price`, `duration`, or `departure`. |
+| `--limit 1..500` | Fare rows to return. Defaults to 20. |
+| `--timeout 5..180` | Seconds to wait for all search results after navigation. Defaults to 90. |
+
+Cabin filters apply to the displayed columns, not to seat assignments. Economy Plus is extra-legroom economy, not Premium Plus or premium economy.
+`business` matches business or Polaris columns. Use `business-or-first` to include domestic First.
+
+## Price contract
+
+- `price` is the displayed cash fare in USD. It is null for awards.
+- `miles` is the displayed award amount converted to a number. `taxes` is its separate cash amount in USD.
+- `price_text` preserves the displayed amount. A rounded `13.5k` label becomes `13500`, not a claim of hidden precision.
+- `discount` and `award_type` preserve cardmember discounts and Saver Award labels. The reader uses the current price, never the crossed-out price.
+- `price_basis` and `fare_note` describe the pricing scope United displays. Prices remain per person regardless of `--adults`.
+- Cash round-trip results show the starting round-trip total per person. Award round-trip results can show one-way miles and taxes per person.
+- `--return` returns outbound choices only. No return flight has been selected, so the result is not a final booked itinerary or guaranteed price.
+- `is_starting_price` identifies a displayed “From” fare. Prices can change when the traveler chooses a fare or return flight.
+- Departure and arrival times are local to their airports. Date labels carry overnight and year-boundary changes.
+- Only flights departing on the requested date are returned. United can include departures on the following day in the same result list.
+
+The reader expands **Show all flights** before filtering, sorting, or applying `--limit`.
+For awards, price sorting uses miles first and cash taxes second. It does not convert miles to money.
+Calendar suggestions and duplicate desktop/mobile fare elements never become additional flight rows.
+`flight_numbers` is empty when the collapsed connecting itinerary does not display its flight numbers. `flight_details` preserves the rendered itinerary text.
+
+## Browser requirements and failures
+
+Use United in English, United States, USD. The command rejects a different locale or currency rather than guessing how to parse prices.
+United requires a MileagePlus sign-in to show award results. Sign in through the browser before using `--miles`.
+Prices reflect the account and availability United displays, including eligible cardmember discounts.
+The command does not read cookies, credentials, browser storage, authentication headers, or account details.
+
+A sign-in wall raises OpenCLI `AUTH_REQUIRED`. It never falls back from miles to money.
+An access challenge, changed search conditions, unreadable fare, or incomplete result load raises an error instead of returning partial prices.
+A confirmed no-flight result or an empty filter match returns no rows.
+
+Multi-city searches, child/infant travelers, other currencies, fare selection, and booking are outside this command.
+
+## Tests and maintenance
+
+```bash
+pnpm -C opencli-plugins/united test
+opencli validate united/flights
+```
+
+`fixtures/cash.json` and `fixtures/miles.json` contain flight-only DOM reader snapshots captured on 2026-09-10.
+They cover cash round-trip totals, current award discounts, mixed cabins, unavailable awards, and overnight flights.
+They contain no account identifiers or authentication data. The unit suite needs only Node.js and runs in CI.
+
+`united-page.mjs` runs inside the page and must remain self-contained.
+United uses separate cash and award layouts. Both expose flight rows and fare cells through ARIA grid roles.
+The reader uses those roles and stable class-name fragments, not generated CSS suffixes.
+Current prices come from the miles and money containers. Hidden unavailable cards can contain a zero-mile node.
+A fare label comes from its column header, with the card's own cabin title as the fallback.
+
+When updating the reader, inspect live money and miles results in the browser, then refresh only the flight data in the fixtures.
+Verify one-way and round-trip pricing scope separately. Do not infer an adult count from the `at` URL parameter: it selects award travel.

--- a/opencli-plugins/united/README.md
+++ b/opencli-plugins/united/README.md
@@ -67,11 +67,16 @@ Cabin filters apply to the displayed columns, not to seat assignments. Economy P
 - Only flights departing on the requested date are returned. United can include departures on the following day in the same result list.
 
 The reader expands **Show all flights** before filtering, sorting, or applying `--limit`.
+It retains the highest reported total if the counter disappears during expansion. Visible flight rows must reach that total before results can complete.
+Expansion without a reported total fails rather than treating a stable partial list as complete.
 For awards, price sorting uses miles first and cash taxes second. It does not convert miles to money.
 Calendar suggestions and duplicate desktop/mobile fare elements never become additional flight rows.
 `flight_numbers` is empty when the collapsed connecting itinerary does not display its flight numbers. `flight_details` preserves the rendered itinerary text.
 
 ## Browser requirements and failures
+
+The command uses a persistent, cookie-backed United site session so award searches reuse the browser tab.
+Cash search remains available without signing in. The adapter owns navigation and checks the displayed sign-in wall rather than requiring authentication for every cash request.
 
 Use United in English, United States, USD. The command rejects a different locale or currency rather than guessing how to parse prices.
 United requires a MileagePlus sign-in to show award results. Sign in through the browser before using `--miles`.
@@ -81,6 +86,9 @@ The command does not read cookies, credentials, browser storage, authentication 
 A sign-in wall raises OpenCLI `AUTH_REQUIRED`. It never falls back from miles to money.
 An access challenge, changed search conditions, unreadable fare, or incomplete result load raises an error instead of returning partial prices.
 A confirmed no-flight result or an empty filter match returns no rows.
+
+Dates use the origin airport’s local calendar. The command validates their format and order, and United decides whether they are bookable.
+It does not compare a departure date against the machine’s UTC date.
 
 Multi-city searches, child/infant travelers, other currencies, fare selection, and booking are outside this command.
 
@@ -93,11 +101,14 @@ opencli validate united/flights
 
 `fixtures/cash.json` and `fixtures/miles.json` contain flight-only DOM reader snapshots captured on 2026-09-10.
 They cover cash round-trip totals, current award discounts, mixed cabins, unavailable awards, and overnight flights.
-They contain no account identifiers or authentication data. The unit suite needs only Node.js and runs in CI.
+They contain no account identifiers or authentication data. `fixtures/responsive.html` tests hidden flight rows and fare cells in both responsive layouts.
+The DOM tests reuse the `jsdom` development dependency declared by `packages/web`. Install the workspace dependencies before running the suite.
+CI runs the plugin’s test script after the workspace install.
 
 `united-page.mjs` runs inside the page and must remain self-contained.
 United uses separate cash and award layouts. Both expose flight rows and fare cells through ARIA grid roles.
 The reader uses those roles and stable class-name fragments, not generated CSS suffixes.
+It excludes hidden rows and fare cells without excluding flights below the viewport.
 Current prices come from the miles and money containers. Hidden unavailable cards can contain a zero-mile node.
 A fare label comes from its column header, with the card's own cabin title as the fallback.
 

--- a/opencli-plugins/united/fixtures/cash.json
+++ b/opencli-plugins/united/fixtures/cash.json
@@ -1,0 +1,185 @@
+{
+  "url": "https://www.united.com/en/us/fsr/choose-flights?f=SFO&t=IAH&d=2026-11-13&r=2026-11-15&at=0&sc=7%2C7&px=2&taxng=1&newHP=True&clm=7&st=bestmatches&tqp=",
+  "language": "en",
+  "currency": "USD",
+  "price_mode": "money",
+  "traveler_text": "2 Adults",
+  "date_heading": "Depart on: November 13",
+  "fare_note": "All fares shown are the total price roundtrip, per person. Additional bag charges may apply. Fare attributes apply to flights operated by United and United Express®. United flights may be listed first.",
+  "loading": false,
+  "login_required": false,
+  "challenge": false,
+  "no_results": false,
+  "show_all": false,
+  "displayed": [],
+  "rows": [
+    {
+      "departure": "12:45 AM",
+      "arrival": "6:32 AM",
+      "departure_note": "",
+      "arrival_note": "",
+      "origin": "SFO",
+      "destination": "IAH",
+      "duration_text": "3H, 47MDuration 3 hours and 47 minutes",
+      "flight_text": "NONSTOP\n12:45 AM\nDeparting at 12:45 AM\n6:32 AM\nArriving at 6:32 AM\nSFO\nOrigin San Francisco, CA, US (SFO)\n3H, 47M\nDuration 3 hours and 47 minutes\nIAH\nDestination Houston, TX, US (IAH)\nUA 604 (Boeing 737 MAX 9)\nFlight Number UA 604. Aircraft Boeing 737 MAX 9\nDetails\nSeats\n275 kg CO2\nCarbon emissions estimate: 275 kilograms.\nLearn more about carbon emissions",
+      "fares": [
+        {
+          "product_id": "ECO-BASIC",
+          "product": "United Economy®(Main cabin)",
+          "miles_text": "",
+          "money_text": "$454",
+          "cabin": "United Economy",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$454\nUnited Economy\ncabin select to view fare options"
+        },
+        {
+          "product_id": "ECONOMY-MERCH-EPLUS",
+          "product": "Economy Plus®(Extra legroom)",
+          "miles_text": "",
+          "money_text": "$823",
+          "cabin": "United Economy",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$823\nUnited Economy\ncabin select to view fare options"
+        },
+        {
+          "product_id": "MIN-BUSINESS-OR-FIRST",
+          "product": "United First®(Extra-spacious seat)",
+          "miles_text": "",
+          "money_text": "$1,784",
+          "cabin": "United First",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$1,784\nUnited First\ncabin select to view fare options"
+        }
+      ]
+    },
+    {
+      "departure": "5:00 AM",
+      "arrival": "10:49 AM",
+      "departure_note": "",
+      "arrival_note": "",
+      "origin": "SFO",
+      "destination": "IAH",
+      "duration_text": "3H, 49MDuration 3 hours and 49 minutes",
+      "flight_text": "NONSTOP\n5:00 AM\nDeparting at 5:00 AM\n10:49 AM\nArriving at 10:49 AM\nSFO\nOrigin San Francisco, CA, US (SFO)\n3H, 49M\nDuration 3 hours and 49 minutes\nIAH\nDestination Houston, TX, US (IAH)\nUA 2168 (Boeing 737 MAX 9)\nFlight Number UA 2168. Aircraft Boeing 737 MAX 9\nDetails\nSeats\n278 kg CO2\nCarbon emissions estimate: 278 kilograms.\nLearn more about carbon emissions",
+      "fares": [
+        {
+          "product_id": "ECO-BASIC",
+          "product": "United Economy®(Main cabin)",
+          "miles_text": "",
+          "money_text": "$386",
+          "cabin": "United Economy",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$386\nUnited Economy\ncabin select to view fare options"
+        },
+        {
+          "product_id": "ECONOMY-MERCH-EPLUS",
+          "product": "Economy Plus®(Extra legroom)",
+          "miles_text": "",
+          "money_text": "$755",
+          "cabin": "United Economy",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$755\nUnited Economy\ncabin select to view fare options"
+        },
+        {
+          "product_id": "MIN-BUSINESS-OR-FIRST",
+          "product": "United First®(Extra-spacious seat)",
+          "miles_text": "",
+          "money_text": "$1,408",
+          "cabin": "United First",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$1,408\nUnited First\ncabin select to view fare options"
+        }
+      ]
+    },
+    {
+      "departure": "11:59 PM",
+      "arrival": "5:46 AM",
+      "departure_note": "",
+      "arrival_note": "Arrives Nov 14",
+      "origin": "SFO",
+      "destination": "IAH",
+      "duration_text": "3H, 47MDuration 3 hours and 47 minutes",
+      "flight_text": "NONSTOP\n \n11:59 PM\nDeparting at 11:59 PM\nArrives Nov 14\n5:46 AM\nArriving at 5:46 AM\nSFO\nOrigin San Francisco, CA, US (SFO)\n3H, 47M\nDuration 3 hours and 47 minutes\nIAH\nDestination Houston, TX, US (IAH)\nUA 505 (Boeing 787-9 Dreamliner)\nFlight Number UA 505. Aircraft Boeing 787-9 Dreamliner\nDetails\nSeats\n349 kg CO2\nCarbon emissions estimate: 349 kilograms.\nLearn more about carbon emissions",
+      "fares": [
+        {
+          "product_id": "ECO-BASIC",
+          "product": "United Economy®(Main cabin)",
+          "miles_text": "",
+          "money_text": "$386",
+          "cabin": "United Economy",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$386\nUnited Economy\ncabin select to view fare options"
+        },
+        {
+          "product_id": "ECONOMY-MERCH-EPLUS",
+          "product": "Economy Plus®(Extra legroom)",
+          "miles_text": "",
+          "money_text": "$755",
+          "cabin": "United Economy",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$755\nUnited Economy\ncabin select to view fare options"
+        },
+        {
+          "product_id": "MIN-BUSINESS-OR-FIRST",
+          "product": "United First®(Extra-spacious seat)",
+          "miles_text": "",
+          "money_text": "$1,346",
+          "cabin": "United First",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$1,346\nUnited First\ncabin select to view fare options"
+        }
+      ]
+    },
+    {
+      "departure": "12:45 AM",
+      "arrival": "6:32 AM",
+      "departure_note": "Departs Nov 14",
+      "arrival_note": "Arrives Nov 14",
+      "origin": "SFO",
+      "destination": "IAH",
+      "duration_text": "3H, 47MDuration 3 hours and 47 minutes",
+      "flight_text": "NONSTOP\nDeparts Nov 14\n12:45 AM\nDeparting at 12:45 AM\nArrives Nov 14\n6:32 AM\nArriving at 6:32 AM\nSFO\nOrigin San Francisco, CA, US (SFO)\n3H, 47M\nDuration 3 hours and 47 minutes\nIAH\nDestination Houston, TX, US (IAH)\nUA 604 (Boeing 737 MAX 9)\nFlight Number UA 604. Aircraft Boeing 737 MAX 9\nDetails\nSeats\n275 kg CO2\nCarbon emissions estimate: 275 kilograms.\nLearn more about carbon emissions",
+      "fares": [
+        {
+          "product_id": "ECO-BASIC",
+          "product": "United Economy®(Main cabin)",
+          "miles_text": "",
+          "money_text": "$454",
+          "cabin": "United Economy",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$454\nUnited Economy\ncabin select to view fare options"
+        },
+        {
+          "product_id": "ECONOMY-MERCH-EPLUS",
+          "product": "Economy Plus®(Extra legroom)",
+          "miles_text": "",
+          "money_text": "$823",
+          "cabin": "United Economy",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$823\nUnited Economy\ncabin select to view fare options"
+        },
+        {
+          "product_id": "MIN-BUSINESS-OR-FIRST",
+          "product": "United First®(Extra-spacious seat)",
+          "miles_text": "",
+          "money_text": "$1,784",
+          "cabin": "United First",
+          "award_type": "",
+          "discount": "",
+          "text": "From\n$1,784\nUnited First\ncabin select to view fare options"
+        }
+      ]
+    }
+  ]
+}

--- a/opencli-plugins/united/fixtures/miles.json
+++ b/opencli-plugins/united/fixtures/miles.json
@@ -1,0 +1,177 @@
+{
+  "url": "https://www.united.com/en/us/fsr/choose-flights?f=SFO&t=IAH&d=2026-11-13&r=2026-11-15&at=1&sc=7%2C7&px=1&pst=9Y8%3D-Y-Y&taxng=1&newHP=True&clm=7&st=bestmatches&tqp=A",
+  "language": "en",
+  "currency": "USD",
+  "price_mode": "miles",
+  "traveler_text": "1 Adult",
+  "date_heading": "Depart on: November 13",
+  "fare_note": "Fares are one-way, per person, and include taxes and fees. Additional bag charges may apply. Fare attributes apply to flights operated by United and United Express\u00ae.",
+  "loading": false,
+  "login_required": false,
+  "challenge": false,
+  "no_results": false,
+  "show_all": false,
+  "displayed": [],
+  "rows": [
+    {
+      "departure": "11:59 PM",
+      "arrival": "5:46 AM",
+      "departure_note": "",
+      "arrival_note": "Arrives Nov 14",
+      "origin": "SFO",
+      "destination": "IAH",
+      "duration_text": "3H, 47MDuration 3 hours and 47 minutes",
+      "flight_text": "Flight Information\nNONSTOP\n\u00a0\n11:59 PM\nDeparting at 11:59 PM\nArrives Nov 14\n5:46 AM\nArriving at 5:46 AM\nSFO\nOrigin San Francisco, CA, US (SFO)\n3H, 47M\nDuration 3 hours and 47 minutes\nIAH\nDestination Houston, TX, US (IAH)\nUA 505 (Boeing 787-9 Dreamliner)\nFlight Number UA 505. Aircraft Boeing 787-9 Dreamliner\nDetails\nSeats\n175 kg CO2\nCarbon emissions estimate: 175 kilograms.\nLearn more about carbon emissions",
+      "fares": [
+        {
+          "product_id": "MIN-ECONOMY-SURP-OR-DISP",
+          "product": "Economy",
+          "miles_text": "13.5k",
+          "money_text": "$5.60",
+          "cabin": "United Economy (XN)",
+          "award_type": "Saver Award",
+          "discount": "cardmembers save 10%",
+          "text": "CARDMEMBERS SAVE 10%\nWas\n15k miles\n+$5.60\nNow\n13.5k\nmiles\n+\n$5.60\nSaver Award\nUnited Economy (XN)\nSelect fare for Economy"
+        },
+        {
+          "product_id": "MIN-BUSINESS-SURP-OR-DISP",
+          "product": "First(lowest)",
+          "miles_text": "59.6k",
+          "money_text": "$5.60",
+          "cabin": "United First (JN)",
+          "award_type": "",
+          "discount": "cardmembers save 10%",
+          "text": "CARDMEMBERS SAVE 10%\nWas\n66.3k miles\n+$5.60\nNow\n59.6k\nmiles\n+\n$5.60\nUnited First (JN)\nSelect fare for First (lowest)"
+        }
+      ]
+    },
+    {
+      "departure": "4:40 PM",
+      "arrival": "10:28 PM",
+      "departure_note": "",
+      "arrival_note": "",
+      "origin": "SFO",
+      "destination": "IAH",
+      "duration_text": "3H, 48MDuration 3 hours and 48 minutes",
+      "flight_text": "Flight Information\nNONSTOP\n4:40 PM\nDeparting at 4:40 PM\n10:28 PM\nArriving at 10:28 PM\nSFO\nOrigin San Francisco, CA, US (SFO)\n3H, 48M\nDuration 3 hours and 48 minutes\nIAH\nDestination Houston, TX, US (IAH)\nUA 2305 (Boeing 737 MAX 9)\nFlight Number UA 2305. Aircraft Boeing 737 MAX 9\nDetails\nSeats\n139 kg CO2\nCarbon emissions estimate: 139 kilograms. This is a lower emissions flight.\nLearn more about carbon emissions",
+      "fares": [
+        {
+          "product_id": "MIN-ECONOMY-SURP-OR-DISP",
+          "product": "Economy",
+          "miles_text": "13.5k",
+          "money_text": "$5.60",
+          "cabin": "United Economy (XN)",
+          "award_type": "Saver Award",
+          "discount": "cardmembers save 10%",
+          "text": "CARDMEMBERS SAVE 10%\nWas\n15k miles\n+$5.60\nNow\n13.5k\nmiles\n+\n$5.60\nSaver Award\nUnited Economy (XN)\nSelect fare for Economy"
+        },
+        {
+          "product_id": "MIN-BUSINESS-SURP-OR-DISP",
+          "product": "First(lowest)",
+          "miles_text": "65.4k",
+          "money_text": "$5.60",
+          "cabin": "United First (JN)",
+          "award_type": "",
+          "discount": "cardmembers save 10%",
+          "text": "CARDMEMBERS SAVE 10%\nWas\n72.7k miles\n+$5.60\nNow\n65.4k\nmiles\n+\n$5.60\nUnited First (JN)\nSelect fare for First (lowest)"
+        }
+      ]
+    },
+    {
+      "departure": "10:50 PM",
+      "arrival": "6:10 AM",
+      "departure_note": "",
+      "arrival_note": "Arrives Nov 14",
+      "origin": "SFO",
+      "destination": "IAH",
+      "duration_text": "5H, 20MDuration 5 hours and 20 minutes",
+      "flight_text": "Flight Information\n1 STOP\n\u00a0\n10:50 PM\nDeparting at 10:50 PM\nArrives Nov 14\n6:10 AM\nArriving at 6:10 AM\nSFO\nOrigin San Francisco, CA, US (SFO)\n5H, 20M\nDuration 5 hours and 20 minutes\nIAH\nDestination Los Angeles, CA, US (LAX)\nLAX\nLos Angeles, CA, US (LAX)\n\u2014\nto\n36M\n36 minutes\nDetails\nSeats\n180 kg CO2\nCarbon emissions estimate: 180 kilograms.\nLearn more about carbon emissions",
+      "fares": [
+        {
+          "product_id": "MIN-ECONOMY-SURP-OR-DISP",
+          "product": "Economy",
+          "miles_text": "13.5k",
+          "money_text": "$5.60",
+          "cabin": "United Economy (XN)",
+          "award_type": "Saver Award",
+          "discount": "cardmembers save 66%",
+          "text": "CARDMEMBERS SAVE 66%\nWas\n39.8k miles\n+$5.60\nNow\n13.5k\nmiles\n+\n$5.60\nSaver Award\nUnited Economy (XN)\nSelect fare for Economy"
+        },
+        {
+          "product_id": "MIN-BUSINESS-SURP-OR-DISP",
+          "product": "First(lowest)",
+          "miles_text": "67.9k",
+          "money_text": "$5.60",
+          "cabin": "United First (JN)",
+          "award_type": "",
+          "discount": "cardmembers save 10%",
+          "text": "CARDMEMBERS SAVE 10%\nWas\n75.5k miles\n+$5.60\nNow\n67.9k\nmiles\n+\n$5.60\nUnited First (JN)\nSelect fare for First (lowest)"
+        }
+      ]
+    },
+    {
+      "departure": "9:20 PM",
+      "arrival": "6:10 AM",
+      "departure_note": "",
+      "arrival_note": "Arrives Nov 14",
+      "origin": "SFO",
+      "destination": "IAH",
+      "duration_text": "6H, 50MDuration 6 hours and 50 minutes",
+      "flight_text": "Flight Information\n1 STOP\n\u00a0\n9:20 PM\nDeparting at 9:20 PM\nArrives Nov 14\n6:10 AM\nArriving at 6:10 AM\nSFO\nOrigin San Francisco, CA, US (SFO)\n6H, 50M\nDuration 6 hours and 50 minutes\nIAH\nDestination Los Angeles, CA, US (LAX)\nLAX\nLos Angeles, CA, US (LAX)\n\u2014\nto\n2H, 2M\n2 hours and 2 minutes\nDetails\nSeats\n195 kg CO2\nCarbon emissions estimate: 195 kilograms.\nLearn more about carbon emissions",
+      "fares": [
+        {
+          "product_id": "MIN-ECONOMY-SURP-OR-DISP",
+          "product": "Economy",
+          "miles_text": "13.5k",
+          "money_text": "$5.60",
+          "cabin": "United Economy (XN)",
+          "award_type": "Saver Award",
+          "discount": "cardmembers save 66%",
+          "text": "CARDMEMBERS SAVE 66%\nWas\n39.8k miles\n+$5.60\nNow\n13.5k\nmiles\n+\n$5.60\nSaver Award\nUnited Economy (XN)\nSelect fare for Economy"
+        },
+        {
+          "product_id": "MIN-BUSINESS-SURP-OR-DISP",
+          "product": "First(lowest)",
+          "miles_text": "27k",
+          "money_text": "$5.60",
+          "cabin": "Mixed cabin",
+          "award_type": "",
+          "discount": "cardmembers save 64%",
+          "text": "CARDMEMBERS SAVE 64%\nWas\n75.5k miles\n+$5.60\nNow\n27k\nmiles\n+\n$5.60\nMixed cabin\nSelect fare for First (lowest)"
+        }
+      ]
+    },
+    {
+      "departure": "7:00 AM",
+      "arrival": "7:08 PM",
+      "departure_note": "",
+      "arrival_note": "",
+      "origin": "SFO",
+      "destination": "IAH",
+      "duration_text": "10H, 8MDuration 10 hours and 8 minutes",
+      "flight_text": "Flight Information\n1 STOP\n7:00 AM\nDeparting at 7:00 AM\n7:08 PM\nArriving at 7:08 PM\nSFO\nOrigin San Francisco, CA, US (SFO)\n10H, 8M\nDuration 10 hours and 8 minutes\nIAH\nDestination Miami, FL, US (MIA)\nMIA\nMiami, FL, US (MIA)\n\u2014\nto\n1H, 24M\n1 hours and 24 minutes\nDetails\nSeats\n346 kg CO2\nCarbon emissions estimate: 346 kilograms.\nLearn more about carbon emissions",
+      "fares": [
+        {
+          "product_id": "MIN-ECONOMY-SURP-OR-DISP",
+          "product": "Economy",
+          "miles_text": "13.5k",
+          "money_text": "$5.60",
+          "cabin": "United Economy (XN)",
+          "award_type": "Saver Award",
+          "discount": "cardmembers save 72%",
+          "text": "CARDMEMBERS SAVE 72%\nWas\n47.4k miles\n+$5.60\nNow\n13.5k\nmiles\n+\n$5.60\nSaver Award\nUnited Economy (XN)\nSelect fare for Economy"
+        },
+        {
+          "product_id": "MIN-BUSINESS-SURP-OR-DISP",
+          "product": "First(lowest)",
+          "miles_text": "0",
+          "money_text": "",
+          "cabin": "",
+          "award_type": "",
+          "discount": "",
+          "text": "Not available"
+        }
+      ]
+    }
+  ]
+}

--- a/opencli-plugins/united/fixtures/responsive.html
+++ b/opencli-plugins/united/fixtures/responsive.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <button aria-label="Currently in English US $ enter to change">English - US $</button>
+    <select><option value="money" selected>Money</option><option value="miles">Miles</option></select>
+    <input type="button" value="1 Adult">
+    <div class="FlightSearchResultsContainer-styles__detailHeading--fixture">Depart on: November 13</div>
+    <div class="FareDisclaimer-styles__disclaimer--fixture">Fares are one-way, per person.</div>
+    <div id="ECONOMY">United Economy</div>
+    <div id="FIRST">United First</div>
+    <div data-layout="desktop">
+      <div role="row">
+        <div role="gridcell">
+          NONSTOP
+          <div class="FlightInfoBlock-styles__departTime--fixture">
+            <span class="FlightInfoBlock-styles__time--fixture">5:00 AM</span>
+          </div>
+          <div class="FlightInfoBlock-styles__arrivalTime--fixture">
+            <span class="FlightInfoBlock-styles__time--fixture">10:49 AM</span>
+          </div>
+          <div class="FlightInfoBlock-styles__departAirport--fixture">SFO</div>
+          <div class="FlightInfoBlock-styles__arrivalAirport--fixture">IAH</div>
+          <div class="FlightInfoBlock-styles__duration--fixture">3H, 49M</div>
+          Flight Number UA 2168.
+        </div>
+        <div role="gridcell" aria-describedby="ECONOMY" style="display:none">
+          <div class="PriceCard-styles__moneyContainer--fixture">
+            <span class="PriceCard-styles__priceValue--fixture">$1</span>
+          </div>
+        </div>
+        <div role="gridcell" aria-describedby="ECONOMY">
+          <div class="PriceCard-styles__moneyContainer--fixture">
+            <span class="PriceCard-styles__priceValue--fixture">$192</span>
+          </div>
+          <div class="PriceCard-styles__cabinDescription--fixture">United Economy</div>
+        </div>
+        <div role="gridcell" aria-describedby="FIRST">
+          <div class="PriceCard-styles__moneyContainer--fixture">
+            <span class="PriceCard-styles__priceValue--fixture">$719</span>
+          </div>
+          <div class="PriceCard-styles__cabinDescription--fixture">United First</div>
+        </div>
+      </div>
+    </div>
+    <div data-layout="mobile" style="display:none"></div>
+    <div data-hidden-extras></div>
+    <div>Displaying 2 of 5</div>
+    <button>Show all flights</button>
+  </body>
+</html>

--- a/opencli-plugins/united/flights.js
+++ b/opencli-plugins/united/flights.js
@@ -1,0 +1,139 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from "@jackwener/opencli/errors";
+import { cli, Strategy } from "@jackwener/opencli/registry";
+import { loadUnitedFlights, UnitedLoginRequiredError } from "./united-browser.mjs";
+import { CABINS, normalizeResults, normalizeSearch, SORTS, STOPS } from "./united-helpers.mjs";
+
+cli({
+  site: "united",
+  name: "flights",
+  access: "read",
+  description: "Search United cash fares or MileagePlus awards (outbound choices for round trips)",
+  example: "opencli united flights SFO IAH 2026-11-13 --miles --stops nonstop -f json",
+  domain: "united.com",
+  strategy: Strategy.PUBLIC,
+  browser: true,
+  args: [
+    {
+      name: "from",
+      type: "string",
+      positional: true,
+      required: true,
+      help: "Origin airport code, e.g. SFO",
+    },
+    {
+      name: "to",
+      type: "string",
+      positional: true,
+      required: true,
+      help: "Destination airport code, e.g. IAH",
+    },
+    {
+      name: "depart",
+      type: "string",
+      positional: true,
+      required: true,
+      help: "Departure date, YYYY-MM-DD",
+    },
+    {
+      name: "return",
+      type: "string",
+      help: "Return date, YYYY-MM-DD. Returns outbound choices, not a selected round trip",
+    },
+    {
+      name: "miles",
+      type: "bool",
+      default: false,
+      help: "Search MileagePlus award miles plus cash taxes. Requires United sign-in",
+    },
+    {
+      name: "adults",
+      type: "int",
+      default: 1,
+      help: "Adult travelers (1-9). Fares remain per person",
+    },
+    {
+      name: "cabin",
+      type: "string",
+      default: "economy",
+      choices: CABINS,
+      help: "Filter displayed fare columns. Economy Plus is not premium economy",
+    },
+    {
+      name: "stops",
+      type: "string",
+      default: "any",
+      choices: STOPS,
+      help: "Maximum stops on the outbound leg",
+    },
+    {
+      name: "max-price",
+      type: "string",
+      help: "Maximum displayed cash fare in USD. Not valid with --miles",
+    },
+    {
+      name: "max-miles",
+      type: "int",
+      help: "Maximum displayed award miles per person. Requires --miles",
+    },
+    { name: "max-duration", type: "int", help: "Maximum outbound duration in minutes" },
+    {
+      name: "exclude-mixed-cabin",
+      type: "bool",
+      default: false,
+      help: "Exclude fares labeled mixed cabin",
+    },
+    {
+      name: "sort",
+      type: "string",
+      default: "best",
+      choices: SORTS,
+      help: "United order, price (miles then taxes for awards), duration, or departure",
+    },
+    {
+      name: "limit",
+      type: "int",
+      default: 20,
+      help: "Maximum fare rows (1-500), after filtering and sorting all flights",
+    },
+    {
+      name: "timeout",
+      type: "int",
+      default: 90,
+      help: "Result-loading deadline in seconds (5-180)",
+    },
+  ],
+  columns: [
+    "rank",
+    "origin",
+    "destination",
+    "departure_date",
+    "departure",
+    "arrival_date",
+    "arrival",
+    "duration_minutes",
+    "stops",
+    "fare_product",
+    "price",
+    "miles",
+    "taxes",
+    "currency",
+    "price_basis",
+  ],
+  func: async (page, args) => {
+    let search;
+    try {
+      search = normalizeSearch(args);
+    } catch (error) {
+      throw new ArgumentError(error.message);
+    }
+    if (!page) throw new CommandExecutionError("Browser session required for united flights");
+    try {
+      const data = await loadUnitedFlights(page, search);
+      return normalizeResults(data, search);
+    } catch (error) {
+      if (error instanceof UnitedLoginRequiredError)
+        throw new AuthRequiredError("united.com", error.message);
+      throw new CommandExecutionError(error.message);
+    }
+  },
+});

--- a/opencli-plugins/united/flights.js
+++ b/opencli-plugins/united/flights.js
@@ -10,8 +10,10 @@ cli({
   description: "Search United cash fares or MileagePlus awards (outbound choices for round trips)",
   example: "opencli united flights SFO IAH 2026-11-13 --miles --stops nonstop -f json",
   domain: "united.com",
-  strategy: Strategy.PUBLIC,
+  strategy: Strategy.COOKIE,
   browser: true,
+  siteSession: "persistent",
+  navigateBefore: false,
   args: [
     {
       name: "from",

--- a/opencli-plugins/united/opencli-plugin.json
+++ b/opencli-plugins/united/opencli-plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "rome-united",
+  "description": "United flight prices in money or MileagePlus miles",
+  "version": "0.1.0",
+  "opencli": ">=1.8.0"
+}

--- a/opencli-plugins/united/package.json
+++ b/opencli-plugins/united/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "rome-opencli-united",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "../../scripts/test-env.sh node --test *.test.mjs"
+  }
+}

--- a/opencli-plugins/united/united-browser.mjs
+++ b/opencli-plugins/united/united-browser.mjs
@@ -1,0 +1,55 @@
+import { assertSearchPage, buildSearchUrl } from "./united-helpers.mjs";
+import { readUnitedPage } from "./united-page.mjs";
+
+export class UnitedLoginRequiredError extends Error {}
+
+export function expandAllFlights() {
+  const button = [...document.querySelectorAll("button")].find(
+    (element) =>
+      /^Show all flights$/i.test((element.textContent || "").trim()) &&
+      element.getClientRects().length &&
+      !element.disabled,
+  );
+  if (!button) return false;
+  button.click();
+  return true;
+}
+
+/** Only navigates and expands search results. Never chooses a fare or reads account state. */
+export async function loadUnitedFlights(page, search, { now = Date.now } = {}) {
+  // A fresh document prevents the SPA from reusing the preceding route or award mode.
+  await page.goto("about:blank");
+  await page.goto(buildSearchUrl(search));
+  const deadline = now() + search.timeout * 1000;
+  let previous = "";
+  let expanded = false;
+  while (now() <= deadline) {
+    const data = await page.evaluate(readUnitedPage);
+    if (data.challenge)
+      throw new Error("United served an access challenge. Clear it in the browser, then retry");
+    if (data.service_error) throw new Error("United could not complete this search. Retry later");
+    if (data.login_required) {
+      throw new UnitedLoginRequiredError(
+        "Sign in to MileagePlus on united.com in this browser, then retry --miles. Cash prices will not be substituted",
+      );
+    }
+    if (!data.loading && (data.rows.length || data.no_results)) {
+      assertSearchPage(data, search);
+      if (data.no_results && !data.rows.length) return data;
+      if (data.show_all && !expanded) {
+        expanded = await page.evaluate(expandAllFlights);
+        previous = "";
+      } else {
+        const [shown, total] = data.displayed;
+        const complete = !data.show_all && (!total || shown >= total || data.rows.length >= total);
+        const signature = JSON.stringify(data.rows);
+        if (complete && signature === previous) return data;
+        previous = signature;
+      }
+    }
+    await page.wait({ time: 1 });
+  }
+  throw new Error(
+    `United did not finish loading all flight results within ${search.timeout}s. Retry or increase --timeout. No partial prices were returned`,
+  );
+}

--- a/opencli-plugins/united/united-browser.mjs
+++ b/opencli-plugins/united/united-browser.mjs
@@ -23,8 +23,12 @@ export async function loadUnitedFlights(page, search, { now = Date.now } = {}) {
   const deadline = now() + search.timeout * 1000;
   let previous = "";
   let expanded = false;
+  let expectedTotal = null;
   while (now() <= deadline) {
     const data = await page.evaluate(readUnitedPage);
+    const total = data.displayed[1];
+    // The counter can disappear during expansion. Its highest total remains the completion bound.
+    if (Number.isInteger(total) && total > 0) expectedTotal = Math.max(expectedTotal ?? 0, total);
     if (data.challenge)
       throw new Error("United served an access challenge. Clear it in the browser, then retry");
     if (data.service_error) throw new Error("United could not complete this search. Retry later");
@@ -35,17 +39,20 @@ export async function loadUnitedFlights(page, search, { now = Date.now } = {}) {
     }
     if (!data.loading && (data.rows.length || data.no_results)) {
       assertSearchPage(data, search);
-      if (data.no_results && !data.rows.length) return data;
+      if (data.no_results && !data.rows.length && expectedTotal === null && !expanded) return data;
       if (data.show_all && !expanded) {
         expanded = await page.evaluate(expandAllFlights);
         previous = "";
       } else {
-        const [shown, total] = data.displayed;
-        const complete = !data.show_all && (!total || shown >= total || data.rows.length >= total);
-        const signature = JSON.stringify(data.rows);
+        const complete =
+          !data.show_all &&
+          (expectedTotal !== null ? data.rows.length >= expectedTotal : !expanded);
+        const signature = complete ? JSON.stringify(data.rows) : "";
         if (complete && signature === previous) return data;
         previous = signature;
       }
+    } else {
+      previous = "";
     }
     await page.wait({ time: 1 });
   }

--- a/opencli-plugins/united/united-browser.test.mjs
+++ b/opencli-plugins/united/united-browser.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { loadUnitedFlights, UnitedLoginRequiredError } from "./united-browser.mjs";
+import { buildSearchUrl, normalizeSearch } from "./united-helpers.mjs";
+
+const fixture = () => JSON.parse(readFileSync(new URL("./fixtures/miles.json", import.meta.url)));
+const search = normalizeSearch(
+  { from: "SFO", to: "IAH", depart: "2026-11-13", return: "2026-11-15", miles: true, timeout: 5 },
+  "2026-09-10",
+);
+function browser(states) {
+  let index = 0;
+  let time = 0;
+  const calls = [];
+  const page = {
+    async goto(url) {
+      calls.push(["goto", url]);
+    },
+    async evaluate(fn) {
+      calls.push(["evaluate", fn.name]);
+      if (fn.name === "expandAllFlights") return true;
+      return structuredClone(states[Math.min(index++, states.length - 1)]);
+    },
+    async wait() {
+      time += 1000;
+    },
+  };
+  return { page, calls, options: { now: () => time } };
+}
+
+test("waits for loading, expands all flights, and requires stable complete results", async () => {
+  const data = fixture();
+  const pending = { ...data, rows: [], loading: true };
+  const partial = { ...data, show_all: true, displayed: [35, 80] };
+  const b = browser([pending, partial, data, data]);
+  assert.deepEqual(await loadUnitedFlights(b.page, search, b.options), data);
+  assert.deepEqual(b.calls.slice(0, 2), [
+    ["goto", "about:blank"],
+    ["goto", buildSearchUrl(search)],
+  ]);
+  assert.equal(b.calls.filter((c) => c[1] === "expandAllFlights").length, 1);
+});
+
+test("login wall is a typed error, not a switch to cash", async () => {
+  const b = browser([{ ...fixture(), login_required: true }]);
+  await assert.rejects(loadUnitedFlights(b.page, search, b.options), UnitedLoginRequiredError);
+  assert.equal(b.calls.filter((c) => c[0] === "goto").length, 2);
+});
+
+test("access challenge fails immediately without bypassing it", async () => {
+  const b = browser([{ ...fixture(), challenge: true }]);
+  await assert.rejects(loadUnitedFlights(b.page, search, b.options), /access challenge/);
+});
+
+test("loading forever, missing rows, and incomplete expansion are not empty success", async () => {
+  for (const patch of [
+    { loading: true, rows: [] },
+    { rows: [] },
+    { show_all: true, displayed: [35, 80] },
+  ]) {
+    const b = browser([{ ...fixture(), ...patch }]);
+    await assert.rejects(loadUnitedFlights(b.page, search, b.options), /No partial prices/);
+    assert.ok(b.calls.filter((c) => c[1] === "expandAllFlights").length <= 1);
+  }
+});
+
+test("explicit no-flights response is distinct from an unloaded page", async () => {
+  const data = { ...fixture(), rows: [], no_results: true, date_heading: "" };
+  const b = browser([data]);
+  assert.deepEqual(await loadUnitedFlights(b.page, search, b.options), data);
+});
+
+test("stale cash results cannot satisfy a miles request", async () => {
+  const b = browser([{ ...fixture(), price_mode: "money" }]);
+  await assert.rejects(loadUnitedFlights(b.page, search, b.options), /money\/miles mode/);
+});
+
+test("United service errors fail immediately instead of timing out or reporting no flights", async () => {
+  const b = browser([{ ...fixture(), rows: [], service_error: true }]);
+  await assert.rejects(loadUnitedFlights(b.page, search, b.options), /Retry later/);
+  assert.equal(b.calls.filter((c) => c[1] === "readUnitedPage").length, 1);
+});

--- a/opencli-plugins/united/united-browser.test.mjs
+++ b/opencli-plugins/united/united-browser.test.mjs
@@ -5,10 +5,14 @@ import { loadUnitedFlights, UnitedLoginRequiredError } from "./united-browser.mj
 import { buildSearchUrl, normalizeSearch } from "./united-helpers.mjs";
 
 const fixture = () => JSON.parse(readFileSync(new URL("./fixtures/miles.json", import.meta.url)));
-const search = normalizeSearch(
-  { from: "SFO", to: "IAH", depart: "2026-11-13", return: "2026-11-15", miles: true, timeout: 5 },
-  "2026-09-10",
-);
+const search = normalizeSearch({
+  from: "SFO",
+  to: "IAH",
+  depart: "2026-11-13",
+  return: "2026-11-15",
+  miles: true,
+  timeout: 5,
+});
 function browser(states) {
   let index = 0;
   let time = 0;
@@ -32,7 +36,12 @@ function browser(states) {
 test("waits for loading, expands all flights, and requires stable complete results", async () => {
   const data = fixture();
   const pending = { ...data, rows: [], loading: true };
-  const partial = { ...data, show_all: true, displayed: [35, 80] };
+  const partial = {
+    ...data,
+    rows: data.rows.slice(0, 2),
+    show_all: true,
+    displayed: [2, data.rows.length],
+  };
   const b = browser([pending, partial, data, data]);
   assert.deepEqual(await loadUnitedFlights(b.page, search, b.options), data);
   assert.deepEqual(b.calls.slice(0, 2), [
@@ -80,4 +89,60 @@ test("United service errors fail immediately instead of timing out or reporting 
   const b = browser([{ ...fixture(), rows: [], service_error: true }]);
   await assert.rejects(loadUnitedFlights(b.page, search, b.options), /Retry later/);
   assert.equal(b.calls.filter((c) => c[1] === "readUnitedPage").length, 1);
+});
+
+test("waits through 2/5 -> 2 -> 2 -> 5 when the total disappears during expansion", async () => {
+  const data = fixture();
+  assert.equal(data.rows.length, 5);
+  const partial = { ...data, rows: data.rows.slice(0, 2) };
+  const b = browser([
+    { ...partial, show_all: true, displayed: [2, 5] },
+    partial,
+    partial,
+    data,
+    data,
+  ]);
+  const result = await loadUnitedFlights(b.page, search, b.options);
+  assert.equal(result.rows.length, 5);
+  assert.equal(b.calls.filter((c) => c[1] === "readUnitedPage").length, 5);
+});
+
+test("does not accept a vanished or reduced counter while visible rows remain incomplete", async () => {
+  const data = fixture();
+  const partial = { ...data, rows: data.rows.slice(0, 2) };
+  for (const displayed of [[], [2, 2], [5, 5]]) {
+    const b = browser([
+      { ...partial, show_all: true, displayed: [2, 5] },
+      { ...partial, displayed },
+    ]);
+    await assert.rejects(loadUnitedFlights(b.page, search, b.options), /No partial prices/);
+  }
+});
+
+test("retains totals observed while the result list is still loading", async () => {
+  const data = fixture();
+  const partial = { ...data, rows: data.rows.slice(0, 2) };
+  const b = browser([{ ...partial, loading: true, displayed: [2, 5] }, partial]);
+  await assert.rejects(loadUnitedFlights(b.page, search, b.options), /No partial prices/);
+});
+
+test("expansion without any total cannot return an unproven stable subset", async () => {
+  const data = fixture();
+  const b = browser([{ ...data, show_all: true }, data]);
+  await assert.rejects(loadUnitedFlights(b.page, search, b.options), /No partial prices/);
+});
+
+test("complete counterless lists that need no expansion still succeed", async () => {
+  const data = fixture();
+  const b = browser([data, data]);
+  assert.deepEqual(await loadUnitedFlights(b.page, search, b.options), data);
+});
+
+test("a transient no-results state cannot erase a known total", async () => {
+  const data = fixture();
+  const b = browser([
+    { ...data, show_all: true, displayed: [2, 5] },
+    { ...data, rows: [], no_results: true },
+  ]);
+  await assert.rejects(loadUnitedFlights(b.page, search, b.options), /No partial prices/);
 });

--- a/opencli-plugins/united/united-command.test.mjs
+++ b/opencli-plugins/united/united-command.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { registerHooks } from "node:module";
+import test from "node:test";
+
+const registryUrl = `data:text/javascript,${encodeURIComponent(`
+  export const Strategy = { PUBLIC: "public", COOKIE: "cookie" };
+  export let command;
+  export function cli(definition) { command = definition; }
+`)}`;
+const errorsUrl = `data:text/javascript,${encodeURIComponent(`
+  export class ArgumentError extends Error {}
+  export class CommandExecutionError extends Error {}
+  export class AuthRequiredError extends Error {
+    constructor(domain, message) { super(message); this.domain = domain; }
+  }
+`)}`;
+const hooks = registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === "@jackwener/opencli/registry")
+      return { url: registryUrl, shortCircuit: true };
+    if (specifier === "@jackwener/opencli/errors") return { url: errorsUrl, shortCircuit: true };
+    return nextResolve(specifier, context);
+  },
+});
+let command;
+try {
+  await import("./flights.js");
+  ({ command } = await import(registryUrl));
+} finally {
+  hooks.deregister();
+}
+
+const fixture = (name) =>
+  JSON.parse(readFileSync(new URL(`./fixtures/${name}.json`, import.meta.url)));
+const args = { from: "SFO", to: "IAH", depart: "2026-11-13", return: "2026-11-15" };
+const pageFor = (data) => ({
+  async goto() {},
+  async wait() {},
+  async evaluate() {
+    return structuredClone(data);
+  },
+});
+
+test("command declares a persistent cookie-backed browser session with adapter-owned navigation", () => {
+  assert.equal(command.strategy, "cookie");
+  assert.equal(command.siteSession, "persistent");
+  assert.equal(command.browser, true);
+  assert.equal(command.navigateBefore, false);
+  assert.equal(command.access, "read");
+});
+
+test("cookie-backed command still permits anonymous cash search", async () => {
+  const rows = await command.func(pageFor(fixture("cash")), { ...args, adults: 2 });
+  assert.equal(rows[0].pricing, "money");
+  assert.equal(rows[0].price, 454);
+});
+
+test("signed-out awards still report United authentication rather than cash fallback", async () => {
+  await assert.rejects(
+    command.func(pageFor({ ...fixture("miles"), login_required: true }), { ...args, miles: true }),
+    (error) => error.constructor.name === "AuthRequiredError" && error.domain === "united.com",
+  );
+});

--- a/opencli-plugins/united/united-dom.test.mjs
+++ b/opencli-plugins/united/united-dom.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import test from "node:test";
+import { readUnitedPage } from "./united-page.mjs";
+
+// Reuse the repository's web-test dependency without adding a plugin runtime dependency.
+const { JSDOM } = createRequire(new URL("../../packages/web/package.json", import.meta.url))(
+  "jsdom",
+);
+const html = readFileSync(new URL("./fixtures/responsive.html", import.meta.url), "utf8");
+
+export function addResponsiveDuplicates(document) {
+  const desktop = document.querySelector('[data-layout="desktop"]');
+  const second = desktop.firstElementChild.cloneNode(true);
+  second.querySelector('[class*="departTime--"] span').textContent = "6:00 AM";
+  second.style.cssText = "position:absolute; top:5000px";
+  desktop.append(second);
+  const mobile = document.querySelector('[data-layout="mobile"]');
+  mobile.innerHTML = desktop.innerHTML;
+  const extras = document.querySelector("[data-hidden-extras]");
+  for (const variant of ["display", "visibility", "hidden", "aria"]) {
+    const duplicate = desktop.firstElementChild.cloneNode(true);
+    if (variant === "display") duplicate.style.display = "none";
+    if (variant === "visibility") duplicate.style.visibility = "hidden";
+    if (variant === "hidden") duplicate.hidden = true;
+    if (variant === "aria") duplicate.setAttribute("aria-hidden", "true");
+    extras.append(duplicate);
+    const hiddenFare = desktop.querySelector('[aria-describedby="FIRST"]').cloneNode(true);
+    if (variant === "display") hiddenFare.style.display = "none";
+    if (variant === "visibility") hiddenFare.style.visibility = "hidden";
+    if (variant === "hidden") hiddenFare.hidden = true;
+    if (variant === "aria") hiddenFare.setAttribute("aria-hidden", "true");
+    desktop.firstElementChild.append(hiddenFare);
+  }
+}
+
+for (const layout of ["desktop", "mobile"]) {
+  test(`reads only displayed flight rows and fare cells in the ${layout} DOM`, () => {
+    const dom = new JSDOM(html, {
+      runScripts: "outside-only",
+      url: "https://www.united.com/en/us/fsr/choose-flights",
+    });
+    try {
+      const { window } = dom;
+      // jsdom implements DOM/CSS selectors, not layout. Supply boxes and innerText for the fixture.
+      window.HTMLElement.prototype.getClientRects = function () {
+        for (let element = this; element; element = element.parentElement) {
+          if (element.hidden || window.getComputedStyle(element).display === "none") return [];
+        }
+        return [{}];
+      };
+      Object.defineProperty(window.HTMLElement.prototype, "innerText", {
+        get() {
+          return this.textContent;
+        },
+      });
+      addResponsiveDuplicates(window.document);
+      for (const element of window.document.querySelectorAll("[data-layout]")) {
+        element.style.display = element.dataset.layout === layout ? "block" : "none";
+      }
+      const data = JSON.parse(JSON.stringify(window.eval(`(${readUnitedPage.toString()})()`)));
+      assert.ok(window.document.querySelectorAll('[role="row"]').length > data.rows.length);
+      assert.equal(data.rows.length, 2);
+      assert.deepEqual(
+        data.rows.map((row) => row.departure),
+        ["5:00 AM", "6:00 AM"],
+      );
+      for (const row of data.rows) {
+        assert.deepEqual(
+          row.fares.map((fare) => fare.money_text),
+          ["$192", "$719"],
+        );
+        assert.deepEqual(
+          row.fares.map((fare) => fare.product),
+          ["United Economy", "United First"],
+        );
+      }
+      assert.deepEqual(data.displayed, [2, 5]);
+    } finally {
+      dom.window.close();
+    }
+  });
+}

--- a/opencli-plugins/united/united-helpers.mjs
+++ b/opencli-plugins/united/united-helpers.mjs
@@ -1,0 +1,346 @@
+export const CABINS = [
+  "economy",
+  "economy-plus",
+  "premium-economy",
+  "business",
+  "first",
+  "business-or-first",
+  "all",
+];
+export const SORTS = ["best", "price", "duration", "departure"];
+export const STOPS = ["any", "nonstop", "one-or-fewer", "two-or-fewer"];
+
+function integer(value, name, min, max) {
+  const number = Number(value);
+  if (
+    typeof value === "boolean" ||
+    value === null ||
+    String(value).trim() === "" ||
+    !Number.isInteger(number) ||
+    number < min ||
+    number > max
+  ) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  }
+  return number;
+}
+
+function positive(value, name) {
+  if (value === undefined || value === null) return null;
+  const number = Number(value);
+  if (typeof value === "boolean" || !Number.isFinite(number) || number <= 0)
+    throw new Error(`${name} must be positive`);
+  return number;
+}
+
+function date(value, name) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(value))) throw new Error(`${name} must use YYYY-MM-DD`);
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`${name} must be a valid calendar date`);
+  }
+  return value;
+}
+
+function choice(value, name, values) {
+  if (!values.includes(value)) throw new Error(`${name} must be one of: ${values.join(", ")}`);
+  return value;
+}
+
+export function normalizeSearch(args, today = new Date().toISOString().slice(0, 10)) {
+  const airport = (value, name) => {
+    const code = String(value || "")
+      .trim()
+      .toUpperCase();
+    if (!/^[A-Z]{3}$/.test(code))
+      throw new Error(`${name} must be a three-letter airport code, such as SFO`);
+    return code;
+  };
+  const from = airport(args.from, "from");
+  const to = airport(args.to, "to");
+  if (from === to) throw new Error("from and to must be different airports");
+  const depart = date(args.depart, "depart");
+  const returnDate = args.return === undefined ? null : date(args.return, "return");
+  if (depart < today) throw new Error("depart must not be in the past");
+  if (returnDate && returnDate < depart) throw new Error("return must be on or after depart");
+  if (args.miles !== undefined && typeof args.miles !== "boolean")
+    throw new Error("miles must be a boolean flag");
+  if (args["exclude-mixed-cabin"] !== undefined && typeof args["exclude-mixed-cabin"] !== "boolean")
+    throw new Error("exclude-mixed-cabin must be a boolean flag");
+  const miles = args.miles ?? false;
+  const maxPrice = positive(args["max-price"], "max-price");
+  const maxMiles =
+    args["max-miles"] === undefined ? null : integer(args["max-miles"], "max-miles", 1, 10000000);
+  if (miles && maxPrice !== null)
+    throw new Error("Use --max-miles for award prices, not --max-price");
+  if (!miles && maxMiles !== null) throw new Error("--max-miles requires --miles");
+  return {
+    from,
+    to,
+    depart,
+    returnDate,
+    miles,
+    maxPrice,
+    maxMiles,
+    adults: integer(args.adults ?? 1, "adults", 1, 9),
+    cabin: choice(args.cabin ?? "economy", "cabin", CABINS),
+    stops: choice(args.stops ?? "any", "stops", STOPS),
+    sort: choice(args.sort ?? "best", "sort", SORTS),
+    limit: integer(args.limit ?? 20, "limit", 1, 500),
+    timeout: integer(args.timeout ?? 90, "timeout", 5, 180),
+    maxDuration:
+      args["max-duration"] === undefined
+        ? null
+        : integer(args["max-duration"], "max-duration", 1, 10080),
+    excludeMixed: args["exclude-mixed-cabin"] ?? false,
+  };
+}
+
+export function buildSearchUrl(search) {
+  const url = new URL("https://www.united.com/en/us/fsr/choose-flights");
+  const params = {
+    f: search.from,
+    t: search.to,
+    d: search.depart,
+    px: String(search.adults),
+    tqp: search.miles ? "A" : "R",
+    sc: search.returnDate ? "7,7" : "7",
+    clm: "7",
+    taxng: "1",
+    newHP: "True",
+    st: "bestmatches",
+  };
+  // `at=1` selects award travel, not the adult count. Cash links omit `at`.
+  if (search.miles) params.at = "1";
+  if (search.returnDate) params.r = search.returnDate;
+  else params.tt = "1";
+  for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+  return url.toString();
+}
+
+/** Validate the loaded search before attaching the requested route/date to any price. */
+export function assertSearchPage(data, search) {
+  const url = new URL(data.url);
+  const params = url.searchParams;
+  if (
+    url.hostname !== "www.united.com" ||
+    url.pathname.toLowerCase() !== "/en/us/fsr/choose-flights"
+  ) {
+    throw new Error("United did not open its English-US flight results page");
+  }
+  const expected = { f: search.from, t: search.to, d: search.depart, px: String(search.adults) };
+  for (const [name, value] of Object.entries(expected)) {
+    if (params.get(name) !== value)
+      throw new Error(`United changed the requested ${name} search condition`);
+  }
+  if (
+    (params.get("r") || null) !== search.returnDate ||
+    (params.get("idx") && params.get("idx") !== "1")
+  ) {
+    throw new Error("United is not showing the requested outbound search");
+  }
+  if (
+    (params.get("at") === "1") !== search.miles ||
+    data.price_mode !== (search.miles ? "miles" : "money")
+  ) {
+    throw new Error("United did not honor the requested money/miles mode. No prices were returned");
+  }
+  if (!/^en(?:-|$)/i.test(data.language) || data.currency !== "USD") {
+    throw new Error(
+      "Set United's locale to English - United States and currency to USD, then retry",
+    );
+  }
+  if (!new RegExp(`^${search.adults} Adults?$`).test(data.traveler_text)) {
+    throw new Error("United did not show the requested adult traveler count");
+  }
+  if (data.no_results && data.rows.length === 0) return;
+  const month = new Date(`${search.depart}T00:00:00Z`).toLocaleString("en-US", {
+    month: "long",
+    timeZone: "UTC",
+  });
+  const heading = new RegExp(`^Depart on:\\s*${month} ${Number(search.depart.slice(8))}$`, "i");
+  if (!heading.test(data.date_heading))
+    throw new Error("United did not show the requested departure date heading");
+}
+
+export function parseMoney(value) {
+  const match = String(value || "")
+    .trim()
+    .match(/^(?:US\s*)?\$\s*(\d+(?:,\d{3})*)(?:\.(\d{2}))?$/);
+  return match ? Number(`${match[1].replaceAll(",", "")}.${match[2] || "00"}`) : null;
+}
+
+/** Converts the displayed value only. A rounded `13.5k` label remains available in the output. */
+export function parseMiles(value) {
+  const match = String(value || "")
+    .trim()
+    .match(/^(\d+(?:,\d{3})*(?:\.\d+)?)\s*([km])?(?:\s*miles)?$/i);
+  if (!match) return null;
+  const number =
+    Number(match[1].replaceAll(",", "")) * ({ k: 1000, m: 1000000 }[match[2]?.toLowerCase()] || 1);
+  const rounded = Math.round(number);
+  return Number.isSafeInteger(rounded) && Math.abs(number - rounded) < 1e-7 ? rounded : null;
+}
+
+export function cabinOf(product) {
+  if (/premium plus|premium economy/i.test(product)) return "premium-economy";
+  if (/economy plus/i.test(product)) return "economy-plus";
+  if (/polaris|business/i.test(product)) return "business";
+  if (/first/i.test(product)) return "first";
+  if (/economy/i.test(product)) return "economy";
+  return "unknown";
+}
+
+export function timeMinutes(value) {
+  const match = String(value).match(/^(\d{1,2}):(\d{2})\s*(AM|PM)$/i);
+  if (!match || Number(match[1]) < 1 || Number(match[1]) > 12 || Number(match[2]) > 59) return null;
+  return (Number(match[1]) % 12) * 60 + Number(match[2]) + (/PM/i.test(match[3]) ? 720 : 0);
+}
+
+export function dateFromNote(note, baseDate) {
+  if (!note?.trim()) return baseDate;
+  const match = note.trim().match(/^(?:Departs|Arrives) ([A-Z][a-z]{2}) (\d{1,2})$/);
+  const month = match
+    ? ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"].indexOf(
+        match[1],
+      )
+    : -1;
+  if (month < 0) throw new Error(`Unrecognized United date label: ${note}`);
+  const year = Number(baseDate.slice(0, 4));
+  const base = Date.parse(`${baseDate}T00:00:00Z`);
+  const candidates = [year - 1, year, year + 1]
+    .map((candidate) => new Date(Date.UTC(candidate, month, Number(match[2]))))
+    .filter(
+      (candidate) =>
+        candidate.getUTCMonth() === month && Math.abs(candidate.getTime() - base) <= 7 * 86400000,
+    )
+    .sort((a, b) => Math.abs(a.getTime() - base) - Math.abs(b.getTime() - base));
+  if (!candidates.length) throw new Error(`United date label is outside this itinerary: ${note}`);
+  return candidates[0].toISOString().slice(0, 10);
+}
+
+export function priceBasis(note) {
+  if (/round\s*-?\s*trip.*per person/i.test(note)) return "round_trip_per_person_starting_total";
+  if (/one-way.*per person/i.test(note)) return "one_way_per_person";
+  return "displayed_price_see_fare_note";
+}
+
+/** One output row per flight and fare column, never calendar prices or crossed-out award prices. */
+export function normalizeResults(data, search, retrievedAt = new Date().toISOString()) {
+  assertSearchPage(data, search);
+  const results = [];
+  for (const [index, flight] of data.rows.entries()) {
+    if (flight.origin !== search.from || flight.destination !== search.to)
+      throw new Error("United returned a flight for a different route");
+    const departureDate = dateFromNote(flight.departure_note, search.depart);
+    if (departureDate !== search.depart) continue;
+    const arrivalDate = dateFromNote(flight.arrival_note, departureDate);
+    const stopsMatch = flight.flight_text.match(/\b(\d+)\s+STOPS?\b/i);
+    const stops = /\bNONSTOP\b/i.test(flight.flight_text)
+      ? 0
+      : stopsMatch
+        ? Number(stopsMatch[1])
+        : null;
+    const duration = flight.duration_text.match(/(?:(\d+)\s*H[,\s]*)?(\d+)\s*M/i);
+    const durationMinutes = duration ? Number(duration[1] || 0) * 60 + Number(duration[2]) : null;
+    if (
+      stops === null ||
+      durationMinutes === null ||
+      timeMinutes(flight.departure) === null ||
+      timeMinutes(flight.arrival) === null
+    ) {
+      throw new Error(
+        "United flight timing or stop labels changed. No partial results were returned",
+      );
+    }
+    if (!flight.fares.length) throw new Error("United exposed a flight without fare columns");
+    for (const fare of flight.fares) {
+      if (/^(?:not available|unavailable|sold out|not offered)$/i.test(fare.text.trim())) continue;
+      if (!fare.product) throw new Error("United fare column label is missing");
+      const cash = parseMoney(fare.money_text);
+      const miles = parseMiles(fare.miles_text);
+      if (
+        search.miles ? miles === null || cash === null : cash === null || Boolean(fare.miles_text)
+      ) {
+        throw new Error(
+          "United fare price format or money/miles mode changed. No partial results were returned",
+        );
+      }
+      const cabin = cabinOf(fare.product);
+      const mixedCabin =
+        /mixed cabin/i.test(`${fare.cabin} ${fare.text}`) ||
+        (fare.cabin.match(/United (?:Economy|First|Business|Polaris|Premium Plus)/g) || []).length >
+          1;
+      const maxStops = { any: Infinity, nonstop: 0, "one-or-fewer": 1, "two-or-fewer": 2 }[
+        search.stops
+      ];
+      const cabinMatches =
+        search.cabin === "all" ||
+        cabin === search.cabin ||
+        (search.cabin === "business-or-first" && ["business", "first"].includes(cabin));
+      if (
+        !cabinMatches ||
+        stops > maxStops ||
+        (search.maxDuration !== null && durationMinutes > search.maxDuration) ||
+        (search.maxPrice !== null && cash > search.maxPrice) ||
+        (search.maxMiles !== null && miles > search.maxMiles) ||
+        (search.excludeMixed && mixedCabin)
+      )
+        continue;
+      results.push({
+        flight_index: index + 1,
+        search_type: search.returnDate ? "round_trip" : "one_way",
+        leg: "outbound",
+        pricing: search.miles ? "miles" : "money",
+        origin: flight.origin,
+        destination: flight.destination,
+        departure_date: departureDate,
+        departure: flight.departure,
+        arrival_date: arrivalDate,
+        arrival: flight.arrival,
+        duration_minutes: durationMinutes,
+        stops,
+        flight_numbers: [
+          ...new Set(
+            [...flight.flight_text.matchAll(/Flight Number ([A-Z0-9]{2,3}\s*\d+)\./g)].map(
+              (match) => match[1],
+            ),
+          ),
+        ],
+        cabin,
+        fare_product: fare.product,
+        cabin_details: fare.cabin,
+        mixed_cabin: mixedCabin,
+        price: search.miles ? null : cash,
+        miles: search.miles ? miles : null,
+        taxes: search.miles ? cash : null,
+        currency: "USD",
+        price_text: search.miles
+          ? `${fare.miles_text} miles + ${fare.money_text}`
+          : fare.money_text,
+        price_basis: priceBasis(data.fare_note),
+        fare_note: data.fare_note,
+        is_starting_price: /\bFrom\b/i.test(fare.text),
+        award_type: fare.award_type,
+        discount: fare.discount,
+        adults: search.adults,
+        return_date: search.returnDate,
+        flight_details: flight.flight_text,
+        url: buildSearchUrl(search),
+        retrieved_at: retrievedAt,
+      });
+    }
+  }
+  const orderPrice = (a, b) =>
+    search.miles ? a.miles - b.miles || a.taxes - b.taxes : a.price - b.price;
+  const sorts = {
+    best: () => 0,
+    price: orderPrice,
+    duration: (a, b) => a.duration_minutes - b.duration_minutes || orderPrice(a, b),
+    departure: (a, b) => timeMinutes(a.departure) - timeMinutes(b.departure) || orderPrice(a, b),
+  };
+  return results
+    .sort(sorts[search.sort])
+    .slice(0, search.limit)
+    .map((row, index) => ({ rank: index + 1, ...row }));
+}

--- a/opencli-plugins/united/united-helpers.mjs
+++ b/opencli-plugins/united/united-helpers.mjs
@@ -47,7 +47,7 @@ function choice(value, name, values) {
   return value;
 }
 
-export function normalizeSearch(args, today = new Date().toISOString().slice(0, 10)) {
+export function normalizeSearch(args) {
   const airport = (value, name) => {
     const code = String(value || "")
       .trim()
@@ -61,7 +61,7 @@ export function normalizeSearch(args, today = new Date().toISOString().slice(0, 
   if (from === to) throw new Error("from and to must be different airports");
   const depart = date(args.depart, "depart");
   const returnDate = args.return === undefined ? null : date(args.return, "return");
-  if (depart < today) throw new Error("depart must not be in the past");
+  // Departure dates are origin-local. United validates bookability without a guessed airport timezone.
   if (returnDate && returnDate < depart) throw new Error("return must be on or after depart");
   if (args.miles !== undefined && typeof args.miles !== "boolean")
     throw new Error("miles must be a boolean flag");

--- a/opencli-plugins/united/united-helpers.test.mjs
+++ b/opencli-plugins/united/united-helpers.test.mjs
@@ -1,0 +1,281 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  assertSearchPage,
+  buildSearchUrl,
+  cabinOf,
+  dateFromNote,
+  normalizeResults,
+  normalizeSearch,
+  parseMiles,
+  parseMoney,
+  priceBasis,
+  timeMinutes,
+} from "./united-helpers.mjs";
+
+const fixture = (name) =>
+  JSON.parse(readFileSync(new URL(`./fixtures/${name}.json`, import.meta.url)));
+const args = { from: "SFO", to: "IAH", depart: "2026-11-13", return: "2026-11-15" };
+const search = (extra = {}) => normalizeSearch({ ...args, ...extra }, "2026-09-10");
+const results = (mode, extra = {}, data = fixture(mode)) =>
+  normalizeResults(
+    data,
+    search({ adults: mode === "cash" ? 2 : 1, miles: mode === "miles", ...extra }),
+    "2026-09-10T00:00:00.000Z",
+  );
+
+test("normalizes airports and defaults", () => {
+  const s = search({ from: " sfo ", to: "iah", return: undefined });
+  assert.equal(s.from, "SFO");
+  assert.equal(s.to, "IAH");
+  assert.equal(s.cabin, "economy");
+  assert.equal(s.returnDate, null);
+});
+
+test("award flag is at, adult count is px", () => {
+  for (const miles of [false, true])
+    for (const adults of [1, 2, 9]) {
+      const p = new URL(buildSearchUrl(search({ miles, adults }))).searchParams;
+      assert.equal(p.get("at"), miles ? "1" : null);
+      assert.equal(p.get("tqp"), miles ? "A" : "R");
+      assert.equal(p.get("px"), String(adults));
+      assert.equal(p.get("r"), "2026-11-15");
+      assert.equal(p.get("sc"), "7,7");
+      assert.equal(p.get("tt"), null);
+    }
+  const oneWay = new URL(buildSearchUrl(search({ return: undefined }))).searchParams;
+  assert.equal(oneWay.get("tt"), "1");
+  assert.equal(oneWay.get("r"), null);
+  assert.equal(oneWay.get("sc"), "7");
+});
+
+for (const invalid of [
+  { from: "San Francisco" },
+  { to: "SFO" },
+  { from: "SFO&t=LAX" },
+  { depart: "2026-02-30" },
+  { depart: "2026-9-12" },
+  { depart: "2024-02-29" },
+  { return: "2026-11-12" },
+  { return: "" },
+  { adults: 0 },
+  { adults: 10 },
+  { adults: 1.5 },
+  { cabin: "suite" },
+  { sort: "cheap" },
+  { stops: "3" },
+  { limit: 0 },
+  { limit: 501 },
+  { timeout: 4 },
+  { miles: "false" },
+  { "max-miles": 10000 },
+  { miles: true, "max-price": 200 },
+  { "max-price": "NaN" },
+  { "max-price": -1 },
+  { miles: true, "max-miles": 2.5 },
+  { "max-duration": 0 },
+]) {
+  test(`rejects invalid search ${JSON.stringify(invalid)}`, () =>
+    assert.throws(() => search(invalid)));
+}
+
+test("accepts leap days and a same-day return", () => {
+  assert.equal(
+    normalizeSearch(
+      { from: "SFO", to: "LAX", depart: "2028-02-29", return: "2028-02-29" },
+      "2026-09-10",
+    ).returnDate,
+    "2028-02-29",
+  );
+});
+
+test("parses USD without treating unknown or unavailable as zero", () => {
+  assert.equal(parseMoney("$1,784"), 1784);
+  assert.equal(parseMoney("$5.60"), 5.6);
+  assert.equal(parseMoney("US $0.00"), 0);
+  for (const value of ["", "Not available", "€200", "CA$200", "$1,23", "$1.2", "Was $500 Now $200"])
+    assert.equal(parseMoney(value), null);
+});
+
+test("parses compact miles without floating point integer errors", () => {
+  for (const [value, expected] of [
+    ["13.5k", 13500],
+    ["65.4k", 65400],
+    ["15,000 miles", 15000],
+    ["1.25M", 1250000],
+    ["0", 0],
+  ])
+    assert.equal(parseMiles(value), expected);
+  for (const value of ["", "$15", "Not available", "1.5 miles", "15kk", "13,5k"])
+    assert.equal(parseMiles(value), null);
+});
+
+test("cash roundtrip is a starting total per person, not multiplied by adults", () => {
+  const rows = results("cash");
+  assert.ok(rows.length);
+  assert.equal(rows[0].price, 454);
+  assert.equal(rows[0].adults, 2);
+  assert.equal(rows[0].price_basis, "round_trip_per_person_starting_total");
+  assert.equal(rows[0].leg, "outbound");
+  assert.equal(rows[0].miles, null);
+  assert.equal(rows[0].taxes, null);
+});
+
+test("award result uses current discounted miles plus taxes, not the crossed-out price", () => {
+  const row = results("miles")[0];
+  assert.equal(row.miles, 13500);
+  assert.equal(row.taxes, 5.6);
+  assert.equal(row.price, null);
+  assert.equal(row.discount, "cardmembers save 10%");
+  assert.equal(row.award_type, "Saver Award");
+  assert.equal(row.price_basis, "one_way_per_person");
+  assert.equal(row.price_text, "13.5k miles + $5.60");
+  assert.equal(row.arrival_date, "2026-11-14");
+});
+
+test("skips unavailable awards even when the hidden miles node is zero", () => {
+  const rows = results("miles", { cabin: "all" });
+  assert.ok(rows.length);
+  assert.ok(rows.every((row) => row.miles > 0));
+});
+
+test("keeps Economy Plus separate from Premium Plus and Economy", () => {
+  assert.equal(cabinOf("Economy Plus®(Extra legroom)"), "economy-plus");
+  assert.equal(cabinOf("United Premium Plus®"), "premium-economy");
+  assert.equal(cabinOf("Premium economy"), "premium-economy");
+  assert.equal(cabinOf("United Polaris® business"), "business");
+  assert.equal(cabinOf("First(lowest)"), "first");
+  assert.ok(results("cash", { cabin: "economy-plus" }).every((row) => row.price >= 700));
+  assert.equal(results("cash", { cabin: "premium-economy" }).length, 0);
+});
+
+test("mixed cabins remain explicit and can be excluded", () => {
+  const all = results("miles", { cabin: "first" });
+  assert.ok(all.some((row) => row.mixed_cabin));
+  assert.ok(
+    results("miles", { cabin: "first", "exclude-mixed-cabin": true }).every(
+      (row) => !row.mixed_cabin,
+    ),
+  );
+});
+
+test("filters then sorts then limits fare rows", () => {
+  const rows = results("miles", { sort: "price", stops: "nonstop", "max-miles": 14000, limit: 1 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].rank, 1);
+  assert.equal(rows[0].miles, 13500);
+  assert.equal(rows[0].stops, 0);
+  assert.equal(results("cash", { "max-price": 1 }).length, 0);
+  assert.equal(results("miles", { "max-duration": 1 }).length, 0);
+});
+
+test("never counts next-day departures as the requested day", () => {
+  const data = fixture("cash");
+  const nextDay = structuredClone(data.rows[0]);
+  nextDay.departure_note = "Departs Nov 14";
+  nextDay.fares[0].money_text = "$1";
+  data.rows.unshift(nextDay);
+  assert.ok(results("cash", { sort: "price" }, data).every((row) => row.price !== 1));
+});
+
+test("handles midnight and year-boundary arrival labels", () => {
+  assert.equal(timeMinutes("12:45 AM"), 45);
+  assert.equal(timeMinutes("12:00 PM"), 720);
+  assert.equal(timeMinutes("11:59 PM"), 1439);
+  assert.equal(timeMinutes("13:00 PM"), null);
+  assert.equal(dateFromNote("Arrives Jan 1", "2026-12-31"), "2027-01-01");
+  assert.equal(dateFromNote("Arrives Dec 31", "2027-01-01"), "2026-12-31");
+  assert.throws(() => dateFromNote("Arrives Feb 30", "2027-02-28"));
+  assert.throws(() => dateFromNote("unknown", "2026-11-13"));
+});
+
+test("keeps unrecognized fare bases explicit", () => {
+  assert.equal(priceBasis("one-way, per person"), "one_way_per_person");
+  assert.equal(
+    priceBasis("All fares shown are the total price roundtrip, per person."),
+    "round_trip_per_person_starting_total",
+  );
+  assert.equal(priceBasis(""), "displayed_price_see_fare_note");
+});
+
+for (const [name, mutate] of [
+  [
+    "wrong mode",
+    (d) => {
+      d.price_mode = "money";
+    },
+  ],
+  [
+    "wrong airport",
+    (d) => {
+      d.url = d.url.replace("t=IAH", "t=LAX");
+    },
+  ],
+  [
+    "wrong date",
+    (d) => {
+      d.date_heading = "Depart on: November 14";
+    },
+  ],
+  [
+    "return leg",
+    (d) => {
+      d.url += "&idx=2";
+    },
+  ],
+  [
+    "wrong adults",
+    (d) => {
+      d.traveler_text = "2 Adults";
+    },
+  ],
+  [
+    "different currency",
+    (d) => {
+      d.currency = "CAD";
+    },
+  ],
+  [
+    "different language",
+    (d) => {
+      d.language = "de";
+    },
+  ],
+  [
+    "wrong site",
+    (d) => {
+      d.url = d.url.replace("www.united.com", "example.com");
+    },
+  ],
+])
+  test(`rejects stale or changed search: ${name}`, () => {
+    const data = fixture("miles");
+    mutate(data);
+    assert.throws(() => assertSearchPage(data, search({ miles: true })));
+  });
+
+test("missing or mismatched prices fail rather than return partial rows", () => {
+  const data = fixture("miles");
+  data.rows[1].fares[0].money_text = "";
+  assert.throws(() => results("miles", {}, data), /No partial/);
+  data.rows[1].fares[0].money_text = "$5.60";
+  data.rows[1].fares[0].miles_text = "unknown";
+  assert.throws(() => results("miles", {}, data), /No partial/);
+});
+
+test("cash does not accept a miles-shaped card", () => {
+  const data = fixture("cash");
+  data.rows[0].fares[0].miles_text = "15k";
+  assert.throws(() => results("cash", {}, data), /mode changed/);
+});
+
+test("rejects bare numeric options and non-boolean flags", () => {
+  for (const invalid of [
+    { adults: true },
+    { adults: "" },
+    { "max-price": true },
+    { "exclude-mixed-cabin": "false" },
+  ])
+    assert.throws(() => search(invalid));
+});

--- a/opencli-plugins/united/united-helpers.test.mjs
+++ b/opencli-plugins/united/united-helpers.test.mjs
@@ -17,7 +17,7 @@ import {
 const fixture = (name) =>
   JSON.parse(readFileSync(new URL(`./fixtures/${name}.json`, import.meta.url)));
 const args = { from: "SFO", to: "IAH", depart: "2026-11-13", return: "2026-11-15" };
-const search = (extra = {}) => normalizeSearch({ ...args, ...extra }, "2026-09-10");
+const search = (extra = {}) => normalizeSearch({ ...args, ...extra });
 const results = (mode, extra = {}, data = fixture(mode)) =>
   normalizeResults(
     data,
@@ -56,7 +56,6 @@ for (const invalid of [
   { from: "SFO&t=LAX" },
   { depart: "2026-02-30" },
   { depart: "2026-9-12" },
-  { depart: "2024-02-29" },
   { return: "2026-11-12" },
   { return: "" },
   { adults: 0 },
@@ -82,10 +81,8 @@ for (const invalid of [
 
 test("accepts leap days and a same-day return", () => {
   assert.equal(
-    normalizeSearch(
-      { from: "SFO", to: "LAX", depart: "2028-02-29", return: "2028-02-29" },
-      "2026-09-10",
-    ).returnDate,
+    normalizeSearch({ from: "SFO", to: "LAX", depart: "2028-02-29", return: "2028-02-29" })
+      .returnDate,
     "2028-02-29",
   );
 });
@@ -278,4 +275,16 @@ test("rejects bare numeric options and non-boolean flags", () => {
     { "exclude-mixed-cabin": "false" },
   ])
     assert.throws(() => search(invalid));
+});
+
+test("leaves origin-local date availability to United across UTC midnight", (t) => {
+  t.mock.timers.enable({ apis: ["Date"], now: new Date("2026-11-14T02:00:00Z") });
+  assert.equal(new Date().toISOString().slice(0, 10), "2026-11-14");
+  const requested = normalizeSearch({ from: "SFO", to: "IAH", depart: "2026-11-13" });
+  assert.equal(requested.depart, "2026-11-13");
+  assert.equal(new URL(buildSearchUrl(requested)).searchParams.get("d"), "2026-11-13");
+});
+
+test("leaves even an old valid date to United instead of guessing an airport timezone", () => {
+  assert.equal(search({ depart: "2024-02-29" }).depart, "2024-02-29");
 });

--- a/opencli-plugins/united/united-page.mjs
+++ b/opencli-plugins/united/united-page.mjs
@@ -3,15 +3,24 @@ export function readUnitedPage() {
   const text = (element) => (element?.textContent || "").replace(/\s+/g, " ").trim();
   const get = (element, selector) => text(element.querySelector(selector));
   const body = document.body?.innerText || "";
-  const visible = (element) => !!element.getClientRects().length;
-  const flightRows = [...document.querySelectorAll('[role="row"]')].filter((element) =>
-    element.querySelector('[class*="FlightInfoBlock-styles__departTime--"]'),
+  const visible = (element) => {
+    const visibility = getComputedStyle(element).visibility;
+    return (
+      !!element.getClientRects().length &&
+      visibility !== "hidden" &&
+      visibility !== "collapse" &&
+      !element.closest('[hidden], [aria-hidden="true"]')
+    );
+  };
+  const flightRows = [...document.querySelectorAll('[role="row"]')].filter(
+    (element) =>
+      visible(element) && element.querySelector('[class*="FlightInfoBlock-styles__departTime--"]'),
   );
   const priceMode = [...document.querySelectorAll("select")].find((element) =>
     [...element.options].some((option) => option.value === "miles"),
   );
   const rows = flightRows.map((row) => {
-    const info = row.querySelector('[role="gridcell"]');
+    const info = [...row.querySelectorAll('[role="gridcell"]')].find(visible);
     const time = (name) =>
       get(row, `[class*="FlightInfoBlock-styles__${name}Time--"] [class*="__time--"]`);
     const dateNote = (name) =>
@@ -29,24 +38,26 @@ export function readUnitedPage() {
       destination: airport("arrival"),
       duration_text: get(row, '[class*="FlightInfoBlock-styles__duration--"]'),
       flight_text: info?.innerText || "",
-      fares: [...row.querySelectorAll('[role="gridcell"][aria-describedby]')].map((cell) => ({
-        product_id: cell.getAttribute("aria-describedby"),
-        product:
-          text(document.getElementById(cell.getAttribute("aria-describedby"))) ||
-          get(cell, '[class*="PriceCard-styles__cabinTitle--"]'),
-        miles_text: get(
-          cell,
-          '[class*="PriceCard-styles__milesContainer--"] [class*="PriceCard-styles__priceValue--"]',
-        ),
-        money_text: get(
-          cell,
-          '[class*="PriceCard-styles__moneyContainer--"] [class*="PriceCard-styles__priceValue--"]',
-        ),
-        cabin: get(cell, '[class*="PriceCard-styles__cabinDescription--"]'),
-        award_type: get(cell, '[class*="PriceCard-styles__discountLabel--"]'),
-        discount: get(cell, '[data-test-id="strikeThroughTag"]'),
-        text: cell.innerText || "",
-      })),
+      fares: [...row.querySelectorAll('[role="gridcell"][aria-describedby]')]
+        .filter(visible)
+        .map((cell) => ({
+          product_id: cell.getAttribute("aria-describedby"),
+          product:
+            text(document.getElementById(cell.getAttribute("aria-describedby"))) ||
+            get(cell, '[class*="PriceCard-styles__cabinTitle--"]'),
+          miles_text: get(
+            cell,
+            '[class*="PriceCard-styles__milesContainer--"] [class*="PriceCard-styles__priceValue--"]',
+          ),
+          money_text: get(
+            cell,
+            '[class*="PriceCard-styles__moneyContainer--"] [class*="PriceCard-styles__priceValue--"]',
+          ),
+          cabin: get(cell, '[class*="PriceCard-styles__cabinDescription--"]'),
+          award_type: get(cell, '[class*="PriceCard-styles__discountLabel--"]'),
+          discount: get(cell, '[data-test-id="strikeThroughTag"]'),
+          text: cell.innerText || "",
+        })),
     };
   });
   const dialogs = [...document.querySelectorAll('[role="dialog"]')].filter(visible);

--- a/opencli-plugins/united/united-page.mjs
+++ b/opencli-plugins/united/united-page.mjs
@@ -1,0 +1,88 @@
+/** Serialized into the browser. Returns flight data and status flags, not account or auth state. */
+export function readUnitedPage() {
+  const text = (element) => (element?.textContent || "").replace(/\s+/g, " ").trim();
+  const get = (element, selector) => text(element.querySelector(selector));
+  const body = document.body?.innerText || "";
+  const visible = (element) => !!element.getClientRects().length;
+  const flightRows = [...document.querySelectorAll('[role="row"]')].filter((element) =>
+    element.querySelector('[class*="FlightInfoBlock-styles__departTime--"]'),
+  );
+  const priceMode = [...document.querySelectorAll("select")].find((element) =>
+    [...element.options].some((option) => option.value === "miles"),
+  );
+  const rows = flightRows.map((row) => {
+    const info = row.querySelector('[role="gridcell"]');
+    const time = (name) =>
+      get(row, `[class*="FlightInfoBlock-styles__${name}Time--"] [class*="__time--"]`);
+    const dateNote = (name) =>
+      get(row, `[class*="FlightInfoBlock-styles__${name}Time--"] [class*="__specialMsg--"]`);
+    const airport = (name) =>
+      (row.querySelector(`[class*="FlightInfoBlock-styles__${name}Airport--"]`)?.innerText || "")
+        .trim()
+        .split(/\s/)[0];
+    return {
+      departure: time("depart"),
+      arrival: time("arrival"),
+      departure_note: dateNote("depart"),
+      arrival_note: dateNote("arrival"),
+      origin: airport("depart"),
+      destination: airport("arrival"),
+      duration_text: get(row, '[class*="FlightInfoBlock-styles__duration--"]'),
+      flight_text: info?.innerText || "",
+      fares: [...row.querySelectorAll('[role="gridcell"][aria-describedby]')].map((cell) => ({
+        product_id: cell.getAttribute("aria-describedby"),
+        product:
+          text(document.getElementById(cell.getAttribute("aria-describedby"))) ||
+          get(cell, '[class*="PriceCard-styles__cabinTitle--"]'),
+        miles_text: get(
+          cell,
+          '[class*="PriceCard-styles__milesContainer--"] [class*="PriceCard-styles__priceValue--"]',
+        ),
+        money_text: get(
+          cell,
+          '[class*="PriceCard-styles__moneyContainer--"] [class*="PriceCard-styles__priceValue--"]',
+        ),
+        cabin: get(cell, '[class*="PriceCard-styles__cabinDescription--"]'),
+        award_type: get(cell, '[class*="PriceCard-styles__discountLabel--"]'),
+        discount: get(cell, '[data-test-id="strikeThroughTag"]'),
+        text: cell.innerText || "",
+      })),
+    };
+  });
+  const dialogs = [...document.querySelectorAll('[role="dialog"]')].filter(visible);
+  return {
+    url: location.href,
+    language: document.documentElement.lang,
+    currency: [...document.querySelectorAll("button[aria-label]")].some((element) =>
+      /Currently in English (?:US|United States)\s*\$/.test(element.getAttribute("aria-label")),
+    )
+      ? "USD"
+      : null,
+    price_mode: priceMode?.value || null,
+    traveler_text: document.querySelector('input[type="button"]')?.value || "",
+    date_heading: get(document, '[class*="FlightSearchResultsContainer-styles__detailHeading--"]'),
+    fare_note: get(document, '[class*="FareDisclaimer-styles__disclaimer--"]'),
+    loading: /Loading results\.\.\./i.test(body),
+    service_error: [...document.querySelectorAll('[role="alert"]')].some((element) =>
+      /unable to complete your request|please try again later/i.test(element.innerText || ""),
+    ),
+    login_required: dialogs.some((dialog) =>
+      /Email or MileagePlus|must be signed-in to see flight results with miles/i.test(
+        dialog.innerText || "",
+      ),
+    ),
+    challenge:
+      /Access Denied|verify (?:that )?you are human|unusual traffic|Press & Hold|Your access to this site has been blocked/i.test(
+        body,
+      ),
+    no_results:
+      /(?:no flights (?:are )?(?:available|found)|could(?:n['’]t| not) find any flights|unable to find (?:any )?flights|no flights match)/i.test(
+        body,
+      ),
+    show_all: [...document.querySelectorAll("button")].some(
+      (button) => visible(button) && /^Show all flights$/i.test(text(button)) && !button.disabled,
+    ),
+    displayed: (body.match(/Displaying\s+(\d+)\s+of\s+(\d+)/i) || []).slice(1).map(Number),
+    rows,
+  };
+}

--- a/opencli-plugins/united/united-page.test.mjs
+++ b/opencli-plugins/united/united-page.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import vm from "node:vm";
+import { readUnitedPage } from "./united-page.mjs";
+
+function read({ body = "", dialogs = [], alerts = [] } = {}) {
+  const document = {
+    body: { innerText: body },
+    documentElement: { lang: "en" },
+    querySelector: () => null,
+    querySelectorAll(selector) {
+      if (selector === '[role="dialog"]') return dialogs;
+      if (selector === '[role="alert"]') return alerts.map((text) => ({ innerText: text }));
+      return [];
+    },
+  };
+  return vm.runInNewContext(`(${readUnitedPage.toString()})()`, {
+    document,
+    location: { href: "https://www.united.com/en/us/fsr/choose-flights" },
+  });
+}
+
+test("reader remains serializable without module-scope helpers", () => {
+  const data = read();
+  assert.equal(data.rows.length, 0);
+  assert.equal(data.no_results, false);
+  assert.equal(data.price_mode, null);
+});
+
+test("reader separates an unloaded page, explicit no flights, and a provider error", () => {
+  assert.equal(read({ body: "Loading results..." }).loading, true);
+  for (const body of [
+    "We couldn't find any flights",
+    "We couldn’t find any flights",
+    "No flights match",
+  ]) {
+    assert.equal(read({ body }).no_results, true);
+  }
+  const failure = read({
+    alerts: [
+      "We're sorry, but united.com was unable to complete your request. Please try again later.",
+    ],
+  });
+  assert.equal(failure.service_error, true);
+  assert.equal(failure.no_results, false);
+});
+
+test("reader detects a visible sign-in wall, not an ordinary sign-in link or hidden dialog", () => {
+  assert.equal(read({ body: "Sign in" }).login_required, false);
+  const dialog = { innerText: "Email or MileagePlus number", getClientRects: () => [] };
+  assert.equal(read({ dialogs: [dialog] }).login_required, false);
+  dialog.getClientRects = () => [{}];
+  assert.equal(read({ dialogs: [dialog] }).login_required, true);
+});
+
+test("reader does not return the page body or account text", () => {
+  const result = read({ body: "Hi SAMPLE_ACCOUNT, 1234567 miles. Account SAMPLE_ID." });
+  assert.doesNotMatch(JSON.stringify(result), /SAMPLE_ACCOUNT|SAMPLE_ID|1234567/);
+});

--- a/opencli-plugins/united/united-page.test.mjs
+++ b/opencli-plugins/united/united-page.test.mjs
@@ -16,6 +16,7 @@ function read({ body = "", dialogs = [], alerts = [] } = {}) {
   };
   return vm.runInNewContext(`(${readUnitedPage.toString()})()`, {
     document,
+    getComputedStyle: () => ({ visibility: "visible" }),
     location: { href: "https://www.united.com/en/us/fsr/choose-flights" },
   });
 }
@@ -47,7 +48,11 @@ test("reader separates an unloaded page, explicit no flights, and a provider err
 
 test("reader detects a visible sign-in wall, not an ordinary sign-in link or hidden dialog", () => {
   assert.equal(read({ body: "Sign in" }).login_required, false);
-  const dialog = { innerText: "Email or MileagePlus number", getClientRects: () => [] };
+  const dialog = {
+    innerText: "Email or MileagePlus number",
+    getClientRects: () => [],
+    closest: () => null,
+  };
   assert.equal(read({ dialogs: [dialog] }).login_required, false);
   dialog.getClientRects = () => [{}];
   assert.equal(read({ dialogs: [dialog] }).login_required, true);


### PR DESCRIPTION
## What this PR does

Rome has no command for United flight prices or MileagePlus award availability. Add `opencli united flights FROM TO DEPART` under `opencli-plugins/united/`.

The command supports one-way searches, round-trip outbound choices, adult counts, cabin and stop filters, price ceilings, duration, sorting, and row limits. `--miles` returns the displayed award amount with cash taxes separate from miles.

Usage and price semantics live in the [United command reference](https://github.com/rome-os/rome/blob/feat/opencli-united-flights/opencli-plugins/united/README.md).

```bash
opencli united flights SFO IAH 2026-11-13 --stops nonstop --sort price -f json
opencli united flights SFO IAH 2026-11-13 --miles --max-miles 20000 -f json
opencli united flights SFO IAH 2026-11-13 --return 2026-11-15 --adults 2 -f json
```

## Design & Invariants

- Read rendered flight rows in both United layouts rather than calling private APIs. The command never reads authentication material or selects a fare.
- A miles request never falls back to money. Signed-out award searches raise `AUTH_REQUIRED`.
- Use current discounted award prices, not crossed-out amounts. Treat unavailable cards as unavailable even when their hidden price node contains zero miles.
- Keep taxes, displayed precision, mixed cabins, and per-person price scope explicit. Round-trip cash starting totals and one-way award amounts are not interchangeable.
- Expand all results before filtering and limiting. Retain the highest reported total across loading states and require that many visible flight rows.
- Ignore hidden responsive flight rows and fare cells without dropping flights below the viewport.
- Reuse a persistent cookie-backed site session. Cash requests remain available without signing in.
- Treat search dates as origin-local calendar dates. United validates bookability rather than the machine’s UTC date.
- Verify the route, date, travelers, locale, and payment mode before returning prices. Exclude departures on the next day.
- Fail on service errors, incomplete loading, or unreadable prices rather than returning partial or stale results.

## Test plan

- [x] `pnpm -C opencli-plugins/united test` — 72 tests pass. Flight-only fixtures cover both layouts, discounted and unavailable awards, mixed cabins, and overnight dates. Browser tests cover expansion, stale results, sign-in walls, and service errors. The suite also runs in CI.
- [x] Regression tests cover hidden responsive rows/cells, delayed `2/5 → 2 → 2 → 5` expansion, vanished/reduced counters, UTC-midnight date crossover, and persistent-session metadata.
- [x] Real Chromium fixture check in desktop and mobile layouts: eight DOM rows yield two visible flights with two visible fares each. The below-viewport flight remains included.
- [x] `opencli validate united/flights` — zero errors or warnings.
- [x] `/app/node_modules/.bin/biome check opencli-plugins/united` and `git diff --check`.
- [x] Install with `opencli plugin install "$PWD/opencli-plugins/united"` and verify generated CLI help.
- [x] Live SFO–IAH cash round-trip CLI search for two adults, November 13–15, 2026. Returned USD 386 per person, not a multiplied traveler total.
- [x] Live signed-in SFO–IAH one-way award CLI search, November 13, 2026. Returned 13,500 displayed miles plus USD 5.60, preserving the cardmember discount.
- [x] Inspect United cash and award DOM extraction, including complete lists of 61 cash flights and 127 award flights.
- [x] Signed-out award CLI search exits 77 with `AUTH_REQUIRED` and returns no cash prices.
- [x] United service-error handling: later additional-route searches received HTTP 428 from United and displayed a retry-later error. The command rejects that state.
- [ ] Successful additional-route/international live smoke. United rejected the later SFO–LAX and SFO–NRT requests, so no successful international result is claimed.
- [ ] Full `pnpm typecheck` and `pnpm test:unit`. Both were attempted but this checkout has no workspace dependencies (`tsc` and `rstest` unavailable). `nix develop` is also unavailable here.
- [ ] `pnpm dev:all`. Attempted but the Docker daemon is unreachable, so the container startup check could not run.

## Not in this PR

- Multi-city, child/infant travelers, and non-USD currencies need separate request and price contracts.
- Fare selection and booking are outside this read-only command.