### PR TITLE
fix(web): remove the routines failing badge

### DIFF
--- a/packages/web/src/i18n/locales/en/routines.json
+++ b/packages/web/src/i18n/locales/en/routines.json
@@ -8,8 +8,6 @@
     "total": "Total",
     "active": "Active",
     "paused": "Paused",
-    "failingCount": "{{n}} failing",
-    "failingAria": "Show {{n}} failing routines",
     "nextUp": "Next up",
     "noUpcoming": "No upcoming runs",
     "etaOverdue": "due now"

--- a/packages/web/src/i18n/locales/zh-CN/routines.json
+++ b/packages/web/src/i18n/locales/zh-CN/routines.json
@@ -8,8 +8,6 @@
     "total": "总计",
     "active": "已启用",
     "paused": "已暂停",
-    "failingCount": "{{n}} 个失败",
-    "failingAria": "查看 {{n}} 个失败的例程",
     "nextUp": "下一个",
     "noUpcoming": "暂无即将到来的运行",
     "etaOverdue": "已到点"

--- a/packages/web/src/pages/RoutinesPage.test.tsx
+++ b/packages/web/src/pages/RoutinesPage.test.tsx
@@ -398,11 +398,9 @@ describe("RoutinesPage", () => {
     expect(screen.queryByRole("button", { name: /Stop Needs approval/ })).toBeNull();
   });
 
-  it("surfaces a failing count and filters the list to the failing routines when clicked", async () => {
+  it("filters failed routines through the list menu without a page-level failure badge", async () => {
     mockBackend({
       routines: [
-        // Errored last run → counts as failing. Scheduled far out so it isn't the
-        // next-up routine (keeps the name out of the panel's next-up line).
         scheduleRoutine({
           id: "s1",
           name: "Inventory sync",
@@ -426,28 +424,42 @@ describe("RoutinesPage", () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     renderPage();
 
-    // The stat panel shows a clickable Failing cell counting the one errored run.
-    const failingCell = await screen.findByRole("button", { name: "Show 1 failing routines" });
-    // All three are listed before filtering.
-    expect(screen.getByText("Morning tidy")).toBeTruthy();
+    expect(await screen.findByText("Morning tidy")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /failing routines/i })).toBeNull();
+    expect(screen.queryByText(/\d+ failing/)).toBeNull();
 
-    await user.click(failingCell);
+    await user.click(screen.getByRole("button", { name: "All routines" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Failing" }));
 
-    // After the click only the failing routine remains in the list.
     await waitFor(() => expect(screen.queryByText("Morning tidy")).toBeNull());
     expect(screen.getByText("Inventory sync")).toBeTruthy();
   });
 
-  it("shows no health indicator at all when nothing is failing", async () => {
+  it("does not show a page-level failure badge for a completed failed one-off", async () => {
     mockBackend({
-      routines: [scheduleRoutine({ id: "s1", name: "Morning tidy" })],
+      routines: [
+        scheduleRoutine({
+          id: "s1",
+          name: "Image test",
+          enabled: false,
+          trigger: { type: "schedule", tzid: "UTC", localTime: "09:00", date: "2026-07-29" },
+          lastFiredAt: "2026-07-29T09:00:00Z",
+          nextRunAt: null,
+          lastRun: { status: "error", firedAt: "2026-07-29T09:00:00Z" },
+        }),
+      ],
     });
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
     renderPage();
 
-    // The page has loaded (the title is up)...
-    expect(await screen.findByRole("heading", { name: "Routines" })).toBeTruthy();
-    // ...but a confirmed-healthy state carries no pill — nothing to click.
-    expect(screen.queryByRole("button", { name: /failing routines/ })).toBeNull();
+    const done = await screen.findByRole("button", { name: /Done/ });
+    expect(screen.queryByRole("button", { name: /failing routines/i })).toBeNull();
+    expect(screen.queryByText(/\d+ failing/)).toBeNull();
+
+    await user.click(done);
+    expect(screen.getByRole("link", { name: "Image test" }).getAttribute("href")).toBe(
+      "/routines/s1",
+    );
   });
 
   it("deletes a routine after the guardian confirms removal", async () => {

--- a/packages/web/src/pages/RoutinesPage.tsx
+++ b/packages/web/src/pages/RoutinesPage.tsx
@@ -47,7 +47,6 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { Tile } from "@/components/ui/tile";
 import {
-  AlertTriangle,
   AlignLeft,
   Calendar as CalendarIcon,
   Check,
@@ -376,8 +375,6 @@ function StatsBar({ routines }: { routines: Routine[] }) {
     .filter((r) => r.enabled && r.nextRunAt && !isPast(r.nextRunAt))
     .sort((a, b) => new Date(a.nextRunAt!).getTime() - new Date(b.nextRunAt!).getTime())[0];
 
-  // Health (failing vs. healthy) is intentionally NOT shown here — it lives as a
-  // red pill beside the page title, and only when something is actually wrong.
   return (
     <div className="flex flex-col overflow-hidden rounded-12 border border-border bg-surface sm:flex-row sm:items-stretch">
       {/* Stat cells — generously spaced, each label-over-number. */}
@@ -391,35 +388,6 @@ function StatsBar({ routines }: { routines: Routine[] }) {
       <div className="h-px w-full bg-border sm:h-auto sm:w-px" />
       <NextUpBlock routine={nextRoutine} />
     </div>
-  );
-}
-
-// The health pill that sits beside the page title — shown ONLY when one or more
-// routines are failing. A confirmed-healthy state shows nothing at all, so good
-// days carry no badge. Clicking it jumps to the failing-filtered list.
-function HealthPill({ failing, onShowFailing }: { failing: number; onShowFailing: () => void }) {
-  const { t } = useTranslation("routines");
-  if (failing === 0) return null;
-  return (
-    <Button
-      type="button"
-      variant="destructive"
-      // `md`, not `sm`: the pill sits beside the page's `text-title` h1, whose
-      // 24px line box would leave a 28px control reading as an afterthought.
-      size="md"
-      shape="pill"
-      onClick={onShowFailing}
-      aria-label={t("stats.failingAria", { n: failing })}
-      className="group"
-    >
-      <AlertTriangle data-icon="inline-start" aria-hidden />
-      <span className="tabular-nums">{t("stats.failingCount", { n: failing })}</span>
-      <ChevronRight
-        data-icon="inline-end"
-        className="transition-transform group-hover:translate-x-0.5"
-        aria-hidden
-      />
-    </Button>
   );
 }
 
@@ -2172,15 +2140,6 @@ export default function RoutinesPage() {
   // skipped by whichever view the guardian happens to be on.
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
 
-  // Health surfaces only as a title-side pill, and only when something is wrong.
-  // Both the count and the jump-to-failing action are derived here so the pill
-  // and the list filter read from the same routines.
-  const failing = routines.filter(isFailing).length;
-  const showFailing = () => {
-    setView("table");
-    setTableFilter("failing");
-  };
-
   const readBackendError = async (res: Response, fallbackKey: string): Promise<string> => {
     const data = await res.json().catch(() => ({}));
     return typeof data?.error === "string" && data.error.length > 0 ? data.error : t(fallbackKey);
@@ -2264,7 +2223,6 @@ export default function RoutinesPage() {
         <header className="flex items-start justify-between gap-3">
           <div className="flex min-w-0 items-center gap-2">
             <h1 className="text-title text-foreground">{t("header.title")}</h1>
-            <HealthPill failing={failing} onShowFailing={showFailing} />
           </div>
           <Button onClick={() => setShowCreate(true)} className="flex-shrink-0">
             <Plus className="size-4" aria-hidden />


### PR DESCRIPTION
## What this PR does

The Routines page can show a persistent “1 failing” badge for a disabled one-time task listed under Done. There is no dismiss control.

Remove the page-level failing badge and its unused translations. Keep the Failing filter and run history so failures remain available for inspection.

## Test plan

- [x] `pnpm --filter rome-web typecheck`
- [x] `pnpm --filter rome-web test src/pages/RoutinesPage.test.tsx src/lib/routine-language.test.ts src/i18n` — 73 tests pass, including the failed one-time task regression.
- [x] Biome check on the four changed files and `git diff --check`.
- [x] Chromium against the mock dashboard: no header failure badge, the Failing menu filters results, and run history retains the failure message. Preview uses the existing kit build because workspace build dependencies are unavailable.
- [ ] Full repository checks: `nix develop` is unavailable, `pnpm typecheck` and `pnpm test:unit` hit missing workspace dependencies, and `pnpm dev:all` cannot reach Docker.

## Not in this PR

- Changes to the Done label or failure acknowledgment. This change only removes the page-level badge.
