### PR TITLE
feat(web): show chat attachment upload progress

### DIFF
--- a/packages/web/src/components/chat/Chat.tsx
+++ b/packages/web/src/components/chat/Chat.tsx
@@ -72,6 +72,7 @@ import type { DelegatedSubagentNode } from "@/components/chat/DelegatedSubagentG
 import {
   ChatComposer,
   type ChatComposerHandle,
+  type ChatComposerSendControls,
   type ChatComposerSnapshot,
 } from "@/components/chat/ChatComposer";
 import type {
@@ -1190,7 +1191,7 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
   //
   // The session decides whether input joins the active run or starts the next.
   const handleComposerSend = useCallback(
-    async (snapshot: ChatComposerSnapshot) => {
+    async (snapshot: ChatComposerSnapshot, controls: ChatComposerSendControls) => {
       // The single composer talks to whoever holds the floor — the open
       // handoff's specialist, or the main agent.
       const sendingSessionId = floorSessionIdRef.current;
@@ -1224,7 +1225,9 @@ export const Chat = forwardRef<ChatHandle, ChatProps>(function ChatView(
           if (ws) formData.set("workspace", JSON.stringify(ws));
           // POST returns JSON `{ turnId }`. SSE lives on a
           // separate GET keyed by turnId.
-          return postSessionTurn(sendingSessionId, formData);
+          return postSessionTurn(sendingSessionId, formData, {
+            onUploadProgress: snapshot.uploads.length ? controls.onUploadProgress : undefined,
+          });
         },
         optimisticContent,
       );

--- a/packages/web/src/components/chat/ChatComponent.tsx
+++ b/packages/web/src/components/chat/ChatComponent.tsx
@@ -12,6 +12,7 @@ import {
 import {
   ChatComposer,
   type ChatComposerHandle,
+  type ChatComposerSendControls,
   type ChatComposerSnapshot,
 } from "@/components/chat/ChatComposer";
 import { ChatEmptyState } from "@/components/chat/ChatEmptyState";
@@ -212,7 +213,7 @@ export function ChatComponent({
   );
 
   const handleDraftSend = useCallback(
-    async (snapshot: ChatComposerSnapshot) => {
+    async (snapshot: ChatComposerSnapshot, controls: ChatComposerSendControls) => {
       if (draftSendInFlightRef.current) return;
       draftSendInFlightRef.current = true;
       setDraftStreamError(null);
@@ -271,7 +272,9 @@ export function ChatComponent({
         const ws = snapshotWorkspaceForSend(workspaceContextRegistry);
         if (ws) formData.set("workspace", JSON.stringify(ws));
 
-        const result = await postSessionTurn(newSessionId, formData);
+        const result = await postSessionTurn(newSessionId, formData, {
+          onUploadProgress: snapshot.uploads.length ? controls.onUploadProgress : undefined,
+        });
         if (!result.ok) {
           const message =
             result.message ||

--- a/packages/web/src/components/chat/ChatComposer.test.tsx
+++ b/packages/web/src/components/chat/ChatComposer.test.tsx
@@ -2,12 +2,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createRef, type RefObject } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeAll, describe, expect, it, rs } from "@rstest/core";
 import { normalizeBondLevel, type PeopleList, type PersonResource } from "@rome/api-types/people";
 import i18n from "@/i18n";
 import {
   ChatComposer,
+  type ChatComposerHandle,
   type ChatComposerProps,
   type ChatComposerSendControls,
 } from "./ChatComposer";
@@ -53,6 +55,7 @@ interface RenderComposerOptions {
   settings?: Record<string, unknown>;
   /** What `GET /api/people` answers. Defaults to a listing with nobody in it. */
   people?: PersonResource[];
+  composerRef?: RefObject<ChatComposerHandle | null>;
 }
 
 function renderComposer(props: Partial<ChatComposerProps>, options: RenderComposerOptions = {}) {
@@ -91,7 +94,7 @@ function renderComposer(props: Partial<ChatComposerProps>, options: RenderCompos
     ...render(
       <MemoryRouter>
         <QueryClientProvider client={queryClient}>
-          <ChatComposer onSend={rs.fn()} {...props} />
+          <ChatComposer ref={options.composerRef} onSend={rs.fn()} {...props} />
         </QueryClientProvider>
       </MemoryRouter>,
     ),
@@ -233,7 +236,7 @@ describe("composer Enter key", () => {
 });
 
 describe("composer attachment uploads", () => {
-  it("shows per-file progress and blocks another send until the upload finishes", async () => {
+  it("shows request progress and locks the composer until the upload finishes", async () => {
     let controls: ChatComposerSendControls | null = null;
     let resolveSend: (() => void) | null = null;
     const sendPending = new Promise<void>((resolve) => {
@@ -243,7 +246,8 @@ describe("composer attachment uploads", () => {
       controls = nextControls;
       return sendPending;
     });
-    const { container } = renderComposer({ onSend });
+    const composerRef = createRef<ChatComposerHandle>();
+    const { container } = renderComposer({ onSend }, { composerRef });
     const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]');
     if (!fileInput) throw new Error("file input not found");
     const first = new File([new Uint8Array(25)], "first.txt", { type: "text/plain" });
@@ -257,9 +261,10 @@ describe("composer attachment uploads", () => {
     expect(
       (screen.getByRole("button", { name: "Uploading files…" }) as HTMLButtonElement).disabled,
     ).toBe(true);
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).disabled).toBe(true);
     expect(
       screen
-        .getByRole("progressbar", { name: "Uploading first.txt" })
+        .getByRole("progressbar", { name: "Attachment upload progress" })
         .getAttribute("aria-valuenow"),
     ).toBe("0");
 
@@ -267,18 +272,20 @@ describe("composer attachment uploads", () => {
     act(() => controls?.onUploadProgress(0.5));
     expect(
       screen
-        .getByRole("progressbar", { name: "Uploading first.txt" })
+        .getByRole("progressbar", { name: "Attachment upload progress" })
         .getAttribute("aria-valuenow"),
-    ).toBe("100");
-    expect(
-      screen
-        .getByRole("progressbar", { name: "Uploading second.txt" })
-        .getAttribute("aria-valuenow"),
-    ).toBe("33");
+    ).toBe("50");
+    expect(screen.getByText("50%")).toBeTruthy();
 
-    // The next message may be drafted while bytes are moving, but it cannot be
-    // submitted into the same multipart request.
-    fireEvent.input(screen.getByRole("textbox"), { target: { value: "next message" } });
+    // Parent drop zones and clipboard pastes bypass the disabled file input,
+    // so the shared add-files boundary must reject both paths too.
+    act(() => composerRef.current?.addFiles([new File(["drop"], "dropped.txt")]));
+    fireEvent.paste(screen.getByRole("textbox"), {
+      clipboardData: { files: [new File(["paste"], "pasted.txt")], items: [] },
+    });
+    expect(screen.queryByText("dropped.txt")).toBeNull();
+    expect(screen.queryByText("pasted.txt")).toBeNull();
+
     expect(
       (screen.getByRole("button", { name: "Uploading files…" }) as HTMLButtonElement).disabled,
     ).toBe(true);
@@ -287,6 +294,33 @@ describe("composer attachment uploads", () => {
 
     act(() => resolveSend?.());
     await waitFor(() => expect(screen.queryByText("first.txt")).toBeNull());
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).disabled).toBe(false);
+  });
+
+  it("restores submitted text and attachments when an upload fails", async () => {
+    let rejectSend: ((reason?: unknown) => void) | null = null;
+    const sendPending = new Promise<void>((_resolve, reject) => {
+      rejectSend = reject;
+    });
+    const onSend = rs.fn(() => sendPending);
+    const { container } = renderComposer({ onSend });
+    const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) throw new Error("file input not found");
+
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["retry"], "retry.txt", { type: "text/plain" })] },
+    });
+    fireEvent.input(screen.getByRole("textbox"), { target: { value: "please retry" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).disabled).toBe(true);
+    act(() => rejectSend?.(new Error("upload failed")));
+
+    await waitFor(() =>
+      expect((screen.getByRole("textbox") as HTMLTextAreaElement).value).toBe("please retry"),
+    );
+    expect(screen.getByText("retry.txt")).toBeTruthy();
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).disabled).toBe(false);
     expect((screen.getByRole("button", { name: "Send" }) as HTMLButtonElement).disabled).toBe(
       false,
     );

--- a/packages/web/src/components/chat/ChatComposer.test.tsx
+++ b/packages/web/src/components/chat/ChatComposer.test.tsx
@@ -1,12 +1,16 @@
 // @rstest-environment jsdom
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeAll, describe, expect, it, rs } from "@rstest/core";
 import { normalizeBondLevel, type PeopleList, type PersonResource } from "@rome/api-types/people";
 import i18n from "@/i18n";
-import { ChatComposer, type ChatComposerProps } from "./ChatComposer";
+import {
+  ChatComposer,
+  type ChatComposerProps,
+  type ChatComposerSendControls,
+} from "./ChatComposer";
 
 beforeAll(async () => {
   await i18n.changeLanguage("en");
@@ -225,6 +229,67 @@ describe("composer Enter key", () => {
     fireEvent.click(screen.getByRole("button", { name: /send/i }));
     expect(onSend).toHaveBeenCalledTimes(1);
     expect(onSend.mock.calls[0][0].text).toBe("hello");
+  });
+});
+
+describe("composer attachment uploads", () => {
+  it("shows per-file progress and blocks another send until the upload finishes", async () => {
+    let controls: ChatComposerSendControls | null = null;
+    let resolveSend: (() => void) | null = null;
+    const sendPending = new Promise<void>((resolve) => {
+      resolveSend = resolve;
+    });
+    const onSend = rs.fn((_snapshot, nextControls: ChatComposerSendControls) => {
+      controls = nextControls;
+      return sendPending;
+    });
+    const { container } = renderComposer({ onSend });
+    const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) throw new Error("file input not found");
+    const first = new File([new Uint8Array(25)], "first.txt", { type: "text/plain" });
+    const second = new File([new Uint8Array(75)], "second.txt", { type: "text/plain" });
+
+    fireEvent.change(fileInput, { target: { files: [first, second] } });
+    fireEvent.input(screen.getByRole("textbox"), { target: { value: "inspect these" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(
+      (screen.getByRole("button", { name: "Uploading files…" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(
+      screen
+        .getByRole("progressbar", { name: "Uploading first.txt" })
+        .getAttribute("aria-valuenow"),
+    ).toBe("0");
+
+    if (!controls) throw new Error("send controls not captured");
+    act(() => controls?.onUploadProgress(0.5));
+    expect(
+      screen
+        .getByRole("progressbar", { name: "Uploading first.txt" })
+        .getAttribute("aria-valuenow"),
+    ).toBe("100");
+    expect(
+      screen
+        .getByRole("progressbar", { name: "Uploading second.txt" })
+        .getAttribute("aria-valuenow"),
+    ).toBe("33");
+
+    // The next message may be drafted while bytes are moving, but it cannot be
+    // submitted into the same multipart request.
+    fireEvent.input(screen.getByRole("textbox"), { target: { value: "next message" } });
+    expect(
+      (screen.getByRole("button", { name: "Uploading files…" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Uploading files…" }));
+    expect(onSend).toHaveBeenCalledTimes(1);
+
+    act(() => resolveSend?.());
+    await waitFor(() => expect(screen.queryByText("first.txt")).toBeNull());
+    expect((screen.getByRole("button", { name: "Send" }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/web/src/components/chat/ChatComposer.test.tsx
+++ b/packages/web/src/components/chat/ChatComposer.test.tsx
@@ -247,7 +247,11 @@ describe("composer attachment uploads", () => {
       return sendPending;
     });
     const composerRef = createRef<ChatComposerHandle>();
-    const { container } = renderComposer({ onSend }, { composerRef });
+    const { container } = renderComposer(
+      { onSend, showProjectSelector: true },
+      { composerRef, settings: { enableImpersonation: true } },
+    );
+    await screen.findByRole("button", { name: "Impersonation" });
     const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]');
     if (!fileInput) throw new Error("file input not found");
     const first = new File([new Uint8Array(25)], "first.txt", { type: "text/plain" });
@@ -262,6 +266,12 @@ describe("composer attachment uploads", () => {
       (screen.getByRole("button", { name: "Uploading files…" }) as HTMLButtonElement).disabled,
     ).toBe(true);
     expect((screen.getByRole("textbox") as HTMLTextAreaElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: "Project" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect(
+      (screen.getByRole("button", { name: "Impersonation" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
     expect(
       screen
         .getByRole("progressbar", { name: "Attachment upload progress" })

--- a/packages/web/src/components/chat/ChatComposer.tsx
+++ b/packages/web/src/components/chat/ChatComposer.tsx
@@ -1069,7 +1069,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
             variant="ghost"
             size="icon-sm"
             onClick={() => fileInputRef.current?.click()}
-            disabled={isComposerBusy || uploadInFlight}
+            disabled={isComposerBusy}
             aria-label={t("composer.uploadFiles")}
             title={t("composer.uploadFiles")}
             className="touch-target"
@@ -1116,9 +1116,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
               size="icon-sm"
               onClick={() => void runSend()}
               disabled={
-                isComposerBusy ||
-                uploadInFlight ||
-                (!inputText.trim() && pendingUploads.length === 0 && !draftSkill)
+                isComposerBusy || (!inputText.trim() && pendingUploads.length === 0 && !draftSkill)
               }
               title={
                 uploadInFlight

--- a/packages/web/src/components/chat/ChatComposer.tsx
+++ b/packages/web/src/components/chat/ChatComposer.tsx
@@ -402,7 +402,11 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
   }, [newProjectName, t, connectOnCreate]);
 
   const addPendingFiles = useCallback((files: File[]) => {
-    if (files.length === 0) return;
+    // The visible file picker is disabled during an upload, but paste and the
+    // parent drop zones enter through this callback directly. Guard the shared
+    // boundary so a file cannot be added to the tray without belonging to the
+    // multipart request whose progress it displays.
+    if (files.length === 0 || uploadInFlightRef.current) return;
     setPendingUploads((prev) => [
       ...prev,
       ...files.map((file) => ({ id: crypto.randomUUID(), file })),
@@ -440,6 +444,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
     () => ({
       focus: () => textareaRef.current?.focus(),
       insertText: (text: string) => {
+        if (uploadInFlightRef.current) return;
         setInputText(text);
         requestAnimationFrame(() => {
           const el = textareaRef.current;
@@ -450,7 +455,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
         });
       },
       setAgentMention: (mention: AgentMention | null) => {
-        if (agentMentionLocked) return;
+        if (agentMentionLocked || uploadInFlightRef.current) return;
         // Mirror acceptMention's cleanup: scoping the draft programmatically
         // must also dismiss any open `@` menu, or its stale anchor/query keeps
         // intercepting Enter/arrow keys against the wrong token.
@@ -460,6 +465,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
         setMentionQuery("");
       },
       setSkillSelection: (skill: SkillSelection | null) => {
+        if (uploadInFlightRef.current) return;
         setDraftSkill(skill);
         setSlashMenuOpen(false);
         setSlashQuery("");
@@ -537,7 +543,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
     [addPendingFiles, disabled],
   );
 
-  const isComposerBusy = disabled || disabledHint != null;
+  const isComposerBusy = disabled || disabledHint != null || uploadInFlight;
 
   const runSend = useCallback(async () => {
     if (isComposerBusy || uploadInFlightRef.current) return;
@@ -562,9 +568,9 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
       skillName: skill?.name,
     };
 
-    // Optimistically clear so the user sees the input wipe immediately. If
-    // onSend rejects, restore the snapshot so they can retry without
-    // re-typing.
+    // Optimistically clear so the user sees the input wipe immediately. The
+    // composer stays locked while attachments upload; if onSend rejects,
+    // restore the snapshot so it can be retried without re-typing.
     setInputText("");
     if (uploads.length === 0) setPendingUploads([]);
     setDraftSkill(null);
@@ -575,7 +581,9 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
         setPendingUploads((current) => current.filter((upload) => !sentIds.has(upload.id)));
       }
     } catch {
-      setInputText(text);
+      // Preserve any value inserted programmatically despite the upload lock
+      // rather than overwriting it with the failed turn.
+      setInputText((current) => current || text);
       if (uploads.length === 0) setPendingUploads(uploads);
       setDraftSkill(skill);
     }
@@ -654,6 +662,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
   );
 
   const handleTextareaChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (uploadInFlightRef.current) return;
     const value = event.target.value;
     setInputText(value);
     const cursor = event.target.selectionEnd ?? value.length;
@@ -938,7 +947,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
         <PendingUploadsList
           uploads={pendingUploads}
           onRemove={removePendingUpload}
-          disabled={isComposerBusy || uploadInFlight}
+          disabled={isComposerBusy}
           uploadProgress={uploadInFlight ? uploadProgress : undefined}
         />
         <SlashSkillMenu

--- a/packages/web/src/components/chat/ChatComposer.tsx
+++ b/packages/web/src/components/chat/ChatComposer.tsx
@@ -581,9 +581,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
         setPendingUploads((current) => current.filter((upload) => !sentIds.has(upload.id)));
       }
     } catch {
-      // Preserve any value inserted programmatically despite the upload lock
-      // rather than overwriting it with the failed turn.
-      setInputText((current) => current || text);
+      setInputText(text);
       if (uploads.length === 0) setPendingUploads(uploads);
       setDraftSkill(skill);
     }
@@ -865,6 +863,11 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
   // name the same specialist.
   const collaborating =
     designingInteraction && !designingInteraction.onApprove ? designingInteraction : null;
+  const sendActionLabel = uploadInFlight
+    ? t("composer.uploadingFiles")
+    : isStreaming
+      ? t("composer.sendWhileRunningTitle")
+      : t("composer.sendTitle");
 
   return (
     <>
@@ -1118,20 +1121,8 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
               disabled={
                 isComposerBusy || (!inputText.trim() && pendingUploads.length === 0 && !draftSkill)
               }
-              title={
-                uploadInFlight
-                  ? t("composer.uploadingFiles")
-                  : isStreaming
-                    ? t("composer.sendWhileRunningTitle")
-                    : t("composer.sendTitle")
-              }
-              aria-label={
-                uploadInFlight
-                  ? t("composer.uploadingFiles")
-                  : isStreaming
-                    ? t("composer.sendWhileRunningTitle")
-                    : t("composer.sendTitle")
-              }
+              title={sendActionLabel}
+              aria-label={sendActionLabel}
               className="touch-target"
             >
               <ArrowUp aria-hidden />

--- a/packages/web/src/components/chat/ChatComposer.tsx
+++ b/packages/web/src/components/chat/ChatComposer.tsx
@@ -331,6 +331,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
 
   const updateLargeModelSelection = useCallback(
     async (next: string) => {
+      if (uploadInFlightRef.current) return;
       setLargeModelSelection(next);
       setComposerError(null);
       const ok = await saveSetting("webchatLargeModel", next).catch(() => false);
@@ -344,6 +345,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
 
   const updateReasoningEffort = useCallback(
     async (next: ReasoningEffort) => {
+      if (uploadInFlightRef.current) return;
       setReasoningEffort(next);
       setComposerError(null);
       const ok = await saveSetting("webchatReasoningEffort", next).catch(() => false);
@@ -523,6 +525,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
   );
 
   const removePendingUpload = useCallback((id: string) => {
+    if (uploadInFlightRef.current) return;
     setPendingUploads((prev) => prev.filter((upload) => upload.id !== id));
   }, []);
 
@@ -677,6 +680,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
 
   const acceptMention = useCallback(
     (mention: AgentMention) => {
+      if (uploadInFlightRef.current) return;
       // Splice out the `@<query>` token that triggered the menu so the chip
       // becomes the single source of truth for "which agent."
       if (mentionAnchorIndex !== null) {
@@ -709,6 +713,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
 
   const acceptSlashSkill = useCallback(
     (skill: SkillSelection) => {
+      if (uploadInFlightRef.current) return;
       // Mirror acceptMention: splice out the leading `/<query>` token so the
       // chip becomes the single source of truth for "which skill" — whatever
       // the user already typed after the cursor stays as the task text.
@@ -916,16 +921,23 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
             mention={effectiveMention}
             pinned={pinnedAgentMention !== null}
             onRemove={
-              collaborating
-                ? collaborating.onCancel
-                : pinnedAgentMention
-                  ? undefined
-                  : () => setDraftAgentMention(null)
+              isComposerBusy
+                ? undefined
+                : collaborating
+                  ? collaborating.onCancel
+                  : pinnedAgentMention
+                    ? undefined
+                    : () => setDraftAgentMention(null)
             }
             removeLabel={collaborating ? "Cancel collaboration" : undefined}
           />
         )}
-        {draftSkill && <SkillCommandChip skill={draftSkill} onRemove={() => setDraftSkill(null)} />}
+        {draftSkill && (
+          <SkillCommandChip
+            skill={draftSkill}
+            onRemove={isComposerBusy ? undefined : () => setDraftSkill(null)}
+          />
+        )}
         <WorkspaceContextChips />
       </div>
       <div data-chat-composer-box className={cn("relative z-10", boxClassName)}>
@@ -957,6 +969,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
           ref={slashMenuRef}
           open={slashMenuOpen && !isComposerBusy}
           onOpenChange={(next) => {
+            if (uploadInFlightRef.current) return;
             setSlashMenuOpen(next);
             if (!next) setSlashQuery("");
           }}
@@ -966,8 +979,9 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
             <div>
               <AgentMentionMenu
                 ref={mentionMenuRef}
-                open={mentionMenuOpen && !agentMentionLocked}
+                open={mentionMenuOpen && !agentMentionLocked && !isComposerBusy}
                 onOpenChange={(next) => {
+                  if (uploadInFlightRef.current) return;
                   setMentionMenuOpen(next);
                   if (!next) {
                     setMentionAnchorIndex(null);
@@ -1010,6 +1024,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
           {showProjectSelector && (
             <ProjectSelector
               ref={projectMenuRef}
+              disabled={isComposerBusy}
               t={t}
               projectCatalog={projectCatalog}
               projectsLoading={projectsLoading}
@@ -1028,6 +1043,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
               connectOnCreate={connectOnCreate}
               setConnectOnCreate={setConnectOnCreate}
               onToggleMenu={async () => {
+                if (uploadInFlightRef.current) return;
                 const nextOpen = !draftProjectMenuOpen;
                 setDraftProjectMenuOpen(nextOpen);
                 setProjectsError(null);
@@ -1039,12 +1055,15 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
                 }
               }}
               onPickProject={(name) => {
+                if (uploadInFlightRef.current) return;
                 setDraftProjectName(name);
                 setDraftProjectMenuOpen(false);
                 setProjectSearchQuery("");
                 setCreateProjectFormOpen(false);
               }}
-              onCreateProject={() => createProjectAndSelect()}
+              onCreateProject={() => {
+                if (!uploadInFlightRef.current) void createProjectAndSelect();
+              }}
             />
           )}
           {pendingConnectPath ? (
@@ -1057,10 +1076,15 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
           ) : null}
           {impersonationEnabled && (
             <ImpersonationMenu
+              disabled={isComposerBusy}
               open={impersonationMenuOpen}
-              onOpenChange={setImpersonationMenuOpen}
+              onOpenChange={(next) => {
+                if (!uploadInFlightRef.current) setImpersonationMenuOpen(next);
+              }}
               selectedPersonId={selectedPersonId}
-              onSelectPersonId={setSelectedPersonId}
+              onSelectPersonId={(id) => {
+                if (!uploadInFlightRef.current) setSelectedPersonId(id);
+              }}
               options={impersonationOptions}
               selectedPerson={selectedPerson}
               selectedPersonLabel={selectedPersonLabel}

--- a/packages/web/src/components/chat/ChatComposer.tsx
+++ b/packages/web/src/components/chat/ChatComposer.tsx
@@ -68,6 +68,11 @@ export interface ChatComposerSnapshot {
   skillName?: string;
 }
 
+export interface ChatComposerSendControls {
+  /** `null` means the browser cannot determine the multipart body size. */
+  onUploadProgress: (progress: number | null) => void;
+}
+
 export interface ChatComposerHandle {
   focus: () => void;
   insertText: (text: string) => void;
@@ -143,10 +148,13 @@ export interface ChatComposerProps {
   // composer owns the box so the pre-send chip row can sit *outside* it; each
   // mount passes its own box look (the floating composer adds backdrop-blur).
   boxClassName?: string;
-  // Called when the user submits. The composer optimistically clears its
-  // input + uploads before invoking; if `onSend` throws, the inputs are
-  // restored.
-  onSend: (snapshot: ChatComposerSnapshot) => void | Promise<void>;
+  // Called when the user submits. The composer clears text immediately but
+  // keeps uploading attachments visible until this promise settles. If it
+  // rejects, the submitted inputs remain available for a retry.
+  onSend: (
+    snapshot: ChatComposerSnapshot,
+    controls: ChatComposerSendControls,
+  ) => void | Promise<void>;
 }
 
 // The empty input is one line box tall, expressed as `1lh` so it resolves
@@ -192,6 +200,8 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
 
   const [inputText, setInputText] = useState("");
   const [pendingUploads, setPendingUploads] = useState<PendingUpload[]>([]);
+  const [uploadInFlight, setUploadInFlight] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
 
   // When `pinnedAgentMention` is set, the session is already bound to an
   // agent — the `@` menu and the local draftAgentMention are inert.
@@ -279,6 +289,9 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const projectMenuRef = useRef<HTMLDivElement>(null);
+  // State drives the UI, while the ref closes the same-event gap before React
+  // commits that state (for example, two rapid Enter keydown events).
+  const uploadInFlightRef = useRef(false);
 
   // Resize the textarea to fit its content. The `onInput` handler below also
   // runs this math, but only on user typing — programmatic clears (e.g. the
@@ -396,6 +409,32 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
     ]);
   }, []);
 
+  const invokeOnSend = useCallback(
+    async (snapshot: ChatComposerSnapshot) => {
+      const tracksUpload = snapshot.uploads.length > 0;
+      if (tracksUpload) {
+        uploadInFlightRef.current = true;
+        setUploadInFlight(true);
+        setUploadProgress(0);
+      }
+      try {
+        await onSend(snapshot, {
+          onUploadProgress: (progress) => {
+            if (!tracksUpload) return;
+            setUploadProgress(progress === null ? null : Math.max(0, Math.min(1, progress)));
+          },
+        });
+      } finally {
+        if (tracksUpload) {
+          uploadInFlightRef.current = false;
+          setUploadInFlight(false);
+          setUploadProgress(null);
+        }
+      }
+    },
+    [onSend],
+  );
+
   useImperativeHandle(
     ref,
     () => ({
@@ -427,7 +466,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
       },
       addFiles: addPendingFiles,
       submit: (text: string, opts?: { skillName?: string }) => {
-        if (disabled || disabledHint != null) return;
+        if (disabled || disabledHint != null || uploadInFlightRef.current) return;
         const trimmed = text.trim();
         const skillName = opts?.skillName ?? draftSkill?.name;
         if (!trimmed && pendingUploads.length === 0 && !skillName) return;
@@ -442,7 +481,15 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
           agentMention: draftAgentMention ?? undefined,
           skillName,
         };
-        void onSend(snapshot);
+        void invokeOnSend(snapshot)
+          .then(() => {
+            const sentIds = new Set(snapshot.uploads.map((upload) => upload.id));
+            setPendingUploads((current) => current.filter((upload) => !sentIds.has(upload.id)));
+          })
+          .catch(() => {
+            // The imperative submit path leaves its inputs in place, so the
+            // parent error banner is sufficient and the turn remains retryable.
+          });
       },
       getMetadataSnapshot: () => ({
         personaId: impersonationEnabled && selectedPersonId ? selectedPersonId : undefined,
@@ -465,6 +512,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
       draftProjectName,
       draftAgentMention,
       onSend,
+      invokeOnSend,
     ],
   );
 
@@ -492,7 +540,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
   const isComposerBusy = disabled || disabledHint != null;
 
   const runSend = useCallback(async () => {
-    if (isComposerBusy) return;
+    if (isComposerBusy || uploadInFlightRef.current) return;
     // A skill chip alone is a sendable turn — the server-expanded prompt asks
     // the agent to read the skill and ask what to do with it.
     if (!inputText.trim() && pendingUploads.length === 0 && !draftSkill) return;
@@ -518,13 +566,17 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
     // onSend rejects, restore the snapshot so they can retry without
     // re-typing.
     setInputText("");
-    setPendingUploads([]);
+    if (uploads.length === 0) setPendingUploads([]);
     setDraftSkill(null);
     try {
-      await onSend(snapshot);
+      await invokeOnSend(snapshot);
+      if (uploads.length > 0) {
+        const sentIds = new Set(uploads.map((upload) => upload.id));
+        setPendingUploads((current) => current.filter((upload) => !sentIds.has(upload.id)));
+      }
     } catch {
       setInputText(text);
-      setPendingUploads(uploads);
+      if (uploads.length === 0) setPendingUploads(uploads);
       setDraftSkill(skill);
     }
   }, [
@@ -540,7 +592,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
     draftProjectName,
     draftAgentMention,
     isComposerBusy,
-    onSend,
+    invokeOnSend,
   ]);
 
   // Re-evaluates whether the cursor sits inside an active mention token
@@ -886,7 +938,8 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
         <PendingUploadsList
           uploads={pendingUploads}
           onRemove={removePendingUpload}
-          disabled={isComposerBusy}
+          disabled={isComposerBusy || uploadInFlight}
+          uploadProgress={uploadInFlight ? uploadProgress : undefined}
         />
         <SlashSkillMenu
           ref={slashMenuRef}
@@ -1007,7 +1060,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
             variant="ghost"
             size="icon-sm"
             onClick={() => fileInputRef.current?.click()}
-            disabled={isComposerBusy}
+            disabled={isComposerBusy || uploadInFlight}
             aria-label={t("composer.uploadFiles")}
             title={t("composer.uploadFiles")}
             className="touch-target"
@@ -1054,11 +1107,23 @@ export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(fu
               size="icon-sm"
               onClick={() => void runSend()}
               disabled={
-                isComposerBusy || (!inputText.trim() && pendingUploads.length === 0 && !draftSkill)
+                isComposerBusy ||
+                uploadInFlight ||
+                (!inputText.trim() && pendingUploads.length === 0 && !draftSkill)
               }
-              title={isStreaming ? t("composer.sendWhileRunningTitle") : t("composer.sendTitle")}
+              title={
+                uploadInFlight
+                  ? t("composer.uploadingFiles")
+                  : isStreaming
+                    ? t("composer.sendWhileRunningTitle")
+                    : t("composer.sendTitle")
+              }
               aria-label={
-                isStreaming ? t("composer.sendWhileRunningTitle") : t("composer.sendTitle")
+                uploadInFlight
+                  ? t("composer.uploadingFiles")
+                  : isStreaming
+                    ? t("composer.sendWhileRunningTitle")
+                    : t("composer.sendTitle")
               }
               className="touch-target"
             >

--- a/packages/web/src/components/chat/composer/ImpersonationMenu.tsx
+++ b/packages/web/src/components/chat/composer/ImpersonationMenu.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import type { PersonResource } from "@rome/api-types/people";
 
 export interface ImpersonationMenuProps {
+  disabled?: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   selectedPersonId: string;
@@ -23,6 +24,7 @@ export interface ImpersonationMenuProps {
 }
 
 export function ImpersonationMenu({
+  disabled = false,
   open,
   onOpenChange,
   selectedPersonId,
@@ -35,7 +37,12 @@ export function ImpersonationMenu({
   const { t } = useTranslation("chat");
 
   return (
-    <DropdownMenu open={open} onOpenChange={onOpenChange}>
+    <DropdownMenu
+      open={open && !disabled}
+      onOpenChange={(next) => {
+        if (!disabled) onOpenChange(next);
+      }}
+    >
       <DropdownMenuTrigger asChild>
         <Button
           type="button"
@@ -46,6 +53,7 @@ export function ImpersonationMenu({
           // appearing is the whole signal. A project and a model always have a
           // value, which is why those two always show one.
           size={selectedPerson ? "sm" : "icon-sm"}
+          disabled={disabled}
           aria-label={t("impersonation.buttonLabel")}
           title={selectedPersonLabel}
           className="touch-target"
@@ -69,7 +77,9 @@ export function ImpersonationMenu({
         </div>
         <div className="p-2">
           <DropdownMenuItem
-            onSelect={() => onSelectPersonId("")}
+            onSelect={() => {
+              if (!disabled) onSelectPersonId("");
+            }}
             className={cn(
               "justify-between rounded-8 px-3 py-2 text-ui",
               !selectedPersonId
@@ -86,7 +96,9 @@ export function ImpersonationMenu({
           {options.map((person) => (
             <DropdownMenuItem
               key={person.id}
-              onSelect={() => onSelectPersonId(person.id)}
+              onSelect={() => {
+                if (!disabled) onSelectPersonId(person.id);
+              }}
               className={cn(
                 "mt-1 justify-between rounded-8 px-3 py-2 text-ui",
                 selectedPersonId === person.id

--- a/packages/web/src/components/chat/composer/PendingUploadsList.tsx
+++ b/packages/web/src/components/chat/composer/PendingUploadsList.tsx
@@ -6,6 +6,8 @@ export interface PendingUploadsListProps {
   uploads: PendingUpload[];
   onRemove: (id: string) => void;
   disabled: boolean;
+  /** Undefined when idle, null for indeterminate, otherwise a 0–1 fraction. */
+  uploadProgress?: number | null;
 }
 
 /**
@@ -13,22 +15,76 @@ export interface PendingUploadsListProps {
  * They share a surface, so a second pill geometry here read as two systems —
  * `ComposerChip` owns height, radius, padding and text size for both.
  */
-export function PendingUploadsList({ uploads, onRemove, disabled }: PendingUploadsListProps) {
+export function PendingUploadsList({
+  uploads,
+  onRemove,
+  disabled,
+  uploadProgress,
+}: PendingUploadsListProps) {
   const { t } = useTranslation("chat");
   if (uploads.length === 0) return null;
+
+  const totalBytes = uploads.reduce((total, upload) => total + upload.file.size, 0);
+  let bytesBefore = 0;
   return (
     <div className="mb-3 flex flex-wrap gap-2">
-      {uploads.map((upload, index) => (
-        <ComposerChip
-          key={upload.id}
-          prefix={t("composer.filePill", { index: index + 1 })}
-          title={upload.file.name}
-          onRemove={disabled ? undefined : () => onRemove(upload.id)}
-          removeLabel={t("composer.removeFile", { name: upload.file.name })}
-        >
-          {upload.file.name}
-        </ComposerChip>
-      ))}
+      {uploads.map((upload, index) => {
+        // FormData sends file parts in append order. Translate the request's
+        // byte progress into each file's portion so completed files reach 100%
+        // before the next file starts. Multipart headers are small and are
+        // deliberately excluded from the estimate.
+        const progress =
+          uploadProgress === undefined ||
+          uploadProgress === null ||
+          totalBytes === 0 ||
+          upload.file.size === 0
+            ? uploadProgress
+            : Math.max(
+                0,
+                Math.min(1, (uploadProgress * totalBytes - bytesBefore) / upload.file.size),
+              );
+        bytesBefore += upload.file.size;
+        const percentage = progress == null ? null : Math.round(progress * 100);
+
+        return (
+          <ComposerChip
+            key={upload.id}
+            prefix={t("composer.filePill", { index: index + 1 })}
+            title={upload.file.name}
+            onRemove={disabled ? undefined : () => onRemove(upload.id)}
+            removeLabel={t("composer.removeFile", { name: upload.file.name })}
+            className={uploadProgress !== undefined ? "relative overflow-hidden" : undefined}
+          >
+            {upload.file.name}
+            {uploadProgress !== undefined && (
+              <>
+                {percentage !== null && (
+                  <span aria-hidden="true" className="ml-1 tabular-nums text-muted-foreground">
+                    {percentage}%
+                  </span>
+                )}
+                <span
+                  role="progressbar"
+                  aria-label={t("composer.uploadProgress", { name: upload.file.name })}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={percentage ?? undefined}
+                  className="absolute inset-x-0 bottom-0 h-0.5 bg-surface-muted"
+                >
+                  <span
+                    className={
+                      progress === null
+                        ? "block h-full w-full animate-pulse bg-primary"
+                        : "block h-full bg-primary transition-[width]"
+                    }
+                    style={progress === null ? undefined : { width: `${percentage}%` }}
+                  />
+                </span>
+              </>
+            )}
+          </ComposerChip>
+        );
+      })}
     </div>
   );
 }

--- a/packages/web/src/components/chat/composer/PendingUploadsList.tsx
+++ b/packages/web/src/components/chat/composer/PendingUploadsList.tsx
@@ -24,67 +24,48 @@ export function PendingUploadsList({
   const { t } = useTranslation("chat");
   if (uploads.length === 0) return null;
 
-  const totalBytes = uploads.reduce((total, upload) => total + upload.file.size, 0);
-  let bytesBefore = 0;
+  const percentage =
+    uploadProgress === undefined || uploadProgress === null
+      ? null
+      : Math.round(uploadProgress * 100);
   return (
-    <div className="mb-3 flex flex-wrap gap-2">
-      {uploads.map((upload, index) => {
-        // FormData sends file parts in append order. Translate the request's
-        // byte progress into each file's portion so completed files reach 100%
-        // before the next file starts. Multipart headers are small and are
-        // deliberately excluded from the estimate.
-        const progress =
-          uploadProgress === undefined ||
-          uploadProgress === null ||
-          totalBytes === 0 ||
-          upload.file.size === 0
-            ? uploadProgress
-            : Math.max(
-                0,
-                Math.min(1, (uploadProgress * totalBytes - bytesBefore) / upload.file.size),
-              );
-        bytesBefore += upload.file.size;
-        const percentage = progress == null ? null : Math.round(progress * 100);
-
-        return (
+    <div className="mb-3">
+      <div className="flex flex-wrap gap-2">
+        {uploads.map((upload, index) => (
           <ComposerChip
             key={upload.id}
             prefix={t("composer.filePill", { index: index + 1 })}
             title={upload.file.name}
             onRemove={disabled ? undefined : () => onRemove(upload.id)}
             removeLabel={t("composer.removeFile", { name: upload.file.name })}
-            className={uploadProgress !== undefined ? "relative overflow-hidden" : undefined}
           >
             {upload.file.name}
-            {uploadProgress !== undefined && (
-              <>
-                {percentage !== null && (
-                  <span aria-hidden="true" className="ml-1 tabular-nums text-muted-foreground">
-                    {percentage}%
-                  </span>
-                )}
-                <span
-                  role="progressbar"
-                  aria-label={t("composer.uploadProgress", { name: upload.file.name })}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-valuenow={percentage ?? undefined}
-                  className="absolute inset-x-0 bottom-0 h-0.5 bg-surface-muted"
-                >
-                  <span
-                    className={
-                      progress === null
-                        ? "block h-full w-full animate-pulse bg-primary"
-                        : "block h-full bg-primary transition-[width]"
-                    }
-                    style={progress === null ? undefined : { width: `${percentage}%` }}
-                  />
-                </span>
-              </>
-            )}
           </ComposerChip>
-        );
-      })}
+        ))}
+      </div>
+      {uploadProgress !== undefined && (
+        <div className="mt-2 flex items-center gap-2 text-aux text-muted-foreground">
+          <span>{t("composer.uploadingFiles")}</span>
+          <span
+            role="progressbar"
+            aria-label={t("composer.uploadProgress")}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={percentage ?? undefined}
+            className="h-1 min-w-16 flex-1 overflow-hidden rounded-full bg-surface-muted"
+          >
+            <span
+              className={
+                uploadProgress === null
+                  ? "block h-full w-full animate-pulse bg-primary"
+                  : "block h-full bg-primary transition-[width]"
+              }
+              style={uploadProgress === null ? undefined : { width: `${percentage}%` }}
+            />
+          </span>
+          {percentage !== null && <span className="tabular-nums">{percentage}%</span>}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/chat/composer/SkillCommandChip.tsx
+++ b/packages/web/src/components/chat/composer/SkillCommandChip.tsx
@@ -15,7 +15,7 @@ export interface SkillSelection {
 
 export interface SkillCommandChipProps {
   skill: SkillSelection;
-  onRemove: () => void;
+  onRemove?: () => void;
 }
 
 /**

--- a/packages/web/src/components/project-selector.tsx
+++ b/packages/web/src/components/project-selector.tsx
@@ -32,6 +32,7 @@ interface ProjectCatalog {
 }
 
 interface ProjectSelectorProps {
+  disabled?: boolean;
   t: TFunction;
   projectCatalog: ProjectCatalog | null;
   projectsLoading: boolean;
@@ -61,6 +62,7 @@ function getProjectDisplayName(name: string): string {
 
 export const ProjectSelector = forwardRef(function ProjectSelector(
   {
+    disabled = false,
     t,
     projectCatalog,
     projectsLoading,
@@ -123,8 +125,9 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
   return (
     <div ref={ref} className="shrink-0">
       <Popover
-        open={menuOpen}
+        open={menuOpen && !disabled}
         onOpenChange={(next) => {
+          if (disabled) return;
           if (next !== menuOpen) onToggleMenu();
         }}
       >
@@ -138,6 +141,7 @@ export const ProjectSelector = forwardRef(function ProjectSelector(
             // loudest thing in a row of muted chrome.
             variant={isDefault ? "ghost" : "secondary"}
             size="sm"
+            disabled={disabled}
             className={cn("max-w-[200px] touch-target", isDefault && "text-muted-foreground")}
             title={isDefault ? t("project.buttonLabel") : draftProjectLabel}
             aria-label={t("project.buttonLabel")}

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -221,6 +221,8 @@
     "dropFiles": "Drop files to upload",
     "removeFile": "Remove {{name}}",
     "filePill": "#File {{index}}",
+    "uploadingFiles": "Uploading files…",
+    "uploadProgress": "Uploading {{name}}",
     "send": "Send",
     "sendTitle": "Send",
     "sendWhileRunningTitle": "Send while agent is working",

--- a/packages/web/src/i18n/locales/en/chat.json
+++ b/packages/web/src/i18n/locales/en/chat.json
@@ -222,7 +222,7 @@
     "removeFile": "Remove {{name}}",
     "filePill": "#File {{index}}",
     "uploadingFiles": "Uploading files…",
-    "uploadProgress": "Uploading {{name}}",
+    "uploadProgress": "Attachment upload progress",
     "send": "Send",
     "sendTitle": "Send",
     "sendWhileRunningTitle": "Send while agent is working",

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -221,6 +221,8 @@
     "dropFiles": "拖放文件以上传",
     "removeFile": "移除 {{name}}",
     "filePill": "#文件 {{index}}",
+    "uploadingFiles": "正在上传文件…",
+    "uploadProgress": "正在上传 {{name}}",
     "send": "发送",
     "sendTitle": "发送",
     "sendWhileRunningTitle": "在 Agent 运行中发送消息",

--- a/packages/web/src/i18n/locales/zh-CN/chat.json
+++ b/packages/web/src/i18n/locales/zh-CN/chat.json
@@ -222,7 +222,7 @@
     "removeFile": "移除 {{name}}",
     "filePill": "#文件 {{index}}",
     "uploadingFiles": "正在上传文件…",
-    "uploadProgress": "正在上传 {{name}}",
+    "uploadProgress": "附件上传进度",
     "send": "发送",
     "sendTitle": "发送",
     "sendWhileRunningTitle": "在 Agent 运行中发送消息",

--- a/packages/web/src/lib/chat-api.test.ts
+++ b/packages/web/src/lib/chat-api.test.ts
@@ -31,4 +31,65 @@ describe("postSessionTurn", () => {
       reason: "not_logged_in",
     });
   });
+
+  it("reports multipart upload progress through XMLHttpRequest", async () => {
+    class FakeXMLHttpRequest {
+      static current: FakeXMLHttpRequest | null = null;
+
+      readonly upload = {
+        onprogress: null as ((event: ProgressEvent) => void) | null,
+        onload: null as (() => void) | null,
+      };
+      status = 0;
+      responseText = "";
+      withCredentials = false;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      onabort: (() => void) | null = null;
+      method = "";
+      url = "";
+      body: Document | XMLHttpRequestBodyInit | null = null;
+
+      constructor() {
+        FakeXMLHttpRequest.current = this;
+      }
+
+      open(method: string, url: string) {
+        this.method = method;
+        this.url = url;
+      }
+
+      send(body: Document | XMLHttpRequestBodyInit | null) {
+        this.body = body;
+      }
+    }
+
+    rs.stubGlobal("XMLHttpRequest", FakeXMLHttpRequest);
+    const progress: Array<number | null> = [];
+    const body = new FormData();
+    const resultPromise = postSessionTurn("session-1", body, {
+      onUploadProgress: (value) => progress.push(value),
+    });
+    const request = FakeXMLHttpRequest.current;
+    expect(request).not.toBeNull();
+    if (!request) throw new Error("XMLHttpRequest was not created");
+
+    request.upload.onprogress?.({
+      lengthComputable: true,
+      loaded: 25,
+      total: 100,
+    } as ProgressEvent);
+    request.upload.onload?.();
+    request.status = 200;
+    request.responseText = JSON.stringify({ turnId: "turn-1" });
+    request.onload?.();
+
+    await expect(resultPromise).resolves.toEqual({ ok: true, data: { turnId: "turn-1" } });
+    expect(progress).toEqual([0.25, 1]);
+    expect(request.method).toBe("POST");
+    expect(request.url).toBe("/api/chat/sessions/session-1/turns");
+    expect(request.withCredentials).toBe(true);
+    expect(request.body).toBe(body);
+    expect(body.has("inputId")).toBe(true);
+  });
 });

--- a/packages/web/src/lib/chat-api.test.ts
+++ b/packages/web/src/lib/chat-api.test.ts
@@ -49,12 +49,16 @@ describe("postSessionTurn", () => {
       method = "";
       url = "";
       body: Document | XMLHttpRequestBodyInit | null = null;
+      uploadListenersAttachedBeforeOpen = false;
 
       constructor() {
         FakeXMLHttpRequest.current = this;
       }
 
       open(method: string, url: string) {
+        this.uploadListenersAttachedBeforeOpen = Boolean(
+          this.upload.onprogress && this.upload.onload,
+        );
         this.method = method;
         this.url = url;
       }
@@ -89,6 +93,7 @@ describe("postSessionTurn", () => {
     expect(request.method).toBe("POST");
     expect(request.url).toBe("/api/chat/sessions/session-1/turns");
     expect(request.withCredentials).toBe(true);
+    expect(request.uploadListenersAttachedBeforeOpen).toBe(true);
     expect(request.body).toBe(body);
     expect(body.has("inputId")).toBe(true);
   });

--- a/packages/web/src/lib/chat-api.ts
+++ b/packages/web/src/lib/chat-api.ts
@@ -437,8 +437,9 @@ function postSessionTurnWithProgress(
 ): Promise<PostTurnResult> {
   return new Promise((resolve, reject) => {
     const request = new XMLHttpRequest();
-    request.open("POST", `/api/chat/sessions/${sessionId}/turns`);
-    request.withCredentials = true;
+    // Attach upload listeners before open(): despite the spec allowing either
+    // order, browsers have historically required this ordering for upload
+    // events to fire reliably.
     request.upload.onprogress = (event) => {
       onUploadProgress(
         event.lengthComputable && event.total > 0 ? event.loaded / event.total : null,
@@ -448,6 +449,8 @@ function postSessionTurnWithProgress(
     // `load` is the browser's authoritative boundary for a fully transferred
     // request body; response processing may continue after it fires.
     request.upload.onload = () => onUploadProgress(1);
+    request.open("POST", `/api/chat/sessions/${sessionId}/turns`);
+    request.withCredentials = true;
     request.onload = () => {
       resolve(
         parseTurnResponseText(

--- a/packages/web/src/lib/chat-api.ts
+++ b/packages/web/src/lib/chat-api.ts
@@ -357,6 +357,14 @@ export type PostTurnResult =
       reason?: ChatErrorReason;
     };
 
+export interface PostSessionTurnOptions {
+  /**
+   * Reports the fraction of the multipart request body transferred to the
+   * server. `null` means the browser did not expose a computable total.
+   */
+  onUploadProgress?: (progress: number | null) => void;
+}
+
 export async function listSessionTurns(sessionId: string): Promise<TurnInfo[] | null> {
   const res = await fetch(`/api/chat/sessions/${sessionId}/turns`, { credentials: "include" });
   if (!res.ok) return null;
@@ -376,44 +384,40 @@ export async function postSessionTurnJson(
   return parseTurnResponse(res);
 }
 
-async function parseTurnResponse(res: Response): Promise<PostTurnResult> {
-  if (res.ok) {
+function parseTurnResponseText(status: number, ok: boolean, raw: string): PostTurnResult {
+  if (ok) {
     try {
-      const data = (await res.json()) as CreateTurnResponse;
+      const data = JSON.parse(raw) as CreateTurnResponse;
       return { ok: true, data };
     } catch {
-      return { ok: false, status: res.status, message: "" };
+      return { ok: false, status, message: "" };
     }
   }
   let message = "";
   let code: ChatErrorCode | undefined;
   let provider: ChatErrorProvider | undefined;
   let reason: ChatErrorReason | undefined;
-  try {
-    const raw = (await res.text()).trim();
-    if (raw) {
-      try {
-        const payload = JSON.parse(raw) as {
-          error?: string;
-          message?: string;
-          code?: ChatErrorCode;
-          provider?: ChatErrorProvider;
-          reason?: ChatErrorReason;
-        };
-        message = payload.error ?? payload.message ?? "";
-        code = payload.code;
-        provider = payload.provider;
-        reason = payload.reason;
-      } catch {
-        message = raw.slice(0, 200);
-      }
+  const trimmed = raw.trim();
+  if (trimmed) {
+    try {
+      const payload = JSON.parse(trimmed) as {
+        error?: string;
+        message?: string;
+        code?: ChatErrorCode;
+        provider?: ChatErrorProvider;
+        reason?: ChatErrorReason;
+      };
+      message = payload.error ?? payload.message ?? "";
+      code = payload.code;
+      provider = payload.provider;
+      reason = payload.reason;
+    } catch {
+      message = trimmed.slice(0, 200);
     }
-  } catch {
-    // ignore
   }
   return {
     ok: false,
-    status: res.status,
+    status,
     message,
     ...(code ? { code } : {}),
     ...(provider ? { provider } : {}),
@@ -421,8 +425,53 @@ async function parseTurnResponse(res: Response): Promise<PostTurnResult> {
   };
 }
 
-export async function postSessionTurn(sessionId: string, body: FormData): Promise<PostTurnResult> {
+async function parseTurnResponse(res: Response): Promise<PostTurnResult> {
+  const raw = await res.text().catch(() => "");
+  return parseTurnResponseText(res.status, res.ok, raw);
+}
+
+function postSessionTurnWithProgress(
+  sessionId: string,
+  body: FormData,
+  onUploadProgress: (progress: number | null) => void,
+): Promise<PostTurnResult> {
+  return new Promise((resolve, reject) => {
+    const request = new XMLHttpRequest();
+    request.open("POST", `/api/chat/sessions/${sessionId}/turns`);
+    request.withCredentials = true;
+    request.upload.onprogress = (event) => {
+      onUploadProgress(
+        event.lengthComputable && event.total > 0 ? event.loaded / event.total : null,
+      );
+    };
+    // The last progress event is not guaranteed to report the exact total.
+    // `load` is the browser's authoritative boundary for a fully transferred
+    // request body; response processing may continue after it fires.
+    request.upload.onload = () => onUploadProgress(1);
+    request.onload = () => {
+      resolve(
+        parseTurnResponseText(
+          request.status,
+          request.status >= 200 && request.status < 300,
+          request.responseText,
+        ),
+      );
+    };
+    request.onerror = () => reject(new TypeError("Failed to fetch"));
+    request.onabort = () => reject(new DOMException("The request was aborted", "AbortError"));
+    request.send(body);
+  });
+}
+
+export async function postSessionTurn(
+  sessionId: string,
+  body: FormData,
+  options: PostSessionTurnOptions = {},
+): Promise<PostTurnResult> {
   if (!body.has("inputId")) body.set("inputId", crypto.randomUUID());
+  if (options.onUploadProgress) {
+    return postSessionTurnWithProgress(sessionId, body, options.onUploadProgress);
+  }
   const res = await fetch(`/api/chat/sessions/${sessionId}/turns`, {
     method: "POST",
     credentials: "include",


### PR DESCRIPTION
## Summary

- report real multipart request progress for chat attachments through `XMLHttpRequest.upload`
- show a progress ring inside each attachment chip, measured over the attached files' bytes, which are written last and in order in the multipart body
- let the user cancel an in-flight upload; the draft stays in place, and resending it unchanged reuses the turn's `inputId` so a request the server already accepted is not recorded twice
- disable attachment changes and guard click, Enter, and imperative sends until the active upload settles
- retain attachments for retry after an upload failure while preserving the existing text-only `fetch` path and multipart API contract

## Investigation

Chat attachments were previously held as local `File` objects in `ChatComposer` and appended to the chat turn's `FormData` only when the message was submitted. The multipart request used `fetch`, which does not expose request-body upload progress in the browser. This change uses XHR only for turns containing attachments and maps the request progress onto each file's byte range. The files are moved to the end of the body and progress is measured over their bytes alone, so the text and workspace fields do not count as file progress. Part headers are ignored, so a ring can finish a few hundred bytes early.

## Test plan

- [x] `pnpm --filter rome-web exec rstest run src/lib/chat-api.test.ts src/components/chat/ChatComposer.test.tsx src/components/project-selector.test.tsx --silent passed-only` (24/24)
- [x] `pnpm --filter rome-web typecheck`
- [x] `pnpm --filter rome-web build`
- [x] `pnpm --filter rome-web test` (174 files, 1,422 tests; run before final rebase, whose intervening upstream commits did not touch this scope)
- [x] `pnpm typecheck` (run before final rebase, whose intervening upstream commits did not touch this scope)

No issue was designated for automatic closure.
