### PR TITLE
docs(coding): fail app verification when the manifest has no tagline

### DIFF
--- a/rome_apps/coding/src/skills/app_creation/SKILL.md
+++ b/rome_apps/coding/src/skills/app_creation/SKILL.md
@@ -99,8 +99,9 @@ Run `system:summon` with the `assistant:assistant` agent and tell it to load
 handoff: `appId`, absolute `$REPO`, artifact path, dashboard/API base URL if
 known, the original user intent, expected happy path, and safe sample inputs.
 The verifier must visit or probe the installed app at runtime and return a
-verdict with evidence, issues, gaps, and suggested extra checks. Include that
-verdict in the final handoff.
+verdict with evidence, issues, gaps, and suggested extra checks. It also fails
+an app whose manifest has no `tagline`, so fill that in before handing off.
+Include that verdict in the final handoff.
 
 ## After setup, before writing code
 

--- a/rome_apps/coding/src/skills/app_remix/SKILL.md
+++ b/rome_apps/coding/src/skills/app_remix/SKILL.md
@@ -146,6 +146,8 @@ source app id in code. Component ids and unrelated package metadata may stay sta
 names, agent names, skill names, and database
 namespaces must remain isolated from the installed source app.
 
+A remix is a new app, so give it its own `tagline` in `app.yaml` (one sentence, ≤ 80 chars / 40 CJK, benefit-first — see REFERENCE.md) even when the source had none; verification fails without it.
+
 Commit the requested change with its authoring note before installation.
 
 ## Install and verify

--- a/rome_apps/coding/src/skills/app_verification/SKILL.md
+++ b/rome_apps/coding/src/skills/app_verification/SKILL.md
@@ -70,9 +70,11 @@ From `<app-root>`:
 grep -n '^tagline:' .rome/artifact/app.yaml
 ```
 
-The installed manifest (the packed artifact, not the source file — a tagline added after the last install is not live) must carry a non-empty `tagline` — it is the only text the
-app's social share card shows and the `og:description` beside it; without one
-the card still renders (icon, name, link) but its description line is empty. A missing, empty, or still-placeholder tagline (the
+The installed manifest must carry a non-empty `tagline`: it is the only text
+the app's social share card shows and the `og:description` beside it; without
+one the card still renders (icon, name, link) but its description line is
+empty. Check the packed artifact, not the source file — a tagline added after
+the last install is not live. A missing, empty, or still-placeholder tagline (the
 scaffold's "One sentence for the share card", or any "<Name> in one sentence"-style
 stub) is a **fail**:
 report "add a one-sentence `tagline` to app.yaml and reinstall" so the creator

--- a/rome_apps/coding/src/skills/app_verification/SKILL.md
+++ b/rome_apps/coding/src/skills/app_verification/SKILL.md
@@ -62,6 +62,23 @@ and its absence means the app was never installed from this source root.
 If the app was changed after the last install, the verification fails: runtime
 behavior would not match source.
 
+### 1b. Share-card tagline
+
+From `<app-root>`:
+
+```sh
+grep -n '^tagline:' app.yaml
+```
+
+The manifest must carry a non-empty `tagline` — it is the only text the
+app's social share card shows and the `og:description` beside it; without one
+the card still renders (icon, name, link) but its description line is empty. A missing, empty, or still-placeholder tagline (the
+scaffold's commented-out example, or "<Name> in one sentence") is a **fail**:
+report "add a one-sentence `tagline` to app.yaml and reinstall" so the creator
+fills it in per [`app_creation/REFERENCE.md`](../app_creation/REFERENCE.md)
+(≤ 80 chars / 40 CJK, benefit-first, like an App Store subtitle). Length and
+line-count are enforced by the installer, so only presence needs checking.
+
 ### 2. Installed app visibility
 
 Visit the running Rome dashboard, using the base URL from the handoff or the

--- a/rome_apps/coding/src/skills/app_verification/SKILL.md
+++ b/rome_apps/coding/src/skills/app_verification/SKILL.md
@@ -67,13 +67,14 @@ behavior would not match source.
 From `<app-root>`:
 
 ```sh
-grep -n '^tagline:' app.yaml
+grep -n '^tagline:' .rome/artifact/app.yaml
 ```
 
-The manifest must carry a non-empty `tagline` — it is the only text the
+The installed manifest (the packed artifact, not the source file — a tagline added after the last install is not live) must carry a non-empty `tagline` — it is the only text the
 app's social share card shows and the `og:description` beside it; without one
 the card still renders (icon, name, link) but its description line is empty. A missing, empty, or still-placeholder tagline (the
-scaffold's commented-out example, or "<Name> in one sentence") is a **fail**:
+scaffold's "One sentence for the share card", or any "<Name> in one sentence"-style
+stub) is a **fail**:
 report "add a one-sentence `tagline` to app.yaml and reinstall" so the creator
 fills it in per [`app_creation/REFERENCE.md`](../app_creation/REFERENCE.md)
 (≤ 80 chars / 40 CJK, benefit-first, like an App Store subtitle). Length and

--- a/rome_apps/coding/src/skills/workflow_creation/SKILL.md
+++ b/rome_apps/coding/src/skills/workflow_creation/SKILL.md
@@ -43,7 +43,7 @@ Reach for `coding:app_creation` instead of this skill only when the thing needs 
 | Per-workflow (you edit) | Shell (template ships it; don't touch) |
 | --- | --- |
 | `src/workflow/definition.ts` — the `runWorkflow(input, ctx)` function | `src/workflow/context.ts` — the `WorkflowContext`/`Json` types the app owns |
-| `app.yaml` `description` + web nav labels | `src/actions/run/` — the run action (calls `runWorkflow`) |
+| `app.yaml` `description`, `tagline`, web nav labels | `src/actions/run/` — the run action (calls `runWorkflow`) |
 | `.rome_store/rome_store.yaml` + `README.md` store listing copy | `src/api/index.ts` — the `POST /run` trigger + `GET /runs` history feed |
 | `src/web/App.tsx` `COPY` block (title + run-button copy) | `src/web/App.tsx` body (incl. "Recent runs") + `styles.css` |
 | `src/assets/icon.svg` — replace the placeholder | `src/db/` — the `runs` history table, migrations, and repository |

--- a/rome_apps/coding/src/skills/workflow_creation/SKILL.md
+++ b/rome_apps/coding/src/skills/workflow_creation/SKILL.md
@@ -192,7 +192,7 @@ Build the workflow first; sort out connections after. Connection *status* (wheth
 
 A workflow is a real Rome app, so its UI follows app_creation's [`AUTHORING.md`](../app_creation/AUTHORING.md), not a workflow-only standard. The template owns the whole page (run button, "Recent runs", `styles.css`), so you author only three surfaces:
 
-- `app.yaml` — a one-line `description` plus `web.navLabel`/`displayName`.
+- `app.yaml` — a one-line `description`, `web.navLabel`/`displayName`, and a `tagline` (uncomment the scaffold line and write one sentence, ≤ 80 chars / 40 CJK, benefit-first — it is the share card's only description, see [`app_creation/REFERENCE.md`](../app_creation/REFERENCE.md)).
 - the `COPY` block (title, what-it-does, run-button verb, `needsInput`) in `src/web/App.tsx`.
 - `src/assets/icon.svg` — replace the template placeholder; never ship the generic glyph.
 
@@ -209,9 +209,10 @@ Hand back to **app_creation** for the tail: commit, then call `system:app_manage
 File edits alone are never a complete task — prove it works:
 
 1. **It builds and installs.** `pnpm build` succeeds and emits `dist/actions/run`, `dist/api`, and `dist/web`, and the install lands. This is the bar for "built" — it does not depend on any toolkit being connected.
-2. **A run returns a result.** `POST /api/apps/<appId>/run` with `{ "input": … }` (or `{}`) returns `{ "result": … }` — `runWorkflow`'s return value; the dashboard's "Run now" button shows the same. Run this once the workflow's toolkits are connected. If it needs a toolkit the guardian hasn't connected yet, `connector:connector_proxy` fails closed, so this smoke run is expected to fail until they connect — that's not a code bug; finish the connect step first, then run it.
+2. **The installed manifest has a tagline.** `grep -n '^tagline:' .rome/artifact/app.yaml` prints a real sentence, not the scaffold's commented line or its placeholder — a workflow is a shareable app and its card has no description without one.
+3. **A run returns a result.** `POST /api/apps/<appId>/run` with `{ "input": … }` (or `{}`) returns `{ "result": … }` — `runWorkflow`'s return value; the dashboard's "Run now" button shows the same. Run this once the workflow's toolkits are connected. If it needs a toolkit the guardian hasn't connected yet, `connector:connector_proxy` fails closed, so this smoke run is expected to fail until they connect — that's not a code bug; finish the connect step first, then run it.
 
-Unlike a full app, a workflow does not need the separate `coding:app_verification` pass — skip it. A workflow is one run action behind a template-shipped shell, so the two checks above are sufficient proof. Confirm them yourself, then report what you built; don't summon a verifier agent.
+Unlike a full app, a workflow does not need the separate `coding:app_verification` pass — skip it. A workflow is one run action behind a template-shipped shell, so the three checks above are sufficient proof. Confirm them yourself, then report what you built; don't summon a verifier agent.
 
 If the request implied a recurring trigger ("every morning", "weekly"), say so when you hand off — the workflow runs on demand now; scheduling it is a separate follow-up.
 


### PR DESCRIPTION
## What this PR does

#346 made `tagline` the only text on an app's share card, but nothing checks that a newly created app has one. This adds the check on both creation paths:

- `coding:app_verification` fails when the installed manifest (`.rome/artifact/app.yaml`, not the source file) has no non-empty, non-placeholder `tagline`, with the instruction to add one and reinstall. `coding:app_creation` names the check in its handoff.
- `coding:workflow_creation` lists `tagline` among the required manifest edits (table and step) and adds it to its own self-check — workflows skip the separate verifier but are shareable apps too.
- `coding:app_remix` tells the agent to give the remix its own `tagline` even when the source app had none, since it runs the same verifier.

Docs only; no code or schema change. Install is unaffected — length and single-line rules are already enforced by the installer, so these checks test presence only.

Refs #202.

## Test plan

- [x] All four skill files read end to end; new text follows each file's existing check layout and links to `app_creation/REFERENCE.md` for the writing rule
