### PR TITLE
perf(core): deduplicate LinkedIn profile syncs

### DIFF
--- a/packages/core/drizzle/system/0064_known_kitty_pryde.sql
+++ b/packages/core/drizzle/system/0064_known_kitty_pryde.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `linkedin_participants` ADD `profile_url` text;--> statement-breakpoint
+ALTER TABLE `linkedin_participants` ADD `last_successful_sync_at` integer;--> statement-breakpoint
+ALTER TABLE `linkedin_participants` ADD `profile_sync_failure_count` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `linkedin_participants` ADD `profile_sync_retry_at` integer;

--- a/packages/core/drizzle/system/meta/0064_snapshot.json
+++ b/packages/core/drizzle/system/meta/0064_snapshot.json
@@ -1,0 +1,3246 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b601eb40-b94c-4a24-a181-bd31b5dd1b4b",
+  "prevId": "6f41c9e4-0a92-47c1-89b9-431756648fd9",
+  "tables": {
+    "action_executions": {
+      "name": "action_executions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initiator": {
+          "name": "initiator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_keys": {
+      "name": "app_keys",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "approvals": {
+      "name": "approvals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_state": {
+          "name": "execution_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_error": {
+          "name": "execution_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_mappings": {
+      "name": "channel_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_channel_mappings_identity": {
+          "name": "idx_channel_mappings_identity",
+          "columns": [
+            "channel",
+            "channel_user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_mappings_person_id_persons_id_fk": {
+          "name": "channel_mappings_person_id_persons_id_fk",
+          "tableFrom": "channel_mappings",
+          "tableTo": "persons",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connection_grants": {
+      "name": "connection_grants",
+      "columns": {
+        "custody": {
+          "name": "custody",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential": {
+          "name": "credential",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conferred_at": {
+          "name": "conferred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_at": {
+          "name": "degraded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "degraded_reason": {
+          "name": "degraded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connection_grants_custody_name_pk": {
+          "columns": [
+            "custody",
+            "name"
+          ],
+          "name": "connection_grants_custody_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connections": {
+      "name": "connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connections_service_unique": {
+          "name": "connections_service_unique",
+          "columns": [
+            "service"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tzid": {
+          "name": "tzid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_time": {
+          "name": "local_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rrule": {
+          "name": "rrule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "execution_journal": {
+      "name": "execution_journal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_execution_id": {
+          "name": "root_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args_hash": {
+          "name": "args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expected_action_name": {
+          "name": "expected_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expected_args_hash": {
+          "name": "expected_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_action_name": {
+          "name": "actual_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actual_args_hash": {
+          "name": "actual_args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ej_root_execution_id": {
+          "name": "idx_ej_root_execution_id",
+          "columns": [
+            "root_execution_id"
+          ],
+          "isUnique": false
+        },
+        "idx_ej_created_at": {
+          "name": "idx_ej_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardian_auth": {
+      "name": "guardian_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guardian_auth_user_id_unique": {
+          "name": "guardian_auth_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_messages": {
+      "name": "linkedin_messages",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_profile_url": {
+          "name": "sender_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_headline": {
+          "name": "sender_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_type": {
+          "name": "sender_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_is_self": {
+          "name": "sender_is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reaction_count": {
+          "name": "reaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_messages_thread_sent": {
+          "name": "idx_linkedin_messages_thread_sent",
+          "columns": [
+            "thread_id",
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_messages_thread_id_message_id_pk": {
+          "columns": [
+            "thread_id",
+            "message_id"
+          ],
+          "name": "linkedin_messages_thread_id_message_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_participants": {
+      "name": "linkedin_participants",
+      "columns": {
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_self": {
+          "name": "is_self",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_successful_sync_at": {
+          "name": "last_successful_sync_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_sync_failure_count": {
+          "name": "profile_sync_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "profile_sync_retry_at": {
+          "name": "profile_sync_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_thread_participants": {
+      "name": "linkedin_thread_participants",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_linkedin_thread_participants_participant": {
+          "name": "idx_linkedin_thread_participants_participant",
+          "columns": [
+            "participant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "linkedin_thread_participants_thread_id_participant_id_pk": {
+          "columns": [
+            "thread_id",
+            "participant_id"
+          ],
+          "name": "linkedin_thread_participants_thread_id_participant_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "linkedin_threads": {
+      "name": "linkedin_threads",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_url": {
+          "name": "thread_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_name": {
+          "name": "person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_name": {
+          "name": "conversation_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread": {
+          "name": "unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "counterparty_type": {
+          "name": "counterparty_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "participants_last_read_at": {
+          "name": "participants_last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_pending_attempts": {
+      "name": "oauth_pending_attempts",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_origin": {
+          "name": "callback_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_oauth_pending_attempts_expires_at": {
+          "name": "idx_oauth_pending_attempts_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "outbound_messages": {
+      "name": "outbound_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_outbound_account": {
+          "name": "idx_outbound_account",
+          "columns": [
+            "channel",
+            "channel_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "outbound_send_receipts": {
+      "name": "outbound_send_receipts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_outbound_send_receipts_expiry": {
+          "name": "idx_outbound_send_receipts_expiry",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "persons": {
+      "name": "persons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bond_level": {
+          "name": "bond_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_path": {
+          "name": "profile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_value": {
+          "name": "scope_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sync_links": {
+      "name": "project_sync_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_type": {
+          "name": "project_link_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_link_extra": {
+          "name": "project_link_extra",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sync_links_project_path_unique": {
+          "name": "project_sync_links_project_path_unique",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_accounts": {
+      "name": "provider_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "provider_accounts_provider_unique": {
+          "name": "provider_accounts_provider_unique",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_messages": {
+      "name": "rome_agent_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_state": {
+          "name": "input_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_to_platform_message_id": {
+          "name": "reply_to_platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_injected_turn_id": {
+          "name": "context_injected_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_messages_session_id": {
+          "name": "idx_rome_agent_messages_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_turn_id": {
+          "name": "idx_rome_agent_messages_turn_id",
+          "columns": [
+            "turn_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_role_created_at": {
+          "name": "idx_rome_agent_messages_role_created_at",
+          "columns": [
+            "role",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_messages_platform_message": {
+          "name": "idx_rome_agent_messages_platform_message",
+          "columns": [
+            "session_id",
+            "platform_message_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_agent_messages\".\"platform_message_id\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_agent_trace_blocks": {
+      "name": "rome_agent_trace_blocks",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_agent_trace_blocks_session_id": {
+          "name": "idx_rome_agent_trace_blocks_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_agent_trace_blocks_terminal_message": {
+          "name": "idx_rome_agent_trace_blocks_terminal_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') IN ('result', 'error')"
+        },
+        "idx_rome_agent_trace_blocks_turn_end_message": {
+          "name": "idx_rome_agent_trace_blocks_turn_end_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false,
+          "where": "json_extract(\"rome_agent_trace_blocks\".\"content\", '$.type') = 'turn_end'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rome_agent_trace_blocks_message_id_seq_pk": {
+          "columns": [
+            "message_id",
+            "seq"
+          ],
+          "name": "rome_agent_trace_blocks_message_id_seq_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rome_sessions": {
+      "name": "rome_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona_id": {
+          "name": "persona_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "large_model_selection": {
+          "name": "large_model_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webchat'"
+        },
+        "source_channel": {
+          "name": "source_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_name": {
+          "name": "source_thread_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_type": {
+          "name": "source_thread_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_settings": {
+          "name": "channel_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_name": {
+          "name": "trigger_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_action_name": {
+          "name": "trigger_action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_execution_id": {
+          "name": "trigger_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_action_execution_id": {
+          "name": "root_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_action_execution_id": {
+          "name": "parent_action_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_turn_id": {
+          "name": "parent_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handoff_spec": {
+          "name": "handoff_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_activity_at": {
+          "name": "last_seen_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rome_sessions_project_path": {
+          "name": "idx_rome_sessions_project_path",
+          "columns": [
+            "project_path"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_sidebar_activity": {
+          "name": "idx_rome_sessions_sidebar_activity",
+          "columns": [
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_project_activity": {
+          "name": "idx_rome_sessions_project_activity",
+          "columns": [
+            "project_path",
+            "type",
+            "activity_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_channel": {
+          "name": "idx_rome_sessions_source_channel",
+          "columns": [
+            "source_channel"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_source_thread": {
+          "name": "idx_rome_sessions_source_thread",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_rome_sessions_channel_address": {
+          "name": "idx_rome_sessions_channel_address",
+          "columns": [
+            "source_channel",
+            "source_thread_id"
+          ],
+          "isUnique": false,
+          "where": "\"rome_sessions\".\"type\" = 'channel' AND \"rome_sessions\".\"source_channel\" IS NOT NULL AND \"rome_sessions\".\"source_thread_id\" IS NOT NULL"
+        },
+        "idx_rome_sessions_parent_session": {
+          "name": "idx_rome_sessions_parent_session",
+          "columns": [
+            "parent_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routine_runs": {
+      "name": "routine_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_routine_runs_routine_id": {
+          "name": "idx_routine_runs_routine_id",
+          "columns": [
+            "routine_id"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_fired_at": {
+          "name": "idx_routine_runs_fired_at",
+          "columns": [
+            "fired_at"
+          ],
+          "isUnique": false
+        },
+        "idx_routine_runs_status": {
+          "name": "idx_routine_runs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "routine_runs_routine_id_routines_id_fk": {
+          "name": "routine_runs_routine_id_routines_id_fk",
+          "tableFrom": "routine_runs",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routines": {
+      "name": "routines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed_by": {
+          "name": "managed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "routines_key_unique": {
+          "name": "routines_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sentinel_log": {
+      "name": "sentinel_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_turn_checkpoints": {
+      "name": "session_turn_checkpoints",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_turn_checkpoints_session_id_sessions_id_fk": {
+          "name": "session_turn_checkpoints_session_id_sessions_id_fk",
+          "tableFrom": "session_turn_checkpoints",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_turn_checkpoints_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "session_turn_checkpoints_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_thread_key": {
+          "name": "channel_thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shared_chats": {
+      "name": "shared_chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_shared_chats_session_id": {
+          "name": "idx_shared_chats_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_chats": {
+      "name": "wa_chats",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_contacts": {
+      "name": "wa_contacts",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify": {
+          "name": "notify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_name": {
+          "name": "verified_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "img_url": {
+          "name": "img_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wa_messages": {
+      "name": "wa_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_jid": {
+          "name": "chat_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_jid": {
+          "name": "sender_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_me": {
+          "name": "from_me",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_media": {
+          "name": "has_media",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "push_name": {
+          "name": "push_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reacts_to_id": {
+          "name": "reacts_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_chat_ts": {
+          "name": "idx_wa_messages_chat_ts",
+          "columns": [
+            "chat_jid",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wa_messages_chat_jid_id_pk": {
+          "columns": [
+            "chat_jid",
+            "id"
+          ],
+          "name": "wa_messages_chat_jid_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_projects": {
+      "name": "webchat_projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webchat_projects_path_unique": {
+          "name": "webchat_projects_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_turn_feedback": {
+      "name": "webchat_turn_feedback",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webchat_turn_feedback_session_id": {
+          "name": "idx_webchat_turn_feedback_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webchat_turn_feedback_session_id_rome_sessions_id_fk": {
+          "name": "webchat_turn_feedback_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_turn_feedback",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webchat_turn_feedback_session_id_turn_id_pk": {
+          "columns": [
+            "session_id",
+            "turn_id"
+          ],
+          "name": "webchat_turn_feedback_session_id_turn_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webchat_workspace_layouts": {
+      "name": "webchat_workspace_layouts",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webchat_workspace_layouts_session_id_rome_sessions_id_fk": {
+          "name": "webchat_workspace_layouts_session_id_rome_sessions_id_fk",
+          "tableFrom": "webchat_workspace_layouts",
+          "tableTo": "rome_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_invocations": {
+      "name": "webhook_invocations",
+      "columns": {
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_url": {
+          "name": "callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_status": {
+          "name": "callback_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_attempted_at": {
+          "name": "callback_attempted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_delivered_at": {
+          "name": "callback_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_response_status": {
+          "name": "callback_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_error": {
+          "name": "callback_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webhook_invocations_created_at": {
+          "name": "idx_webhook_invocations_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_webhook_invocations_action_name": {
+          "name": "idx_webhook_invocations_action_name",
+          "columns": [
+            "action_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/system/meta/_journal.json
+++ b/packages/core/drizzle/system/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1789017483838,
       "tag": "0063_equal_tigra",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "6",
+      "when": 1789110244086,
+      "tag": "0064_known_kitty_pryde",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/channels/linkedin-cli.test.ts
+++ b/packages/core/src/channels/linkedin-cli.test.ts
@@ -169,6 +169,7 @@ describe("parseThreadSnapshot", () => {
             returned_message_count: 2,
             message_id: "m1",
             sent_at: "2026-08-19T20:52:09.488Z",
+            sender_participant_id: "ACoAAAda0001",
             sender_name: "Ada Lovelace",
             sender_type: "member",
             sender_profile_url: "https://www.linkedin.com/in/ada/",
@@ -191,6 +192,7 @@ describe("parseThreadSnapshot", () => {
     );
     expect(messages).toHaveLength(2);
     expect(messages[0].sentAt?.toISOString()).toBe("2026-08-19T20:52:09.488Z");
+    expect(messages[0].senderParticipantId).toBe("ACoAAAda0001");
     expect(messages[0].reactionCount).toBe(1);
     expect(messages[1].sentAt).toBeNull();
     expect(messages[1].senderIsSelf).toBe(true);

--- a/packages/core/src/channels/linkedin-cli.ts
+++ b/packages/core/src/channels/linkedin-cli.ts
@@ -237,6 +237,7 @@ const snapshotRowSchema = z.object({
   participant_count: z.number().nullish(),
   message_id: z.string().min(1),
   sent_at: z.string().nullish(),
+  sender_participant_id: z.string().nullish(),
   sender_name: z.string().nullish(),
   sender_type: z.string().nullish(),
   sender_profile_url: z.string().nullish(),
@@ -264,6 +265,7 @@ export interface LinkedInSnapshotMessage {
   participantCount: number | null;
   messageId: string;
   sentAt: Date | null;
+  senderParticipantId: string | null;
   senderName: string | null;
   senderType: string | null;
   senderProfileUrl: string | null;
@@ -288,6 +290,7 @@ export function parseThreadSnapshot(result: OpencliResult): LinkedInSnapshotMess
     participantCount: row.participant_count ?? null,
     messageId: row.message_id,
     sentAt: parseIsoDate(row.sent_at),
+    senderParticipantId: row.sender_participant_id || null,
     senderName: row.sender_name ?? null,
     senderType: row.sender_type ?? null,
     senderProfileUrl: row.sender_profile_url ?? null,

--- a/packages/core/src/channels/linkedin-profile-sync.test.ts
+++ b/packages/core/src/channels/linkedin-profile-sync.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "@rstest/core";
+import {
+  LinkedInParticipantProfileSynchronizer,
+  type LinkedInParticipantProfileStore,
+} from "./linkedin-profile-sync.js";
+import type {
+  LinkedInParticipantInput,
+  LinkedInParticipantProfileSyncState,
+  LinkedInThreadParticipantInput,
+} from "./linkedin-sync.js";
+
+const ada: LinkedInParticipantInput = {
+  participantId: "ACoAAAda0001",
+  name: "Ada Lovelace",
+  headline: "Engineer",
+  profileUrl: "https://www.linkedin.com/in/ACoAAAda0001/",
+  type: "member",
+  isSelf: false,
+};
+
+class ProfileStore implements LinkedInParticipantProfileStore {
+  states = new Map<string, LinkedInParticipantProfileSyncState>();
+  writes: string[] = [];
+  attempts: string[] = [];
+  fail = new Set<string>();
+
+  constructor(private readonly now: () => Date) {}
+
+  async getParticipantProfileSyncStates(
+    participantIds: string[],
+  ): Promise<Map<string, LinkedInParticipantProfileSyncState>> {
+    return new Map(
+      participantIds.flatMap((id) => {
+        const state = this.states.get(id);
+        return state ? [[id, state] as const] : [];
+      }),
+    );
+  }
+
+  async upsertParticipantProfile(participant: LinkedInParticipantInput): Promise<void> {
+    this.attempts.push(participant.participantId);
+    if (this.fail.has(participant.participantId)) throw new Error("profile store unavailable");
+    this.writes.push(participant.participantId);
+    this.states.set(participant.participantId, {
+      participantId: participant.participantId,
+      lastSuccessfulSyncAt: this.now(),
+      profileSyncFailureCount: 0,
+      profileSyncRetryAt: null,
+    });
+  }
+
+  async recordParticipantProfileSyncFailure(
+    participant: LinkedInThreadParticipantInput,
+    failureCount: number,
+    retryAt: Date,
+  ): Promise<void> {
+    const previous = this.states.get(participant.participantId);
+    this.states.set(participant.participantId, {
+      participantId: participant.participantId,
+      lastSuccessfulSyncAt: previous?.lastSuccessfulSyncAt ?? null,
+      profileSyncFailureCount: failureCount,
+      profileSyncRetryAt: retryAt,
+    });
+  }
+}
+
+describe("LinkedInParticipantProfileSynchronizer", () => {
+  it("reuses a recent successful profile from durable state", async () => {
+    const now = new Date("2026-09-11T06:00:00Z");
+    const store = new ProfileStore(() => now);
+    store.states.set(ada.participantId, {
+      participantId: ada.participantId,
+      lastSuccessfulSyncAt: new Date("2026-09-11T05:00:00Z"),
+      profileSyncFailureCount: 0,
+      profileSyncRetryAt: null,
+    });
+    const synchronizer = new LinkedInParticipantProfileSynchronizer(store, {
+      refreshIntervalMs: 24 * 60 * 60_000,
+      now: () => now,
+    });
+
+    expect((await synchronizer.sync([ada])).get(ada.participantId)).toBe("fresh");
+    expect(store.attempts).toEqual([]);
+  });
+
+  it("deduplicates concurrent work for one profile without serializing other profiles", async () => {
+    const now = new Date("2026-09-11T06:00:00Z");
+    const store = new ProfileStore(() => now);
+    const releases = new Map<string, () => void>();
+    store.upsertParticipantProfile = async (participant) => {
+      store.attempts.push(participant.participantId);
+      await new Promise<void>((resolve) => releases.set(participant.participantId, resolve));
+      store.writes.push(participant.participantId);
+    };
+    const grace = { ...ada, participantId: "ACoAAGrace002", name: "Grace Hopper" };
+    const synchronizer = new LinkedInParticipantProfileSynchronizer(store, { now: () => now });
+
+    const firstAda = synchronizer.sync([ada]);
+    const secondAda = synchronizer.sync([{ ...ada, headline: "Mathematician" }]);
+    const graceSync = synchronizer.sync([grace]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(store.attempts).toEqual([ada.participantId, grace.participantId]);
+    releases.get(ada.participantId)?.();
+    releases.get(grace.participantId)?.();
+    await Promise.all([firstAda, secondAda, graceSync]);
+    expect(store.writes).toEqual([ada.participantId, grace.participantId]);
+  });
+
+  it("backs off failures without advancing success and resets after a successful retry", async () => {
+    let now = new Date("2026-09-11T06:00:00Z");
+    const store = new ProfileStore(() => now);
+    const previousSuccess = new Date("2026-09-01T06:00:00Z");
+    store.states.set(ada.participantId, {
+      participantId: ada.participantId,
+      lastSuccessfulSyncAt: previousSuccess,
+      profileSyncFailureCount: 0,
+      profileSyncRetryAt: null,
+    });
+    store.fail.add(ada.participantId);
+    const synchronizer = new LinkedInParticipantProfileSynchronizer(store, {
+      refreshIntervalMs: 24 * 60 * 60_000,
+      retryBaseMs: 5 * 60_000,
+      retryMaxMs: 6 * 60 * 60_000,
+      now: () => now,
+    });
+
+    expect((await synchronizer.sync([ada])).get(ada.participantId)).toBe("failed");
+    expect(store.states.get(ada.participantId)).toEqual({
+      participantId: ada.participantId,
+      lastSuccessfulSyncAt: previousSuccess,
+      profileSyncFailureCount: 1,
+      profileSyncRetryAt: new Date("2026-09-11T06:05:00Z"),
+    });
+    expect((await synchronizer.sync([ada])).get(ada.participantId)).toBe("backoff");
+    expect(store.attempts).toEqual([ada.participantId]);
+
+    now = new Date("2026-09-11T06:05:00Z");
+    store.fail.delete(ada.participantId);
+    expect((await synchronizer.sync([ada])).get(ada.participantId)).toBe("synced");
+    expect(store.states.get(ada.participantId)).toEqual({
+      participantId: ada.participantId,
+      lastSuccessfulSyncAt: now,
+      profileSyncFailureCount: 0,
+      profileSyncRetryAt: null,
+    });
+  });
+
+  it("fails open when freshness cannot be read and records a retry best-effort", async () => {
+    const now = new Date("2026-09-11T06:00:00Z");
+    const store = new ProfileStore(() => now);
+    store.getParticipantProfileSyncStates = async () => {
+      throw new Error("profile state unavailable");
+    };
+    const synchronizer = new LinkedInParticipantProfileSynchronizer(store, {
+      retryBaseMs: 5 * 60_000,
+      now: () => now,
+    });
+
+    await expect(synchronizer.sync([ada])).resolves.toEqual(
+      new Map([[ada.participantId, "failed"]]),
+    );
+    expect(store.writes).toEqual([]);
+    expect(store.states.get(ada.participantId)).toMatchObject({
+      lastSuccessfulSyncAt: null,
+      profileSyncFailureCount: 1,
+      profileSyncRetryAt: new Date("2026-09-11T06:05:00Z"),
+    });
+  });
+
+  it("caps exponential retry deadlines", async () => {
+    let now = new Date("2026-09-11T06:00:00Z");
+    const store = new ProfileStore(() => now);
+    store.fail.add(ada.participantId);
+    const synchronizer = new LinkedInParticipantProfileSynchronizer(store, {
+      retryBaseMs: 100,
+      retryMaxMs: 250,
+      now: () => now,
+    });
+
+    for (const expectedDelay of [100, 200, 250]) {
+      expect((await synchronizer.sync([ada])).get(ada.participantId)).toBe("failed");
+      const state = store.states.get(ada.participantId)!;
+      expect(state.profileSyncRetryAt!.getTime() - now.getTime()).toBe(expectedDelay);
+      now = state.profileSyncRetryAt!;
+    }
+  });
+});

--- a/packages/core/src/channels/linkedin-profile-sync.ts
+++ b/packages/core/src/channels/linkedin-profile-sync.ts
@@ -1,0 +1,153 @@
+import { createLogger } from "../logger.js";
+import type {
+  LinkedInParticipantInput,
+  LinkedInParticipantProfileSyncState,
+  LinkedInThreadParticipantInput,
+} from "./linkedin-sync.js";
+
+const log = createLogger("linkedin-profile-sync");
+
+export const DEFAULT_LINKEDIN_PROFILE_REFRESH_INTERVAL_MS = 24 * 60 * 60_000;
+export const DEFAULT_LINKEDIN_PROFILE_RETRY_BASE_MS = 5 * 60_000;
+export const DEFAULT_LINKEDIN_PROFILE_RETRY_MAX_MS = 6 * 60 * 60_000;
+
+export interface LinkedInParticipantProfileStore {
+  getParticipantProfileSyncStates(
+    participantIds: string[],
+  ): Promise<Map<string, LinkedInParticipantProfileSyncState>>;
+  upsertParticipantProfile(participant: LinkedInParticipantInput): Promise<void>;
+  recordParticipantProfileSyncFailure(
+    participant: LinkedInThreadParticipantInput,
+    failureCount: number,
+    retryAt: Date,
+  ): Promise<void>;
+}
+
+export interface LinkedInParticipantProfileSynchronizerOptions {
+  refreshIntervalMs?: number;
+  retryBaseMs?: number;
+  retryMaxMs?: number;
+  /** Test seam for freshness and retry deadlines. */
+  now?: () => Date;
+}
+
+export type LinkedInParticipantProfileSyncResult = "synced" | "fresh" | "backoff" | "failed";
+
+/**
+ * Account-scoped profile cache shared by every LinkedIn thread in this
+ * process. The durable store carries freshness across restarts; `inFlight`
+ * closes the smaller race where concurrent threads expose the same account.
+ * This consumes basic metadata already attached to messaging responses; it
+ * never calls LinkedIn's separate `contact-info` profile endpoint.
+ */
+export class LinkedInParticipantProfileSynchronizer {
+  private readonly refreshIntervalMs: number;
+  private readonly retryBaseMs: number;
+  private readonly retryMaxMs: number;
+  private readonly now: () => Date;
+  private readonly inFlight = new Map<string, Promise<LinkedInParticipantProfileSyncResult>>();
+
+  constructor(
+    private readonly store: LinkedInParticipantProfileStore,
+    opts: LinkedInParticipantProfileSynchronizerOptions = {},
+  ) {
+    this.refreshIntervalMs = opts.refreshIntervalMs ?? DEFAULT_LINKEDIN_PROFILE_REFRESH_INTERVAL_MS;
+    this.retryBaseMs = opts.retryBaseMs ?? DEFAULT_LINKEDIN_PROFILE_RETRY_BASE_MS;
+    this.retryMaxMs = opts.retryMaxMs ?? DEFAULT_LINKEDIN_PROFILE_RETRY_MAX_MS;
+    this.now = opts.now ?? (() => new Date());
+  }
+
+  async sync(
+    participants: LinkedInParticipantInput[],
+  ): Promise<Map<string, LinkedInParticipantProfileSyncResult>> {
+    const unique = new Map(
+      participants.map((participant) => [participant.participantId, participant]),
+    );
+    const entries = await Promise.all(
+      [...unique.values()].map(
+        async (participant) =>
+          [participant.participantId, await this.syncOne(participant)] as const,
+      ),
+    );
+    return new Map(entries);
+  }
+
+  private syncOne(
+    participant: LinkedInParticipantInput,
+  ): Promise<LinkedInParticipantProfileSyncResult> {
+    const existing = this.inFlight.get(participant.participantId);
+    if (existing) return existing;
+
+    const attempt = this.attempt(participant).finally(() => {
+      if (this.inFlight.get(participant.participantId) === attempt) {
+        this.inFlight.delete(participant.participantId);
+      }
+    });
+    this.inFlight.set(participant.participantId, attempt);
+    return attempt;
+  }
+
+  private async attempt(
+    participant: LinkedInParticipantInput,
+  ): Promise<LinkedInParticipantProfileSyncResult> {
+    const now = this.now();
+    let state: LinkedInParticipantProfileSyncState | undefined;
+    try {
+      state = (await this.store.getParticipantProfileSyncStates([participant.participantId])).get(
+        participant.participantId,
+      );
+    } catch (error) {
+      return this.handleFailure(participant, undefined, now, error);
+    }
+    if (state?.profileSyncRetryAt && state.profileSyncRetryAt.getTime() > now.getTime()) {
+      return "backoff";
+    }
+    if (
+      state?.lastSuccessfulSyncAt &&
+      now.getTime() - state.lastSuccessfulSyncAt.getTime() < this.refreshIntervalMs
+    ) {
+      return "fresh";
+    }
+
+    try {
+      await this.store.upsertParticipantProfile(participant);
+      return "synced";
+    } catch (error) {
+      return this.handleFailure(participant, state, now, error);
+    }
+  }
+
+  private async handleFailure(
+    participant: LinkedInParticipantInput,
+    state: LinkedInParticipantProfileSyncState | undefined,
+    now: Date,
+    error: unknown,
+  ): Promise<LinkedInParticipantProfileSyncResult> {
+    const failureCount = (state?.profileSyncFailureCount ?? 0) + 1;
+    const retryAt = new Date(now.getTime() + this.retryDelayMs(failureCount));
+    try {
+      await this.store.recordParticipantProfileSyncFailure(
+        { participantId: participant.participantId, isSelf: participant.isSelf },
+        failureCount,
+        retryAt,
+      );
+    } catch (recordError) {
+      log.warn("linkedin profile sync failure state could not be recorded", {
+        participantId: participant.participantId,
+        error: recordError instanceof Error ? recordError.message : String(recordError),
+      });
+    }
+    log.warn("linkedin participant profile sync failed", {
+      participantId: participant.participantId,
+      failureCount,
+      retryAt: retryAt.toISOString(),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return "failed";
+  }
+
+  private retryDelayMs(failureCount: number): number {
+    const exponent = Math.min(Math.max(0, failureCount - 1), 30);
+    return Math.min(this.retryMaxMs, this.retryBaseMs * 2 ** exponent);
+  }
+}

--- a/packages/core/src/channels/linkedin-sync.ts
+++ b/packages/core/src/channels/linkedin-sync.ts
@@ -61,6 +61,7 @@ export interface LinkedInParticipantInput {
   participantId: string;
   name?: string | null;
   headline?: string | null;
+  profileUrl?: string | null;
   /** `member` | `organization` | `agent` | `custom`. */
   type?: string | null;
   /**
@@ -71,6 +72,21 @@ export interface LinkedInParticipantInput {
    * its own viewer, so the producer can always answer.
    */
   isSelf: boolean;
+}
+
+/** The thread-scoped facts needed to replace authoritative membership. */
+export interface LinkedInThreadParticipantInput {
+  participantId: string;
+  /** Viewer-relative identity; kept current even when profile metadata is cached. */
+  isSelf: boolean;
+}
+
+/** Durable per-profile freshness and retry state. */
+export interface LinkedInParticipantProfileSyncState {
+  participantId: string;
+  lastSuccessfulSyncAt: Date | null;
+  profileSyncFailureCount: number;
+  profileSyncRetryAt: Date | null;
 }
 
 /** One participant of a thread, person-level facts folded in. */
@@ -88,6 +104,9 @@ export interface LinkedInThreadCursor {
   lastMessageAt: Date | null;
   lastMessagePreview: string | null;
   lastSyncedAt: Date | null;
+  /** The last authoritative membership read, or null when only message-derived
+   *  participant data is available. Profile freshness is stored per account. */
+  participantsLastReadAt: Date | null;
 }
 
 /** One mirrored message joined with its thread, for the history talk feature. */
@@ -125,7 +144,7 @@ export interface LinkedInSyncSink {
    *  never "unset what an earlier snapshot learned".
    *
    *  The snapshot's participant count is deliberately absent: how many people
-   *  are on a thread follows from the membership `upsertThreadParticipants`
+   *  are on a thread follows from the authoritative membership replacement
    *  stores, and a scalar copied off the snapshot could only disagree with it. */
   markThreadSynced(
     threadId: string,
@@ -138,17 +157,22 @@ export interface LinkedInSyncSink {
   ): Promise<void>;
   /** Mirrored history, newest last; `threadId: null` spans every thread. */
   fetchHistory?(threadId: string | null, since: Date): Promise<LinkedInHistoryMessage[]>;
-  /**
-   * Replace a thread's membership with exactly `participants` (an empty array
-   * empties the thread) and record that the membership was read just now.
-   *
-   * Optional, and the poller treats it as a capability probe: a sink that
-   * cannot store membership is never made to pay for the crawl that produces
-   * it.
-   */
-  upsertThreadParticipants?(
+  /** Replace authoritative thread membership without refreshing profile metadata. */
+  replaceThreadParticipantMembership?(
     threadId: string,
-    participants: LinkedInParticipantInput[],
+    participants: LinkedInThreadParticipantInput[],
+  ): Promise<void>;
+  /** Read profile freshness in one durable namespace shared by all threads. */
+  getParticipantProfileSyncStates?(
+    participantIds: string[],
+  ): Promise<Map<string, LinkedInParticipantProfileSyncState>>;
+  /** Persist one successful basic-profile sync and clear its retry state. */
+  upsertParticipantProfile?(participant: LinkedInParticipantInput): Promise<void>;
+  /** Persist a failed profile sync without advancing its last success. */
+  recordParticipantProfileSyncFailure?(
+    participant: LinkedInThreadParticipantInput,
+    failureCount: number,
+    retryAt: Date,
   ): Promise<void>;
   /**
    * Seed participants from messages the sink already holds — no opencli call.

--- a/packages/core/src/channels/linkedin.test.ts
+++ b/packages/core/src/channels/linkedin.test.ts
@@ -12,9 +12,11 @@ import { LinkedInStoreRepository } from "../db/repositories/linkedin-store.js";
 import type {
   LinkedInMessageInput,
   LinkedInParticipantInput,
+  LinkedInParticipantProfileSyncState,
   LinkedInSyncSink,
   LinkedInThreadCursor,
   LinkedInThreadInput,
+  LinkedInThreadParticipantInput,
 } from "./linkedin-sync.js";
 
 function ok(payload: unknown): OpencliResult {
@@ -95,16 +97,56 @@ function participantRow(threadId: string, participantId: string, overrides = {})
 
 /** A sink that can hold membership, unlike {@link FakeSink}. */
 class ParticipantSink extends FakeSink {
-  participantSets = new Map<string, LinkedInParticipantInput[]>();
+  participantSets = new Map<string, LinkedInThreadParticipantInput[]>();
   participantWrites: string[] = [];
+  profileStates = new Map<string, LinkedInParticipantProfileSyncState>();
+  profileWrites: LinkedInParticipantInput[] = [];
+  profileFailures = new Map<string, Error>();
   backfills = 0;
 
-  async upsertThreadParticipants(
+  async replaceThreadParticipantMembership(
     threadId: string,
-    participants: LinkedInParticipantInput[],
+    participants: LinkedInThreadParticipantInput[],
   ): Promise<void> {
     this.participantWrites.push(threadId);
     this.participantSets.set(threadId, participants);
+  }
+
+  async getParticipantProfileSyncStates(
+    participantIds: string[],
+  ): Promise<Map<string, LinkedInParticipantProfileSyncState>> {
+    return new Map(
+      participantIds.flatMap((id) => {
+        const state = this.profileStates.get(id);
+        return state ? [[id, state] as const] : [];
+      }),
+    );
+  }
+
+  async upsertParticipantProfile(participant: LinkedInParticipantInput): Promise<void> {
+    const failure = this.profileFailures.get(participant.participantId);
+    if (failure) throw failure;
+    this.profileWrites.push(participant);
+    this.profileStates.set(participant.participantId, {
+      participantId: participant.participantId,
+      lastSuccessfulSyncAt: new Date(),
+      profileSyncFailureCount: 0,
+      profileSyncRetryAt: null,
+    });
+  }
+
+  async recordParticipantProfileSyncFailure(
+    participant: LinkedInThreadParticipantInput,
+    failureCount: number,
+    retryAt: Date,
+  ): Promise<void> {
+    const previous = this.profileStates.get(participant.participantId);
+    this.profileStates.set(participant.participantId, {
+      participantId: participant.participantId,
+      lastSuccessfulSyncAt: previous?.lastSuccessfulSyncAt ?? null,
+      profileSyncFailureCount: failureCount,
+      profileSyncRetryAt: retryAt,
+    });
   }
 
   async backfillParticipantsFromMessages(): Promise<void> {
@@ -152,6 +194,7 @@ describe("threadNeedsSnapshot", () => {
     lastMessageAt: new Date("2026-08-19T20:00:00Z"),
     lastMessagePreview: "hello",
     lastSyncedAt: new Date("2026-08-19T20:01:00Z"),
+    participantsLastReadAt: null,
   };
 
   it("is stale when never seen or never snapshotted", () => {
@@ -207,6 +250,7 @@ describe("LinkedInInboxPoller.pollOnce", () => {
       lastMessageAt: new Date("2026-08-19T20:00:00.000Z"),
       lastMessagePreview: "hello",
       lastSyncedAt: new Date(),
+      participantsLastReadAt: null,
     });
     const run = rs.fn(async (args: string[]) => {
       if (args[1] === "inbox") return ok([inboxRow("t1", "2026-08-19T20:00:00.000Z")]);
@@ -273,10 +317,15 @@ describe("LinkedInInboxPoller participant sync", () => {
       expect.anything(),
     );
     expect(sink.participantSets.get("t1")).toEqual([
+      { participantId: "ACoAAAda0001", isSelf: false },
+      { participantId: "ACoAASelf0003", isSelf: true },
+    ]);
+    expect(sink.profileWrites).toEqual([
       {
         participantId: "ACoAAAda0001",
         name: "Ada",
         headline: "Engineer",
+        profileUrl: "https://www.linkedin.com/in/ACoAAAda0001/",
         type: "member",
         isSelf: false,
       },
@@ -284,6 +333,7 @@ describe("LinkedInInboxPoller participant sync", () => {
         participantId: "ACoAASelf0003",
         name: "Jane Doe",
         headline: "Engineer",
+        profileUrl: "https://www.linkedin.com/in/ACoAASelf0003/",
         type: "member",
         isSelf: true,
       },
@@ -315,7 +365,7 @@ describe("LinkedInInboxPoller participant sync", () => {
       participantRow("t1", "ACoAAGrace002", { participant_index: 2 }),
     ];
     const run = participantRun(() => members);
-    const poller = makePoller(sink, run);
+    const poller = makePoller(sink, run, { membershipRefreshIntervalMs: 0 });
 
     await poller.pollOnce();
     // Grace left, someone new joined; the thread is stale again next tick.
@@ -330,6 +380,147 @@ describe("LinkedInInboxPoller participant sync", () => {
       "ACoAAAda0001",
       "ACoAANew00004",
     ]);
+  });
+
+  it("does not re-read recent membership when a thread changes", async () => {
+    const sink = new ParticipantSink();
+    sink.cursors.set("t1", {
+      threadId: "t1",
+      lastMessageAt: new Date("2026-08-19T19:00:00.000Z"),
+      lastMessagePreview: "old",
+      lastSyncedAt: new Date("2026-08-19T19:01:00.000Z"),
+      participantsLastReadAt: new Date(),
+    });
+    const run = participantRun(() => [participantRow("t1", "ACoAAAda0001")]);
+
+    await makePoller(sink, run).pollOnce();
+
+    expect(run.mock.calls.map((c) => c[0][1])).toEqual(["inbox", "thread-snapshot"]);
+    expect(sink.participantWrites).toEqual([]);
+  });
+
+  it("refreshes membership after its check expires", async () => {
+    const sink = new ParticipantSink();
+    sink.cursors.set("t1", {
+      threadId: "t1",
+      lastMessageAt: new Date("2026-08-19T19:00:00.000Z"),
+      lastMessagePreview: "old",
+      lastSyncedAt: new Date("2026-08-19T19:01:00.000Z"),
+      participantsLastReadAt: new Date(0),
+    });
+    const run = participantRun(() => [participantRow("t1", "ACoAAAda0001")]);
+
+    await makePoller(sink, run).pollOnce();
+
+    expect(run.mock.calls.map((c) => c[0][1])).toEqual([
+      "inbox",
+      "thread-snapshot",
+      "thread-participants",
+    ]);
+    expect(sink.participantWrites).toEqual(["t1"]);
+  });
+
+  it("reuses one recent profile across authoritative reads of different threads", async () => {
+    const sink = new ParticipantSink();
+    const run = rs.fn(async (args: string[]) => {
+      if (args[1] === "inbox") {
+        return ok([
+          inboxRow("t1", "2026-08-19T20:00:00.000Z"),
+          inboxRow("t2", "2026-08-19T19:00:00.000Z"),
+        ]);
+      }
+      const threadId = args.join(" ").includes("/t2/") ? "t2" : "t1";
+      if (args[1] === "thread-participants") {
+        return ok([participantRow(threadId, "ACoAAAda0001")]);
+      }
+      return ok([snapshotRow(threadId, `m-${threadId}`)]);
+    });
+
+    await makePoller(sink, run, { membershipRefreshIntervalMs: 0 }).pollOnce();
+
+    expect(sink.participantWrites).toEqual(["t1", "t2"]);
+    expect(run.mock.calls.filter((call) => call[0][1] === "thread-participants")).toHaveLength(2);
+    expect(sink.profileWrites.map((profile) => profile.participantId)).toEqual(["ACoAAAda0001"]);
+  });
+
+  it("refreshes membership even when every returned profile is recent", async () => {
+    const sink = new ParticipantSink();
+    sink.profileStates.set("ACoAAAda0001", {
+      participantId: "ACoAAAda0001",
+      lastSuccessfulSyncAt: new Date(),
+      profileSyncFailureCount: 0,
+      profileSyncRetryAt: null,
+    });
+    const run = participantRun(() => [participantRow("t1", "ACoAAAda0001")]);
+
+    await makePoller(sink, run).pollOnce();
+
+    expect(sink.participantWrites).toEqual(["t1"]);
+    expect(sink.profileWrites).toEqual([]);
+  });
+
+  it("refreshes an expired message sender profile without re-reading recent membership", async () => {
+    const sink = new ParticipantSink();
+    sink.cursors.set("t1", {
+      threadId: "t1",
+      lastMessageAt: new Date("2026-08-19T19:00:00.000Z"),
+      lastMessagePreview: "old",
+      lastSyncedAt: new Date("2026-08-19T19:01:00.000Z"),
+      participantsLastReadAt: new Date(),
+    });
+    sink.profileStates.set("ACoAAAda0001", {
+      participantId: "ACoAAAda0001",
+      lastSuccessfulSyncAt: new Date(0),
+      profileSyncFailureCount: 0,
+      profileSyncRetryAt: null,
+    });
+    const run = rs.fn(async (args: string[]) => {
+      if (args[1] === "inbox") return ok([inboxRow("t1", "2026-08-19T20:00:00.000Z")]);
+      return ok([
+        {
+          ...snapshotRow("t1", "m1"),
+          sender_participant_id: "ACoAAAda0001",
+          sender_profile_url: "https://www.linkedin.com/in/ACoAAAda0001/",
+          sender_headline: "Engineer",
+          sender_type: "member",
+        },
+      ]);
+    });
+
+    await makePoller(sink, run).pollOnce();
+
+    expect(run.mock.calls.map((call) => call[0][1])).toEqual(["inbox", "thread-snapshot"]);
+    expect(sink.participantWrites).toEqual([]);
+    expect(sink.profileWrites.map((profile) => profile.participantId)).toEqual(["ACoAAAda0001"]);
+  });
+
+  it("keeps message and group-state sync when a profile update fails", async () => {
+    const sink = new ParticipantSink();
+    sink.profileFailures.set("ACoAAAda0001", new Error("profile write failed"));
+    const run = rs.fn(async (args: string[]) => {
+      if (args[1] === "inbox") return ok([inboxRow("t1", "2026-08-19T20:00:00.000Z")]);
+      if (args[1] === "thread-participants") return ok([participantRow("t1", "ACoAAAda0001")]);
+      return ok([
+        {
+          ...snapshotRow("t1", "m1"),
+          conversation_is_group: true,
+          sender_participant_id: "ACoAAAda0001",
+          sender_profile_url: "https://www.linkedin.com/in/ACoAAAda0001/",
+          sender_type: "member",
+        },
+      ]);
+    });
+
+    await expect(makePoller(sink, run).pollOnce()).resolves.toBeUndefined();
+
+    expect(sink.messages.map((message) => message.messageId)).toEqual(["m1"]);
+    expect(sink.syncedMeta.get("t1")?.isGroup).toBe(true);
+    expect(sink.participantWrites).toEqual(["t1"]);
+    expect(sink.profileStates.get("ACoAAAda0001")).toMatchObject({
+      lastSuccessfulSyncAt: null,
+      profileSyncFailureCount: 1,
+      profileSyncRetryAt: expect.any(Date),
+    });
   });
 
   it("does not crawl participants a sink cannot store", async () => {

--- a/packages/core/src/channels/linkedin.ts
+++ b/packages/core/src/channels/linkedin.ts
@@ -25,13 +25,23 @@ import {
   type LinkedInInboxRow,
   type RunOpencli,
 } from "./linkedin-cli.js";
-import type { LinkedInSyncSink, LinkedInThreadCursor } from "./linkedin-sync.js";
+import {
+  LinkedInParticipantProfileSynchronizer,
+  type LinkedInParticipantProfileSynchronizerOptions,
+} from "./linkedin-profile-sync.js";
+import {
+  linkedInMemberIdFromProfileUrl,
+  type LinkedInParticipantInput,
+  type LinkedInSyncSink,
+  type LinkedInThreadCursor,
+} from "./linkedin-sync.js";
 
 const log = createLogger("linkedin");
 
 const DEFAULT_INBOX_LIMIT = 40;
 const DEFAULT_THREAD_FETCH_LIMIT = 25;
 const DEFAULT_MAX_SNAPSHOTS_PER_TICK = 6;
+const DEFAULT_MEMBERSHIP_REFRESH_INTERVAL_MS = 60 * 60_000;
 const SNAPSHOT_TIMEOUT_MS = 240_000;
 /** One failed tick is routine (a Chrome restart, a slow page); the guardian is
  *  warned once failures look persistent. */
@@ -52,6 +62,10 @@ export interface LinkedInPollerOptions {
   inboxLimit?: number;
   threadFetchLimit?: number;
   maxSnapshotsPerTick?: number;
+  /** Minimum age of an authoritative membership read before refreshing it. */
+  membershipRefreshIntervalMs?: number;
+  /** Account-scoped profile freshness and retry policy. */
+  profileSync?: LinkedInParticipantProfileSynchronizerOptions;
   /** Test seam for the jitter draw. */
   random?: () => number;
 }
@@ -87,6 +101,8 @@ export class LinkedInInboxPoller {
   private readonly inboxLimit: number;
   private readonly threadFetchLimit: number;
   private readonly maxSnapshotsPerTick: number;
+  private readonly membershipRefreshIntervalMs: number;
+  private readonly profileSynchronizer: LinkedInParticipantProfileSynchronizer | null;
   private readonly random: () => number;
 
   private callbacks: LinkedInPollerCallbacks | null = null;
@@ -110,6 +126,22 @@ export class LinkedInInboxPoller {
     this.inboxLimit = opts.inboxLimit ?? DEFAULT_INBOX_LIMIT;
     this.threadFetchLimit = opts.threadFetchLimit ?? DEFAULT_THREAD_FETCH_LIMIT;
     this.maxSnapshotsPerTick = opts.maxSnapshotsPerTick ?? DEFAULT_MAX_SNAPSHOTS_PER_TICK;
+    this.membershipRefreshIntervalMs =
+      opts.membershipRefreshIntervalMs ?? DEFAULT_MEMBERSHIP_REFRESH_INTERVAL_MS;
+    const getStates = opts.sink.getParticipantProfileSyncStates?.bind(opts.sink);
+    const upsertProfile = opts.sink.upsertParticipantProfile?.bind(opts.sink);
+    const recordFailure = opts.sink.recordParticipantProfileSyncFailure?.bind(opts.sink);
+    this.profileSynchronizer =
+      getStates && upsertProfile && recordFailure
+        ? new LinkedInParticipantProfileSynchronizer(
+            {
+              getParticipantProfileSyncStates: getStates,
+              upsertParticipantProfile: upsertProfile,
+              recordParticipantProfileSyncFailure: recordFailure,
+            },
+            opts.profileSync,
+          )
+        : null;
     this.random = opts.random ?? Math.random;
   }
 
@@ -188,14 +220,18 @@ export class LinkedInInboxPoller {
 
     for (const row of batch) {
       if (this.stopped) return;
-      await this.snapshotThread(row, signal);
+      await this.snapshotThread(row, cursors.get(row.threadId), signal);
     }
     if (batch.length > 0) {
       log.info("linkedin threads synced", { threads: batch.length });
     }
   }
 
-  private async snapshotThread(row: LinkedInInboxRow, signal?: AbortSignal): Promise<void> {
+  private async snapshotThread(
+    row: LinkedInInboxRow,
+    cursor: LinkedInThreadCursor | undefined,
+    signal?: AbortSignal,
+  ): Promise<void> {
     const result = await this.run(
       [
         "linkedin",
@@ -230,7 +266,29 @@ export class LinkedInInboxPoller {
       conversationTitle: messages.find((m) => m.conversationTitle)?.conversationTitle ?? null,
       isGroup: messages.find((m) => m.conversationIsGroup != null)?.conversationIsGroup ?? null,
     });
-    await this.syncThreadParticipants(row, signal);
+    await this.syncMessageProfiles(messages);
+    await this.syncThreadParticipants(row, cursor, signal);
+  }
+
+  private async syncMessageProfiles(
+    messages: ReturnType<typeof parseThreadSnapshot>,
+  ): Promise<void> {
+    if (!this.profileSynchronizer) return;
+    const profiles: LinkedInParticipantInput[] = [];
+    for (const message of messages) {
+      const participantId =
+        message.senderParticipantId ?? linkedInMemberIdFromProfileUrl(message.senderProfileUrl);
+      if (!participantId) continue;
+      profiles.push({
+        participantId,
+        name: message.senderName,
+        headline: message.senderHeadline,
+        profileUrl: message.senderProfileUrl,
+        type: message.senderType,
+        isSelf: message.senderIsSelf,
+      });
+    }
+    await this.profileSynchronizer.sync(profiles);
   }
 
   /**
@@ -246,10 +304,23 @@ export class LinkedInInboxPoller {
    * already mirrored. A signed-out session is the exception: that is not a
    * per-thread hiccup, and the grant owner has to hear about it.
    */
-  private async syncThreadParticipants(row: LinkedInInboxRow, signal?: AbortSignal): Promise<void> {
-    const upsert = this.sink.upsertThreadParticipants?.bind(this.sink);
+  private async syncThreadParticipants(
+    row: LinkedInInboxRow,
+    cursor: LinkedInThreadCursor | undefined,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const replaceMembership = this.sink.replaceThreadParticipantMembership?.bind(this.sink);
     // No point paying for a crawl whose result nothing can store.
-    if (!upsert) return;
+    if (!replaceMembership) return;
+    // A snapshot refreshes the send-safety group verdict independently.
+    // Authoritative membership has its own thread-scoped clock, so one active
+    // conversation does not need a second page load for every message.
+    if (
+      cursor?.participantsLastReadAt &&
+      Date.now() - cursor.participantsLastReadAt.getTime() < this.membershipRefreshIntervalMs
+    ) {
+      return;
+    }
 
     let participants: ReturnType<typeof parseThreadParticipants>;
     try {
@@ -267,14 +338,21 @@ export class LinkedInInboxPoller {
       return;
     }
 
-    await upsert(
+    await replaceMembership(
       row.threadId,
       participants.map((p) => ({
         participantId: p.participantId,
-        name: p.name,
-        headline: p.headline,
-        type: p.type,
         isSelf: p.isSelf,
+      })),
+    );
+    await this.profileSynchronizer?.sync(
+      participants.map((participant) => ({
+        participantId: participant.participantId,
+        name: participant.name,
+        headline: participant.headline,
+        profileUrl: participant.profileUrl,
+        type: participant.type,
+        isSelf: participant.isSelf,
       })),
     );
   }

--- a/packages/core/src/db/repositories/linkedin-store.test.ts
+++ b/packages/core/src/db/repositories/linkedin-store.test.ts
@@ -38,6 +38,7 @@ describe("LinkedInStoreRepository", () => {
     expect(cursor?.lastMessageAt?.getTime()).toBe(at.getTime());
     expect(cursor?.lastMessagePreview).toBe("See you Sunday?");
     expect(cursor?.lastSyncedAt).toBeNull();
+    expect(cursor?.participantsLastReadAt).toBeNull();
   });
 
   describe("reply targets", () => {
@@ -289,6 +290,20 @@ describe("LinkedInStoreRepository", () => {
       expect(columns.map((c) => c.name)).toContain("participants_last_read_at");
     });
 
+    it("the migrations add durable per-profile sync and retry state", () => {
+      const columns = testDb.db.all(
+        sql`SELECT name FROM pragma_table_info('linkedin_participants')`,
+      ) as Array<{ name: string }>;
+      expect(columns.map((column) => column.name)).toEqual(
+        expect.arrayContaining([
+          "profile_url",
+          "last_successful_sync_at",
+          "profile_sync_failure_count",
+          "profile_sync_retry_at",
+        ]),
+      );
+    });
+
     it("upserting the same participant set twice leaves one row per participant", async () => {
       await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
       await repo.upsertThreadParticipants("t1", [ada, grace, self]);
@@ -459,6 +474,9 @@ describe("LinkedInStoreRepository", () => {
         // x.9s and stored as x.0s still lands inside it.
         expect(readAt).toBeGreaterThanOrEqual(Math.floor(before / 1000) * 1000);
         expect(readAt).toBeLessThanOrEqual(after);
+        expect(
+          (await repo.getThreadCursors(["t1"])).get("t1")?.participantsLastReadAt?.getTime(),
+        ).toBe(readAt);
       });
 
       it("a later read advances the last-read time", async () => {
@@ -492,6 +510,82 @@ describe("LinkedInStoreRepository", () => {
           self.participantId,
         ]);
         expect(set.lastReadAt).not.toBeNull();
+      });
+    });
+
+    describe("participant profile freshness", () => {
+      it("replaces membership without claiming that profile metadata was refreshed", async () => {
+        await repo.upsertThreads([thread("t1", new Date("2026-08-19T20:00:00Z"))]);
+
+        await repo.replaceThreadParticipantMembership("t1", [
+          { participantId: ada.participantId, isSelf: false },
+          { participantId: self.participantId, isSelf: true },
+        ]);
+
+        expect((await repo.getThreadParticipantSet("t1")).lastReadAt).not.toBeNull();
+        const states = await repo.getParticipantProfileSyncStates([
+          ada.participantId,
+          self.participantId,
+        ]);
+        expect(states.get(ada.participantId)).toMatchObject({
+          lastSuccessfulSyncAt: null,
+          profileSyncFailureCount: 0,
+          profileSyncRetryAt: null,
+        });
+        expect(states.get(self.participantId)?.lastSuccessfulSyncAt).toBeNull();
+      });
+
+      it("a successful profile sync stores metadata and clears prior backoff", async () => {
+        const retryAt = new Date("2026-09-12T06:00:00Z");
+        await repo.recordParticipantProfileSyncFailure(
+          { participantId: ada.participantId, isSelf: false },
+          3,
+          retryAt,
+        );
+
+        await repo.upsertParticipantProfile({
+          ...ada,
+          profileUrl: "https://www.linkedin.com/in/ACoAAAda0001/",
+        });
+
+        const state = (await repo.getParticipantProfileSyncStates([ada.participantId])).get(
+          ada.participantId,
+        );
+        expect(state?.lastSuccessfulSyncAt).not.toBeNull();
+        expect(state?.profileSyncFailureCount).toBe(0);
+        expect(state?.profileSyncRetryAt).toBeNull();
+        const rows = testDb.db.all(sql`
+          SELECT profile_url AS profileUrl
+          FROM linkedin_participants
+          WHERE participant_id = ${ada.participantId}
+        `) as Array<{ profileUrl: string | null }>;
+        expect(rows[0]?.profileUrl).toBe("https://www.linkedin.com/in/ACoAAAda0001/");
+      });
+
+      it("a failure preserves the last success and retry state across repository instances", async () => {
+        await repo.upsertParticipantProfile(ada);
+        const successfulAt = (await repo.getParticipantProfileSyncStates([ada.participantId])).get(
+          ada.participantId,
+        )?.lastSuccessfulSyncAt;
+        const retryAt = new Date("2026-09-12T06:00:00Z");
+
+        await repo.recordParticipantProfileSyncFailure(
+          { participantId: ada.participantId, isSelf: false },
+          2,
+          retryAt,
+        );
+
+        const recreated = new LinkedInStoreRepository(testDb.db);
+        expect(
+          (await recreated.getParticipantProfileSyncStates([ada.participantId])).get(
+            ada.participantId,
+          ),
+        ).toEqual({
+          participantId: ada.participantId,
+          lastSuccessfulSyncAt: successfulAt,
+          profileSyncFailureCount: 2,
+          profileSyncRetryAt: retryAt,
+        });
       });
     });
 

--- a/packages/core/src/db/repositories/linkedin-store.ts
+++ b/packages/core/src/db/repositories/linkedin-store.ts
@@ -11,11 +11,13 @@ import type {
   LinkedInHistoryMessage,
   LinkedInMessageInput,
   LinkedInParticipantInput,
+  LinkedInParticipantProfileSyncState,
   LinkedInParticipantRow,
   LinkedInReplyTarget,
   LinkedInSyncSink,
   LinkedInThreadCursor,
   LinkedInThreadInput,
+  LinkedInThreadParticipantInput,
 } from "../../channels/linkedin-sync.js";
 
 // The member-id form lives with the poller/store contract, not here: it is the
@@ -234,6 +236,7 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
           lastMessageAt: linkedinThreads.lastMessageAt,
           lastMessagePreview: linkedinThreads.lastMessagePreview,
           lastSyncedAt: linkedinThreads.lastSyncedAt,
+          participantsLastReadAt: linkedinThreads.participantsLastReadAt,
         })
         .from(linkedinThreads)
         .where(inArray(linkedinThreads.threadId, chunk));
@@ -290,59 +293,98 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
     threadId: string,
     participants: LinkedInParticipantInput[],
   ): Promise<void> {
+    await this.replaceThreadParticipants(threadId, participants, true);
+  }
+
+  /**
+   * Replace thread membership without treating the attached profile fields as
+   * freshly synchronized. The poller uses this path because relationship and
+   * profile freshness have separate clocks even though LinkedIn returns both
+   * in one conversation response.
+   */
+  async replaceThreadParticipantMembership(
+    threadId: string,
+    participants: LinkedInThreadParticipantInput[],
+  ): Promise<void> {
+    await this.replaceThreadParticipants(threadId, participants, false);
+  }
+
+  private async replaceThreadParticipants(
+    threadId: string,
+    participants: LinkedInThreadParticipantInput[],
+    refreshProfiles: boolean,
+  ): Promise<void> {
     const now = new Date();
-    // Snapshots have been seen to repeat an id; keep the last entry per id so
-    // the insert never conflicts with itself inside one statement.
     const unique = new Map(participants.map((p) => [p.participantId, p]));
     const ids = [...unique.keys()];
 
     await this.db.transaction((tx) => {
       for (const chunk of chunked([...unique.values()], UPSERT_CHUNK)) {
-        tx.insert(linkedinParticipants)
-          .values(
-            chunk.map((p) => ({
-              participantId: p.participantId,
-              name: p.name ?? null,
-              headline: p.headline ?? null,
-              type: p.type ?? null,
-              isSelf: p.isSelf,
-              firstSyncedAt: now,
-              updatedAt: now,
-            })),
-          )
-          // coalesce(excluded, existing) for the same reason as threads: a
-          // snapshot that omits a field never wipes one an earlier snapshot
-          // learned. `is_self` takes the new value verbatim because it
-          // describes the viewer rather than the snapshot, which is why the
-          // input type makes it required.
-          .onConflictDoUpdate({
-            target: linkedinParticipants.participantId,
-            set: {
-              name: sql`coalesce(excluded.name, name)`,
-              headline: sql`coalesce(excluded.headline, headline)`,
-              type: sql`coalesce(excluded.type, type)`,
-              isSelf: sql`excluded.is_self`,
-              updatedAt: sql`excluded.updated_at`,
-            },
-          })
-          .run();
+        if (refreshProfiles) {
+          const profiles = chunk as LinkedInParticipantInput[];
+          tx.insert(linkedinParticipants)
+            .values(
+              profiles.map((participant) => ({
+                participantId: participant.participantId,
+                name: participant.name ?? null,
+                headline: participant.headline ?? null,
+                profileUrl: participant.profileUrl ?? null,
+                type: participant.type ?? null,
+                isSelf: participant.isSelf,
+                lastSuccessfulSyncAt: now,
+                profileSyncFailureCount: 0,
+                profileSyncRetryAt: null,
+                firstSyncedAt: now,
+                updatedAt: now,
+              })),
+            )
+            .onConflictDoUpdate({
+              target: linkedinParticipants.participantId,
+              set: {
+                name: sql`coalesce(excluded.name, name)`,
+                headline: sql`coalesce(excluded.headline, headline)`,
+                profileUrl: sql`coalesce(excluded.profile_url, profile_url)`,
+                type: sql`coalesce(excluded.type, type)`,
+                isSelf: sql`excluded.is_self`,
+                lastSuccessfulSyncAt: sql`excluded.last_successful_sync_at`,
+                profileSyncFailureCount: 0,
+                profileSyncRetryAt: null,
+                updatedAt: sql`excluded.updated_at`,
+              },
+            })
+            .run();
+        } else {
+          tx.insert(linkedinParticipants)
+            .values(
+              chunk.map((participant) => ({
+                participantId: participant.participantId,
+                isSelf: participant.isSelf,
+                firstSyncedAt: now,
+                updatedAt: now,
+              })),
+            )
+            .onConflictDoUpdate({
+              target: linkedinParticipants.participantId,
+              set: {
+                isSelf: sql`excluded.is_self`,
+                updatedAt: sql`excluded.updated_at`,
+              },
+            })
+            .run();
+        }
 
         tx.insert(linkedinThreadParticipants)
           .values(
-            chunk.map((p) => ({
+            chunk.map((participant) => ({
               threadId,
-              participantId: p.participantId,
+              participantId: participant.participantId,
               firstSyncedAt: now,
             })),
           )
-          // Membership carries no mutable facts, so a re-snapshot is a no-op
-          // that preserves the original first-seen time.
           .onConflictDoNothing()
           .run();
       }
 
-      // Drop whoever left the thread. Deleting by "not in the new set" rather
-      // than clearing first keeps `first_synced_at` intact for those who stayed.
       tx.delete(linkedinThreadParticipants)
         .where(
           ids.length === 0
@@ -354,14 +396,92 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
         )
         .run();
 
-      // The membership is only as good as the read it came from, so the age of
-      // that read is stored with it. A no-op when the listing has not created
-      // the thread row yet — the next listing will.
       tx.update(linkedinThreads)
         .set({ participantsLastReadAt: now, updatedAt: now })
         .where(eq(linkedinThreads.threadId, threadId))
         .run();
     });
+  }
+
+  async getParticipantProfileSyncStates(
+    participantIds: string[],
+  ): Promise<Map<string, LinkedInParticipantProfileSyncState>> {
+    const states = new Map<string, LinkedInParticipantProfileSyncState>();
+    for (const chunk of chunked([...new Set(participantIds)], UPSERT_CHUNK)) {
+      const rows = await this.db
+        .select({
+          participantId: linkedinParticipants.participantId,
+          lastSuccessfulSyncAt: linkedinParticipants.lastSuccessfulSyncAt,
+          profileSyncFailureCount: linkedinParticipants.profileSyncFailureCount,
+          profileSyncRetryAt: linkedinParticipants.profileSyncRetryAt,
+        })
+        .from(linkedinParticipants)
+        .where(inArray(linkedinParticipants.participantId, chunk));
+      for (const row of rows) states.set(row.participantId, row);
+    }
+    return states;
+  }
+
+  /** A successful profile write advances freshness and clears its backoff. */
+  async upsertParticipantProfile(participant: LinkedInParticipantInput): Promise<void> {
+    const now = new Date();
+    await this.db
+      .insert(linkedinParticipants)
+      .values({
+        participantId: participant.participantId,
+        name: participant.name ?? null,
+        headline: participant.headline ?? null,
+        profileUrl: participant.profileUrl ?? null,
+        type: participant.type ?? null,
+        isSelf: participant.isSelf,
+        lastSuccessfulSyncAt: now,
+        profileSyncFailureCount: 0,
+        profileSyncRetryAt: null,
+        firstSyncedAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: linkedinParticipants.participantId,
+        set: {
+          name: sql`coalesce(excluded.name, name)`,
+          headline: sql`coalesce(excluded.headline, headline)`,
+          profileUrl: sql`coalesce(excluded.profile_url, profile_url)`,
+          type: sql`coalesce(excluded.type, type)`,
+          isSelf: sql`excluded.is_self`,
+          lastSuccessfulSyncAt: sql`excluded.last_successful_sync_at`,
+          profileSyncFailureCount: 0,
+          profileSyncRetryAt: null,
+          updatedAt: sql`excluded.updated_at`,
+        },
+      });
+  }
+
+  /** A failed profile write preserves the previous success timestamp. */
+  async recordParticipantProfileSyncFailure(
+    participant: LinkedInThreadParticipantInput,
+    failureCount: number,
+    retryAt: Date,
+  ): Promise<void> {
+    const now = new Date();
+    await this.db
+      .insert(linkedinParticipants)
+      .values({
+        participantId: participant.participantId,
+        isSelf: participant.isSelf,
+        profileSyncFailureCount: failureCount,
+        profileSyncRetryAt: retryAt,
+        firstSyncedAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: linkedinParticipants.participantId,
+        set: {
+          isSelf: sql`excluded.is_self`,
+          profileSyncFailureCount: failureCount,
+          profileSyncRetryAt: retryAt,
+          updatedAt: sql`excluded.updated_at`,
+        },
+      });
   }
 
   /**
@@ -423,6 +543,7 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
         participantId,
         name: (row.senderName as string | null) ?? null,
         headline: (row.senderHeadline as string | null) ?? null,
+        profileUrl: (row.senderProfileUrl as string | null) ?? null,
         type: (row.senderType as string | null) ?? null,
         isSelf: Boolean(row.senderIsSelf),
       });
@@ -438,6 +559,7 @@ export class LinkedInStoreRepository implements LinkedInSyncSink {
               participantId: p.participantId,
               name: p.name ?? null,
               headline: p.headline ?? null,
+              profileUrl: p.profileUrl ?? null,
               type: p.type ?? null,
               isSelf: p.isSelf,
               firstSyncedAt: now,

--- a/packages/core/src/db/schema/system.ts
+++ b/packages/core/src/db/schema/system.ts
@@ -315,10 +315,16 @@ export const linkedinParticipants = sqliteTable("linkedin_participants", {
   participantId: text("participant_id").primaryKey(),
   name: text("name"),
   headline: text("headline"),
+  profileUrl: text("profile_url"),
   // 'member' | 'organization' | 'agent' | 'custom', as the snapshot reports it.
   type: text("type"),
   // True for the account owner's own row in a thread's participant list.
   isSelf: integer("is_self", { mode: "boolean" }).notNull().default(false),
+  // Profile freshness is account-scoped rather than thread-scoped: the same
+  // LinkedIn account can appear in many conversations.
+  lastSuccessfulSyncAt: integer("last_successful_sync_at", { mode: "timestamp" }),
+  profileSyncFailureCount: integer("profile_sync_failure_count").notNull().default(0),
+  profileSyncRetryAt: integer("profile_sync_retry_at", { mode: "timestamp" }),
   firstSyncedAt: integer("first_synced_at", { mode: "timestamp" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });


### PR DESCRIPTION
## What this PR does

Every changed LinkedIn thread still requires a fresh `thread-snapshot` so message delivery and the snapshot-derived `isGroup` safety state remain immediate. The former implementation also treated each thread's participant read as proof that every returned profile was fresh, so the same person could be processed repeatedly across conversations.

This revision for Manager task `t-79ca7e57` separates two freshness domains:

- authoritative thread membership is refreshed per thread after one hour;
- basic participant profile metadata is refreshed per stable `participantId` after 24 hours, shared across threads and process restarts.

## Verified LinkedIn interface constraint

The implementation was checked against:

- `opencli-plugins/linkedin/thread-participants.js`
- `opencli-plugins/linkedin/thread-snapshot.js`
- `opencli-plugins/linkedin/thread-snapshot-helpers.mjs`

Both commands navigate to the same messaging conversation and consume LinkedIn conversation/message responses. The response couples authoritative participant references with basic profile metadata (`name`, `headline`, `type`, and `profile_url`); there is no relationship-only read to call instead. Accordingly, this PR separates relationship and profile freshness in Rome's persistence/processing layer rather than pretending the network interface is separable. It intentionally does not add `linkedin contact-info`, which is a different public-profile contact-information feature.

## Design and invariants

- Inbox diffing and `thread-snapshot` continue for every changed thread.
- Snapshot message writes and snapshot-derived `isGroup` updates happen before membership/profile refreshes and survive their failures.
- Membership has an independent per-thread timestamp. Missing, expired, and previously failed membership reads still issue `thread-participants`; a profile's freshness never stands in for verified membership.
- Basic profile freshness is persisted on `linkedin_participants` as `last_successful_sync_at`, so one recent success is reused across sessions and all threads containing that participant.
- Same-participant profile processing is coalesced with an in-flight map. Different participants proceed independently. Underlying thread reads are deliberately not merged because each establishes that thread's membership.
- Profile failure does not advance or erase the last successful timestamp. Failure count and next retry time are persisted independently.
- Retry uses exponential backoff from 5 minutes, capped at 6 hours. A successful retry resets failure state.
- Profile retries occur when a future changed snapshot or due membership response presents the participant; no new scheduler, inbox cadence, message scope, reply behavior, or deployment setting is introduced.

The one-hour membership and 24-hour basic-profile windows are conservative defaults: relationship changes that affect reply targeting are bounded more tightly, while metadata such as headline can be reused longer. Quiet conversations are only reconsidered when the existing polling flow sees them again.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm --filter @rome/core test:unit` — 390 files, 4,554 tests
- [x] `pnpm --filter @rome/core lint` — passes; one unrelated pre-existing warning in `src/apps/migrate-to-lockfile.ts`
- [x] `pnpm db:check`
- [x] `pnpm --filter @rome/core build`
- [x] `node --test opencli-plugins/linkedin/*.test.mjs` — 62 tests
- [x] Targeted LinkedIn/store/send-safety coverage — 5 files, 103 tests
- [ ] `pnpm dev:all` — Docker is unavailable in the worker environment

Coverage includes migration/persistence, cross-repository reuse, recent and expired profile state, relationship/profile independence, same-profile concurrency coalescing, different-profile concurrency, failure without success advancement, durable retry backoff and reset, message/group immediacy, participant replacement, and failure-not-dropping-message behavior.
