### PR TITLE
fix(browser): preserve sessions and native browser identity

### DIFF
--- a/scripts/docker/chrome-cdp-supervisor.test.ts
+++ b/scripts/docker/chrome-cdp-supervisor.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "@rstest/core";
 
@@ -48,6 +48,44 @@ async function waitForCount(path: string, minimum: number) {
 }
 
 describe("rome-start-chrome-cdp.sh", () => {
+  it("rejects a guard that exits before signaling readiness", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "rome-chrome-readiness-"));
+    tempDirs.push(tempDir);
+    makeExecutable(join(tempDir, "rome-apply-cdp-stealth.sh"), "#!/usr/bin/env bash\nexit 7\n");
+    const source = readFileSync(resolve(PROJECT_ROOT, SCRIPT_PATH), "utf8");
+    const startGuard = source.match(/^start_stealth_guard\(\) \{\n[\s\S]*?^}\n/m)?.[0];
+    expect(startGuard).toBeDefined();
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `
+info() { :; }
+err() { printf '%s\\n' "$*" >&2; }
+${startGuard?.replaceAll("/tmp/chrome-stealth.log", '"$TEST_STEALTH_LOG"')}
+start_stealth_guard
+`,
+      ],
+      {
+        encoding: "utf8",
+        timeout: 2_000,
+        env: {
+          ...process.env,
+          ENABLE_STEALTH: "1",
+          SCRIPT_DIR: tempDir,
+          TMPDIR: tempDir,
+          TEST_STEALTH_LOG: join(tempDir, "stealth.log"),
+          max_attempts: "3",
+        },
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("CDP stealth guard exited unexpectedly");
+  });
+
   it("restarts Chrome when the browser process exits", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "rome-chrome-supervisor-"));
     tempDirs.push(tempDir);

--- a/scripts/docker/fixtures/stealth-websocket.py
+++ b/scripts/docker/fixtures/stealth-websocket.py
@@ -14,24 +14,42 @@ class Connection:
         self.scenario = os.environ["CDP_SCENARIO"]
         self.idle_reads = 0
         self.new_page_sent = False
+        self.auto_attached_sessions = set()
+        self.late_frame_sent = False
 
-    def attached(self, target_id, session_id, waiting=False):
-        return {
+    def attached(self, target_id, session_id, waiting=False, target_type="page", parent=None):
+        event = {
             "method": "Target.attachedToTarget",
             "params": {
                 "sessionId": session_id,
-                "targetInfo": {"targetId": target_id, "type": "page"},
+                "targetInfo": {"targetId": target_id, "type": target_type},
                 "waitingForDebugger": waiting,
             },
         }
+        if parent is not None:
+            event["sessionId"] = parent
+        return event
 
     def send(self, raw):
         message = json.loads(raw)
         self.commands.append(message)
         method = message["method"]
+        session_id = message.get("sessionId")
         result = {}
-        if method == "Target.setAutoAttach" and self.scenario != "empty":
-            self.pending.append(self.attached("existing", "session-existing"))
+        if method == "Target.setAutoAttach":
+            self.auto_attached_sessions.add(session_id)
+            if session_id is None and self.scenario != "empty":
+                self.pending.append(self.attached("existing", "session-existing"))
+            elif self.scenario == "nested-iframes":
+                children = {
+                    "session-existing": "existing-frame",
+                    "session-existing-frame": "existing-nested-frame",
+                }
+                if session_id in children:
+                    child = children[session_id]
+                    self.pending.append(self.attached(
+                        child, "session-" + child, False, "iframe", session_id
+                    ))
         elif method == "Target.getTargets":
             result = {
                 "targetInfos": [] if self.scenario == "empty" else [
@@ -51,6 +69,17 @@ class Connection:
         ):
             self.pending.append(WebSocketTimeoutException("CDP response timed out"))
             return
+        elif (
+            self.scenario == "nested-iframes"
+            and method == "Runtime.runIfWaitingForDebugger"
+            and session_id in self.auto_attached_sessions
+        ):
+            children = {"session-new": "new-frame", "session-new-frame": "new-nested-frame"}
+            if session_id in children:
+                child = children[session_id]
+                self.pending.append(self.attached(
+                    child, "session-" + child, True, "iframe", session_id
+                ))
         self.pending.append({"id": message["id"], "result": result})
 
     def recv(self):
@@ -59,12 +88,22 @@ class Connection:
             if isinstance(message, Exception):
                 raise message
             return json.dumps(message)
-        if self.scenario in {"idle", "command-timeout"} and self.idle_reads < 2:
+        if self.scenario in {"idle", "command-timeout", "nested-iframes"} and self.idle_reads < 2:
             self.idle_reads += 1
             raise WebSocketTimeoutException("no browser events")
         if not self.new_page_sent:
             self.new_page_sent = True
             return json.dumps(self.attached("new", "session-new", True))
+        if (
+            self.scenario == "nested-iframes"
+            and not self.late_frame_sent
+            and "session-existing-frame" in self.auto_attached_sessions
+        ):
+            self.late_frame_sent = True
+            return json.dumps(self.attached(
+                "late-nested-frame", "session-late-nested-frame", True,
+                "iframe", "session-existing-frame"
+            ))
         return ""
 
     def close(self):

--- a/scripts/docker/fixtures/stealth-websocket.py
+++ b/scripts/docker/fixtures/stealth-websocket.py
@@ -1,0 +1,75 @@
+import json
+import os
+from pathlib import Path
+
+
+class WebSocketTimeoutException(Exception):
+    pass
+
+
+class Connection:
+    def __init__(self):
+        self.pending = []
+        self.commands = []
+        self.scenario = os.environ["CDP_SCENARIO"]
+        self.idle_reads = 0
+        self.new_page_sent = False
+
+    def attached(self, target_id, session_id, waiting=False):
+        return {
+            "method": "Target.attachedToTarget",
+            "params": {
+                "sessionId": session_id,
+                "targetInfo": {"targetId": target_id, "type": "page"},
+                "waitingForDebugger": waiting,
+            },
+        }
+
+    def send(self, raw):
+        message = json.loads(raw)
+        self.commands.append(message)
+        method = message["method"]
+        result = {}
+        if method == "Target.setAutoAttach" and self.scenario != "empty":
+            self.pending.append(self.attached("existing", "session-existing"))
+        elif method == "Target.getTargets":
+            result = {
+                "targetInfos": [] if self.scenario == "empty" else [
+                    {"targetId": "existing", "type": "page"}
+                ]
+            }
+        elif method == "Target.createTarget":
+            result = {"targetId": "created"}
+            self.pending.append(self.attached("created", "session-created", True))
+        elif method == "Target.attachToTarget":
+            result = {"sessionId": "session-manual"}
+            self.pending.append(self.attached(message["params"]["targetId"], "session-manual"))
+        elif (
+            self.scenario == "command-timeout"
+            and message.get("sessionId") == "session-new"
+            and method == "Emulation.setLocaleOverride"
+        ):
+            self.pending.append(WebSocketTimeoutException("CDP response timed out"))
+            return
+        self.pending.append({"id": message["id"], "result": result})
+
+    def recv(self):
+        if self.pending:
+            message = self.pending.pop(0)
+            if isinstance(message, Exception):
+                raise message
+            return json.dumps(message)
+        if self.scenario in {"idle", "command-timeout"} and self.idle_reads < 2:
+            self.idle_reads += 1
+            raise WebSocketTimeoutException("no browser events")
+        if not self.new_page_sent:
+            self.new_page_sent = True
+            return json.dumps(self.attached("new", "session-new", True))
+        return ""
+
+    def close(self):
+        Path(os.environ["CDP_TRACE_FILE"]).write_text(json.dumps(self.commands))
+
+
+def create_connection(url, timeout):
+    return Connection()

--- a/scripts/docker/rome-apply-cdp-stealth.sh
+++ b/scripts/docker/rome-apply-cdp-stealth.sh
@@ -154,14 +154,6 @@ browser_ws="$(printf '%s' "$browser_version_json" | python3 -c "import json, sys
   exit 1
 }
 
-if [[ -z "$CHROME_USER_AGENT" ]]; then
-  CHROME_USER_AGENT="$(printf '%s' "$browser_version_json" | python3 -c "import json, sys; print(json.load(sys.stdin).get('User-Agent', ''))")"
-  if [[ -z "$CHROME_USER_AGENT" ]]; then
-    err "cannot determine browser user agent from ${CDP_BASE}/json/version"
-    exit 1
-  fi
-fi
-
 stealth_js_file="${SCRIPT_DIR}/stealth-inject.js"
 if [[ ! -f "$stealth_js_file" ]]; then
   err "stealth injector not found at ${stealth_js_file}"
@@ -169,7 +161,10 @@ if [[ ! -f "$stealth_js_file" ]]; then
 fi
 
 geo_params="$(get_geo_for_timezone "$TIMEZONE")"
-ua_metadata="$(build_ua_metadata)"
+ua_metadata='{}'
+if [[ -n "$CHROME_USER_AGENT" ]]; then
+  ua_metadata="$(build_ua_metadata)"
+fi
 BROWSER_WS="$browser_ws" \
   STEALTH_JS_FILE="$stealth_js_file" \
   READY_FILE="$READY_FILE" \
@@ -307,7 +302,8 @@ def configure_target(session_id: str, target_info: dict, waiting_for_debugger: b
                 session_id,
             )
             send("Network.enable", {}, session_id)
-            send("Network.setUserAgentOverride", build_ua_override(), session_id)
+            if chrome_user_agent:
+                send("Network.setUserAgentOverride", build_ua_override(), session_id)
         if target_type in {"page", "iframe"}:
             send("Page.addScriptToEvaluateOnNewDocument", {"source": stealth_js}, session_id)
             # Enable the Page agent so registered scripts also run in OOPIF documents.

--- a/scripts/docker/rome-apply-cdp-stealth.sh
+++ b/scripts/docker/rome-apply-cdp-stealth.sh
@@ -321,6 +321,7 @@ def handle_event(message: dict) -> None:
 
 
 try:
+    # Auto-attach includes existing targets and emits the events that configure them.
     send(
         "Target.setAutoAttach",
         {
@@ -331,34 +332,18 @@ try:
     )
 
     targets = send("Target.getTargets", {}).get("result", {}).get("targetInfos", [])
-    page_targets = [target for target in targets if target.get("type") in {"page", "iframe"}]
-
-    if not any(target.get("type") == "page" for target in page_targets):
-        created_target_id = (
-            send("Target.createTarget", {"url": "about:blank"})
-            .get("result", {})
-            .get("targetId")
-        )
-        if created_target_id:
-            page_targets.append({"targetId": created_target_id, "type": "page"})
-
-    for target in page_targets:
-        target_id = target.get("targetId")
-        if not target_id:
-            continue
-        try:
-            response = send("Target.attachToTarget", {"targetId": target_id, "flatten": True})
-            session_id = response.get("result", {}).get("sessionId")
-            if session_id:
-                configure_target(session_id, target, False)
-        except Exception as exc:
-            log(f"failed to attach to {target.get('type', 'target')} {target_id}: {exc}")
+    if not any(target.get("type") == "page" for target in targets):
+        send("Target.createTarget", {"url": "about:blank"})
 
     set_ready()
     log("browser-level stealth guard active")
 
     while True:
-        raw = ws.recv()
+        try:
+            raw = ws.recv()
+        except websocket.WebSocketTimeoutException:
+            # Quiet browsers may emit no events. Command-response waits still time out.
+            continue
         if not raw:
             fail("browser CDP connection closed")
         handle_event(json.loads(raw))

--- a/scripts/docker/rome-apply-cdp-stealth.sh
+++ b/scripts/docker/rome-apply-cdp-stealth.sh
@@ -270,11 +270,26 @@ def build_ua_override() -> dict:
     }
 
 
+def auto_attach(session_id: str | None = None) -> None:
+    send(
+        "Target.setAutoAttach",
+        {
+            "autoAttach": True,
+            "waitForDebuggerOnStart": True,
+            "flatten": True,
+        },
+        session_id,
+    )
+
+
 def configure_target(session_id: str, target_info: dict, waiting_for_debugger: bool) -> None:
     target_type = target_info.get("type", "")
     target_id = target_info.get("targetId", "")
 
     try:
+        if target_type in {"page", "iframe"}:
+            # Auto-attach follows one level. Watch each document's children before resuming it.
+            auto_attach(session_id)
         if target_type == "page":
             send("Emulation.setGeolocationOverride", geo_params, session_id)
             send("Emulation.setTimezoneOverride", {"timezoneId": timezone}, session_id)
@@ -293,12 +308,11 @@ def configure_target(session_id: str, target_info: dict, waiting_for_debugger: b
             )
             send("Network.enable", {}, session_id)
             send("Network.setUserAgentOverride", build_ua_override(), session_id)
+        if target_type in {"page", "iframe"}:
             send("Page.addScriptToEvaluateOnNewDocument", {"source": stealth_js}, session_id)
+            # Enable the Page agent so registered scripts also run in OOPIF documents.
             send("Page.enable", {}, session_id)
-            log(f"stealth configured for page {target_id}")
-        elif target_type == "iframe":
-            send("Page.addScriptToEvaluateOnNewDocument", {"source": stealth_js}, session_id)
-            log(f"stealth configured for iframe {target_id}")
+            log(f"stealth configured for {target_type} {target_id}")
     except Exception as exc:
         log(f"stealth injection failed on {target_type or 'target'} {target_id}: {exc}")
     finally:
@@ -321,15 +335,7 @@ def handle_event(message: dict) -> None:
 
 
 try:
-    # Auto-attach includes existing targets and emits the events that configure them.
-    send(
-        "Target.setAutoAttach",
-        {
-            "autoAttach": True,
-            "waitForDebuggerOnStart": True,
-            "flatten": True,
-        },
-    )
+    auto_attach()
 
     targets = send("Target.getTargets", {}).get("result", {}).get("targetInfos", [])
     if not any(target.get("type") == "page" for target in targets):

--- a/scripts/docker/rome-apply-cdp-stealth.test.ts
+++ b/scripts/docker/rome-apply-cdp-stealth.test.ts
@@ -1,6 +1,7 @@
-import { readFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "@rstest/core";
 
@@ -8,9 +9,67 @@ const PROJECT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const SCRIPT_PATH = "scripts/docker/rome-apply-cdp-stealth.sh";
 const scriptSource = readFileSync(resolve(PROJECT_ROOT, SCRIPT_PATH), "utf8");
 const helperSource = scriptSource.match(/^get_ua_architecture\(\) \{\n[\s\S]*?^}\n/m)?.[0];
+const guardSource = scriptSource.match(/  python3 <<'PY'\n([\s\S]*)\nPY\s*$/)?.[1];
 
 if (!helperSource) {
   throw new Error("get_ua_architecture helper not found");
+}
+
+if (!guardSource) {
+  throw new Error("embedded CDP guard not found");
+}
+
+type CdpCommand = { method: string; sessionId?: string };
+
+function runGuard(scenario: "idle" | "command-timeout" | "existing" | "empty") {
+  const directory = mkdtempSync(join(tmpdir(), "rome-stealth-guard-"));
+  const traceFile = join(directory, "commands.json");
+  const readyFile = join(directory, "ready");
+  try {
+    copyFileSync(
+      resolve(PROJECT_ROOT, "scripts/docker/fixtures/stealth-websocket.py"),
+      join(directory, "websocket.py"),
+    );
+    // Postpone annotations so the container's Python code also runs under host Python 3.9.
+    const result = spawnSync(
+      "python3",
+      ["-c", `from __future__ import annotations\n${guardSource}`],
+      {
+        cwd: directory,
+        encoding: "utf8",
+        timeout: 2_000,
+        env: {
+          ...process.env,
+          PYTHONPATH: directory,
+          CDP_SCENARIO: scenario,
+          CDP_TRACE_FILE: traceFile,
+          BROWSER_WS: "ws://test.invalid/browser",
+          STEALTH_JS_FILE: resolve(PROJECT_ROOT, "scripts/docker/stealth-inject.js"),
+          READY_FILE: readyFile,
+          TIMEZONE: "America/Los_Angeles",
+          CHROME_LANG: "en-US",
+          CHROME_USER_AGENT: "TestChrome",
+          ACCEPT_LANG: "en-US,en;q=0.9",
+          STEALTH_LANGUAGES: '["en-US", "en"]',
+          UA_METADATA: '{"platform":"Linux"}',
+          GEO_PARAMS: '{"latitude":34,"longitude":-118,"accuracy":100}',
+        },
+      },
+    );
+    expect(result.error).toBeUndefined();
+    if (!existsSync(traceFile)) {
+      throw new Error(`CDP fixture did not finish: ${result.stderr}`);
+    }
+    return {
+      status: result.status,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      ready: existsSync(readyFile),
+      commands: JSON.parse(readFileSync(traceFile, "utf8")) as CdpCommand[],
+    };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 }
 
 function getUaArchitecture(source: string) {
@@ -44,5 +103,58 @@ describe("rome-apply-cdp-stealth.sh UA architecture", () => {
     expect(
       getUaArchitecture("Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 Chrome/133.0.0.0"),
     ).toBe("x86");
+  });
+});
+
+describe("rome-apply-cdp-stealth.sh guard lifecycle", () => {
+  it("handles a new tab after repeated idle timeouts and exits on disconnect", () => {
+    const result = runGuard("idle");
+
+    expect(result.ready).toBe(true);
+    expect(result.stdout).toContain("stealth configured for page new");
+    expect(result.commands).toContainEqual(
+      expect.objectContaining({
+        method: "Runtime.runIfWaitingForDebugger",
+        sessionId: "session-new",
+      }),
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("[stealth] browser CDP connection closed\n");
+  });
+
+  it("configures each existing tab once through automatic attachment", () => {
+    const result = runGuard("existing");
+
+    expect(result.stdout.match(/stealth configured for page existing/g)).toHaveLength(1);
+    expect(
+      result.commands.filter((command) => command.method === "Emulation.setLocaleOverride"),
+    ).toHaveLength(2);
+  });
+
+  it("configures and resumes the initial tab when the browser starts without pages", () => {
+    const result = runGuard("empty");
+
+    expect(result.ready).toBe(true);
+    expect(result.stdout.match(/stealth configured for page created/g)).toHaveLength(1);
+    expect(result.commands).toContainEqual(
+      expect.objectContaining({
+        method: "Runtime.runIfWaitingForDebugger",
+        sessionId: "session-created",
+      }),
+    );
+  });
+
+  it("reports a command timeout and still resumes the affected tab", () => {
+    const result = runGuard("command-timeout");
+
+    expect(result.stdout).toContain("stealth injection failed on page new: CDP response timed out");
+    expect(result.stdout).not.toContain("stealth configured for page new");
+    expect(result.commands).toContainEqual(
+      expect.objectContaining({
+        method: "Runtime.runIfWaitingForDebugger",
+        sessionId: "session-new",
+      }),
+    );
+    expect(result.stderr).toBe("[stealth] browser CDP connection closed\n");
   });
 });

--- a/scripts/docker/rome-apply-cdp-stealth.test.ts
+++ b/scripts/docker/rome-apply-cdp-stealth.test.ts
@@ -21,7 +21,10 @@ if (!guardSource) {
 
 type CdpCommand = { method: string; sessionId?: string; params?: Record<string, unknown> };
 
-function runGuard(scenario: "idle" | "command-timeout" | "existing" | "empty" | "nested-iframes") {
+function runGuard(
+  scenario: "idle" | "command-timeout" | "existing" | "empty" | "nested-iframes",
+  userAgent = "TestChrome",
+) {
   const directory = mkdtempSync(join(tmpdir(), "rome-stealth-guard-"));
   const traceFile = join(directory, "commands.json");
   const readyFile = join(directory, "ready");
@@ -48,7 +51,7 @@ function runGuard(scenario: "idle" | "command-timeout" | "existing" | "empty" | 
           READY_FILE: readyFile,
           TIMEZONE: "America/Los_Angeles",
           CHROME_LANG: "en-US",
-          CHROME_USER_AGENT: "TestChrome",
+          CHROME_USER_AGENT: userAgent,
           ACCEPT_LANG: "en-US,en;q=0.9",
           STEALTH_LANGUAGES: '["en-US", "en"]',
           UA_METADATA: '{"platform":"Linux"}',
@@ -107,6 +110,27 @@ describe("rome-apply-cdp-stealth.sh UA architecture", () => {
 });
 
 describe("rome-apply-cdp-stealth.sh guard lifecycle", () => {
+  it("keeps native user-agent metadata when no override is configured", () => {
+    const result = runGuard("idle", "");
+
+    expect(result.ready).toBe(true);
+    expect(result.stdout).toContain("stealth configured for page new");
+    expect(
+      result.commands.some((command) => command.method === "Network.setUserAgentOverride"),
+    ).toBe(false);
+  });
+
+  it("applies an explicitly configured user agent", () => {
+    const result = runGuard("existing", "ConfiguredChrome");
+
+    expect(result.commands).toContainEqual(
+      expect.objectContaining({
+        method: "Network.setUserAgentOverride",
+        params: expect.objectContaining({ userAgent: "ConfiguredChrome" }),
+      }),
+    );
+  });
+
   it("handles a new tab after repeated idle timeouts and exits on disconnect", () => {
     const result = runGuard("idle");
 

--- a/scripts/docker/rome-apply-cdp-stealth.test.ts
+++ b/scripts/docker/rome-apply-cdp-stealth.test.ts
@@ -19,9 +19,9 @@ if (!guardSource) {
   throw new Error("embedded CDP guard not found");
 }
 
-type CdpCommand = { method: string; sessionId?: string };
+type CdpCommand = { method: string; sessionId?: string; params?: Record<string, unknown> };
 
-function runGuard(scenario: "idle" | "command-timeout" | "existing" | "empty") {
+function runGuard(scenario: "idle" | "command-timeout" | "existing" | "empty" | "nested-iframes") {
   const directory = mkdtempSync(join(tmpdir(), "rome-stealth-guard-"));
   const traceFile = join(directory, "commands.json");
   const readyFile = join(directory, "ready");
@@ -155,6 +155,47 @@ describe("rome-apply-cdp-stealth.sh guard lifecycle", () => {
         sessionId: "session-new",
       }),
     );
+    expect(result.stderr).toBe("[stealth] browser CDP connection closed\n");
+  });
+
+  it("configures existing and new nested iframes before resuming their scripts", () => {
+    const result = runGuard("nested-iframes");
+    const frames = [
+      "existing-frame",
+      "existing-nested-frame",
+      "new-frame",
+      "new-nested-frame",
+      "late-nested-frame",
+    ];
+
+    expect(result.ready).toBe(true);
+    for (const frame of frames) {
+      const commands = result.commands.filter(
+        (command) => command.sessionId === `session-${frame}`,
+      );
+      expect(commands).toContainEqual(
+        expect.objectContaining({
+          method: "Target.setAutoAttach",
+          params: { autoAttach: true, waitForDebuggerOnStart: true, flatten: true },
+        }),
+      );
+      expect(
+        commands.filter((command) => command.method === "Page.addScriptToEvaluateOnNewDocument"),
+      ).toHaveLength(1);
+      expect(commands.filter((command) => command.method === "Page.enable")).toHaveLength(1);
+      expect(result.stdout).toContain(`stealth configured for iframe ${frame}`);
+    }
+
+    for (const target of ["new", "new-frame", "new-nested-frame", "late-nested-frame"]) {
+      const methods = result.commands
+        .filter((command) => command.sessionId === `session-${target}`)
+        .map((command) => command.method);
+      const resumeIndex = methods.indexOf("Runtime.runIfWaitingForDebugger");
+      expect(resumeIndex).toBeGreaterThan(methods.indexOf("Target.setAutoAttach"));
+      expect(resumeIndex).toBeGreaterThan(methods.indexOf("Page.addScriptToEvaluateOnNewDocument"));
+      expect(resumeIndex).toBeGreaterThan(methods.indexOf("Page.enable"));
+    }
+    expect(result.stdout).not.toContain("stealth injection failed");
     expect(result.stderr).toBe("[stealth] browser CDP connection closed\n");
   });
 });

--- a/scripts/docker/rome-start-chrome-cdp.sh
+++ b/scripts/docker/rome-start-chrome-cdp.sh
@@ -281,14 +281,6 @@ start_chrome_instance() {
 
   wait_for_internal_cdp || return 1
 
-  if [[ -z "$CHROME_USER_AGENT" ]]; then
-    CHROME_USER_AGENT="$(curl -sf "http://127.0.0.1:${CHROME_INTERNAL_PORT}/json/version" | python3 -c "import json, sys; print(json.load(sys.stdin).get('User-Agent', ''))")"
-    if [[ -z "$CHROME_USER_AGENT" ]]; then
-      err "could not determine browser user agent from CDP"
-      return 1
-    fi
-  fi
-
   ensure_cdp_proxy
   wait_for_external_cdp || return 1
   start_stealth_guard || return 1

--- a/scripts/docker/rome-start-chrome-cdp.sh
+++ b/scripts/docker/rome-start-chrome-cdp.sh
@@ -12,7 +12,7 @@ CHROME_USER_DATA_DIR="${ROME_CHROME_USER_DATA_DIR:-$HOME/.rome/chrome-profile}"
 # (which mounts $HOME/.rome): the cache is regenerable and, left in the profile,
 # grows to tens of GB and fills the host disk. Default to an ephemeral path on
 # the container's writable layer (wiped on recreate) and hard-cap its size.
-# Logins (cookies/localStorage) stay in CHROME_USER_DATA_DIR, so they persist.
+# Persistent cookies and localStorage stay in CHROME_USER_DATA_DIR.
 CHROME_DISK_CACHE_DIR="${ROME_CHROME_DISK_CACHE_DIR:-$HOME/chrome-cache}"
 CHROME_DISK_CACHE_SIZE="${ROME_CHROME_DISK_CACHE_SIZE:-536870912}"
 CHROME_WINDOW_SIZE="${ROME_CHROME_WINDOW_SIZE:-1280,800}"
@@ -129,6 +129,8 @@ chrome_args=(
   --no-first-run
   --no-default-browser-check
   --password-store=basic
+  # A persistent profile alone does not restore session cookies after a clean exit.
+  --restore-last-session
   "--user-data-dir=$CHROME_USER_DATA_DIR"
   "--disk-cache-dir=$CHROME_DISK_CACHE_DIR"
   "--disk-cache-size=$CHROME_DISK_CACHE_SIZE"
@@ -233,8 +235,9 @@ start_stealth_guard() {
   fi
 
   info "starting CDP stealth guard"
-  local stealth_ready_file stealth_script
-  stealth_ready_file="$(mktemp)"
+  local stealth_ready_dir stealth_ready_file stealth_script
+  stealth_ready_dir="$(mktemp -d)"
+  stealth_ready_file="$stealth_ready_dir/ready"
   stealth_script="$SCRIPT_DIR/rome-apply-cdp-stealth.sh"
   CDP_PORT="$CHROME_INTERNAL_PORT" \
     READY_FILE="$stealth_ready_file" \
@@ -248,12 +251,12 @@ start_stealth_guard() {
   local attempt=0
   while ((attempt < max_attempts)); do
     if [[ -f "$stealth_ready_file" ]]; then
-      rm -f "$stealth_ready_file"
+      rm -rf "$stealth_ready_dir"
       return 0
     fi
     if ! kill -0 "$STEALTH_PID" 2>/dev/null; then
       err "CDP stealth guard exited unexpectedly; see /tmp/chrome-stealth.log"
-      rm -f "$stealth_ready_file"
+      rm -rf "$stealth_ready_dir"
       return 1
     fi
     sleep 0.2
@@ -261,7 +264,7 @@ start_stealth_guard() {
   done
 
   err "CDP stealth guard did not become ready; see /tmp/chrome-stealth.log"
-  rm -f "$stealth_ready_file"
+  rm -rf "$stealth_ready_dir"
   return 1
 }
 

--- a/scripts/docker/stealth-inject.js
+++ b/scripts/docker/stealth-inject.js
@@ -4,6 +4,16 @@
 (() => {
   "use strict";
 
+  const configuredLanguages = globalThis.__ROME_STEALTH_LANGUAGES__;
+  try {
+    delete globalThis.__ROME_STEALTH_LANGUAGES__;
+  } catch {}
+
+  // Replacing native properties can make ordinary Chrome fail site compatibility checks.
+  if (navigator.webdriver !== true) {
+    return;
+  }
+
   const NATIVE_FUNCTION_STRINGS = new WeakMap();
   const originalFunctionToString = Function.prototype.toString;
 
@@ -44,7 +54,7 @@
   };
 
   const getNavigatorLanguages = () => {
-    const configured = normalizeLanguages(globalThis.__ROME_STEALTH_LANGUAGES__);
+    const configured = normalizeLanguages(configuredLanguages);
     if (configured.length > 0) {
       return configured;
     }
@@ -72,9 +82,6 @@
 
   // 2. navigator.languages
   const navigatorLanguages = Object.freeze(getNavigatorLanguages());
-  try {
-    delete globalThis.__ROME_STEALTH_LANGUAGES__;
-  } catch {}
   defineGetter(navigator, "languages", () => [...navigatorLanguages]);
 
   // 3. navigator.plugins / navigator.mimeTypes

--- a/scripts/docker/stealth-inject.test.ts
+++ b/scripts/docker/stealth-inject.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createContext, runInContext } from "node:vm";
+import { describe, expect, it } from "@rstest/core";
+
+const payload = readFileSync(
+  fileURLToPath(new URL("./stealth-inject.js", import.meta.url)),
+  "utf8",
+);
+
+function browserContext(webdriver: boolean) {
+  const context = createContext({
+    __ROME_STEALTH_LANGUAGES__: ["fr-FR"],
+    navigator: {
+      webdriver,
+      languages: ["en-US", "en"],
+      plugins: [{}],
+      connection: {},
+      hardwareConcurrency: 18,
+      deviceMemory: 8,
+    },
+    screen: { width: 1600, height: 900 },
+    window: { chrome: { runtime: {} }, innerWidth: 1280, innerHeight: 720, outerHeight: 800 },
+  });
+  runInContext("globalThis.originalToString = Function.prototype.toString", context);
+  return context;
+}
+
+describe("stealth browser payload", () => {
+  it("leaves a native browser's properties and built-ins intact", () => {
+    const context = browserContext(false);
+
+    runInContext(payload, context);
+
+    expect(runInContext("Function.prototype.toString === originalToString", context)).toBe(true);
+    expect(runInContext("navigator.webdriver", context)).toBe(false);
+    expect(
+      runInContext("Object.getOwnPropertyDescriptor(navigator, 'webdriver').get", context),
+    ).toBeUndefined();
+    expect(runInContext("navigator.hardwareConcurrency", context)).toBe(18);
+    expect(runInContext("screen.width", context)).toBe(1600);
+    expect(runInContext("window.outerHeight", context)).toBe(800);
+    expect(runInContext("navigator.languages[0]", context)).toBe("en-US");
+    expect(runInContext("'__ROME_STEALTH_LANGUAGES__' in globalThis", context)).toBe(false);
+  });
+
+  it("retains the shims for a browser that reports WebDriver automation", () => {
+    const context = browserContext(true);
+
+    runInContext(payload, context);
+
+    expect(runInContext("navigator.webdriver", context)).toBeUndefined();
+    expect(runInContext("navigator.hardwareConcurrency", context)).toBe(8);
+    expect(runInContext("screen.width", context)).toBe(1280);
+    expect(runInContext("navigator.languages[0]", context)).toBe("fr-FR");
+    expect(runInContext("'__ROME_STEALTH_LANGUAGES__' in globalThis", context)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What this PR does

Closing Chrome discards session-only site logins even when its profile survives. The CDP guard exits after five idle seconds, configures some targets repeatedly, and can report readiness before startup completes. Browser-level attachment also misses nested cross-origin iframes.

Keeping the guard running exposes another compatibility problem: unconditional shims replace native Chromium properties and fabricate user-agent metadata. Controlled Delta searches returned HTTP 444 with these overrides and HTTP 200 with native values.

Restore browser sessions, repair guard lifecycle and recursive frame attachment, and preserve native browser identity by default. JavaScript shims apply only when the browser reports WebDriver automation. User-agent metadata changes only when a user-agent override is explicitly configured.

## Design & Invariants

- The guard remains enabled by default. Its locale, timezone, viewport, and frame setup remain active.
- Native Chromium JavaScript properties and built-ins remain intact when it does not report WebDriver automation. The payload also removes its temporary language configuration global.
- Explicit user-agent overrides and WebDriver shims remain supported.
- Idle event timeouts do not terminate the guard. Command-response timeouts still report failures, and a disconnected browser ends the guard.
- Each page and iframe session watches its children before resuming. The Page agent is enabled for both kinds of document.
- Startup succeeds only after the guard writes its readiness signal.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit`, including native browser identity, explicit overrides, guard lifecycle, nested frames, and readiness regressions
- [x] `bash -n scripts/docker/rome-start-chrome-cdp.sh scripts/docker/rome-apply-cdp-stealth.sh`
- [x] Verify idle survival and attachment of a new tab in live Chromium.
- [x] Verify existing and nested OOPIF attachment in isolated Chromium with `--enable-automation`. Confirm injection before the first frame script, including a nested frame created after idle.
- [x] Compare fresh Delta search submissions using native values, full overrides, and partial overrides. Verify first-submission results and offer API responses with the corrected guard running.
- [x] Confirm that the local Rome container reaches `Rome started` and remains healthy.
- [ ] Recover the existing Delta profile: it still receives HTTP 444 despite the browser correction. A site-data reset requires approval because it removes saved Delta sign-in state.
- [ ] `pnpm dev:all`: blocked by the existing host port 80 conflict between Rome and Traefik. The original Traefik configuration was restored.

Host checks used Node 24 because Nix is unavailable on the test host. The local browser contains the correction. The PR remains a draft while recovery of the existing Delta profile is unverified.

## Not in this PR

- Automatic deletion of site data, because it would remove user login state.
