### PR TITLE
feat(core): app tagline for social cards

### DIFF
--- a/packages/app-template/template/app.yaml
+++ b/packages/app-template/template/app.yaml
@@ -3,11 +3,12 @@ id: __APP_ID__
 name: __APP_NAME__
 version: 0.1.0
 description: __APP_NAME__ app
-# Shown on the app's social share card. One sentence, at most 80 characters
-# (40 for CJK): lead with what the user gets, no jargon — write it like an
-# App Store subtitle, and update it when the app's purpose changes.
-# Fill it in or delete the line; a placeholder tagline is worse than none (the card falls back to the first sentence of description).
-tagline: __APP_NAME__ in one sentence
+# Shown on the app's social share card and as the preview text beside it.
+# One sentence, at most 80 characters (40 for CJK): lead with what the user
+# gets, no jargon — write it like an App Store subtitle. Without it the card
+# shows no description at all, so fill it in and update it when the app's
+# purpose changes.
+# tagline: One sentence for the share card
 icon: assets/icon.svg
 appRoot: dist
 includeSource: true

--- a/packages/app-template/template/app.yaml
+++ b/packages/app-template/template/app.yaml
@@ -6,6 +6,7 @@ description: __APP_NAME__ app
 # Shown on the app's social share card. One sentence, at most 80 characters
 # (40 for CJK): lead with what the user gets, no jargon — write it like an
 # App Store subtitle, and update it when the app's purpose changes.
+# Fill it in or delete the line; a placeholder tagline is worse than none (the card falls back to the first sentence of description).
 tagline: __APP_NAME__ in one sentence
 icon: assets/icon.svg
 appRoot: dist

--- a/packages/app-template/template/app.yaml
+++ b/packages/app-template/template/app.yaml
@@ -3,6 +3,10 @@ id: __APP_ID__
 name: __APP_NAME__
 version: 0.1.0
 description: __APP_NAME__ app
+# Shown on the app's social share card. One sentence, at most 80 characters
+# (40 for CJK): lead with what the user gets, no jargon — write it like an
+# App Store subtitle, and update it when the app's purpose changes.
+tagline: __APP_NAME__ in one sentence
 icon: assets/icon.svg
 appRoot: dist
 includeSource: true

--- a/packages/app-template/workflow/app.yaml
+++ b/packages/app-template/workflow/app.yaml
@@ -3,6 +3,10 @@ id: __APP_ID__
 name: __APP_NAME__
 version: 0.1.0
 description: __APP_NAME__ — a workflow that composes actions in plain TypeScript control flow.
+# Shown on the app's social share card. One sentence, at most 80 characters
+# (40 for CJK): lead with what the user gets, no jargon — write it like an
+# App Store subtitle, and update it when the app's purpose changes.
+tagline: __APP_NAME__ in one sentence
 icon: assets/icon.svg
 appRoot: dist
 includeSource: true

--- a/packages/app-template/workflow/app.yaml
+++ b/packages/app-template/workflow/app.yaml
@@ -3,11 +3,12 @@ id: __APP_ID__
 name: __APP_NAME__
 version: 0.1.0
 description: __APP_NAME__ — a workflow that composes actions in plain TypeScript control flow.
-# Shown on the app's social share card. One sentence, at most 80 characters
-# (40 for CJK): lead with what the user gets, no jargon — write it like an
-# App Store subtitle, and update it when the app's purpose changes.
-# Fill it in or delete the line; a placeholder tagline is worse than none (the card falls back to the first sentence of description).
-tagline: __APP_NAME__ in one sentence
+# Shown on the app's social share card and as the preview text beside it.
+# One sentence, at most 80 characters (40 for CJK): lead with what the user
+# gets, no jargon — write it like an App Store subtitle. Without it the card
+# shows no description at all, so fill it in and update it when the app's
+# purpose changes.
+# tagline: One sentence for the share card
 icon: assets/icon.svg
 appRoot: dist
 includeSource: true

--- a/packages/app-template/workflow/app.yaml
+++ b/packages/app-template/workflow/app.yaml
@@ -6,6 +6,7 @@ description: __APP_NAME__ — a workflow that composes actions in plain TypeScri
 # Shown on the app's social share card. One sentence, at most 80 characters
 # (40 for CJK): lead with what the user gets, no jargon — write it like an
 # App Store subtitle, and update it when the app's purpose changes.
+# Fill it in or delete the line; a placeholder tagline is worse than none (the card falls back to the first sentence of description).
 tagline: __APP_NAME__ in one sentence
 icon: assets/icon.svg
 appRoot: dist

--- a/packages/core/src/api/app-document-routes.e2e.test.ts
+++ b/packages/core/src/api/app-document-routes.e2e.test.ts
@@ -54,6 +54,7 @@ function buildRedditFixture(): ResolvedApp {
       id: "reddit",
       version: "0.0.1",
       description: 'Watches <subreddits> & "more"',
+      tagline: 'Watches <subreddits> & "more"',
       agents: [],
       actions: [],
       skills: [],

--- a/packages/core/src/api/app-social-card.test.ts
+++ b/packages/core/src/api/app-social-card.test.ts
@@ -10,7 +10,7 @@ const reddit = {
   state: "installed",
   enabled: true,
   displayName: "Reddit Radar",
-  manifest: { id: "reddit", description: "Watches subreddits" },
+  manifest: { id: "reddit", description: "Watches subreddits", tagline: "Watches subreddits" },
   web: { displayName: "Reddit Radar" },
 };
 
@@ -86,5 +86,12 @@ describe("buildAppSocialCard", () => {
     const card = await buildAppSocialCard(deps, req("/full/apps/reddit"));
     expect(card?.title).toBe("Reddit Radar");
     expect(card).not.toHaveProperty("imageUrl");
+  });
+
+  it("omits description when the app has no tagline", async () => {
+    const untagged = { ...reddit, manifest: { id: "reddit", description: "Watches subreddits" } };
+    const deps = { appCatalog: catalogWith({ reddit: untagged }), ogImageStore: storeWith(null) };
+    const card = await buildAppSocialCard(deps, req("/apps/reddit"));
+    expect(card).not.toHaveProperty("description");
   });
 });

--- a/packages/core/src/api/app-social-card.ts
+++ b/packages/core/src/api/app-social-card.ts
@@ -1,5 +1,6 @@
 import type { AppCatalog } from "../apps/catalog.js";
 import type { OgImageStore } from "../apps/og/store.js";
+import { cardDescription } from "../apps/og/subscriber.js";
 import { appIdToPathSegment } from "../apps/packaging/app-id.js";
 import type { ResolvedApp } from "../apps/state.js";
 import { getExternalRequestOrigin } from "../lib/request-origin.js";
@@ -61,10 +62,11 @@ export async function buildAppSocialCard(
   // The card image is auxiliary: any lookup failure just means "no image yet"
   // and the shell keeps its static og:image.
   const image = await deps.ogImageStore.stat(appId).catch(() => null);
+  const description = cardDescription(view.manifest);
   return {
     title: view.displayName,
-    description: view.manifest.description,
     url: `${origin}${pathname}`,
+    ...(description ? { description } : {}),
     ...(image
       ? {
           imageUrl: `${origin}/app-og/${appIdToPathSegment(appId)}.png?v=${Math.floor(image.mtimeMs)}`,

--- a/packages/core/src/apps/installer.ts
+++ b/packages/core/src/apps/installer.ts
@@ -486,6 +486,7 @@ export class AppInstaller {
       id: data.id,
       version: data.version,
       description: data.description,
+      tagline: data.tagline,
       name: data.name,
       icon: data.icon,
       appRoot: data.appRoot,

--- a/packages/core/src/apps/manager.test.ts
+++ b/packages/core/src/apps/manager.test.ts
@@ -8,6 +8,7 @@ import { PACKED_ARTIFACT_SENTINEL, packArtifact, packBundle } from "./packaging/
 import { remixApp } from "./remix.js";
 import { createTestApps, type TestAppsHarness } from "./test-helpers.js";
 import { AppLockfileSchema, APPS_LOCKFILE_SCHEMA_VERSION, type SpecSource } from "./lockfile.js";
+import type { ResolvedApp } from "./state.js";
 
 const SAMPLE_MANIFEST = `formatVersion: 1
 id: testapp
@@ -335,6 +336,23 @@ describe("AppManager", () => {
     });
 
     expect(existsSync(harness.lockfilePath)).toBe(false);
+  });
+
+  it("install keeps the manifest tagline", async () => {
+    const root = await makeWorkspace(
+      join(harness.profileRoot, "fixture-tagline-app"),
+      `formatVersion: 1
+id: testapp
+version: 0.0.1
+description: behavioral test fixture
+tagline: One line for the card.
+`,
+    );
+    const source: SpecSource = { mode: "bundle", path: await packWorkspace(root) };
+    await harness.appManager.install({ source });
+
+    const view = harness.catalog.get("testapp") as ResolvedApp;
+    expect(view.manifest.tagline).toBe("One line for the card.");
   });
 
   it("a failure inside materialize records state=failed and preserves prior hash", async () => {

--- a/packages/core/src/apps/og/store.test.ts
+++ b/packages/core/src/apps/og/store.test.ts
@@ -15,7 +15,7 @@ describe("createOgImageStore", () => {
 
   it("writes, stats, reads and removes one file per app", async () => {
     const store = createOgImageStore(root);
-    expect(store.path("@acme/radar")).toBe(join(root, "%40acme%2Fradar.png"));
+    expect(store.path("@acme/radar")).toBe(join(root, "%40acme%2Fradar.v2.png"));
     expect(await store.stat("reddit")).toBeNull();
     expect(await store.read("reddit")).toBeNull();
 

--- a/packages/core/src/apps/og/store.ts
+++ b/packages/core/src/apps/og/store.ts
@@ -3,6 +3,13 @@ import { join } from "node:path";
 import { getProfileAppsDir } from "../../paths.js";
 import { appIdToPathSegment } from "../packaging/app-id.js";
 
+/**
+ * Bumped whenever the card's look or inputs change. It is part of the on-disk
+ * name, so a card rendered by an older format is simply never read again and
+ * the next event renders a fresh one — no timestamp guessing.
+ */
+export const CARD_FORMAT_VERSION = 2;
+
 export interface OgImageStore {
   path(appId: string): string;
   write(appId: string, png: Buffer): Promise<void>;
@@ -19,7 +26,8 @@ function isEnoent(err: unknown): boolean {
 export function createOgImageStore(
   rootDir: string = join(getProfileAppsDir(), "og"),
 ): OgImageStore {
-  const path = (appId: string) => join(rootDir, `${appIdToPathSegment(appId)}.png`);
+  const path = (appId: string) =>
+    join(rootDir, `${appIdToPathSegment(appId)}.v${CARD_FORMAT_VERSION}.png`);
   return {
     path,
     async write(appId, png) {

--- a/packages/core/src/apps/og/subscriber.test.ts
+++ b/packages/core/src/apps/og/subscriber.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CatalogEvent, ResolvedApp } from "../state.js";
 import { createOgImageStore } from "./store.js";
-import { cardDescription, createAppOgImageSubscriber } from "./subscriber.js";
+import { CARD_RENDERER_STAMP, cardDescription, createAppOgImageSubscriber } from "./subscriber.js";
 
 function resolvedApp(overrides: Partial<ResolvedApp> = {}): ResolvedApp {
   return {
@@ -77,6 +77,26 @@ describe("createAppOgImageSubscriber", () => {
 
     const stale = new Date("2026-08-01T00:00:00.000Z");
     utimesSync(store.path("reddit"), stale, stale);
+    await handler({ appId: "reddit", change: "changed", current: resolvedApp() });
+    await tick();
+    expect(calls).toBe(1);
+  });
+
+  it("regenerates an image that predates the renderer stamp even when newer than updatedAt", async () => {
+    const store = createOgImageStore(root);
+    let calls = 0;
+    const handler = createAppOgImageSubscriber({
+      store,
+      host: null,
+      generate: async () => {
+        calls += 1;
+        return Buffer.from("png");
+      },
+    });
+    await store.write("reddit", Buffer.from("old-renderer"));
+    const beforeStamp = new Date(CARD_RENDERER_STAMP - 60_000);
+    utimesSync(store.path("reddit"), beforeStamp, beforeStamp);
+    // updatedAt (2026-09-01) is older than the file, so only the stamp forces the render.
     await handler({ appId: "reddit", change: "changed", current: resolvedApp() });
     await tick();
     expect(calls).toBe(1);

--- a/packages/core/src/apps/og/subscriber.test.ts
+++ b/packages/core/src/apps/og/subscriber.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CatalogEvent, ResolvedApp } from "../state.js";
 import { createOgImageStore } from "./store.js";
-import { CARD_RENDERER_STAMP, cardDescription, createAppOgImageSubscriber } from "./subscriber.js";
+import { cardDescription, createAppOgImageSubscriber } from "./subscriber.js";
 
 function resolvedApp(overrides: Partial<ResolvedApp> = {}): ResolvedApp {
   return {
@@ -82,26 +82,6 @@ describe("createAppOgImageSubscriber", () => {
     expect(calls).toBe(1);
   });
 
-  it("regenerates an image that predates the renderer stamp even when newer than updatedAt", async () => {
-    const store = createOgImageStore(root);
-    let calls = 0;
-    const handler = createAppOgImageSubscriber({
-      store,
-      host: null,
-      generate: async () => {
-        calls += 1;
-        return Buffer.from("png");
-      },
-    });
-    await store.write("reddit", Buffer.from("old-renderer"));
-    const beforeStamp = new Date(CARD_RENDERER_STAMP - 60_000);
-    utimesSync(store.path("reddit"), beforeStamp, beforeStamp);
-    // updatedAt (2026-09-01) is older than the file, so only the stamp forces the render.
-    await handler({ appId: "reddit", change: "changed", current: resolvedApp() });
-    await tick();
-    expect(calls).toBe(1);
-  });
-
   it("ignores disabled apps, apps without a frontend, bare views, and removes on uninstall", async () => {
     const store = createOgImageStore(root);
     let calls = 0;
@@ -165,30 +145,31 @@ describe("createAppOgImageSubscriber", () => {
 
   it("keeps the newest render when an older one finishes last", async () => {
     const store = createOgImageStore(root);
-    const gates: Array<() => void> = [];
-    let n = 0;
+    // Gates keyed by the app's updatedAt: the two renders reach `generate`
+    // after independent fs stats, so arrival order is not event order.
+    const gates = new Map<string, () => void>();
     const handler = createAppOgImageSubscriber({
       store,
       host: null,
-      generate: async () => {
-        const mine = ++n;
-        await new Promise<void>((r) => gates.push(r));
-        return Buffer.from(`render-${mine}`);
+      generate: async (app) => {
+        await new Promise<void>((r) => gates.set(app.updatedAt, r));
+        return Buffer.from(app.updatedAt);
       },
     });
-    await handler({ appId: "reddit", change: "added", current: resolvedApp() });
+    const older = "2026-09-01T00:00:00.000Z";
+    const newer = "2026-09-02T00:00:00.000Z";
+    await handler({ appId: "reddit", change: "added", current: resolvedApp({ updatedAt: older }) });
     await handler({
       appId: "reddit",
       change: "changed",
-      current: resolvedApp({ updatedAt: "2026-09-02T00:00:00.000Z" }),
+      current: resolvedApp({ updatedAt: newer }),
     });
+    while (gates.size < 2) await tick();
+    gates.get(newer)?.(); // newest finishes first
     await tick();
-    expect(gates).toHaveLength(2);
-    gates[1](); // newest finishes first
+    gates.get(older)?.(); // stale one finishes last
     await tick();
-    gates[0](); // stale one finishes last
-    await tick();
-    expect((await store.read("reddit"))?.toString()).toBe("render-2");
+    expect((await store.read("reddit"))?.toString()).toBe(newer);
   });
 
   it("does not recreate the card when removal arrives while a write is queued", async () => {

--- a/packages/core/src/apps/og/subscriber.test.ts
+++ b/packages/core/src/apps/og/subscriber.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CatalogEvent, ResolvedApp } from "../state.js";
 import { createOgImageStore } from "./store.js";
-import { createAppOgImageSubscriber } from "./subscriber.js";
+import { cardDescription, createAppOgImageSubscriber } from "./subscriber.js";
 
 function resolvedApp(overrides: Partial<ResolvedApp> = {}): ResolvedApp {
   return {
@@ -20,6 +20,23 @@ function resolvedApp(overrides: Partial<ResolvedApp> = {}): ResolvedApp {
 }
 
 const tick = () => new Promise((r) => setTimeout(r, 20));
+
+describe("cardDescription", () => {
+  it("prefers the tagline when present", () => {
+    expect(
+      cardDescription({
+        tagline: "Never miss a good thread",
+        description: "Watches subreddits. Posts a daily digest.",
+      }),
+    ).toBe("Never miss a good thread");
+  });
+
+  it("falls back to the first sentence of the description", () => {
+    expect(cardDescription({ description: "Watches subreddits. Posts a daily digest." })).toBe(
+      "Watches subreddits.",
+    );
+  });
+});
 
 describe("createAppOgImageSubscriber", () => {
   let root: string;

--- a/packages/core/src/apps/og/subscriber.test.ts
+++ b/packages/core/src/apps/og/subscriber.test.ts
@@ -22,19 +22,14 @@ function resolvedApp(overrides: Partial<ResolvedApp> = {}): ResolvedApp {
 const tick = () => new Promise((r) => setTimeout(r, 20));
 
 describe("cardDescription", () => {
-  it("prefers the tagline when present", () => {
-    expect(
-      cardDescription({
-        tagline: "Never miss a good thread",
-        description: "Watches subreddits. Posts a daily digest.",
-      }),
-    ).toBe("Never miss a good thread");
+  it("returns the tagline when present", () => {
+    expect(cardDescription({ tagline: "Never miss a good thread" })).toBe(
+      "Never miss a good thread",
+    );
   });
 
-  it("falls back to the first sentence of the description", () => {
-    expect(cardDescription({ description: "Watches subreddits. Posts a daily digest." })).toBe(
-      "Watches subreddits.",
-    );
+  it("returns null when there is no tagline", () => {
+    expect(cardDescription({})).toBeNull();
   });
 });
 

--- a/packages/core/src/apps/og/subscriber.ts
+++ b/packages/core/src/apps/og/subscriber.ts
@@ -26,14 +26,6 @@ async function readIcon(app: ResolvedApp): Promise<OgIcon | null> {
   }
 }
 
-/**
- * When the card renderer itself last changed (template, fonts, or where the
- * text comes from). A PNG older than this is stale even if it is newer than
- * its app, so the next event re-renders it. Bump the date whenever the card's
- * look or inputs change.
- */
-export const CARD_RENDERER_STAMP = Date.parse("2026-09-11T00:00:00Z");
-
 /** Card description: the author's tagline, or null when there isn't one. */
 export function cardDescription(manifest: { tagline?: string }): string | null {
   return manifest.tagline ?? null;
@@ -115,9 +107,7 @@ export function createAppOgImageSubscriber(opts: AppOgImageSubscriberOptions): S
 
     void (async () => {
       const existing = await opts.store.stat(app.appId);
-      if (existing && existing.mtimeMs > Math.max(Date.parse(app.updatedAt), CARD_RENDERER_STAMP)) {
-        return;
-      }
+      if (existing && existing.mtimeMs > Date.parse(app.updatedAt)) return;
       const link = opts.host ? `${opts.host}/full/apps/${appIdToPathSegment(app.appId)}` : null;
       const png = await generate(app, link);
       await enqueue(app.appId, async () => {

--- a/packages/core/src/apps/og/subscriber.ts
+++ b/packages/core/src/apps/og/subscriber.ts
@@ -5,7 +5,7 @@ import { appIdToPathSegment } from "../packaging/app-id.js";
 import type { CatalogEvent, ResolvedApp, SubscriberHandler } from "../state.js";
 import { svgToPng } from "./rasterize.js";
 import type { OgImageStore } from "./store.js";
-import { type OgIcon, renderOgSvg } from "./template.js";
+import { firstSentence, type OgIcon, renderOgSvg } from "./template.js";
 
 const log = createLogger("app-og-image");
 
@@ -26,11 +26,16 @@ async function readIcon(app: ResolvedApp): Promise<OgIcon | null> {
   }
 }
 
+/** Card description: the author's tagline, or a mechanical fallback. */
+export function cardDescription(manifest: { tagline?: string; description: string }): string {
+  return manifest.tagline ?? firstSentence(manifest.description);
+}
+
 /** Template + rasterizer for one app. */
 async function generateOgImage(app: ResolvedApp, link: string | null): Promise<Buffer> {
   const svg = renderOgSvg({
     name: app.displayName,
-    description: app.manifest.description,
+    description: cardDescription(app.manifest),
     link,
     icon: await readIcon(app),
   });

--- a/packages/core/src/apps/og/subscriber.ts
+++ b/packages/core/src/apps/og/subscriber.ts
@@ -5,7 +5,7 @@ import { appIdToPathSegment } from "../packaging/app-id.js";
 import type { CatalogEvent, ResolvedApp, SubscriberHandler } from "../state.js";
 import { svgToPng } from "./rasterize.js";
 import type { OgImageStore } from "./store.js";
-import { firstSentence, type OgIcon, renderOgSvg } from "./template.js";
+import { type OgIcon, renderOgSvg } from "./template.js";
 
 const log = createLogger("app-og-image");
 
@@ -26,9 +26,9 @@ async function readIcon(app: ResolvedApp): Promise<OgIcon | null> {
   }
 }
 
-/** Card description: the author's tagline, or a mechanical fallback. */
-export function cardDescription(manifest: { tagline?: string; description: string }): string {
-  return manifest.tagline ?? firstSentence(manifest.description);
+/** Card description: the author's tagline, or null when there isn't one. */
+export function cardDescription(manifest: { tagline?: string }): string | null {
+  return manifest.tagline ?? null;
 }
 
 /** Template + rasterizer for one app. */

--- a/packages/core/src/apps/og/subscriber.ts
+++ b/packages/core/src/apps/og/subscriber.ts
@@ -26,6 +26,14 @@ async function readIcon(app: ResolvedApp): Promise<OgIcon | null> {
   }
 }
 
+/**
+ * When the card renderer itself last changed (template, fonts, or where the
+ * text comes from). A PNG older than this is stale even if it is newer than
+ * its app, so the next event re-renders it. Bump the date whenever the card's
+ * look or inputs change.
+ */
+export const CARD_RENDERER_STAMP = Date.parse("2026-09-11T00:00:00Z");
+
 /** Card description: the author's tagline, or null when there isn't one. */
 export function cardDescription(manifest: { tagline?: string }): string | null {
   return manifest.tagline ?? null;
@@ -107,7 +115,9 @@ export function createAppOgImageSubscriber(opts: AppOgImageSubscriberOptions): S
 
     void (async () => {
       const existing = await opts.store.stat(app.appId);
-      if (existing && existing.mtimeMs > Date.parse(app.updatedAt)) return;
+      if (existing && existing.mtimeMs > Math.max(Date.parse(app.updatedAt), CARD_RENDERER_STAMP)) {
+        return;
+      }
       const link = opts.host ? `${opts.host}/full/apps/${appIdToPathSegment(app.appId)}` : null;
       const png = await generate(app, link);
       await enqueue(app.appId, async () => {

--- a/packages/core/src/apps/og/template.test.ts
+++ b/packages/core/src/apps/og/template.test.ts
@@ -1,6 +1,6 @@
 // packages/core/src/apps/og/template.test.ts
 import { describe, expect, it } from "@rstest/core";
-import { renderOgSvg, wrapText } from "./template.js";
+import { firstSentence, renderOgSvg, wrapText } from "./template.js";
 
 const base = {
   name: "Reddit Radar",
@@ -27,6 +27,50 @@ describe("wrapText", () => {
 
   it("hard-cuts a single word longer than the budget", () => {
     expect(wrapText("abcdefghijkl", 5, 1)).toEqual(["abcd…"]);
+  });
+});
+
+describe("firstSentence", () => {
+  it("cuts at the first English terminator", () => {
+    expect(firstSentence("Watches subreddits. Posts a daily digest.")).toBe("Watches subreddits.");
+  });
+
+  it("cuts at the first Chinese terminator", () => {
+    // Fullwidth terminators end a sentence on their own — Chinese prose is
+    // conventionally written with no space after 。！？, unlike English.
+    expect(firstSentence("自动完成小红书选题调研。每日推送候选笔记。")).toBe(
+      "自动完成小红书选题调研。",
+    );
+  });
+
+  it("cuts at the first Chinese terminator even with no space before the next sentence", () => {
+    expect(firstSentence("自动完成选题调研。你只需要审核。")).toBe("自动完成选题调研。");
+  });
+
+  it("cuts at the first fullwidth terminator in mixed Chinese/English text", () => {
+    expect(firstSentence("Rome 代理来处理。You only review.")).toBe("Rome 代理来处理。");
+  });
+
+  it("cuts at a question mark", () => {
+    expect(firstSentence("Ever lost a tab? This brings it back.")).toBe("Ever lost a tab?");
+  });
+
+  it("returns the whole trimmed text when there is no terminator", () => {
+    expect(firstSentence("  Watches subreddits and posts digests  ")).toBe(
+      "Watches subreddits and posts digests",
+    );
+  });
+
+  it("is fine cutting inside an abbreviation like e.g.", () => {
+    expect(firstSentence("Tracks things, e.g. subreddits and threads.")).toBe(
+      "Tracks things, e.g.",
+    );
+  });
+
+  it("does not cut ASCII terminators without trailing whitespace, e.g. a version number", () => {
+    expect(firstSentence("Runs v1.2 beta of the ingestion pipeline.")).toBe(
+      "Runs v1.2 beta of the ingestion pipeline.",
+    );
   });
 });
 
@@ -64,5 +108,16 @@ describe("renderOgSvg", () => {
   it("omits the link line when there is no host", () => {
     const svg = renderOgSvg({ ...base, link: null });
     expect(svg).not.toContain('y="566"');
+  });
+
+  it("wraps a long description across three lines, third baseline at y=492", () => {
+    const long =
+      "This app watches every subreddit you care about, ranks the best posts of the day, and drops a tidy digest into your inbox each morning without fail.";
+    const svg = renderOgSvg({ ...base, description: long });
+    const spans = svg.match(/<tspan x="96" y="\d+">/g) ?? [];
+    expect(spans).toHaveLength(3);
+    expect(svg).toContain('<tspan x="96" y="396">');
+    expect(svg).toContain('<tspan x="96" y="444">');
+    expect(svg).toContain('<tspan x="96" y="492">');
   });
 });

--- a/packages/core/src/apps/og/template.test.ts
+++ b/packages/core/src/apps/og/template.test.ts
@@ -1,6 +1,6 @@
 // packages/core/src/apps/og/template.test.ts
 import { describe, expect, it } from "@rstest/core";
-import { firstSentence, renderOgSvg, wrapText } from "./template.js";
+import { renderOgSvg, wrapText } from "./template.js";
 
 const base = {
   name: "Reddit Radar",
@@ -27,50 +27,6 @@ describe("wrapText", () => {
 
   it("hard-cuts a single word longer than the budget", () => {
     expect(wrapText("abcdefghijkl", 5, 1)).toEqual(["abcd…"]);
-  });
-});
-
-describe("firstSentence", () => {
-  it("cuts at the first English terminator", () => {
-    expect(firstSentence("Watches subreddits. Posts a daily digest.")).toBe("Watches subreddits.");
-  });
-
-  it("cuts at the first Chinese terminator", () => {
-    // Fullwidth terminators end a sentence on their own — Chinese prose is
-    // conventionally written with no space after 。！？, unlike English.
-    expect(firstSentence("自动完成小红书选题调研。每日推送候选笔记。")).toBe(
-      "自动完成小红书选题调研。",
-    );
-  });
-
-  it("cuts at the first Chinese terminator even with no space before the next sentence", () => {
-    expect(firstSentence("自动完成选题调研。你只需要审核。")).toBe("自动完成选题调研。");
-  });
-
-  it("cuts at the first fullwidth terminator in mixed Chinese/English text", () => {
-    expect(firstSentence("Rome 代理来处理。You only review.")).toBe("Rome 代理来处理。");
-  });
-
-  it("cuts at a question mark", () => {
-    expect(firstSentence("Ever lost a tab? This brings it back.")).toBe("Ever lost a tab?");
-  });
-
-  it("returns the whole trimmed text when there is no terminator", () => {
-    expect(firstSentence("  Watches subreddits and posts digests  ")).toBe(
-      "Watches subreddits and posts digests",
-    );
-  });
-
-  it("is fine cutting inside an abbreviation like e.g.", () => {
-    expect(firstSentence("Tracks things, e.g. subreddits and threads.")).toBe(
-      "Tracks things, e.g.",
-    );
-  });
-
-  it("does not cut ASCII terminators without trailing whitespace, e.g. a version number", () => {
-    expect(firstSentence("Runs v1.2 beta of the ingestion pipeline.")).toBe(
-      "Runs v1.2 beta of the ingestion pipeline.",
-    );
   });
 });
 
@@ -110,14 +66,19 @@ describe("renderOgSvg", () => {
     expect(svg).not.toContain('y="566"');
   });
 
-  it("wraps a long description across three lines, third baseline at y=492", () => {
+  it("wraps a long description across two lines, no third baseline", () => {
     const long =
-      "This app watches every subreddit you care about, ranks the best posts of the day, and drops a tidy digest into your inbox each morning without fail.";
+      "This app watches every subreddit you care about and ranks the best posts of the day.";
     const svg = renderOgSvg({ ...base, description: long });
     const spans = svg.match(/<tspan x="96" y="\d+">/g) ?? [];
-    expect(spans).toHaveLength(3);
+    expect(spans).toHaveLength(2);
     expect(svg).toContain('<tspan x="96" y="396">');
     expect(svg).toContain('<tspan x="96" y="444">');
-    expect(svg).toContain('<tspan x="96" y="492">');
+    expect(svg).not.toContain('<tspan x="96" y="492">');
+  });
+
+  it("renders no description line when description is null", () => {
+    const svg = renderOgSvg({ ...base, description: null });
+    expect(svg).not.toContain('<tspan x="96"');
   });
 });

--- a/packages/core/src/apps/og/template.ts
+++ b/packages/core/src/apps/og/template.ts
@@ -10,7 +10,8 @@ export interface OgIcon {
 
 export interface OgTemplateInput {
   name: string;
-  description: string;
+  /** author-written tagline; null → no description line. */
+  description: string | null;
   /** e.g. `jessie.romeos.cc/full/apps/reddit`; null hides the line. */
   link: string | null;
   icon: OgIcon | null;
@@ -83,21 +84,6 @@ export function wrapText(text: string, budget: number, maxLines: number): string
   return lines;
 }
 
-/**
- * Cuts `text` at its first sentence terminator, keeping the terminator.
- * Fullwidth terminators (`。`, `！`, `？`) end a sentence on their own, since
- * Chinese prose is conventionally written with no space before the next
- * sentence; ASCII terminators (`.`, `!`, `?`) only count when followed by
- * whitespace or end-of-string, so "e.g. " cuts but "v1.2" does not. Falls
- * back to the whole trimmed text when no terminator is found. Purely
- * mechanical — an abbreviation like "e.g." reads as a sentence end.
- */
-export function firstSentence(text: string): string {
-  const trimmed = text.trim();
-  const match = /^(.*?(?:[。！？]|[.!?](?=\s|$)))/s.exec(trimmed);
-  return match ? match[1].trim() : trimmed;
-}
-
 function iconSlot(icon: OgIcon | null): string {
   if (icon === null) {
     // Rome mark as the default app icon, centred in the 96px art box.
@@ -120,9 +106,10 @@ function nameSlot(name: string): string {
     .join("\n  ");
 }
 
-function descriptionSlot(description: string): string {
-  const lines = wrapText(description, 56, 3);
-  const baselines = [396, 444, 492];
+function descriptionSlot(description: string | null): string {
+  if (description === null) return "";
+  const lines = wrapText(description, 56, 2);
+  const baselines = [396, 444];
   const spans = lines
     .map((line, idx) => `<tspan x="96" y="${baselines[idx]}">${escapeXml(line)}</tspan>`)
     .join("\n    ");

--- a/packages/core/src/apps/og/template.ts
+++ b/packages/core/src/apps/og/template.ts
@@ -83,6 +83,21 @@ export function wrapText(text: string, budget: number, maxLines: number): string
   return lines;
 }
 
+/**
+ * Cuts `text` at its first sentence terminator, keeping the terminator.
+ * Fullwidth terminators (`。`, `！`, `？`) end a sentence on their own, since
+ * Chinese prose is conventionally written with no space before the next
+ * sentence; ASCII terminators (`.`, `!`, `?`) only count when followed by
+ * whitespace or end-of-string, so "e.g. " cuts but "v1.2" does not. Falls
+ * back to the whole trimmed text when no terminator is found. Purely
+ * mechanical — an abbreviation like "e.g." reads as a sentence end.
+ */
+export function firstSentence(text: string): string {
+  const trimmed = text.trim();
+  const match = /^(.*?(?:[。！？]|[.!?](?=\s|$)))/s.exec(trimmed);
+  return match ? match[1].trim() : trimmed;
+}
+
 function iconSlot(icon: OgIcon | null): string {
   if (icon === null) {
     // Rome mark as the default app icon, centred in the 96px art box.
@@ -106,8 +121,8 @@ function nameSlot(name: string): string {
 }
 
 function descriptionSlot(description: string): string {
-  const lines = wrapText(description, 56, 2);
-  const baselines = [396, 444];
+  const lines = wrapText(description, 56, 3);
+  const baselines = [396, 444, 492];
   const spans = lines
     .map((line, idx) => `<tspan x="96" y="${baselines[idx]}">${escapeXml(line)}</tspan>`)
     .join("\n    ");

--- a/packages/core/src/apps/og/template.ts
+++ b/packages/core/src/apps/og/template.ts
@@ -2,6 +2,7 @@
 // 1200x630 social card. Fixed layout with four slots (icon, name, description,
 // link); geometry and budgets match jessie_local_rome_study spec §4.4. SVG has
 // no automatic wrapping, so lines are broken here by a width-unit budget.
+import { widthUnits } from "../packaging/width-units.js";
 
 export interface OgIcon {
   mime: "image/svg+xml" | "image/png";
@@ -40,11 +41,7 @@ function escapeXml(value: string): string {
 }
 
 /** Width units: CJK / fullwidth count 2, everything else 1. */
-function units(text: string): number {
-  let total = 0;
-  for (const ch of text) total += (ch.codePointAt(0) ?? 0) > 0x2e7f ? 2 : 1;
-  return total;
-}
+const units = widthUnits;
 
 /**
  * Greedy character wrap that prefers the last space in the line (English

--- a/packages/core/src/apps/packaging/manifest-tagline.test.ts
+++ b/packages/core/src/apps/packaging/manifest-tagline.test.ts
@@ -30,6 +30,13 @@ describe("AppManifestSchema tagline", () => {
     );
   });
 
+  it("trims surrounding whitespace and rejects blank taglines", () => {
+    expect(AppManifestSchema.parse({ ...base, tagline: "  Hello there  " }).tagline).toBe(
+      "Hello there",
+    );
+    expect(() => AppManifestSchema.parse({ ...base, tagline: "   " })).toThrow(/blank/);
+  });
+
   it("rejects multi-line taglines", () => {
     expect(() => AppManifestSchema.parse({ ...base, tagline: "one\ntwo" })).toThrow(/single line/);
     expect(() => AppManifestSchema.parse({ ...base, tagline: "one\r\ntwo" })).toThrow(

--- a/packages/core/src/apps/packaging/manifest-tagline.test.ts
+++ b/packages/core/src/apps/packaging/manifest-tagline.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "@rstest/core";
+import { AppManifestSchema, TAGLINE_MAX_WIDTH_UNITS } from "./manifest.js";
+import { widthUnits } from "./width-units.js";
+
+const base = { formatVersion: 1, id: "cardapp", version: "0.0.1", description: "for agents" };
+
+describe("widthUnits", () => {
+  it("counts Latin as 1 and CJK as 2", () => {
+    expect(widthUnits("abc")).toBe(3);
+    expect(widthUnits("你好")).toBe(4);
+    expect(widthUnits("a你")).toBe(3);
+    expect(widthUnits("")).toBe(0);
+  });
+});
+
+describe("AppManifestSchema tagline", () => {
+  it("accepts a one-line tagline up to the width budget", () => {
+    expect(TAGLINE_MAX_WIDTH_UNITS).toBe(80);
+    expect(AppManifestSchema.parse({ ...base, tagline: "a".repeat(80) }).tagline).toHaveLength(80);
+    expect(AppManifestSchema.parse({ ...base, tagline: "你".repeat(40) }).tagline).toHaveLength(40);
+    expect(AppManifestSchema.parse(base).tagline).toBeUndefined();
+  });
+
+  it("rejects taglines over the width budget, in Latin or CJK", () => {
+    expect(() => AppManifestSchema.parse({ ...base, tagline: "a".repeat(81) })).toThrow(
+      /80 width units/,
+    );
+    expect(() => AppManifestSchema.parse({ ...base, tagline: "你".repeat(41) })).toThrow(
+      /80 width units/,
+    );
+  });
+
+  it("rejects multi-line taglines", () => {
+    expect(() => AppManifestSchema.parse({ ...base, tagline: "one\ntwo" })).toThrow(/single line/);
+    expect(() => AppManifestSchema.parse({ ...base, tagline: "one\r\ntwo" })).toThrow(
+      /single line/,
+    );
+  });
+});

--- a/packages/core/src/apps/packaging/manifest.ts
+++ b/packages/core/src/apps/packaging/manifest.ts
@@ -112,8 +112,9 @@ export const AppManifestSchema = z
       .refine((v) => valid(v) !== null, "must be a valid semver version"),
     description: z.string().min(1),
     // One-line, author-written hook for the app's social share card
-    // (≤ 80 width units — 80 Latin chars or 40 CJK). Card falls back to the
-    // first sentence of `description` when absent.
+    // (≤ 80 width units — 80 Latin chars or 40 CJK — is the display rule; the
+    // schema only caps length at 160 characters, the template truncates on
+    // width). Card falls back to the first sentence of `description` when absent.
     tagline: z.string().min(1).max(160).optional(),
     name: z.string().min(1).optional(),
     icon: z.string().min(1).optional(),

--- a/packages/core/src/apps/packaging/manifest.ts
+++ b/packages/core/src/apps/packaging/manifest.ts
@@ -114,7 +114,7 @@ export const AppManifestSchema = z
     // One-line, author-written hook for the app's social share card
     // (≤ 80 width units — 80 Latin chars or 40 CJK — is the display rule; the
     // schema only caps length at 160 characters, the template truncates on
-    // width). Card falls back to the first sentence of `description` when absent.
+    // width). Without it the card shows no description.
     tagline: z.string().min(1).max(160).optional(),
     name: z.string().min(1).optional(),
     icon: z.string().min(1).optional(),

--- a/packages/core/src/apps/packaging/manifest.ts
+++ b/packages/core/src/apps/packaging/manifest.ts
@@ -122,7 +122,8 @@ export const AppManifestSchema = z
     // Without it the card shows no description.
     tagline: z
       .string()
-      .min(1)
+      .trim()
+      .min(1, "tagline must not be blank")
       .refine((v) => !/[\r\n]/.test(v), "tagline must be a single line")
       .refine(
         (v) => widthUnits(v) <= TAGLINE_MAX_WIDTH_UNITS,

--- a/packages/core/src/apps/packaging/manifest.ts
+++ b/packages/core/src/apps/packaging/manifest.ts
@@ -8,6 +8,10 @@ import {
   ArtifactLocalNameV2Schema,
   isValidArtifactReference,
 } from "./artifact-name.js";
+import { widthUnits } from "./width-units.js";
+
+/** Display budget for `tagline`, shared with the social-card template. */
+export const TAGLINE_MAX_WIDTH_UNITS = 80;
 
 /** SQL identifier rule for `app.yaml#db.tablePrefix`; reused by manifest validation and the uninstall-purge primitive. */
 export const TABLE_PREFIX_PATTERN = /^[a-z][a-z0-9_]*$/;
@@ -111,11 +115,20 @@ export const AppManifestSchema = z
       .min(1)
       .refine((v) => valid(v) !== null, "must be a valid semver version"),
     description: z.string().min(1),
-    // One-line, author-written hook for the app's social share card
-    // (≤ 80 width units — 80 Latin chars or 40 CJK — is the display rule; the
-    // schema only caps length at 160 characters, the template truncates on
-    // width). Without it the card shows no description.
-    tagline: z.string().min(1).max(160).optional(),
+    // One-line, author-written hook for the app's social share card. The
+    // schema enforces the display contract — a single line of at most 80
+    // width units (80 Latin characters or 40 CJK) — so the rendered image and
+    // the og:description text always carry the same, untruncated sentence.
+    // Without it the card shows no description.
+    tagline: z
+      .string()
+      .min(1)
+      .refine((v) => !/[\r\n]/.test(v), "tagline must be a single line")
+      .refine(
+        (v) => widthUnits(v) <= TAGLINE_MAX_WIDTH_UNITS,
+        `tagline must be at most ${TAGLINE_MAX_WIDTH_UNITS} width units (80 Latin characters or 40 CJK)`,
+      )
+      .optional(),
     name: z.string().min(1).optional(),
     icon: z.string().min(1).optional(),
     appRoot: z.string().min(1).optional(),

--- a/packages/core/src/apps/packaging/manifest.ts
+++ b/packages/core/src/apps/packaging/manifest.ts
@@ -111,6 +111,10 @@ export const AppManifestSchema = z
       .min(1)
       .refine((v) => valid(v) !== null, "must be a valid semver version"),
     description: z.string().min(1),
+    // One-line, author-written hook for the app's social share card
+    // (≤ 80 width units — 80 Latin chars or 40 CJK). Card falls back to the
+    // first sentence of `description` when absent.
+    tagline: z.string().min(1).max(160).optional(),
     name: z.string().min(1).optional(),
     icon: z.string().min(1).optional(),
     appRoot: z.string().min(1).optional(),

--- a/packages/core/src/apps/packaging/width-units.ts
+++ b/packages/core/src/apps/packaging/width-units.ts
@@ -1,0 +1,11 @@
+/**
+ * Display width of a string in card units: CJK and other fullwidth code
+ * points (above U+2E7F) count 2, everything else 1. Shared by the manifest
+ * `tagline` rule and the social-card template so "80 units" means the same
+ * thing at validation time and at render time.
+ */
+export function widthUnits(text: string): number {
+  let total = 0;
+  for (const ch of text) total += (ch.codePointAt(0) ?? 0) > 0x2e7f ? 2 : 1;
+  return total;
+}

--- a/packages/core/src/apps/types.ts
+++ b/packages/core/src/apps/types.ts
@@ -125,6 +125,11 @@ export interface RomeAppManifest {
   id: string;
   version: string;
   description: string;
+  /**
+   * One-line, author-written hook for the app's social share card. Falls
+   * back to the first sentence of `description` when absent.
+   */
+  tagline?: string;
   /** Human-readable App name. Consumed by both Rome Cloud and Rome. */
   name?: string;
   /** Path relative to appRoot to an icon asset (svg/png/webp). */

--- a/packages/core/src/apps/types.ts
+++ b/packages/core/src/apps/types.ts
@@ -126,8 +126,9 @@ export interface RomeAppManifest {
   version: string;
   description: string;
   /**
-   * One-line, author-written hook for the app's social share card. Falls
-   * back to the first sentence of `description` when absent.
+   * One-line, author-written hook for the app's social share card. When
+   * absent the card shows no description at all — there is no fallback to
+   * `description`.
    */
   tagline?: string;
   /** Human-readable App name. Consumed by both Rome Cloud and Rome. */

--- a/packages/core/src/lib/social-meta.test.ts
+++ b/packages/core/src/lib/social-meta.test.ts
@@ -80,6 +80,13 @@ describe("renderSocialMeta", () => {
     expect(html).toContain('<meta property="og:title" content="Reddit Radar" />');
   });
 
+  it("omits og:description and twitter:description when the card has no description", () => {
+    const html = renderSocialMeta(SHELL, { ...card, description: undefined });
+    expect(html).not.toContain("og:description");
+    expect(html).not.toContain("twitter:description");
+    expect(html).toContain('<meta property="og:title" content="Reddit Radar" />');
+  });
+
   it("omits image tags when neither the card nor the shell has one", () => {
     const shellWithoutImage = [
       "<html><head>",

--- a/packages/core/src/lib/social-meta.ts
+++ b/packages/core/src/lib/social-meta.ts
@@ -12,7 +12,8 @@ const SHELL_OG_IMAGE_RE = /<meta property="og:image" content="([^"]*)"/;
 
 export interface SocialCard {
   title: string;
-  description: string;
+  /** Omitted → no og:description / twitter:description tags. */
+  description?: string;
   /** Absolute URL of the page being shared. */
   url: string;
   /** Absolute URL of a 1200x630 image; omitted → the shell's own og:image is kept. */
@@ -41,15 +42,16 @@ function resolveImageValue(card: SocialCard, existingBlock: string): string | nu
 
 function socialTags(card: SocialCard, imageValue: string | null): string {
   const t = escapeHtml(card.title);
-  const d = escapeHtml(card.description);
   const u = escapeHtml(card.url);
   const lines = [
     '<meta property="og:type" content="website" />',
     '<meta property="og:site_name" content="Rome" />',
     `<meta property="og:title" content="${t}" />`,
-    `<meta property="og:description" content="${d}" />`,
-    `<meta property="og:url" content="${u}" />`,
   ];
+  if (card.description !== undefined) {
+    lines.push(`<meta property="og:description" content="${escapeHtml(card.description)}" />`);
+  }
+  lines.push(`<meta property="og:url" content="${u}" />`);
   if (imageValue !== null) {
     lines.push(
       `<meta property="og:image" content="${imageValue}" />`,
@@ -60,8 +62,10 @@ function socialTags(card: SocialCard, imageValue: string | null): string {
   lines.push(
     '<meta name="twitter:card" content="summary_large_image" />',
     `<meta name="twitter:title" content="${t}" />`,
-    `<meta name="twitter:description" content="${d}" />`,
   );
+  if (card.description !== undefined) {
+    lines.push(`<meta name="twitter:description" content="${escapeHtml(card.description)}" />`);
+  }
   if (imageValue !== null) {
     lines.push(`<meta name="twitter:image" content="${imageValue}" />`);
   }

--- a/rome_apps/assistant/app.yaml
+++ b/rome_apps/assistant/app.yaml
@@ -4,6 +4,7 @@ name: Assistant
 icon: assets/icon.svg
 version: 0.1.6
 description: 'General assistance agents and routine-management guidance. Provides the routine-from-chat skill — reach for it first whenever the guardian wants something to happen automatically: it turns a plain-language "do this automatically" request into an event-triggered ("text me when I get an email from my landlord") or scheduled ("remind me every Friday at 9am") routine instead of hand-building a trigger.'
+tagline: "Your everyday assistant that runs routines for you."
 
 agents:
   - agents/assistant.yaml

--- a/rome_apps/briefing/app.yaml
+++ b/rome_apps/briefing/app.yaml
@@ -1,9 +1,11 @@
 formatVersion: 1
 id: briefing
+name: Briefing
 version: 0.3.0
 description: >-
   Scheduled morning and evening briefings that fold in your calendar, recent
   messages, and the findings of recurring scouting tasks run by the assistant.
+tagline: "Your day, briefed morning and evening from your calendar, messages, and scouts."
 icon: assets/icon.svg
 appRoot: dist
 

--- a/rome_apps/browser-automation/app.yaml
+++ b/rome_apps/browser-automation/app.yaml
@@ -4,6 +4,7 @@ name: Browser Automation
 icon: assets/icon.svg
 version: 0.2.1
 description: Operate the agent's browser to visit and act on websites via predefined automation actions/scripts exposed by the `opencli` tool. You can get the supported commands by running shell command `opencli <site_name> --help`, where site_name can be amazon, google, instagram, linkedin, producthunt, substack, twitter, wikipedia, xiaohongshu, youtube or more. To know all available commands, run `opencli list`. Also drives ChatGPT through the logged-in browser session — `chatgpt_chat` sends a prompt and returns the markdown response, and `chatgpt_image` generates a ChatGPT image and saves it to disk.
+tagline: "Hand any website task to an agent that drives the browser for you."
 appRoot: dist
 
 web:

--- a/rome_apps/coding/app.yaml
+++ b/rome_apps/coding/app.yaml
@@ -7,6 +7,7 @@ description: >-
   Planning and coding agents, the app_creation skill, and a frontend gallery of
   live UI mocks. Use app_creation when visuals are important, such as for apps,
   dashboards, games, and other Rome experiences that need a polished UI.
+tagline: "Plan, build, and preview apps with agents that write the code."
 appRoot: dist
 
 web:

--- a/rome_apps/coding/src/skills/app_creation/REFERENCE.md
+++ b/rome_apps/coding/src/skills/app_creation/REFERENCE.md
@@ -64,7 +64,7 @@ name: Coding                     # Display name — Title Case words ("Morning B
 icon: assets/icon.svg            # Optional
 version: 0.2.8                   # Semantic version
 description: Short description
-tagline: One sentence for the share card # Optional; ≤ 80 chars (40 CJK); benefit-first, no jargon — an App Store subtitle
+tagline: One sentence for the share card # Commented out by default; ≤ 80 chars (40 CJK), benefit-first, no jargon — an App Store subtitle. It is the card's only description (no fallback), so uncomment and fill it in.
 appRoot: dist                    # Optional; defaults to source root if omitted
 includeSource: true              # Optional; publish src/ with the Store bundle
 remix:                            # Rome-managed lineage for a derived app

--- a/rome_apps/coding/src/skills/app_creation/REFERENCE.md
+++ b/rome_apps/coding/src/skills/app_creation/REFERENCE.md
@@ -64,6 +64,7 @@ name: Coding                     # Display name — Title Case words ("Morning B
 icon: assets/icon.svg            # Optional
 version: 0.2.8                   # Semantic version
 description: Short description
+tagline: One sentence for the share card # Optional; ≤ 80 chars (40 CJK); benefit-first, no jargon — an App Store subtitle
 appRoot: dist                    # Optional; defaults to source root if omitted
 includeSource: true              # Optional; publish src/ with the Store bundle
 remix:                            # Rome-managed lineage for a derived app

--- a/rome_apps/coding/src/skills/app_creation/REFERENCE.md
+++ b/rome_apps/coding/src/skills/app_creation/REFERENCE.md
@@ -64,7 +64,7 @@ name: Coding                     # Display name — Title Case words ("Morning B
 icon: assets/icon.svg            # Optional
 version: 0.2.8                   # Semantic version
 description: Short description
-tagline: One sentence for the share card # Commented out by default; ≤ 80 chars (40 CJK), benefit-first, no jargon — an App Store subtitle. It is the card's only description (no fallback), so uncomment and fill it in.
+# tagline: One sentence for the share card   # Optional — uncomment and fill in: ≤ 80 chars (40 CJK), benefit-first, no jargon, like an App Store subtitle. It is the card's only description (no fallback).
 appRoot: dist                    # Optional; defaults to source root if omitted
 includeSource: true              # Optional; publish src/ with the Store bundle
 remix:                            # Rome-managed lineage for a derived app

--- a/rome_apps/coding/src/skills/app_creation/SKILL.md
+++ b/rome_apps/coding/src/skills/app_creation/SKILL.md
@@ -60,6 +60,11 @@ mkdir -p "$REPO" && cd "$REPO"
 #    already list it: the workflow template has no web UI.
 pnpm add @rome-os/app-runtime@latest @rome-os/app-web-sdk@latest @rome-os/ui@latest
 
+# Also fill in app.yaml: `name`, `description` (written for agents), and
+# `tagline` (written for people: one sentence, ≤ 80 chars / 40 CJK,
+# benefit-first, like an App Store subtitle — it is the share card's text;
+# update it whenever the app's purpose changes).
+
 # 4. git init AFTER scaffolding. Initializing on top of the freshly
 #    materialized template means commit #1 (next step) is "the scaffold as
 #    shipped" and every subsequent diff is scoped to the agent's own work.

--- a/rome_apps/coding/src/skills/app_creation/SKILL.md
+++ b/rome_apps/coding/src/skills/app_creation/SKILL.md
@@ -62,8 +62,9 @@ pnpm add @rome-os/app-runtime@latest @rome-os/app-web-sdk@latest @rome-os/ui@lat
 
 # Also fill in app.yaml: `name`, `description` (written for agents), and
 # `tagline` (written for people: one sentence, ≤ 80 chars / 40 CJK,
-# benefit-first, like an App Store subtitle — it is the share card's text;
-# update it whenever the app's purpose changes).
+# benefit-first, like an App Store subtitle). The tagline is the share card's
+# ONLY description — there is no fallback — so uncomment and fill it in, and
+# update it whenever the app's purpose changes.
 
 # 4. git init AFTER scaffolding. Initializing on top of the freshly
 #    materialized template means commit #1 (next step) is "the scaffold as

--- a/rome_apps/connector/app.yaml
+++ b/rome_apps/connector/app.yaml
@@ -1,5 +1,6 @@
 formatVersion: 1
 id: connector
+name: Connector
 icon: assets/icon.svg
 version: 0.7.0
 # NOTE: the connectable-toolkit slugs below mirror SUPPORTED_CONNECTORS in
@@ -13,6 +14,7 @@ description: |
   For GitHub, prefer the `gh` CLI and `git` directly in the shell (`gh api`, `gh pr`, `git clone/push`) — it's Rome-managed (no Composio). If a `gh`/`git` call reports it is not authenticated, ask the guardian to connect GitHub at `/settings`. To react to GitHub events (push, PRs, issues), use `connector_github_subscribe` (NOT `connector_event_subscribe`, which is Composio-only) — it registers Rome's own webhook on the repo/org and returns the event-bus topic a routine binds to. To stop receiving them, use `connector_github_unsubscribe` with the same repo/org.
 
   Slack is also Rome-managed (no Composio): act on it with `connector_proxy` (toolkit `slack`) against the Slack Web API — e.g. POST `/api/chat.postMessage`, `/api/conversations.list`, `/api/search.messages`. Do NOT use `connector_login`/`connector_connect`/`connector_tool_execute` for Slack. If a Slack call comes back not-connected, ask the guardian to connect Slack at `/settings`.
+tagline: "Give your agent Gmail, Slack, GitHub, Notion, and 15 more, in one click."
 appRoot: dist
 
 web:

--- a/rome_apps/dream/app.yaml
+++ b/rome_apps/dream/app.yaml
@@ -1,8 +1,10 @@
 formatVersion: 1
 id: dream
+name: Dream
 icon: assets/icon.svg
 version: 0.1.5
 description: Periodic self-review agent that summarizes recent conversations and updates memory
+tagline: "Your Rome reflects on recent conversations and remembers what matters."
 appRoot: dist
 
 web:

--- a/rome_apps/inbox/app.yaml
+++ b/rome_apps/inbox/app.yaml
@@ -4,6 +4,7 @@ name: Inbox
 icon: assets/icon.svg
 version: 0.2.13
 description: Incoming-message triage, routing, and channel hooks
+tagline: "Every message, triaged and routed before you even open it."
 appRoot: dist
 
 web:

--- a/rome_apps/recap/app.yaml
+++ b/rome_apps/recap/app.yaml
@@ -4,6 +4,7 @@ name: Recap
 icon: assets/icon.svg
 version: 0.1.1
 description: Spoken recaps for completed WebChat turns
+tagline: "Hear a spoken recap of every chat, hands-free."
 appRoot: dist
 
 web:

--- a/rome_apps/replay/app.yaml
+++ b/rome_apps/replay/app.yaml
@@ -8,6 +8,7 @@ description: >-
   block-by-block in chat — reproducing the recorded assistant text, thinking,
   tool calls and results. Replay is inert; no model is called and no action is
   re-executed.
+tagline: "Replay any recorded chat step by step, exactly as it happened."
 appRoot: dist
 
 # Web UI: multi-upload trace.json, drag to order, "replay in chat".

--- a/rome_apps/showcases/app.yaml
+++ b/rome_apps/showcases/app.yaml
@@ -1,8 +1,10 @@
 formatVersion: 1
 id: showcases
+name: Showcases
 icon: assets/icon.svg
 version: 0.1.0
 description: Import, view, export, and share static Rome agent trace showcases.
+tagline: "Show off what your agents did, one shareable trace at a time."
 appRoot: dist
 
 web:

--- a/rome_apps/skills/app.yaml
+++ b/rome_apps/skills/app.yaml
@@ -4,6 +4,7 @@ name: Skills
 icon: assets/icon.svg
 version: 0.2.0
 description: Browse every skill installed on this Rome, start a chat that uses one (each skill is a slash command in webchat), and import or generate new skills with the import-skill skill.
+tagline: "Every skill your Rome knows, one slash command away."
 appRoot: dist
 
 web:

--- a/rome_apps/system/app.yaml
+++ b/rome_apps/system/app.yaml
@@ -4,6 +4,7 @@ name: System
 icon: assets/icon.svg
 version: 0.2.20
 description: "Core system actions for scheduling, messaging, approvals, app store access, and subagent orchestration. In Rome context, 'store' / 'app store' usually means the Rome App Store. Reach here first for app_store_search (search/read Rome Store listings), app_management (install from the Rome Store with source.mode='appstore', install / uninstall / enable / disable a Rome app, or scaffold a new dev app — first-party apps ship with Rome, so only enable/disable applies to them), send_message (send a message through any registered channel adapter), send_user_message (start or continue a webchat conversation on the guardian's behalf), and generate_image (generate an image from a text prompt via the connected image provider)."
+tagline: "The control room: scheduling, messaging, approvals, and the app store."
 appRoot: dist
 
 web:

--- a/rome_apps/welcome-to-rome/app.yaml
+++ b/rome_apps/welcome-to-rome/app.yaml
@@ -4,6 +4,7 @@ name: Welcome to Rome
 icon: assets/icon.svg
 version: 0.1.0
 description: Conversational first-run onboarding. The guardian chats with Rome in the standard Chat UI; a turn-middleware state machine drives the conversation, rendering the app's own inline cards and handing the heavy steps to specialist agents.
+tagline: "Set up your Rome in one friendly conversation."
 appRoot: dist
 
 web:

--- a/rome_apps/workflow-studio/app.yaml
+++ b/rome_apps/workflow-studio/app.yaml
@@ -4,6 +4,7 @@ name: Workflows
 icon: assets/icon.svg
 version: 0.1.0
 description: Describe an automation in plain language; approve the short spec, and it's built into a runnable workflow in one conversation.
+tagline: "Describe an automation in plain words and watch it become a workflow."
 appRoot: dist
 
 web:


### PR DESCRIPTION
## What this PR does

The social card from #341 fills its description slot from `app.yaml`'s `description`. On the first-party apps that field is written for agents, not people: it runs from one word to 724 characters, and for `connector` it is a page of API instructions. Cut to two lines it reads as a truncated manual, not a hook.

This PR gives apps a place to say what they are in one line: an optional `tagline` in `app.yaml`. It is the card's only description: the image shows it, and it becomes the `og:description` / `twitter:description` text beside the image. Without one the card shows no description and the preview text is omitted — a deliberate choice over falling back to `description`, so that every card is either well written or quiet, never a truncated manual. The scaffold template and the `app_creation` skill ask agents to write a tagline (benefit-first, ≤ 80 characters, like an App Store subtitle) and to keep it current when an app's purpose changes. The 14 first-party apps get theirs here, and the four that shipped without a `name` (briefing, connector, dream, showcases) get one, so cards stop showing the kebab id.

Refs #202.

## Design & Invariants

- `tagline` is optional and author-owned. Nothing generates it at render time; no model is involved. Apps without one (store apps, apps built before this change) get a card with icon, name, link, and no description until an author or agent adds a tagline; the scaffold ships the line commented out rather than with a placeholder that could leak onto a card.
- One source for both surfaces: `cardDescription(manifest)` feeds the rendered image and the document handler's `og:description`, so the picture and the text beside it never disagree.
- Changing `app.yaml` flips the first-party artifact hash, so the next boot reinstalls those apps and the subscriber from #341 regenerates their cards — no manual step.
- Cards rendered before this change are re-rendered too: the on-disk name now carries `CARD_FORMAT_VERSION` (`<id>.v2.png`), so a description-based PNG from #341 is simply never read again and the next event renders a fresh one. Bump the version whenever the card's look or inputs change; the public URL (`/app-og/<id>.png`) does not change.
- The schema enforces the tagline contract rather than documenting it: trimmed, non-blank, single line, at most 80 width units (Latin 1, CJK 2 — `packaging/width-units.ts`, shared with the template).
- Store apps (rome-apps) are untouched; their authors can add a tagline whenever they like.

## Test plan

- [x] `pnpm typecheck`, `pnpm test:unit`
- [x] `apps/og/template.test.ts`: null description renders no description line; `apps/og/subscriber.test.ts`: `cardDescription` returns the tagline or null; `api/app-social-card.test.ts` + `lib/social-meta.test.ts`: no `og:description` / `twitter:description` without a tagline; `apps/manager.test.ts`: the installer carries `tagline` into the catalog
- [x] All 14 first-party manifests parse against the tightened `AppManifestSchema` with `name` and `tagline`; `packaging/manifest-tagline.test.ts` covers the Latin/CJK width boundaries, blank and multi-line rejection; `store.test.ts` covers the versioned file name
- [x] Local dev instance on this branch: the 13 first-party cards regenerated with their taglines and the four fixed names (rendered PNGs eyeballed)


