### PR TITLE
fix(browser): preserve sessions and keep the stealth guard running

### DIFF
--- a/scripts/docker/chrome-cdp-supervisor.test.ts
+++ b/scripts/docker/chrome-cdp-supervisor.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "@rstest/core";
 
@@ -48,6 +48,44 @@ async function waitForCount(path: string, minimum: number) {
 }
 
 describe("rome-start-chrome-cdp.sh", () => {
+  it("rejects a guard that exits before signaling readiness", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "rome-chrome-readiness-"));
+    tempDirs.push(tempDir);
+    makeExecutable(join(tempDir, "rome-apply-cdp-stealth.sh"), "#!/usr/bin/env bash\nexit 7\n");
+    const source = readFileSync(resolve(PROJECT_ROOT, SCRIPT_PATH), "utf8");
+    const startGuard = source.match(/^start_stealth_guard\(\) \{\n[\s\S]*?^}\n/m)?.[0];
+    expect(startGuard).toBeDefined();
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `
+info() { :; }
+err() { printf '%s\\n' "$*" >&2; }
+${startGuard?.replaceAll("/tmp/chrome-stealth.log", '"$TEST_STEALTH_LOG"')}
+start_stealth_guard
+`,
+      ],
+      {
+        encoding: "utf8",
+        timeout: 2_000,
+        env: {
+          ...process.env,
+          ENABLE_STEALTH: "1",
+          SCRIPT_DIR: tempDir,
+          TMPDIR: tempDir,
+          TEST_STEALTH_LOG: join(tempDir, "stealth.log"),
+          max_attempts: "3",
+        },
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("CDP stealth guard exited unexpectedly");
+  });
+
   it("restarts Chrome when the browser process exits", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "rome-chrome-supervisor-"));
     tempDirs.push(tempDir);

--- a/scripts/docker/fixtures/stealth-websocket.py
+++ b/scripts/docker/fixtures/stealth-websocket.py
@@ -1,0 +1,75 @@
+import json
+import os
+from pathlib import Path
+
+
+class WebSocketTimeoutException(Exception):
+    pass
+
+
+class Connection:
+    def __init__(self):
+        self.pending = []
+        self.commands = []
+        self.scenario = os.environ["CDP_SCENARIO"]
+        self.idle_reads = 0
+        self.new_page_sent = False
+
+    def attached(self, target_id, session_id, waiting=False):
+        return {
+            "method": "Target.attachedToTarget",
+            "params": {
+                "sessionId": session_id,
+                "targetInfo": {"targetId": target_id, "type": "page"},
+                "waitingForDebugger": waiting,
+            },
+        }
+
+    def send(self, raw):
+        message = json.loads(raw)
+        self.commands.append(message)
+        method = message["method"]
+        result = {}
+        if method == "Target.setAutoAttach" and self.scenario != "empty":
+            self.pending.append(self.attached("existing", "session-existing"))
+        elif method == "Target.getTargets":
+            result = {
+                "targetInfos": [] if self.scenario == "empty" else [
+                    {"targetId": "existing", "type": "page"}
+                ]
+            }
+        elif method == "Target.createTarget":
+            result = {"targetId": "created"}
+            self.pending.append(self.attached("created", "session-created", True))
+        elif method == "Target.attachToTarget":
+            result = {"sessionId": "session-manual"}
+            self.pending.append(self.attached(message["params"]["targetId"], "session-manual"))
+        elif (
+            self.scenario == "command-timeout"
+            and message.get("sessionId") == "session-new"
+            and method == "Emulation.setLocaleOverride"
+        ):
+            self.pending.append(WebSocketTimeoutException("CDP response timed out"))
+            return
+        self.pending.append({"id": message["id"], "result": result})
+
+    def recv(self):
+        if self.pending:
+            message = self.pending.pop(0)
+            if isinstance(message, Exception):
+                raise message
+            return json.dumps(message)
+        if self.scenario in {"idle", "command-timeout"} and self.idle_reads < 2:
+            self.idle_reads += 1
+            raise WebSocketTimeoutException("no browser events")
+        if not self.new_page_sent:
+            self.new_page_sent = True
+            return json.dumps(self.attached("new", "session-new", True))
+        return ""
+
+    def close(self):
+        Path(os.environ["CDP_TRACE_FILE"]).write_text(json.dumps(self.commands))
+
+
+def create_connection(url, timeout):
+    return Connection()

--- a/scripts/docker/rome-apply-cdp-stealth.sh
+++ b/scripts/docker/rome-apply-cdp-stealth.sh
@@ -321,6 +321,7 @@ def handle_event(message: dict) -> None:
 
 
 try:
+    # Auto-attach includes existing targets and emits the events that configure them.
     send(
         "Target.setAutoAttach",
         {
@@ -331,34 +332,18 @@ try:
     )
 
     targets = send("Target.getTargets", {}).get("result", {}).get("targetInfos", [])
-    page_targets = [target for target in targets if target.get("type") in {"page", "iframe"}]
-
-    if not any(target.get("type") == "page" for target in page_targets):
-        created_target_id = (
-            send("Target.createTarget", {"url": "about:blank"})
-            .get("result", {})
-            .get("targetId")
-        )
-        if created_target_id:
-            page_targets.append({"targetId": created_target_id, "type": "page"})
-
-    for target in page_targets:
-        target_id = target.get("targetId")
-        if not target_id:
-            continue
-        try:
-            response = send("Target.attachToTarget", {"targetId": target_id, "flatten": True})
-            session_id = response.get("result", {}).get("sessionId")
-            if session_id:
-                configure_target(session_id, target, False)
-        except Exception as exc:
-            log(f"failed to attach to {target.get('type', 'target')} {target_id}: {exc}")
+    if not any(target.get("type") == "page" for target in targets):
+        send("Target.createTarget", {"url": "about:blank"})
 
     set_ready()
     log("browser-level stealth guard active")
 
     while True:
-        raw = ws.recv()
+        try:
+            raw = ws.recv()
+        except websocket.WebSocketTimeoutException:
+            # Quiet browsers may emit no events. Command-response waits still time out.
+            continue
         if not raw:
             fail("browser CDP connection closed")
         handle_event(json.loads(raw))

--- a/scripts/docker/rome-apply-cdp-stealth.test.ts
+++ b/scripts/docker/rome-apply-cdp-stealth.test.ts
@@ -1,6 +1,7 @@
-import { readFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "@rstest/core";
 
@@ -8,9 +9,67 @@ const PROJECT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const SCRIPT_PATH = "scripts/docker/rome-apply-cdp-stealth.sh";
 const scriptSource = readFileSync(resolve(PROJECT_ROOT, SCRIPT_PATH), "utf8");
 const helperSource = scriptSource.match(/^get_ua_architecture\(\) \{\n[\s\S]*?^}\n/m)?.[0];
+const guardSource = scriptSource.match(/  python3 <<'PY'\n([\s\S]*)\nPY\s*$/)?.[1];
 
 if (!helperSource) {
   throw new Error("get_ua_architecture helper not found");
+}
+
+if (!guardSource) {
+  throw new Error("embedded CDP guard not found");
+}
+
+type CdpCommand = { method: string; sessionId?: string };
+
+function runGuard(scenario: "idle" | "command-timeout" | "existing" | "empty") {
+  const directory = mkdtempSync(join(tmpdir(), "rome-stealth-guard-"));
+  const traceFile = join(directory, "commands.json");
+  const readyFile = join(directory, "ready");
+  try {
+    copyFileSync(
+      resolve(PROJECT_ROOT, "scripts/docker/fixtures/stealth-websocket.py"),
+      join(directory, "websocket.py"),
+    );
+    // Postpone annotations so the container's Python code also runs under host Python 3.9.
+    const result = spawnSync(
+      "python3",
+      ["-c", `from __future__ import annotations\n${guardSource}`],
+      {
+        cwd: directory,
+        encoding: "utf8",
+        timeout: 2_000,
+        env: {
+          ...process.env,
+          PYTHONPATH: directory,
+          CDP_SCENARIO: scenario,
+          CDP_TRACE_FILE: traceFile,
+          BROWSER_WS: "ws://test.invalid/browser",
+          STEALTH_JS_FILE: resolve(PROJECT_ROOT, "scripts/docker/stealth-inject.js"),
+          READY_FILE: readyFile,
+          TIMEZONE: "America/Los_Angeles",
+          CHROME_LANG: "en-US",
+          CHROME_USER_AGENT: "TestChrome",
+          ACCEPT_LANG: "en-US,en;q=0.9",
+          STEALTH_LANGUAGES: '["en-US", "en"]',
+          UA_METADATA: '{"platform":"Linux"}',
+          GEO_PARAMS: '{"latitude":34,"longitude":-118,"accuracy":100}',
+        },
+      },
+    );
+    expect(result.error).toBeUndefined();
+    if (!existsSync(traceFile)) {
+      throw new Error(`CDP fixture did not finish: ${result.stderr}`);
+    }
+    return {
+      status: result.status,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      ready: existsSync(readyFile),
+      commands: JSON.parse(readFileSync(traceFile, "utf8")) as CdpCommand[],
+    };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 }
 
 function getUaArchitecture(source: string) {
@@ -44,5 +103,58 @@ describe("rome-apply-cdp-stealth.sh UA architecture", () => {
     expect(
       getUaArchitecture("Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 Chrome/133.0.0.0"),
     ).toBe("x86");
+  });
+});
+
+describe("rome-apply-cdp-stealth.sh guard lifecycle", () => {
+  it("handles a new tab after repeated idle timeouts and exits on disconnect", () => {
+    const result = runGuard("idle");
+
+    expect(result.ready).toBe(true);
+    expect(result.stdout).toContain("stealth configured for page new");
+    expect(result.commands).toContainEqual(
+      expect.objectContaining({
+        method: "Runtime.runIfWaitingForDebugger",
+        sessionId: "session-new",
+      }),
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("[stealth] browser CDP connection closed\n");
+  });
+
+  it("configures each existing tab once through automatic attachment", () => {
+    const result = runGuard("existing");
+
+    expect(result.stdout.match(/stealth configured for page existing/g)).toHaveLength(1);
+    expect(
+      result.commands.filter((command) => command.method === "Emulation.setLocaleOverride"),
+    ).toHaveLength(2);
+  });
+
+  it("configures and resumes the initial tab when the browser starts without pages", () => {
+    const result = runGuard("empty");
+
+    expect(result.ready).toBe(true);
+    expect(result.stdout.match(/stealth configured for page created/g)).toHaveLength(1);
+    expect(result.commands).toContainEqual(
+      expect.objectContaining({
+        method: "Runtime.runIfWaitingForDebugger",
+        sessionId: "session-created",
+      }),
+    );
+  });
+
+  it("reports a command timeout and still resumes the affected tab", () => {
+    const result = runGuard("command-timeout");
+
+    expect(result.stdout).toContain("stealth injection failed on page new: CDP response timed out");
+    expect(result.stdout).not.toContain("stealth configured for page new");
+    expect(result.commands).toContainEqual(
+      expect.objectContaining({
+        method: "Runtime.runIfWaitingForDebugger",
+        sessionId: "session-new",
+      }),
+    );
+    expect(result.stderr).toBe("[stealth] browser CDP connection closed\n");
   });
 });

--- a/scripts/docker/rome-start-chrome-cdp.sh
+++ b/scripts/docker/rome-start-chrome-cdp.sh
@@ -12,7 +12,7 @@ CHROME_USER_DATA_DIR="${ROME_CHROME_USER_DATA_DIR:-$HOME/.rome/chrome-profile}"
 # (which mounts $HOME/.rome): the cache is regenerable and, left in the profile,
 # grows to tens of GB and fills the host disk. Default to an ephemeral path on
 # the container's writable layer (wiped on recreate) and hard-cap its size.
-# Logins (cookies/localStorage) stay in CHROME_USER_DATA_DIR, so they persist.
+# Persistent cookies and localStorage stay in CHROME_USER_DATA_DIR.
 CHROME_DISK_CACHE_DIR="${ROME_CHROME_DISK_CACHE_DIR:-$HOME/chrome-cache}"
 CHROME_DISK_CACHE_SIZE="${ROME_CHROME_DISK_CACHE_SIZE:-536870912}"
 CHROME_WINDOW_SIZE="${ROME_CHROME_WINDOW_SIZE:-1280,800}"
@@ -129,6 +129,8 @@ chrome_args=(
   --no-first-run
   --no-default-browser-check
   --password-store=basic
+  # A persistent profile alone does not restore session cookies after a clean exit.
+  --restore-last-session
   "--user-data-dir=$CHROME_USER_DATA_DIR"
   "--disk-cache-dir=$CHROME_DISK_CACHE_DIR"
   "--disk-cache-size=$CHROME_DISK_CACHE_SIZE"
@@ -233,8 +235,9 @@ start_stealth_guard() {
   fi
 
   info "starting CDP stealth guard"
-  local stealth_ready_file stealth_script
-  stealth_ready_file="$(mktemp)"
+  local stealth_ready_dir stealth_ready_file stealth_script
+  stealth_ready_dir="$(mktemp -d)"
+  stealth_ready_file="$stealth_ready_dir/ready"
   stealth_script="$SCRIPT_DIR/rome-apply-cdp-stealth.sh"
   CDP_PORT="$CHROME_INTERNAL_PORT" \
     READY_FILE="$stealth_ready_file" \
@@ -248,12 +251,12 @@ start_stealth_guard() {
   local attempt=0
   while ((attempt < max_attempts)); do
     if [[ -f "$stealth_ready_file" ]]; then
-      rm -f "$stealth_ready_file"
+      rm -rf "$stealth_ready_dir"
       return 0
     fi
     if ! kill -0 "$STEALTH_PID" 2>/dev/null; then
       err "CDP stealth guard exited unexpectedly; see /tmp/chrome-stealth.log"
-      rm -f "$stealth_ready_file"
+      rm -rf "$stealth_ready_dir"
       return 1
     fi
     sleep 0.2
@@ -261,7 +264,7 @@ start_stealth_guard() {
   done
 
   err "CDP stealth guard did not become ready; see /tmp/chrome-stealth.log"
-  rm -f "$stealth_ready_file"
+  rm -rf "$stealth_ready_dir"
   return 1
 }
 


### PR DESCRIPTION
## What this PR does

Closing Chrome discards session-only site logins even when its profile survives. The CDP stealth guard also exits after five idle seconds. Duplicate attachments can fail locale setup, and the supervisor can report readiness before the guard starts.

Restore the last browser session, tolerate idle event timeouts, configure browser-level targets through automatic attachment, and wait for the guard to write its readiness signal.

This draft contains only a cherry-pick of `de8f8755e` (`fix(browser): preserve sessions and keep the stealth guard running`) onto current `main`. It provides an isolated comparison with #347.

## Design & Invariants

- Stealth remains enabled by default with the original browser identity overrides.
- Idle event timeouts do not terminate the guard. Command-response timeouts still report failures, and a disconnected browser ends the guard.
- Startup succeeds only after the guard signals readiness.

## Test plan

- [x] Verify that the branch adds exactly one commit and that its browser scripts match `de8f8755e` byte for byte.
- [x] `pnpm typecheck`
- [x] `pnpm test:unit`
- [x] Apply the first commit's launcher, guard, and original JavaScript payload to the local container and verify matching checksums.
- [x] Restart the container and confirm unchanged Delta login-cookie fingerprints.
- [x] Submit a fresh logged-in Delta search. Verify a new search key, uncached HTTP 200 responses, and rendered flights.
- [x] Close Chrome cleanly, confirm automatic restart, and submit another fresh logged-in search. The second search also generated a new key and returned uncached HTTP 200 responses.
- [x] Confirm `Rome started` and a healthy local container.
- [ ] `pnpm dev:all`: the existing host port 80 conflict between Rome and Traefik blocks this check.

Host checks used Node 24 because Nix is unavailable on the test host. Live results cover the existing signed-in profile and do not establish compatibility for every site or profile.

## Not in this PR

- Recursive iframe attachment from `592561210`, excluded for the requested first-commit comparison. The known OOPIF coverage gap remains.
- Native browser identity preservation from `7a74829d2`, excluded for the same comparison.

- Startup tab convergence: repeated restarts added blank tabs during the comparison. The launcher behavior is unchanged in this isolated commit.
