### PR TITLE
feat(opencli): support multiple Google Flights airports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Test Google OpenCLI plugin
+        run: pnpm -C opencli-plugins/google test
       - name: Test Delta OpenCLI plugin
         run: pnpm -C opencli-plugins/delta test
       - name: Test United OpenCLI plugin

--- a/opencli-plugins/README.md
+++ b/opencli-plugins/README.md
@@ -257,6 +257,16 @@ The Google plugin adds a browser-backed, read-only flight search command. It acc
 codes, cities, or airport names, supports one-way and round-trip dates, cabin/passenger settings,
 and can filter or sort the returned flight choices without clicking into a booking flow.
 
+For multiple airports, pass comma-separated airport codes on either side, such as `SFO,OAK` and
+`IAH,HOU`. Lists accept up to seven distinct codes per side, ignore case and whitespace, and remove duplicates.
+A comma-separated argument that starts with a three-letter airport code uses list syntax. All entries must be airport codes.
+Single city and airport names remain supported, including city names with commas such as `Paris, France`.
+
+The command selects each airport through the Google Flights multi-airport picker and verifies the committed search after a reload.
+It fails if Google cannot select or retain an airport, rather than returning results for only part of the requested route.
+Google ranks the combined search. Filters, `--sort`, and `--limit` apply across the displayed choices, not separately to each airport pair.
+Each row retains its actual airport pair in `leg_route`. Google may show only a subset of available flights.
+
 One-way searches return complete one-way itinerary choices. For a round-trip search, Google first
 shows **outbound options only** and does not reveal the return choices until an outbound flight is
 selected. Accordingly, each row is labeled `result_type=outbound_option`: every `leg_*` field and
@@ -268,6 +278,9 @@ finalized round-trip itinerary; follow the returned Google Flights URL to select
 opencli google flights SFO LAX 2026-08-10 --return 2026-08-17 --limit 5
 opencli google flights "San Francisco" Tokyo 2026-09-08 --cabin business --sort price -f json
 opencli google flights JFK LHR 2026-10-01 --stops nonstop --max-price 900 --airline "Delta,Virgin"
+opencli google flights SFO,OAK IAH,HOU 2026-10-15 --sort price -f json
+opencli google flights SFO,OAK IAH,HOU 2026-10-15 --return 2026-10-20 --stops nonstop
+opencli google flights SFO IAH,HOU 2026-10-15 --limit 5
 ```
 
 ### Google Shopping

--- a/opencli-plugins/google/flight-airports.mjs
+++ b/opencli-plugins/google/flight-airports.mjs
@@ -1,0 +1,142 @@
+const AIRPORT_CODE = /^[a-z]{3}$/i;
+
+// A leading airport code opts into list syntax. Commas in city names remain text.
+export function parseFlightLocation(value, name) {
+  const text = String(value || "").trim();
+  if (!text) throw new Error(`${name} must not be empty`);
+  const parts = text.split(",").map((part) => part.trim());
+  if (parts.length === 1 || (parts[0] !== "" && !AIRPORT_CODE.test(parts[0]))) {
+    return { query: text, airports: null };
+  }
+  if (!parts.every((part) => AIRPORT_CODE.test(part))) {
+    throw new Error(
+      `${name} airport lists must contain only comma-separated three-letter airport codes`,
+    );
+  }
+  const airports = [...new Set(parts.map((part) => part.toUpperCase()))];
+  if (airports.length > 7) throw new Error(`${name} supports at most 7 distinct airports`);
+  return { query: airports[0], airports };
+}
+
+// Runs in the page. Keep every DOM dependency inside this function for OpenCLI serialization.
+export function flightAirportPicker({ side, action, code }) {
+  const visible = (element) =>
+    element &&
+    element.getClientRects().length > 0 &&
+    getComputedStyle(element).visibility !== "hidden";
+  const label = side === "origin" ? "Where from?" : "Where to?";
+  const dialog = document.querySelector(`[role="dialog"][aria-label="Enter your ${side}"]`);
+  const chips = () =>
+    Array.from(dialog?.querySelectorAll("div[data-code]") || []).filter((element) =>
+      element.querySelector('[aria-label="Remove"]'),
+    );
+  if (action === "read") {
+    return dialog ? chips().map((element) => element.getAttribute("data-code")) : null;
+  }
+  if (action === "open") {
+    const input = Array.from(document.querySelectorAll("input[aria-label]")).find(
+      (element) => element.getAttribute("aria-label").startsWith(label) && visible(element),
+    );
+    if (!input) return false;
+    input.click();
+    return true;
+  }
+  if (!visible(dialog)) return false;
+  if (action === "enable") {
+    const multiple = Array.from(dialog.querySelectorAll("button[aria-label]")).find(
+      (element) =>
+        element.getAttribute("aria-label").endsWith(", Select multiple airports") &&
+        visible(element),
+    );
+    if (multiple) multiple.click();
+    return visible(dialog.querySelector('button[aria-label="Done"]'));
+  }
+  if (action === "remove") {
+    const chip = chips().find((element) => element.getAttribute("data-code") === code);
+    if (!chip) return false;
+    chip.querySelector('[aria-label="Remove"]').click();
+    return true;
+  }
+  if (action === "type") {
+    const input = Array.from(dialog.querySelectorAll('input[role="combobox"]')).find(visible);
+    if (!input) return false;
+    input.value = code;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    return true;
+  }
+  if (action === "select") {
+    const option = Array.from(
+      dialog.querySelectorAll(
+        'li[data-type="1"][role="option"], li[data-type="1"][role="checkbox"]',
+      ),
+    ).find((element) => element.getAttribute("data-code") === code && visible(element));
+    if (!option) return false;
+    option.click();
+    return true;
+  }
+  if (action === "done") {
+    const done = dialog.querySelector('button[aria-label="Done"]');
+    if (!visible(done)) return false;
+    done.click();
+    return true;
+  }
+  throw new Error(`Unknown airport picker action: ${action}`);
+}
+
+function sameAirports(actual, expected) {
+  return (
+    actual && actual.length === expected.length && expected.every((code) => actual.includes(code))
+  );
+}
+
+export async function configureFlightAirports(page, selections) {
+  const step = (side, action, code) =>
+    page.evaluate(`(${flightAirportPicker.toString()})(${JSON.stringify({ side, action, code })})`);
+  const until = async (read, message) => {
+    for (let attempt = 0; attempt < 40; attempt++) {
+      if (await read()) return;
+      await page.wait(0.2);
+    }
+    throw new Error(message);
+  };
+  for (const [side, airports] of Object.entries(selections)) {
+    if (!airports) continue;
+    const failure = `Could not configure Google Flights ${side} airports: ${airports.join(",")}`;
+    await until(() => step(side, "open"), failure);
+    await until(() => step(side, "enable"), failure);
+    const selected = await step(side, "read");
+    if (!selected) throw new Error(failure);
+    for (const code of selected.filter((code) => !airports.includes(code))) {
+      if (!(await step(side, "remove", code))) throw new Error(failure);
+      await until(async () => !(await step(side, "read"))?.includes(code), failure);
+    }
+    for (const code of airports) {
+      if ((await step(side, "read"))?.includes(code)) continue;
+      if (!(await step(side, "type", code))) throw new Error(failure);
+      await until(
+        () => step(side, "select", code),
+        `${failure}. Airport ${code} was not selectable`,
+      );
+      await until(async () => (await step(side, "read"))?.includes(code), failure);
+    }
+    await until(async () => sameAirports(await step(side, "read"), airports), failure);
+    // Done changes the search URL. Submit separately from waits in the page context.
+    if (!(await step(side, "done"))) throw new Error(failure);
+    await page.wait(0.5);
+  }
+}
+
+// Check the committed, reloaded search, not the transient chips in an open picker.
+export async function verifyFlightAirports(page, selections) {
+  for (const [side, airports] of Object.entries(selections)) {
+    if (!airports) continue;
+    const actual = await page.evaluate(
+      `(${flightAirportPicker.toString()})(${JSON.stringify({ side, action: "read" })})`,
+    );
+    if (!sameAirports(actual, airports)) {
+      throw new Error(
+        `Google Flights did not retain the requested ${side} airports: ${airports.join(",")}`,
+      );
+    }
+  }
+}

--- a/opencli-plugins/google/flight-airports.test.mjs
+++ b/opencli-plugins/google/flight-airports.test.mjs
@@ -1,0 +1,379 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import { FLIGHT_PRICE_PATTERN_SOURCE } from "./flight-labels.mjs";
+import { createRequire } from "node:module";
+import test from "node:test";
+import {
+  configureFlightAirports,
+  flightAirportPicker,
+  parseFlightLocation,
+  verifyFlightAirports,
+} from "./flight-airports.mjs";
+
+const { JSDOM } = createRequire(new URL("../../packages/web/package.json", import.meta.url))(
+  "jsdom",
+);
+
+for (const value of [
+  "SFO",
+  "sfo",
+  "San Francisco",
+  "San Francisco International Airport",
+  "Paris, France",
+  "New York, USA",
+]) {
+  test(`preserves single-location input: ${value}`, () => {
+    assert.deepEqual(parseFlightLocation(` ${value} `, "from"), { query: value, airports: null });
+  });
+}
+
+test("normalizes lists, deduplicates codes, and seeds only the first airport", () => {
+  assert.deepEqual(parseFlightLocation(" sfo, OAK,sfo ", "from"), {
+    query: "SFO",
+    airports: ["SFO", "OAK"],
+  });
+  assert.deepEqual(parseFlightLocation("iah,HOU", "to"), {
+    query: "IAH",
+    airports: ["IAH", "HOU"],
+  });
+  assert.deepEqual(parseFlightLocation("sfo,SFO", "from"), { query: "SFO", airports: ["SFO"] });
+});
+
+for (const value of [
+  "",
+  " ",
+  "SFO,",
+  ",SFO",
+  "SFO,,OAK",
+  "SFO,Oakland",
+  "SFO,O4K",
+  "SFO,<script>",
+  "SFO,OAK,SJC,LAX,JFK,EWR,LGA,BOS",
+]) {
+  test(`rejects an empty location or malformed airport list: ${value}`, () => {
+    assert.throws(() => parseFlightLocation(value, "to"), /to /);
+  });
+}
+
+test("allows seven distinct airports after deduplication", () => {
+  assert.equal(parseFlightLocation("SFO,OAK,SJC,LAX,JFK,EWR,LGA,SFO", "from").airports.length, 7);
+});
+
+// Minimal DOM from the live picker contract: chip divs, exact data-code/data-type suggestions,
+// and checkbox roles after multi-select hydrates (option roles during the transition).
+function browser({
+  role = "checkbox",
+  missing,
+  extra = [],
+  drop,
+  selectionDelay = 2,
+  suggestionDelay = 2,
+} = {}) {
+  const dom = new JSDOM('<html lang="en"><body></body></html>', { runScripts: "outside-only" });
+  const { window } = dom;
+  window.HTMLElement.prototype.getClientRects = function () {
+    for (let element = this; element; element = element.parentElement) {
+      if (element.hidden || window.getComputedStyle(element).display === "none") return [];
+    }
+    return [{}];
+  };
+  const calls = [];
+  let tick = 0;
+  const pending = [];
+  const later = (delay, fn) => pending.push({ time: tick + delay, fn });
+  for (const [side, initial] of [
+    ["origin", "SFO"],
+    ["destination", "IAH"],
+  ]) {
+    const label = side === "origin" ? "Where from?" : "Where to?";
+    const title = side === "origin" ? "Origin" : "Destination";
+    const root = window.document.createElement("section");
+    root.innerHTML = `<input aria-label="${label} Test ${initial}">
+      <div role="dialog" aria-label="Enter your ${side}" hidden>
+        <div class="chips" role="listbox"></div><input role="combobox" aria-label="Where else?">
+        <button aria-label="${title}, Select multiple airports"></button>
+        <button aria-label="Done" hidden></button><ul class="suggestions"></ul>
+      </div>`;
+    window.document.body.append(root);
+    const dialog = root.querySelector('[role="dialog"]');
+    const chips = dialog.querySelector(".chips");
+    const addChip = (code) => {
+      const chip = window.document.createElement("div");
+      chip.dataset.code = code;
+      chip.innerHTML = `<div role="option">${code}</div><div role="button" aria-label="Remove"></div>`;
+      chip.querySelector('[aria-label="Remove"]').onclick = () => chip.remove();
+      chips.append(chip);
+    };
+    for (const code of [initial, ...(side === "origin" ? extra : [])]) addChip(code);
+    root.querySelector("input").onclick = () => {
+      dialog.hidden = false;
+    };
+    const multiple = dialog.querySelector("button");
+    const done = dialog.querySelector('[aria-label="Done"]');
+    multiple.onclick = () => {
+      multiple.hidden = true;
+      done.hidden = false;
+    };
+    done.onclick = () => {
+      calls.push(["done", side]);
+      const url = new window.URL(window.location.href);
+      url.searchParams.set(side, [...chips.children].map((chip) => chip.dataset.code).join(","));
+      window.history.replaceState(null, "", url);
+      dialog.hidden = true;
+    };
+    dialog.querySelector("input").oninput = (event) => {
+      const code = event.target.value;
+      calls.push(["type", side, code]);
+      const suggestions = dialog.querySelector(".suggestions");
+      suggestions.innerHTML = "";
+      later(suggestionDelay, () => {
+        // A city and a hidden airport with the same code must not be selected.
+        suggestions.innerHTML = `<li role="${role}" data-type="3" data-code="${code}">City</li>
+          <li role="${role}" data-type="1" data-code="${code}" hidden>Hidden airport</li>`;
+        for (const bad of suggestions.children)
+          bad.onclick = () => {
+            throw new Error("selected a city or hidden option");
+          };
+        if (missing === code) return;
+        const option = window.document.createElement("li");
+        option.setAttribute("role", role);
+        option.dataset.type = "1";
+        option.dataset.code = code;
+        option.onclick = () => {
+          calls.push(["select", side, code]);
+          if (drop !== code) later(selectionDelay, () => addChip(code));
+        };
+        suggestions.append(option);
+      });
+    };
+  }
+  const page = {
+    async evaluate(script) {
+      return JSON.parse(JSON.stringify(window.eval(script)));
+    },
+    async wait() {
+      tick++;
+      const ready = pending.filter((job) => job.time <= tick);
+      for (const job of ready) {
+        pending.splice(pending.indexOf(job), 1);
+        job.fn();
+      }
+    },
+  };
+  return { dom, page, calls, close: () => dom.window.close() };
+}
+
+for (const role of ["checkbox", "option"]) {
+  test(`configures both lists with delayed ${role} suggestions and verifies the closed pickers`, async () => {
+    const b = browser({ role, extra: ["SJC"] });
+    try {
+      const selections = { origin: ["SFO", "OAK"], destination: ["IAH", "HOU"] };
+      await configureFlightAirports(b.page, selections);
+      await verifyFlightAirports(b.page, selections);
+      assert.deepEqual(b.calls, [
+        ["type", "origin", "OAK"],
+        ["select", "origin", "OAK"],
+        ["done", "origin"],
+        ["type", "destination", "HOU"],
+        ["select", "destination", "HOU"],
+        ["done", "destination"],
+      ]);
+      assert.equal(b.dom.window.document.querySelector('[data-code="SJC"]'), null);
+    } finally {
+      b.close();
+    }
+  });
+}
+
+for (const side of ["origin", "destination"]) {
+  test(`supports a list on only the ${side} side`, async () => {
+    const b = browser();
+    try {
+      const selections = {
+        origin: null,
+        destination: null,
+        [side]: side === "origin" ? ["SFO", "OAK"] : ["IAH", "HOU"],
+      };
+      await configureFlightAirports(b.page, selections);
+      await verifyFlightAirports(b.page, selections);
+      assert.ok(b.calls.every((call) => call[1] === side));
+    } finally {
+      b.close();
+    }
+  });
+}
+
+test("single-location searches do not touch the airport UI", async () => {
+  const page = {
+    evaluate() {
+      throw new Error("unexpected browser call");
+    },
+  };
+  await configureFlightAirports(page, { origin: null, destination: null });
+  await verifyFlightAirports(page, { origin: null, destination: null });
+});
+
+for (const options of [{ missing: "OAK" }, { drop: "OAK" }]) {
+  test(`fails closed when an airport cannot be selected: ${JSON.stringify(options)}`, async () => {
+    const b = browser(options);
+    try {
+      await assert.rejects(
+        configureFlightAirports(b.page, { origin: ["SFO", "OAK"] }),
+        /origin airports: SFO,OAK/,
+      );
+      assert.equal(b.calls.filter((call) => call[0] === "done").length, 0);
+    } finally {
+      b.close();
+    }
+  });
+}
+
+test("rejects a narrowed, expanded, or missing committed selection", async () => {
+  const b = browser();
+  try {
+    await assert.rejects(
+      verifyFlightAirports(b.page, { origin: ["SFO", "OAK"] }),
+      /did not retain/,
+    );
+    await assert.rejects(verifyFlightAirports(b.page, { origin: [] }), /did not retain/);
+    b.dom.window.document.querySelector('[aria-label="Enter your origin"]').remove();
+    await assert.rejects(verifyFlightAirports(b.page, { origin: ["SFO"] }), /did not retain/);
+  } finally {
+    b.close();
+  }
+});
+
+test("missing picker controls time out instead of returning partial-route results", async () => {
+  const b = browser();
+  try {
+    b.dom.window.document.body.innerHTML = "Consent required";
+    await assert.rejects(
+      configureFlightAirports(b.page, { origin: ["SFO", "OAK"] }),
+      /Could not configure/,
+    );
+  } finally {
+    b.close();
+  }
+});
+
+test("picker helpers serialize without module closures", () => {
+  const b = browser();
+  try {
+    assert.deepEqual(
+      JSON.parse(
+        JSON.stringify(
+          b.dom.window.eval(`(${flightAirportPicker})({side:'origin',action:'read'})`),
+        ),
+      ),
+      ["SFO"],
+    );
+  } finally {
+    b.close();
+  }
+});
+
+function commandFixture(options = {}) {
+  const b = browser(options);
+  let command;
+  const source = readFileSync(new URL("./flights.js", import.meta.url), "utf8").replace(
+    /^import[\s\S]*?from "[^"]+";\n/gm,
+    "",
+  );
+  vm.runInNewContext(source, {
+    cli: (definition) => {
+      command = definition;
+    },
+    Strategy: { PUBLIC: "public" },
+    CommandExecutionError: Error,
+    FLIGHT_PRICE_PATTERN_SOURCE,
+    configureFlightAirports,
+    parseFlightLocation,
+    verifyFlightAirports,
+    URL,
+  });
+  const defaults = Object.fromEntries(
+    command.args.filter((arg) => arg.default !== undefined).map((arg) => [arg.name, arg.default]),
+  );
+  const navigations = [];
+  const extractions = [];
+  const page = {
+    ...b.page,
+    async goto(url) {
+      navigations.push(url);
+      b.dom.reconfigure({ url });
+      if (options.narrowOnReload && navigations.length > 1) {
+        b.dom.window.document.querySelector('.chips [data-code="OAK"]')?.remove();
+      }
+    },
+    async evaluate(script) {
+      if (script.includes("var cards =")) {
+        extractions.push({ script, navigations: [...navigations] });
+        return { available: 1, items: [{ leg_route: "OAK–HOU" }] };
+      }
+      return b.page.evaluate(script);
+    },
+  };
+  return {
+    ...b,
+    navigations,
+    extractions,
+    run: (args) => command.func(page, { ...defaults, depart: "2026-10-15", ...args }),
+  };
+}
+
+for (const returnDate of [undefined, "2026-10-20"]) {
+  test(`command reloads the combined route before extraction (${returnDate ? "round trip" : "one way"})`, async () => {
+    const b = commandFixture();
+    try {
+      await b.run({ from: "sfo,OAK", to: "iah,HOU", return: returnDate });
+      assert.equal(b.navigations.length, 2);
+      const query = new URL(b.navigations[0]).searchParams.get("q");
+      assert.ok(query.includes("from SFO to IAH"));
+      assert.ok(!query.includes(","));
+      assert.equal(query.includes("through 2026-10-20"), Boolean(returnDate));
+      const committed = new URL(b.navigations[1]);
+      assert.equal(committed.searchParams.get("origin"), "SFO,OAK");
+      assert.equal(committed.searchParams.get("destination"), "IAH,HOU");
+      assert.equal(b.extractions.length, 1);
+      assert.equal(b.extractions[0].navigations.length, 2);
+      assert.ok(b.extractions[0].script.includes(`"roundTrip":${Boolean(returnDate)}`));
+    } finally {
+      b.close();
+    }
+  });
+}
+
+test("command fails before extracting when Google narrows the committed route", async () => {
+  const b = commandFixture({ narrowOnReload: true });
+  try {
+    await assert.rejects(b.run({ from: "SFO,OAK", to: "IAH,HOU" }), /did not retain/);
+    assert.equal(b.extractions.length, 0);
+  } finally {
+    b.close();
+  }
+});
+
+test("command rejects malformed lists before navigation", async () => {
+  const b = commandFixture();
+  try {
+    await assert.rejects(b.run({ from: "SFO,,OAK", to: "IAH" }), /comma-separated/);
+    assert.equal(b.navigations.length, 0);
+  } finally {
+    b.close();
+  }
+});
+
+test("single-location command keeps its natural-language URL and avoids the picker", async () => {
+  const b = commandFixture();
+  try {
+    await b.run({ from: "Paris, France", to: "Tokyo" });
+    assert.equal(b.navigations.length, 1);
+    assert.ok(
+      new URL(b.navigations[0]).searchParams.get("q").includes("from Paris, France to Tokyo"),
+    );
+    assert.equal(b.calls.length, 0);
+  } finally {
+    b.close();
+  }
+});

--- a/opencli-plugins/google/flights.js
+++ b/opencli-plugins/google/flights.js
@@ -1,5 +1,10 @@
 import { CommandExecutionError } from "@jackwener/opencli/errors";
 import { cli, Strategy } from "@jackwener/opencli/registry";
+import {
+  configureFlightAirports,
+  parseFlightLocation,
+  verifyFlightAirports,
+} from "./flight-airports.mjs";
 import { FLIGHT_PRICE_PATTERN_SOURCE } from "./flight-labels.mjs";
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
@@ -185,14 +190,14 @@ cli({
       type: "string",
       positional: true,
       required: true,
-      help: "Origin airport code, city, or airport name",
+      help: "Origin airport code, city, airport name, or comma-separated airport codes (SFO,OAK)",
     },
     {
       name: "to",
       type: "string",
       positional: true,
       required: true,
-      help: "Destination airport code, city, or airport name",
+      help: "Destination airport code, city, airport name, or comma-separated airport codes (IAH,HOU)",
     },
     {
       name: "depart",
@@ -294,10 +299,21 @@ cli({
   func: async (page, kwargs) => {
     if (!page) throw new CommandExecutionError("Browser session required for google flights");
 
-    const origin = String(kwargs.from || "").trim();
-    const destination = String(kwargs.to || "").trim();
-    if (!origin) throw new CommandExecutionError("from must not be empty");
-    if (!destination) throw new CommandExecutionError("to must not be empty");
+    let originLocation;
+    let destinationLocation;
+    try {
+      originLocation = parseFlightLocation(kwargs.from, "from");
+      destinationLocation = parseFlightLocation(kwargs.to, "to");
+    } catch (error) {
+      throw new CommandExecutionError(error.message);
+    }
+    const origin = originLocation.query;
+    const destination = destinationLocation.query;
+    const airportSelections = {
+      origin: originLocation.airports,
+      destination: destinationLocation.airports,
+    };
+    const hasAirportLists = Boolean(originLocation.airports || destinationLocation.airports);
 
     const departDate = validateDate(String(kwargs.depart || ""), "depart");
     const returnDate = kwargs.return ? validateDate(String(kwargs.return), "return") : null;
@@ -342,6 +358,17 @@ cli({
     // discard locale parameters. Reapply them before using English aria-label
     // prose or English passenger/cabin controls, then verify the rendered locale.
     await normalizeFlightLocale(page, searchUrl.toString(), currency, region);
+    if (hasAirportLists) {
+      try {
+        await configureFlightAirports(page, airportSelections);
+        // A fresh load prevents the initial single-airport cards from leaking into the combined search.
+        await page.goto(await page.evaluate("window.location.href"));
+        await normalizeFlightLocale(page, searchUrl.toString(), currency, region);
+        await verifyFlightAirports(page, airportSelections);
+      } catch (error) {
+        throw new CommandExecutionError(error.message);
+      }
+    }
     try {
       await page.wait({
         selector: 'li.pIav2d [role="link"][aria-label]',

--- a/opencli-plugins/google/package.json
+++ b/opencli-plugins/google/package.json
@@ -4,6 +4,6 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "test": "../../scripts/test-env.sh node --test flight-labels.test.mjs jobs-helpers.test.mjs maps-helpers.test.mjs shopping-helpers.test.mjs"
+    "test": "../../scripts/test-env.sh node --test flight-labels.test.mjs flight-airports.test.mjs jobs-helpers.test.mjs maps-helpers.test.mjs shopping-helpers.test.mjs"
   }
 }


### PR DESCRIPTION
## What this PR does

Google Flights accepts only a natural-language origin and destination query, so `SFO,OAK` to `IAH,HOU` does not reliably select all requested airports.

This adds comma-separated airport lists on either side, with examples in the [Google Flights command reference](opencli-plugins/README.md#google-flights). Codes ignore case and whitespace, deduplicate, and allow up to seven distinct airports per side. A list starts with a three-letter airport code. Single city and airport names keep their natural-language search path.

## Design & Invariants

- Use the rendered Google Flights multi-airport picker to select exact airport codes, rather than depend on natural-language parsing or an undocumented URL encoding.
- Keep one native combined search rather than merge four independent searches. Google ranks the combined results, and the existing filters, sort, and limit operate across the displayed choices. `leg_route` identifies each actual airport pair.
- Verify the exact selected airport sets, commit each picker, reload the resulting URL, and verify the persisted selections before extracting flights. Missing controls, unavailable airports, or narrowed selections fail rather than return partial-route results.
- Preserve the existing round-trip contract: rows describe outbound options, and prices are starting round-trip totals before return selection.
- Cover checkbox and transitional option suggestion roles, delayed suggestions and chip updates, hidden duplicates, city suggestions, malformed input, and command ordering. The Google plugin test suite now runs in CI alongside the airline plugins.

## Test plan

- [x] `pnpm -C opencli-plugins/google test` — 67 passing tests, including 32 new parser, DOM, and command integration tests
- [x] Biome check on `opencli-plugins/google`, `node --check` on the changed command/helper, and `git diff --check`
- [x] Live CLI: `google flights SFO,OAK IAH,HOU 2026-10-15 --sort price --limit 5` — combined canonical URL and sorted results spanning SFO–IAH, OAK–IAH, and OAK–HOU
- [x] Live CLI: same route with `--return 2026-10-20 --adults 2 --cabin business --stops nonstop --sort price --limit 5` — correct outbound price scope and both airport sets retained. Browser inspection confirmed both dates, two passengers, and Business
- [x] Live CLI: destination-only list `SFO IAH,HOU` and single-airport regression `SFO IAH`
- [ ] Full repo `pnpm typecheck` and `pnpm test:unit` — attempted, blocked by missing workspace dependencies (`tsc` and `rstest`). Nix is unavailable in this container
- [ ] `pnpm dev:all` — attempted, blocked by an unreachable Docker daemon

## Not in this PR

- Multiple free-text city names in one list — exact airport codes avoid ambiguous place resolution
- Exhaustive flight enumeration or return-flight selection — the command keeps the existing displayed-choice and outbound-option contracts
