### PR TITLE
feat(opencli): add American Airlines cash and miles flight search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
         run: pnpm -C opencli-plugins/delta test
       - name: Test United OpenCLI plugin
         run: pnpm -C opencli-plugins/united test
+      - name: Test American Airlines OpenCLI plugin
+        run: pnpm -C opencli-plugins/aa test
       - name: Test Southwest OpenCLI plugin
         run: pnpm -C opencli-plugins/southwest test
       - run: pnpm lint

--- a/opencli-plugins/README.md
+++ b/opencli-plugins/README.md
@@ -53,6 +53,10 @@ Agents pick up new/changed commands automatically: the `browser-automation` skil
 
 ## Rome-owned commands
 
+- `opencli aa flights FROM TO DEPART [--return DATE] [--miles]` — searches American Airlines cash fares
+  or AAdvantage awards, with separate award taxes, fare and stop filters, and explicit per-passenger price scope.
+  See the [American Airlines command reference](aa/README.md) for examples and browser requirements.
+
 - `opencli southwest flights FROM TO DEPART [--return DATE] [--miles]` — searches Southwest cash fares
   or Rapid Rewards points, with separate award taxes, fare-product and stop filters, and per-person, each-way prices.
   `--points` also selects award pricing. See the [Southwest command reference](southwest/README.md) for examples and browser requirements.

--- a/opencli-plugins/aa/README.md
+++ b/opencli-plugins/aa/README.md
@@ -1,0 +1,99 @@
+# American Airlines flights
+
+```bash
+opencli aa flights FROM TO YYYY-MM-DD [--return YYYY-MM-DD] [--miles]
+```
+
+Search aa.com for cash fares or AAdvantage awards. Use three-letter airport codes and travel dates.
+The command reads displayed results and does not select flights, reserve tickets, or spend money or miles.
+
+```bash
+opencli aa flights SFO DFW 2026-11-13 --sort price -f json
+opencli aa flights SFO DFW 2026-11-13 --miles --fare main --max-miles 30000 --stops nonstop
+opencli aa flights JFK LHR 2026-11-13 --return 2026-11-20 --adults 2 --miles --fare business -f json
+opencli aa flights JFK LHR 2026-11-13 --return 2026-11-20 --fare premium --max-price 6000
+opencli aa flights LAX MIA 2026-11-13 --stops one-or-fewer --max-duration 600 --sort departure --limit 10
+```
+
+## Search conditions
+
+| Option | Meaning |
+| --- | --- |
+| `--return DATE` | Round-trip search. Results describe outbound choices, with starting round-trip prices |
+| `--miles` | AAdvantage award pricing instead of cash |
+| `--adults N` | 1–9 adult passengers. Default: 1 |
+| `--fare NAME` | Exact displayed fare group or cabin. Default: `all` |
+| `--stops TYPE` | `any`, `nonstop`, `one-or-fewer`, or `two-or-fewer` |
+| `--max-price USD` | Per-person displayed cash price ceiling. Cash searches only |
+| `--max-miles N` | Per-person displayed miles ceiling. Requires `--miles` |
+| `--max-duration N` | Outbound duration ceiling, in minutes |
+| `--sort TYPE` | `best` preserves AA order. Also accepts `price`, `duration`, and `departure` |
+| `--limit N` | 1–500 fare rows after filtering and sorting. Default: 20 |
+| `--timeout N` | Result-loading deadline of 5–180 seconds. Default: 90 |
+
+Cash fare filters are `main`, `main-extra`, `premium-economy`, and `premium`.
+AA groups cash Business and First fares under Premium. The command does not infer a specific cabin from that group.
+Award cabin filters are `main`, `premium-economy`, `business`, and `first`.
+An unavailable fare or a filter with no matching offers produces no row.
+
+Fare, stop, price, and duration filters apply locally to the displayed results, before sorting and limiting.
+AA can limit or rank the displayed flights. This command does not claim to search every possible itinerary.
+`displayed_flight_count` records the result count supplied by AA, not the number of returned fare rows.
+Award price sorting compares miles first, then the cash taxes and charges.
+
+## Price and itinerary scope
+
+Each available cash fare group or award cabin produces one row per flight choice.
+
+- `price` is the displayed USD cash fare. It is null for awards.
+- `miles` is the displayed award amount as an integer. For example, `32.5K` becomes `32500`.
+- `taxes` is the separate cash component displayed with an award, including any carrier charges. It is not another mileage price.
+- Cash rows have `taxes=null`. The result page does not itemize cash-fare taxes separately.
+- `price_display` preserves the original amount and cash component, without adding precision to rounded site prices.
+- Prices remain **per passenger**, even with `--adults 2` or more. The command does not multiply them into a party total.
+- Cash rows carry `fare_kind=fare_group_minimum`, not a specific ticket product selected from the fare drawer.
+
+For one-way cash searches, `price_basis=per_person_one_way_starting` marks a fare-group minimum.
+One-way award offers use `price_basis=per_person_one_way`.
+
+For round trips, AA displays a round-trip price before the return flight is selected.
+Rows use `result_type=outbound_option` and `price_basis=per_person_round_trip_starting_total_return_not_selected`.
+Flight numbers, dates, times, duration, and stops describe **only the outbound itinerary**.
+The price is a starting round-trip quote, not an outbound-only charge or a finalized round-trip ticket.
+Open `search_url` to select flights and confirm the final price.
+
+Departure and arrival clocks use airport-local time, in 24-hour format.
+Arrival dates apply the day offset shown by AA, including overnight and international date-line changes.
+`segments` preserves the displayed flight numbers, aircraft, and operating-carrier notices.
+`search_url` recreates the search without including AA search-session identifiers.
+
+## Browser requirements
+
+Use an English-US aa.com session and a desktop browser at least 1024 pixels wide.
+Both cash and award searches worked while signed out during validation.
+If AA requires a login or presents an access challenge, resolve it in the browser and retry.
+The command reports the failure instead of returning cash results for an award request.
+It does not read or modify cookies, tokens, or authentication storage.
+
+The loader verifies the rendered route, dates, adult count, trip type, and miles checkbox.
+It waits for a stable result set that matches AA's displayed count.
+Missing fields, altered searches, incomplete results, expired sessions, and unrecognized prices fail instead of producing partial prices.
+AA can block repeated searches. Avoid rapid retries after an access-denied response.
+
+For local CDP development:
+
+```bash
+opencli plugin install /absolute/path/to/opencli-plugins/aa
+opencli --cdp-endpoint http://127.0.0.1:9222 aa flights SFO DFW 2026-11-13 --miles -f json
+pnpm -C opencli-plugins/aa test
+```
+
+## Fixtures
+
+The four fixture pairs contain sanitized result-page fragments captured on 2026-09-11.
+They cover SFO–DFW one-way cash and miles, plus JFK–LHR round-trip cash and miles for two adults.
+Each HTML fixture retains five flight choices and adjusts its displayed count to five.
+Headers, selected search fields, flight cards, and prices remain. Account data, scripts, SVGs, and search-session identifiers are absent.
+
+The test suite covers the pure parser, serialized DOM reader, loading state machine, and command registration.
+DOM tests use the existing web workspace's jsdom development dependency. The plugin has no runtime dependencies beyond OpenCLI.

--- a/opencli-plugins/aa/aa-browser.mjs
+++ b/opencli-plugins/aa/aa-browser.mjs
@@ -1,0 +1,60 @@
+import { assertSearchPage, buildSearchUrl } from "./aa-helpers.mjs";
+import { readAaPage } from "./aa-page.mjs";
+
+export class AaLoginRequiredError extends Error {}
+
+/** Reads a fresh search without selecting a fare, accessing auth storage, or creating a booking. */
+export async function loadAaFlights(page, search, { now = Date.now } = {}) {
+  const deadline = now() + search.timeout * 1000;
+  await page.goto("about:blank");
+  await page.goto(buildSearchUrl(search));
+  let previous = "";
+  let expected = null;
+  while (now() <= deadline) {
+    let data;
+    try {
+      data = await page.evaluate(readAaPage);
+    } catch (error) {
+      if (
+        !/execution context was destroyed|cannot find context with specified id/i.test(
+          error.message,
+        )
+      )
+        throw error;
+      previous = "";
+      await page.wait({ time: 1 });
+      continue;
+    }
+    if (data.challenge)
+      throw new Error("AA served an access challenge. Resolve it in the browser, then retry");
+    if (data.login_required)
+      throw new AaLoginRequiredError(
+        "Log in to aa.com in this browser, then retry. Cash fares will not be substituted for miles",
+      );
+    if (data.expired)
+      throw new Error("AA's search session expired. Retry the command to start a new search");
+    if (data.error && !data.no_results)
+      throw new Error(`AA could not complete the search: ${data.error}`);
+    if (data.ready && Number.isInteger(data.expected_count))
+      expected = Math.max(expected ?? 0, data.expected_count);
+    if (data.ready && !data.loading) {
+      const complete =
+        expected !== null && data.rows.length === expected && (expected > 0 || data.no_results);
+      // AA mounts the results grid before its date controls finish hydrating.
+      const hydrated =
+        data.search?.depart &&
+        data.search?.date_label &&
+        (!search.returnDate || data.search?.return_date);
+      const signature = complete && hydrated ? JSON.stringify(data) : "";
+      if (signature && signature === previous) {
+        assertSearchPage(data, search);
+        return { ...data, expected_count: expected };
+      }
+      previous = signature;
+    } else previous = "";
+    await page.wait({ time: 1 });
+  }
+  throw new Error(
+    `AA did not finish loading the displayed flights within ${search.timeout}s. Retry or increase --timeout. No partial prices were returned`,
+  );
+}

--- a/opencli-plugins/aa/aa-browser.test.mjs
+++ b/opencli-plugins/aa/aa-browser.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AaLoginRequiredError, loadAaFlights } from "./aa-browser.mjs";
+import { buildSearchUrl } from "./aa-helpers.mjs";
+import { fixture, mockPage, searchFor } from "./test-fixtures.mjs";
+
+test("navigates fresh and waits for a stable complete result set", async () => {
+  const d = fixture();
+  const p = mockPage([
+    { ...d, ready: false },
+    { ...d, loading: true },
+    { ...d, rows: d.rows.slice(0, 2) },
+    d,
+  ]);
+  assert.deepEqual(await loadAaFlights(p, searchFor(), { now: p.now }), d);
+  assert.deepEqual(p.urls, ["about:blank", buildSearchUrl(searchFor())]);
+  assert.ok(p.now() >= 4000);
+});
+for (const [key, pattern] of [
+  ["challenge", /challenge/],
+  ["expired", /expired/],
+  ["login_required", /Log in/],
+  ["error", /could not complete/],
+])
+  test(`fails on ${key}`, async () => {
+    const p = mockPage([{ ...fixture(), [key]: true }]);
+    await assert.rejects(loadAaFlights(p, searchFor(), { now: p.now }), pattern);
+  });
+test("login errors are distinguishable and never trigger cash fallback", async () => {
+  const p = mockPage([{ ...fixture(), login_required: true }]);
+  await assert.rejects(loadAaFlights(p, searchFor("award"), { now: p.now }), AaLoginRequiredError);
+  assert.equal(p.urls.length, 2);
+  assert.ok(p.urls[1].includes("searchType=Award"));
+});
+test("remembers the highest expected count across a count regression", async () => {
+  const d = fixture();
+  const p = mockPage([d, { ...d, expected_count: 2, rows: d.rows.slice(0, 2) }]);
+  await assert.rejects(
+    loadAaFlights(p, searchFor("cash", { timeout: 5 }), { now: p.now }),
+    /No partial/,
+  );
+});
+test("never emits a stable partial page", async () => {
+  const d = fixture();
+  const p = mockPage([{ ...d, rows: d.rows.slice(0, 1) }]);
+  await assert.rejects(
+    loadAaFlights(p, searchFor("cash", { timeout: 5 }), { now: p.now }),
+    /No partial/,
+  );
+});
+test("does not equate a transient zero result count with no availability", async () => {
+  const p = mockPage([{ ...fixture(), rows: [], expected_count: 0 }]);
+  await assert.rejects(
+    loadAaFlights(p, searchFor("cash", { timeout: 5 }), { now: p.now }),
+    /No partial/,
+  );
+});
+test("waits for stable explicitly empty results", async () => {
+  const d = { ...fixture(), rows: [], expected_count: 0, no_results: true };
+  const p = mockPage([d]);
+  assert.deepEqual(await loadAaFlights(p, searchFor(), { now: p.now }), d);
+});
+test("rejects stale search conditions before returning fares", async () => {
+  const d = fixture();
+  d.search.miles = true;
+  const p = mockPage([d]);
+  await assert.rejects(loadAaFlights(p, searchFor(), { now: p.now }), /miles/);
+});
+
+test("waits for date hydration even when the grid is mounted and complete", async () => {
+  const d = fixture("round-award");
+  const early = structuredClone(d);
+  early.search.depart = "";
+  early.search.return_date = "";
+  const p = mockPage([early, early, d]);
+  assert.deepEqual(await loadAaFlights(p, searchFor("round-award"), { now: p.now }), d);
+  assert.ok(p.now() >= 3000);
+});
+test("retries transient navigation context destruction, not arbitrary evaluate failures", async () => {
+  const p = mockPage([fixture()]);
+  const read = p.evaluate;
+  let first = true;
+  p.evaluate = async (fn) => {
+    if (first) {
+      first = false;
+      throw new Error("Execution context was destroyed");
+    }
+    return read(fn);
+  };
+  assert.equal((await loadAaFlights(p, searchFor(), { now: p.now })).rows.length, 5);
+  p.evaluate = async () => {
+    throw new Error("unexpected exception");
+  };
+  await assert.rejects(loadAaFlights(p, searchFor(), { now: p.now }), /unexpected exception/);
+});

--- a/opencli-plugins/aa/aa-command.test.mjs
+++ b/opencli-plugins/aa/aa-command.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { registerHooks } from "node:module";
+import test from "node:test";
+import { argsFor, fixture, mockPage } from "./test-fixtures.mjs";
+
+const registryUrl = `data:text/javascript,${encodeURIComponent(`
+export const Strategy={COOKIE:'cookie'};
+export let command;
+export function cli(definition){command=definition;}
+`)}`;
+const errorsUrl = `data:text/javascript,${encodeURIComponent(`
+export class ArgumentError extends Error {}
+export class CommandExecutionError extends Error {}
+export class AuthRequiredError extends Error {constructor(domain,message){super(message);this.domain=domain;}}
+`)}`;
+const hooks = registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === "@jackwener/opencli/registry")
+      return { url: registryUrl, shortCircuit: true };
+    if (specifier === "@jackwener/opencli/errors") return { url: errorsUrl, shortCircuit: true };
+    return nextResolve(specifier, context);
+  },
+});
+let command;
+try {
+  await import("./flights.js");
+  ({ command } = await import(registryUrl));
+} finally {
+  hooks.deregister();
+}
+const args = argsFor();
+test("registers a read-only persistent browser command", () => {
+  assert.equal(command.site, "aa");
+  assert.equal(command.name, "flights");
+  assert.equal(command.access, "read");
+  assert.equal(command.strategy, "cookie");
+  assert.equal(command.siteSession, "persistent");
+  assert.equal(command.browser, true);
+  assert.equal(command.navigateBefore, false);
+  for (const name of ["miles", "max-miles", "return", "adults", "fare", "stops"])
+    assert.ok(command.args.some((a) => a.name === name));
+});
+for (const mode of ["cash", "award", "round-cash", "round-award"])
+  test(`executes ${mode}`, async () => {
+    const rows = await command.func(mockPage([fixture(mode)]), argsFor(mode));
+    assert.ok(rows.length > 0);
+    assert.equal(rows[0].pricing, mode.includes("award") ? "miles" : "cash");
+  });
+test("bad arguments fail before navigation", async () => {
+  const page = {
+    async goto() {
+      assert.fail("must not navigate");
+    },
+  };
+  await assert.rejects(
+    command.func(page, { ...args, depart: "2026-02-30" }),
+    (e) => e.constructor.name === "ArgumentError",
+  );
+});
+test("missing browser and provider failures are typed", async () => {
+  await assert.rejects(command.func(null, args), /Browser session required/);
+  await assert.rejects(
+    command.func(mockPage([{ ...fixture(), challenge: true }]), args),
+    (e) => e.constructor.name === "CommandExecutionError",
+  );
+  await assert.rejects(
+    command.func(mockPage([{ ...fixture(), login_required: true }]), args),
+    (e) => e.constructor.name === "AuthRequiredError" && e.domain === "aa.com",
+  );
+});

--- a/opencli-plugins/aa/aa-dom.test.mjs
+++ b/opencli-plugins/aa/aa-dom.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import test from "node:test";
+import { readAaPage } from "./aa-page.mjs";
+import { normalizeResults } from "./aa-helpers.mjs";
+import { fixture, searchFor } from "./test-fixtures.mjs";
+
+// The web test workspace owns jsdom. AA has no runtime dependencies.
+const { JSDOM } = createRequire(new URL("../../packages/web/package.json", import.meta.url))(
+  "jsdom",
+);
+function makeDom(mode = "cash") {
+  const dom = new JSDOM(readFileSync(new URL(`./fixtures/${mode}.html`, import.meta.url), "utf8"), {
+    url: "https://www.aa.com/booking/choose-flights/1",
+    runScripts: "outside-only",
+  });
+  const { window: w } = dom;
+  w.HTMLElement.prototype.getClientRects = function () {
+    for (let e = this; e; e = e.parentElement)
+      if (e.hidden || w.getComputedStyle(e).display === "none") return [];
+    return [{}];
+  };
+  Object.defineProperty(w.HTMLElement.prototype, "innerText", {
+    get() {
+      return this.textContent;
+    },
+  });
+  const poison = () => {
+    throw new Error("Authentication material must not be accessed");
+  };
+  for (const key of ["localStorage", "sessionStorage"])
+    Object.defineProperty(w, key, { get: poison });
+  Object.defineProperty(w.document, "cookie", { get: poison, set: poison });
+  return dom;
+}
+const read = (dom) => JSON.parse(JSON.stringify(dom.window.eval(`(${readAaPage.toString()})()`)));
+for (const mode of ["cash", "award", "round-cash", "round-award"])
+  test(`serialized page reader parses captured ${mode} DOM without auth storage`, () => {
+    const d = read(makeDom(mode));
+    assert.deepEqual(d, fixture(mode));
+    const rows = normalizeResults(d, searchFor(mode));
+    assert.equal(d.expected_count, 5);
+    assert.equal(d.rows.length, 5);
+    assert.equal(rows.length, { cash: 15, award: 9, "round-cash": 18, "round-award": 13 }[mode]);
+    assert.equal(
+      rows[0].price,
+      mode.includes("award") ? null : mode.startsWith("round") ? 697 : 206,
+    );
+    assert.equal(
+      rows[0].miles,
+      mode.includes("award") ? (mode.startsWith("round") ? 45000 : 27000) : null,
+    );
+    assert.equal(
+      rows[0].taxes,
+      mode.includes("award") ? (mode.startsWith("round") ? 549.03 : 5.6) : null,
+    );
+  });
+test("ignores hidden responsive duplicates, hidden fare buttons and calendar prices", () => {
+  const dom = makeDom();
+  const d = dom.window.document;
+  const row = d.querySelector("app-slice-details");
+  const clone = row.cloneNode(true);
+  clone.hidden = true;
+  row.after(clone);
+  const fare = row.querySelector("button.btn-flight");
+  const hidden = fare.cloneNode(true);
+  hidden.style.display = "none";
+  fare.after(hidden);
+  d.body.insertAdjacentHTML(
+    "afterbegin",
+    '<div class="calendar"><span class="per-pax-amount">$1</span></div>',
+  );
+  assert.equal(normalizeResults(read(dom), searchFor()).length, 15);
+});
+test("reads actual current amount rather than a hidden crossed-out amount", () => {
+  const dom = makeDom();
+  dom.window.document
+    .querySelector("button.btn-flight .price")
+    .insertAdjacentHTML("afterbegin", '<span class="per-pax-amount" hidden>$1</span>');
+  assert.equal(normalizeResults(read(dom), searchFor())[0].price, 206);
+});
+test("disabled fare buttons cannot create zero-mile awards", () => {
+  const dom = makeDom("award");
+  const d = dom.window.document;
+  const b = d.querySelector("button.btn-flight").cloneNode(true);
+  b.disabled = true;
+  b.querySelector(".per-pax-amount").textContent = "0K";
+  d.querySelector(".products-row").append(b);
+  assert.equal(normalizeResults(read(dom), searchFor("award")).length, 9);
+});
+test("changed search checkbox never silently turns awards into cash", () => {
+  const dom = makeDom("award");
+  dom.window.document.querySelector("#redeem-miles").checked = false;
+  assert.throws(() => normalizeResults(read(dom), searchFor("award")), /miles/);
+});
+test("finds a visible loading indicator and error notification", () => {
+  const dom = makeDom();
+  dom.window.document.body.insertAdjacentHTML(
+    "afterbegin",
+    '<div role="progressbar"></div><app-error-notification>Search failed</app-error-notification>',
+  );
+  const d = read(dom);
+  assert.equal(d.loading, true);
+  assert.equal(d.error, "Search failed");
+});
+test("detects access blocks and expired sessions", () => {
+  const dom = makeDom();
+  dom.window.document.body.textContent = "Access Denied";
+  assert.equal(read(dom).challenge, true);
+  dom.window.document.body.textContent = "Your session expired";
+  assert.equal(read(dom).expired, true);
+});
+test("safely reads the transient empty document during navigation", () => {
+  const dom = makeDom();
+  dom.window.document.documentElement.remove();
+  const data = read(dom);
+  assert.equal(data.ready, false);
+  assert.equal(data.language, "");
+});
+test("missing fields and changed locale fail closed", () => {
+  const dom = makeDom();
+  dom.window.document.querySelector(".duration").remove();
+  assert.throws(() => normalizeResults(read(dom), searchFor()), /No partial/);
+  const other = makeDom();
+  other.window.document.documentElement.lang = "es";
+  assert.throws(() => normalizeResults(read(other), searchFor()), /English/);
+});
+
+test("award names survive delayed analytics data-product attributes", () => {
+  const dom = makeDom("award");
+  dom.window.document
+    .querySelectorAll("[data-product]")
+    .forEach((e) => e.removeAttribute("data-product"));
+  const rows = normalizeResults(read(dom), searchFor("award"));
+  assert.equal(rows[0].fare_product, "Main");
+  assert.equal(rows[1].fare_product, "First");
+});
+
+test("preserves award overnight and extended-layover notices", () => {
+  const rows = normalizeResults(read(makeDom("award")), searchFor("award"));
+  assert.ok(rows.some((r) => r.alerts.includes("Extended layover")));
+  const round = normalizeResults(read(makeDom("round-award")), searchFor("round-award"));
+  assert.ok(round.some((r) => r.alerts.includes("Overnight travel")));
+});

--- a/opencli-plugins/aa/aa-helpers.mjs
+++ b/opencli-plugins/aa/aa-helpers.mjs
@@ -1,0 +1,326 @@
+export const STOPS = ["any", "nonstop", "one-or-fewer", "two-or-fewer"];
+export const SORTS = ["best", "price", "duration", "departure"];
+export const FARES = [
+  "all",
+  "main",
+  "main-extra",
+  "premium-economy",
+  "premium",
+  "business",
+  "first",
+];
+
+function integer(value, name, min, max) {
+  const n = Number(value);
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    String(value).trim() === "" ||
+    !Number.isInteger(n) ||
+    n < min ||
+    n > max
+  )
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  return n;
+}
+function date(value, name) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(value))) throw new Error(`${name} must use YYYY-MM-DD`);
+  const d = new Date(`${value}T00:00:00Z`);
+  if (!Number.isFinite(d.getTime()) || d.toISOString().slice(0, 10) !== value)
+    throw new Error(`${name} must be a valid calendar date`);
+  return value;
+}
+function choice(value, name, values) {
+  if (!values.includes(value)) throw new Error(`${name} must be one of: ${values.join(", ")}`);
+  return value;
+}
+export function normalizeSearch(args) {
+  const airport = (v, name) => {
+    const s = String(v || "")
+      .trim()
+      .toUpperCase();
+    if (!/^[A-Z]{3}$/.test(s))
+      throw new Error(`${name} must be a three-letter airport code, such as SFO`);
+    return s;
+  };
+  const from = airport(args.from, "from");
+  const to = airport(args.to, "to");
+  if (from === to) throw new Error("from and to must be different airports");
+  const depart = date(args.depart, "depart");
+  const returnDate = args.return === undefined ? null : date(args.return, "return");
+  // AA validates origin-local bookability and its current schedule window.
+  if (returnDate && returnDate < depart) throw new Error("return must be on or after depart");
+  if (args.miles !== undefined && typeof args.miles !== "boolean")
+    throw new Error("miles must be a boolean flag");
+  const miles = args.miles ?? false;
+  const maxMiles =
+    args["max-miles"] === undefined ? null : integer(args["max-miles"], "max-miles", 1, 10000000);
+  let maxPrice = null;
+  if (args["max-price"] !== undefined) {
+    if (
+      !/^\d+(?:\.\d{1,2})?$/.test(String(args["max-price"])) ||
+      !Number.isFinite(Number(args["max-price"])) ||
+      Number(args["max-price"]) <= 0
+    )
+      throw new Error("max-price must be a positive USD amount");
+    maxPrice = Number(args["max-price"]);
+  }
+  if (miles && maxPrice !== null) throw new Error("Use --max-miles for awards, not --max-price");
+  if (!miles && maxMiles !== null) throw new Error("--max-miles requires --miles");
+  const fare = choice(args.fare === undefined ? "all" : args.fare, "fare", FARES);
+  if (!miles && ["business", "first"].includes(fare))
+    throw new Error(
+      "Cash results group Business / First under --fare premium. Use --miles for cabin-specific awards",
+    );
+  if (miles && ["main-extra", "premium"].includes(fare))
+    throw new Error(
+      "Awards use --fare main, premium-economy, business, or first, not cash fare groups",
+    );
+  return {
+    from,
+    to,
+    depart,
+    returnDate,
+    miles,
+    maxMiles,
+    maxPrice,
+    fare,
+    adults: integer(args.adults === undefined ? 1 : args.adults, "adults", 1, 9),
+    stops: choice(args.stops === undefined ? "any" : args.stops, "stops", STOPS),
+    sort: choice(args.sort === undefined ? "best" : args.sort, "sort", SORTS),
+    limit: integer(args.limit === undefined ? 20 : args.limit, "limit", 1, 500),
+    timeout: integer(args.timeout === undefined ? 90 : args.timeout, "timeout", 5, 180),
+    maxDuration:
+      args["max-duration"] === undefined
+        ? null
+        : integer(args["max-duration"], "max-duration", 1, 10080),
+  };
+}
+
+export function buildSearchUrl(search) {
+  const slices = [
+    {
+      orig: search.from,
+      origNearby: false,
+      dest: search.to,
+      destNearby: false,
+      date: search.depart,
+    },
+  ];
+  if (search.returnDate)
+    slices.push({
+      orig: search.to,
+      origNearby: false,
+      dest: search.from,
+      destNearby: false,
+      date: search.returnDate,
+    });
+  const url = new URL("https://www.aa.com/booking/search/find-flights");
+  url.search = new URLSearchParams({
+    locale: "en_US",
+    fareType: "Lowest",
+    pax: String(search.adults),
+    adult: String(search.adults),
+    type: search.returnDate ? "RoundTrip" : "OneWay",
+    searchType: search.miles ? "Award" : "Revenue",
+    cabin: "",
+    carriers: "ALL",
+    travelType: "personal",
+    slices: JSON.stringify(slices),
+  }).toString();
+  return url.toString();
+}
+
+export function assertSearchPage(data, search) {
+  if (data.origin !== "https://www.aa.com" || data.path !== "/booking/choose-flights/1")
+    throw new Error("AA did not open its outbound flight results page");
+  if (!/^en(?:-|$)/i.test(data.language))
+    throw new Error("Set aa.com to English (United States) and retry");
+  if (data.width < 1024)
+    throw new Error("AA flight search requires a desktop browser at least 1024px wide");
+  const s = data.search;
+  const shortDate = (d) => (d ? `${d.slice(5, 7)}/${d.slice(8, 10)}/${d.slice(2, 4)}` : null);
+  const dateLabel = new Date(`${search.depart}T12:00:00Z`).toLocaleDateString("en-US", {
+    timeZone: "UTC",
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+  const expected = {
+    from: search.from,
+    to: search.to,
+    header_from: search.from,
+    header_to: search.to,
+    depart: shortDate(search.depart),
+    return_date: shortDate(search.returnDate),
+    miles: search.miles,
+    trip_type: search.returnDate ? "Round trip" : "One way",
+    header_passengers: String(search.adults),
+    direction: "DEPART",
+    date_label: dateLabel,
+  };
+  for (const [key, value] of Object.entries(expected))
+    if (s?.[key] !== value)
+      throw new Error(`AA did not preserve the requested search field: ${key}`);
+  if (
+    !Array.isArray(s.passengers) ||
+    s.passengers.length !== 1 ||
+    s.passengers[0].type !== "adult" ||
+    s.passengers[0].count !== search.adults
+  )
+    throw new Error("AA did not preserve the requested adult passengers");
+}
+
+export function parseMoney(text) {
+  const m = String(text).match(/^\$(\d{1,3}(?:,\d{3})+|\d+)(?:\.(\d{1,2}))?$/);
+  const amount = m ? Number(`${m[1].replaceAll(",", "")}.${m[2] || "0"}`) : null;
+  return Number.isFinite(amount) ? amount : null;
+}
+export function parseMiles(text) {
+  const m = String(text).match(/^(\d{1,3}(?:,\d{3})+|\d+)(?:\.(\d{1,3}))?([KM])?$/i);
+  if (!m) return null;
+  const value =
+    Number(`${m[1].replaceAll(",", "")}.${m[2] || "0"}`) *
+    ({ K: 1000, M: 1000000 }[m[3]?.toUpperCase()] || 1);
+  const rounded = Math.round(value);
+  return Math.abs(value - rounded) < 1e-6 && rounded > 0 ? rounded : null;
+}
+export function parseClock(text) {
+  const m = String(text).match(
+    /^(\d{1,2}):(\d{2})\s*(AM|PM)\s*([+-]\d+)?(?:\s*,\s*Arrives on [A-Za-z]+ \d{1,2})?$/,
+  );
+  if (!m || Number(m[1]) < 1 || Number(m[1]) > 12 || Number(m[2]) > 59) return null;
+  const hour = (Number(m[1]) % 12) + (m[3] === "PM" ? 12 : 0);
+  return { time: `${String(hour).padStart(2, "0")}:${m[2]}`, dayOffset: Number(m[4] || 0) };
+}
+function durationMinutes(text) {
+  const m = String(text).match(/^(?:(\d+)h\s*)?(?:(\d+)m)?$/);
+  if (!m || (!m[1] && !m[2]) || Number(m[2] || 0) > 59) return null;
+  const n = Number(m[1] || 0) * 60 + Number(m[2] || 0);
+  return n > 0 ? n : null;
+}
+function addDays(day, offset) {
+  const d = new Date(`${day}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + offset);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Validates every displayed row before applying filters or limits. Prices remain per passenger. */
+export function normalizeResults(data, search) {
+  assertSearchPage(data, search);
+  if (
+    !Number.isInteger(data.expected_count) ||
+    data.rows.length !== data.expected_count ||
+    (!data.rows.length && !data.no_results)
+  )
+    throw new Error(
+      "AA did not load the complete displayed result set. No partial prices were returned",
+    );
+  const results = [];
+  const ids = new Set();
+  for (const [index, raw] of data.rows.entries()) {
+    const fail = (detail) => {
+      throw new Error(
+        `Cannot read AA flight ${index + 1}: ${detail}. No partial prices were returned`,
+      );
+    };
+    if (!raw.id || ids.has(raw.id)) fail("missing or duplicate flight identity");
+    ids.add(raw.id);
+    if (raw.origin !== search.from || raw.destination !== search.to)
+      fail("route differs from the search");
+    const departure = parseClock(raw.departure);
+    const arrival = parseClock(raw.arrival);
+    const duration = durationMinutes(raw.duration);
+    const stopsMatch = raw.stops.match(/^(\d+) stops?\b/);
+    const stops = raw.stops === "Nonstop" ? 0 : stopsMatch ? Number(stopsMatch[1]) : null;
+    if (
+      !departure ||
+      departure.dayOffset !== 0 ||
+      !arrival ||
+      Math.abs(arrival.dayOffset) > 7 ||
+      !duration ||
+      stops === null
+    )
+      fail("unrecognized times, duration, or stops");
+    if (
+      !raw.segments.length ||
+      raw.segments.some((s) => !/^\w{2,3} \d+[A-Z]?$/.test(s.flight_number))
+    )
+      fail("missing flight numbers");
+    const fares = raw.fares.filter((f) => !f.unavailable);
+    if (!fares.length) fail("no readable available fares");
+    const fareNames = new Set();
+    for (const fare of fares) {
+      if (!fare.name || fareNames.has(fare.name)) fail("missing or duplicate fare name");
+      fareNames.add(fare.name);
+      const scope = search.returnDate ? "Round trip" : "One way";
+      if (fare.scope !== `${scope}${fare.group ? " from" : ""}`) fail("unrecognized price scope");
+      if (fare.group && (!fare.description.endsWith(`${scope}, per person.`) || search.miles))
+        fail("unverified fare-group price basis");
+      const price = search.miles ? null : parseMoney(fare.amount);
+      const miles = search.miles ? parseMiles(fare.amount) : null;
+      const taxes = search.miles ? parseMoney(fare.addon.replace(/^\+\s*/, "")) : null;
+      if (
+        search.miles ? miles === null || taxes === null : price === null || price <= 0 || fare.addon
+      )
+        fail("unrecognized cash/miles amount or taxes");
+      results.push({
+        rank: 0,
+        flight_rank: index + 1,
+        result_type: search.returnDate ? "outbound_option" : "one_way_itinerary",
+        origin: raw.origin,
+        destination: raw.destination,
+        departure_date: search.depart,
+        departure: departure.time,
+        arrival_date: addDays(search.depart, arrival.dayOffset),
+        arrival: arrival.time,
+        duration_minutes: duration,
+        stops,
+        stops_text: raw.stops,
+        flight_numbers: raw.segments.map((s) => s.flight_number).join(", "),
+        segments: raw.segments,
+        fare_product: fare.name,
+        fare_kind: fare.group ? "fare_group_minimum" : "cabin_offer",
+        price,
+        miles,
+        taxes,
+        currency: "USD",
+        price_display: [fare.amount, fare.addon].filter(Boolean).join(" "),
+        price_basis: search.returnDate
+          ? "per_person_round_trip_starting_total_return_not_selected"
+          : fare.group
+            ? "per_person_one_way_starting"
+            : "per_person_one_way",
+        price_scope_label: fare.scope,
+        passengers: search.adults,
+        return_date: search.returnDate,
+        pricing: search.miles ? "miles" : "cash",
+        loyalty_program: search.miles ? "AAdvantage" : null,
+        alerts: raw.alerts,
+        displayed_flight_count: data.expected_count,
+        search_url: buildSearchUrl(search),
+      });
+    }
+  }
+  const stopLimit = { any: Infinity, nonstop: 0, "one-or-fewer": 1, "two-or-fewer": 2 }[
+    search.stops
+  ];
+  const filtered = results.filter(
+    (r) =>
+      (search.fare === "all" ||
+        r.fare_product.toLowerCase().replaceAll(" ", "-") === search.fare) &&
+      r.stops <= stopLimit &&
+      (search.maxPrice === null || r.price <= search.maxPrice) &&
+      (search.maxMiles === null || r.miles <= search.maxMiles) &&
+      (search.maxDuration === null || r.duration_minutes <= search.maxDuration),
+  );
+  if (search.sort !== "best")
+    filtered.sort((a, b) => {
+      if (search.sort === "price")
+        return search.miles ? a.miles - b.miles || a.taxes - b.taxes : a.price - b.price;
+      if (search.sort === "duration") return a.duration_minutes - b.duration_minutes;
+      return a.departure.localeCompare(b.departure);
+    });
+  return filtered.slice(0, search.limit).map((r, i) => ({ ...r, rank: i + 1 }));
+}

--- a/opencli-plugins/aa/aa-helpers.test.mjs
+++ b/opencli-plugins/aa/aa-helpers.test.mjs
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  assertSearchPage,
+  buildSearchUrl,
+  normalizeResults,
+  normalizeSearch,
+  parseClock,
+  parseMiles,
+  parseMoney,
+} from "./aa-helpers.mjs";
+import { argsFor, fixture, searchFor } from "./test-fixtures.mjs";
+
+test("normalizes airport codes and safe defaults", () => {
+  const s = normalizeSearch(argsFor("cash", { from: " sfo ", to: "dfw" }));
+  assert.equal(s.from, "SFO");
+  assert.equal(s.to, "DFW");
+  assert.equal(s.adults, 1);
+  assert.equal(s.miles, false);
+  assert.equal(s.returnDate, null);
+});
+for (const [key, value] of [
+  ["from", "San Francisco"],
+  ["to", "SFO"],
+  ["from", "SFO,OAK"],
+  ["depart", "2026-02-30"],
+  ["depart", "11/13/2026"],
+  ["return", "2026-11-12"],
+  ["return", ""],
+  ["adults", 0],
+  ["adults", 10],
+  ["adults", 1.2],
+  ["adults", null],
+  ["miles", "true"],
+  ["max-price", "NaN"],
+  ["max-price", "12.345"],
+  ["max-price", 0],
+  ["max-miles", 1000],
+  ["limit", 0],
+  ["limit", 501],
+  ["timeout", 4],
+  ["timeout", 181],
+  ["max-duration", -1],
+  ["stops", "three"],
+  ["sort", "cheapest"],
+  ["fare", "first"],
+])
+  test(`rejects invalid ${key}=${value}`, () =>
+    assert.throws(() => normalizeSearch(argsFor("cash", { [key]: value }))));
+for (const args of [
+  { miles: true, "max-price": 500 },
+  { miles: true, "max-miles": 0 },
+  { miles: true, fare: "premium" },
+  { miles: true, fare: "main-extra" },
+])
+  test(`rejects conflicting award options ${JSON.stringify(args)}`, () =>
+    assert.throws(() => normalizeSearch(argsFor("cash", args))));
+test("accepts leap days, same-day returns, and nine passengers", () => {
+  const s = normalizeSearch(
+    argsFor("cash", { depart: "2028-02-29", return: "2028-02-29", adults: 9 }),
+  );
+  assert.equal(s.adults, 9);
+});
+for (const mode of ["cash", "award", "round-cash", "round-award"])
+  test(`constructs public ${mode} search link`, () => {
+    const s = searchFor(mode);
+    const u = new URL(buildSearchUrl(s));
+    const p = u.searchParams;
+    const slices = JSON.parse(p.get("slices"));
+    assert.equal(u.origin, "https://www.aa.com");
+    assert.equal(p.get("searchType"), s.miles ? "Award" : "Revenue");
+    assert.equal(p.get("adult"), String(s.adults));
+    assert.equal(p.get("pax"), String(s.adults));
+    assert.equal(slices.length, s.returnDate ? 2 : 1);
+    assert.equal(slices[0].orig, s.from);
+    assert.equal(slices[0].dest, s.to);
+    assert.equal(slices[0].date, s.depart);
+    assert.equal(slices[0].origNearby, false);
+    assert.equal(p.get("carriers"), "ALL");
+    assert.equal(p.get("locale"), "en_US");
+    if (s.returnDate) {
+      assert.equal(slices[1].orig, s.to);
+      assert.equal(slices[1].date, s.returnDate);
+    }
+  });
+for (const [input, expected] of [
+  ["27K", 27000],
+  ["32.5K", 32500],
+  ["1.25M", 1250000],
+  ["10,000", 10000],
+  ["0.001K", 1],
+  ["NaN", null],
+  ["$206", null],
+  ["12,34K", null],
+  ["0", null],
+  ["1.5", null],
+  ["27K + $5.60", null],
+])
+  test(`parses miles ${input}`, () => assert.equal(parseMiles(input), expected));
+for (const [input, expected] of [
+  ["$1,000.53", 1000.53],
+  ["$206", 206],
+  ["$0.00", 0],
+  ["$5.6", 5.6],
+  ["CA$206", null],
+  ["€206", null],
+  ["$12,34", null],
+  ["$5.60 +", null],
+])
+  test(`parses money ${input}`, () => assert.equal(parseMoney(input), expected));
+test("parses midnight, noon, overnight and prior-day arrivals", () => {
+  assert.deepEqual(parseClock("12:00 AM"), { time: "00:00", dayOffset: 0 });
+  assert.deepEqual(parseClock("12:00 PM"), { time: "12:00", dayOffset: 0 });
+  assert.deepEqual(parseClock("5:50 AM+1 , Arrives on November 14"), {
+    time: "05:50",
+    dayOffset: 1,
+  });
+  assert.deepEqual(parseClock("8:00 AM -1"), { time: "08:00", dayOffset: -1 });
+  for (const s of ["13:00 PM", "12:60 AM", "5:30", "06:55 PM unknown"])
+    assert.equal(parseClock(s), null);
+});
+for (const field of [
+  "from",
+  "to",
+  "depart",
+  "return_date",
+  "miles",
+  "trip_type",
+  "header_from",
+  "header_to",
+  "header_passengers",
+  "direction",
+  "date_label",
+])
+  test(`rejects changed search field ${field}`, () => {
+    const d = fixture();
+    d.search[field] = "wrong";
+    assert.throws(() => assertSearchPage(d, searchFor()), /preserve/);
+  });
+for (const passengers of [
+  null,
+  [],
+  [{ type: "child", count: 1 }],
+  [{ type: "adult", count: 2 }],
+  [
+    { type: "adult", count: 1 },
+    { type: "infant", count: 1 },
+  ],
+])
+  test(`rejects altered travelers ${JSON.stringify(passengers)}`, () => {
+    const d = fixture();
+    d.search.passengers = passengers;
+    assert.throws(() => assertSearchPage(d, searchFor()), /passengers/);
+  });
+for (const field of ["origin", "path", "language", "width"])
+  test(`rejects unsupported ${field}`, () => {
+    const d = fixture();
+    d[field] = field === "width" ? 800 : "other";
+    assert.throws(() => assertSearchPage(d, searchFor()));
+  });
+test("cash is a fare-group minimum, not an exact cabin or a party total", () => {
+  const rows = normalizeResults(fixture(), searchFor());
+  assert.equal(rows.length, 15);
+  assert.equal(rows[0].price, 206);
+  assert.equal(rows[0].miles, null);
+  assert.equal(rows[0].taxes, null);
+  assert.equal(rows[0].fare_kind, "fare_group_minimum");
+  assert.equal(rows[0].price_basis, "per_person_one_way_starting");
+  assert.equal(rows[6].arrival_date, "2026-11-14");
+});
+test("awards separate miles and cash taxes and omit unavailable products", () => {
+  const rows = normalizeResults(fixture("award"), searchFor("award"));
+  assert.equal(rows.length, 9);
+  assert.equal(rows[0].miles, 27000);
+  assert.equal(rows[0].taxes, 5.6);
+  assert.equal(rows[0].price, null);
+  assert.equal(rows[6].taxes, 11.2);
+  assert.equal(rows.at(-1).flight_numbers, "AS 1450, AA 2438");
+});
+for (const mode of ["round-cash", "round-award"])
+  test(`${mode} labels a starting round-trip per-person total, with no return selected`, () => {
+    const rows = normalizeResults(fixture(mode), searchFor(mode));
+    assert.equal(rows[0].passengers, 2);
+    assert.equal(rows[0].result_type, "outbound_option");
+    assert.equal(rows[0].price_basis, "per_person_round_trip_starting_total_return_not_selected");
+    assert.equal(rows[0].price, mode === "round-cash" ? 697 : null);
+    assert.equal(rows[0].miles, mode === "round-award" ? 45000 : null);
+    assert.equal(rows[0].taxes, mode === "round-award" ? 549.03 : null);
+  });
+test("filters and sorts before limiting", () => {
+  const rows = normalizeResults(
+    fixture("award"),
+    searchFor("award", {
+      fare: "main",
+      stops: "nonstop",
+      sort: "price",
+      "max-miles": 30000,
+      "max-duration": 220,
+      limit: 1,
+    }),
+  );
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].miles, 23500);
+  assert.equal(rows[0].rank, 1);
+  const cash = normalizeResults(
+    fixture(),
+    searchFor("cash", { fare: "main", sort: "price", "max-price": "210", limit: 2 }),
+  );
+  assert.equal(cash.length, 2);
+  assert.equal(cash[1].price, 206);
+});
+test("price ties on awards sort by taxes and otherwise preserve AA order", () => {
+  const d = fixture("award");
+  d.rows[0].fares[0].amount = "10K";
+  d.rows[0].fares[0].addon = "+ $20.00";
+  const rows = normalizeResults(d, searchFor("award", { sort: "price", fare: "main" }));
+  assert.equal(rows[0].taxes, 11.2);
+});
+for (const sort of ["departure", "duration"])
+  test(`sorts ${sort}`, () => {
+    const rows = normalizeResults(fixture(), searchFor("cash", { sort }));
+    const key = sort === "departure" ? "departure" : "duration_minutes";
+    for (let i = 1; i < rows.length; i++) assert.ok(rows[i][key] >= rows[i - 1][key]);
+  });
+test("empty filters return empty rows", () =>
+  assert.deepEqual(normalizeResults(fixture(), searchFor("cash", { "max-price": "1" })), []));
+test("explicit verified empty result returns no fares", () => {
+  const d = fixture();
+  d.rows = [];
+  d.expected_count = 0;
+  d.no_results = true;
+  assert.deepEqual(normalizeResults(d, searchFor()), []);
+});
+for (const mutate of [
+  (d) => d.rows.pop(),
+  (d) => (d.expected_count = null),
+  (d) => (d.rows[4].origin = "OAK"),
+  (d) => (d.rows[4].departure = "invalid"),
+  (d) => (d.rows[4].arrival = "bad"),
+  (d) => (d.rows[4].stops = "unknown"),
+  (d) => (d.rows[4].duration = "0h 0m"),
+  (d) => (d.rows[4].segments = []),
+  (d) => (d.rows[4].id = d.rows[0].id),
+  (d) => (d.rows[4].fares[0].amount = "27K"),
+  (d) => (d.rows[4].fares[0].scope = "Round trip from"),
+  (d) => (d.rows[4].fares[0].description = "unknown"),
+  (d) => (d.rows[4].fares = []),
+])
+  test(`fails closed before limits: ${mutate}`, () => {
+    const d = fixture();
+    mutate(d);
+    assert.throws(
+      () => normalizeResults(d, searchFor("cash", { limit: 1 })),
+      /No partial|partial prices|complete/,
+    );
+  });
+test("missing award taxes or cash fallback fail closed", () => {
+  for (const patch of [{ addon: "" }, { amount: "$206" }, { amount: "0K" }]) {
+    const d = fixture("award");
+    Object.assign(d.rows[0].fares[0], patch);
+    assert.throws(() => normalizeResults(d, searchFor("award")), /No partial/);
+  }
+});
+
+test("rejects null filters instead of silently using defaults", () => {
+  for (const key of ["fare", "stops", "sort"])
+    assert.throws(() => normalizeSearch(argsFor("cash", { [key]: null })));
+});
+test("non-finite monetary input is not a fare", () => {
+  assert.equal(parseMoney(`$${"9".repeat(400)}`), null);
+});

--- a/opencli-plugins/aa/aa-page.mjs
+++ b/opencli-plugins/aa/aa-page.mjs
@@ -1,0 +1,104 @@
+export function readAaPage() {
+  const clean = (v) =>
+    String(v ?? "")
+      .replace(/\s+/g, " ")
+      .trim();
+  const visible = (e) =>
+    !!e &&
+    e.getClientRects().length > 0 &&
+    !e.closest('[hidden], [aria-hidden="true"]') &&
+    getComputedStyle(e).visibility !== "hidden";
+  const text = (e, selector) => clean(e?.querySelector(selector)?.textContent);
+  const visibleText = (e, selector) =>
+    clean([...e.querySelectorAll(selector)].find(visible)?.textContent);
+  const form = document.querySelector("app-modify-search");
+  const matrix = [
+    ...document.querySelectorAll("app-results-matrix, app-results-grid-desktop"),
+  ].find(visible);
+  const body = document.body?.innerText || "";
+  let passengers = null;
+  try {
+    passengers = JSON.parse(
+      form?.querySelector("[data-passengers]")?.getAttribute("data-passengers") || "null",
+    );
+  } catch {}
+  const count = text(matrix, ".result-count").match(/^(\d+) results?$/);
+  const cards = matrix
+    ? [...matrix.querySelectorAll("app-slice-details, .flight-row")].filter(visible)
+    : [];
+  return {
+    origin: location.origin,
+    path: location.pathname,
+    language: document.documentElement?.lang || "",
+    width: window.innerWidth,
+    ready: !!matrix,
+    challenge:
+      /access denied|verify you are human|unusual traffic|pardon our interruption|request (?:has been )?blocked/i.test(
+        body,
+      ),
+    login_required: /\/loyalty\/login/.test(location.pathname),
+    expired:
+      /session-timeout/.test(location.pathname) || /your session (?:has )?expired/i.test(body),
+    error: [
+      ...document.querySelectorAll(
+        "app-error-notification, app-request-modified-notification, [role=alert]",
+      ),
+    ]
+      .filter(visible)
+      .map((e) => clean(e.innerText))
+      .filter(Boolean)
+      .join(" "),
+    no_results:
+      /no flights (?:are )?(?:available|found)|we couldn.t find (?:any )?flights|no results (?:found|match)/i.test(
+        body,
+      ),
+    loading: [
+      ...document.querySelectorAll(
+        "[role=progressbar], [aria-busy=true], mat-spinner, mat-progress-spinner",
+      ),
+    ].some(visible),
+    expected_count: count ? Number(count[1]) : null,
+    search: {
+      from: form?.querySelector("#matOriginAirport")?.value ?? null,
+      to: form?.querySelector("#matDestinationAirport")?.value ?? null,
+      depart: form?.querySelector('input[id^="date-input-first-"]')?.value ?? null,
+      return_date: form?.querySelector('input[id^="date-input-second-"]')?.value || null,
+      miles: form?.querySelector("#redeem-miles")?.checked ?? null,
+      trip_type: text(form, 'mat-select[name="tripType"]'),
+      passengers,
+      header_from: text(form, "app-modify-search-header .origin"),
+      header_to: text(form, "app-modify-search-header .destination").replace(/,$/, "").trim(),
+      header_passengers: text(form, "app-modify-search-header .passenger-count"),
+      direction: text(document, "#flight-direction-text"),
+      date_label: text(document, "app-depart-return-header-desktop .date"),
+    },
+    rows: cards.map((row) => ({
+      id: row.id || row.querySelector(".slice-column")?.id || "",
+      origin: text(row, ".origin .city-code"),
+      destination: text(row, ".destination .city-code"),
+      departure: text(row, ".origin .time, .origin .flt-times"),
+      arrival: text(row, ".destination .time, .destination .flt-times"),
+      duration: text(row, ".duration"),
+      stops: text(row, "app-stops-tooltip"),
+      segments: [...row.querySelectorAll(".leg-info")].map((e) => ({
+        flight_number: text(e, ".flight-number"),
+        aircraft: text(e, ".aircraft, .aircraft-name"),
+        operator: text(e, "app-operated-by"),
+      })),
+      alerts: text(row, "app-matrix-slice-alerts") || text(row, ".slice-info .alerts"),
+      fares: [...row.querySelectorAll("button.btn-flight")].filter(visible).map((e) => ({
+        group: !!e.closest("app-product-groups"),
+        name:
+          e.getAttribute("data-product") || text(e, ".hidden-product-group, .hidden-product-type"),
+        amount: visibleText(e, ".per-pax-amount"),
+        addon: visibleText(e, ".per-pax-addon"),
+        scope: text(e, ".trip-type"),
+        description: text(e, ".a11y-drawer-button-text, .hidden-flight-details"),
+        unavailable:
+          e.disabled ||
+          e.getAttribute("aria-disabled") === "true" ||
+          /not available|sold out/i.test(e.innerText),
+      })),
+    })),
+  };
+}

--- a/opencli-plugins/aa/fixtures/award.html
+++ b/opencli-plugins/aa/fixtures/award.html
@@ -1,0 +1,717 @@
+<html lang="en">
+<head>
+</head>
+<body>
+<app-modify-search>
+<app-modify-search-header>
+<span class="origin">SFO</span>
+<span class="destination"> DFW,</span>
+<span class="passenger-count">1</span>
+</app-modify-search-header>
+<mat-select role="combobox" aria-haspopup="listbox" name="tripType" class="mat-mdc-select ng-untouched ng-pristine ng-valid" aria-labelledby="mat-select-value-0" id="mat-select-0" tabindex="0" aria-expanded="false" aria-required="false" aria-disabled="false" aria-invalid="false">
+<div cdk-overlay-origin="" class="mat-mdc-select-trigger">
+<div class="mat-mdc-select-value" id="mat-select-value-0">
+<span class="mat-mdc-select-value-text">
+<span class="mat-mdc-select-min-line">One way</span>
+</span>
+</div>
+<div class="mat-mdc-select-arrow-wrapper">
+<div class="mat-mdc-select-arrow">
+</div>
+</div>
+</div>
+</mat-select>
+<input type="checkbox" id="redeem-miles" name="redeemMiles" class="ng-untouched ng-pristine ng-valid" value="on" checked="">
+<input matinput="" type="text" class="mat-mdc-autocomplete-trigger mat-mdc-input-element ng-untouched ng-pristine ng-valid mat-mdc-form-field-input-control mdc-text-field__input cdk-text-field-autofill-monitored" aria-label="Departure airport" placeholder="City / airport" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="listbox" id="matOriginAirport" name="orig" aria-invalid="false" aria-required="false" value="SFO">
+<input matinput="" type="text" class="mat-mdc-autocomplete-trigger mat-mdc-input-element ng-untouched ng-pristine ng-valid mat-mdc-form-field-input-control mdc-text-field__input cdk-text-field-autofill-monitored" aria-label="Arrival airport" placeholder="City / airport" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="listbox" id="matDestinationAirport" name="dest" aria-invalid="false" aria-required="false" value="DFW">
+<input autocomplete="off" type="text" class="auto-growing-input agc-date-input-has-value agc-date-input-full-date" spellcheck="false" placeholder="mm/dd/yy" id="date-input-first-agc-date-input-0" aria-labelledby="date-accessible-label-first-agc-date-input-0" aria-label="Date, press Enter to open calendar" aria-describedby="date-input-describedby-agc-date-input-0" aria-invalid="false" maxlength="8" style="width: 73px;" value="11/13/26">
+<div data-passengers="[{&quot;type&quot;:&quot;adult&quot;,&quot;count&quot;:1}]">
+</div>
+</app-modify-search>
+<app-depart-return-header-desktop>
+<div class="pad-top-xs hide-for-small-only desktop-only">
+<h2>
+<em>
+<app-depart-return-multicity-text>
+<span id="flight-direction-text">DEPART</span>
+</app-depart-return-multicity-text>
+</em>
+<div class="city-pair"> San Francisco, CA to Dallas/Fort Worth, TX </div>
+</h2>
+<h3 class="date">Friday, November 13, 2026</h3>
+<div class="aa-flight-info">
+<span aria-hidden="true" class="icon-error icon-small">
+</span> American Airlines flights may be listed first. </div>
+</div>
+</app-depart-return-header-desktop>
+
+<app-results-grid-desktop>
+<div tabindex="-1" class="results-desktop">
+<div class="results-header">
+<app-filter-container id="filter-container" tabindex="-1">
+<div class="filter-container">
+<h2 id="flights-by-heading" class="show-for-sr">
+<span>Filter flights by </span>
+<span class="filter-flights-by-stops">Stops, </span>
+<span class="filter-flights-by-airlines">Airlines, </span>
+</h2>
+<div class="filters-row">
+<div aria-hidden="true" class="filter-by">Filter by:</div>
+<div class="pills">
+<app-filter-stops>
+<div class="pill-container">
+<button type="button" id="btn-stops-filter" class="pill active" aria-haspopup="dialog">
+<div aria-hidden="true" class="pill-text">Stops</div>
+<span class="show-for-sr pill-text">Filter flights by Stops</span>
+<div class="pill-arrow">
+</div>
+</button>
+</div>
+</app-filter-stops>
+<app-filter-airlines>
+<div class="pill-container">
+<button type="button" id="btn-airlines-filter" class="pill active" aria-haspopup="dialog">
+<div aria-hidden="true" class="pill-text"> Airlines </div>
+<span class="show-for-sr pill-text">Filter flights by Airlines</span>
+<div class="pill-arrow">
+</div>
+</button>
+</div>
+</app-filter-airlines>
+</div>
+<div class="result-clear">
+<span role="status" aria-live="polite" aria-atomic="true" class="result-count">5 results</span>
+</div>
+<div class="clearfix">
+</div>
+</div>
+</div>
+</app-filter-container>
+<div role="group" aria-label="Sorting options" class="cabin-header-row">
+<span id="sort-screen-reader-text" role="status" aria-live="polite" aria-atomic="true" class="show-for-sr">
+</span>
+<div id="sort-by">
+<div class="sort-columns">
+<div id="sort-by-departure">
+<button type="button" id="btn-sort-by-departure">
+<span id="screen-reader-departure" class="show-for-sr"> Sort by depart, not sorted, press to sort early to late </span>
+<div aria-hidden="true" class="sort-text"> Depart </div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+<div id="sort-by-arrival">
+<button type="button" id="btn-sort-by-arrival">
+<span id="screen-reader-arrival" class="show-for-sr"> Sort by arrive, not sorted, press to sort early to late </span>
+<div aria-hidden="true" class="sort-text"> Arrive </div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+<div id="sort-by-duration">
+<button type="button" id="btn-sort-by-duration">
+<span id="screen-reader-duration" class="show-for-sr"> Sort by duration, not sorted, press to sort short to long </span>
+<div aria-hidden="true" class="sort-text"> Duration </div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+</div>
+</div>
+<div class="cabin-headers">
+<div class="cabin-headers-inner">
+<div class="cabin-header cabin-coach cabin-size-2">
+<div class="product-and-sort">
+<div class="product-tooltip">
+<app-cabin-tooltip>
+<button type="button" apptooltip="" aria-expanded="false" aria-haspopup="dialog" class="cabin-tooltip-button coach text-left">Main</button>
+</app-cabin-tooltip>
+</div>
+<div class="product-arrows">
+<button type="button" id="btn-sort-by-product_price_0">
+<span class="show-for-sr" id="screen-reader-product_price_0"> Sort by Main Cabin, not sorted, press to sort low to high </span>
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</button>
+</div>
+</div>
+</div>
+<div class="cabin-header cabin-first cabin-size-2">
+<div class="product-and-sort">
+<div class="product-tooltip">
+<app-cabin-tooltip>
+<button type="button" apptooltip="" aria-expanded="false" aria-haspopup="dialog" class="cabin-tooltip-button first text-left">First</button>
+</app-cabin-tooltip>
+</div>
+<div class="product-arrows">
+<button type="button" id="btn-sort-by-product_price_1">
+<span class="show-for-sr" id="screen-reader-product_price_1"> Sort by First, not sorted, press to sort low to high </span>
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</button>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="results-grid-container">
+<div class="flight-row">
+<div tabindex="-1" class="slice-column" id="flight-details-0">
+<app-slice-info-desktop>
+<div class="slice-info">
+<div class="origin">
+<div class="city-code">SFO</div>
+<div class="flt-times">5:35 AM</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">DFW</div>
+<div class="flt-times"> 11:14 AM </div>
+</div>
+<div class="duration-stops">
+<div class="duration">3h 39m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details flight-number"> AA 402 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 321-Airbus A321 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="detailsDialogLink btn-link">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 5:35 AM Nonstop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="viewSeatsLink btn-link">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 5:35 AM Nonstop</span>
+</button>
+</div>
+</div>
+</app-slice-info-desktop>
+</div>
+<div class="products-column">
+<app-available-products-desktop>
+<div class="products-row">
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight0-product0" data-slice="0" data-flightstr="AA402" data-product="Main">
+<span class="show-for-sr hidden-product-type" data-slice="0" data-flightstr="AA402" data-product="Main">Main</span>
+<div class="premium" data-slice="0" data-flightstr="AA402" data-product="Main">
+</div>
+<div class="trip-type regular" data-slice="0" data-flightstr="AA402" data-product="Main">One way</div>
+<app-choose-flights-price-desktop data-slice="0" data-flightstr="AA402" data-product="Main">
+<span class="per-pax-amount" data-slice="0" data-flightstr="AA402" data-product="Main">27K</span>
+<div class="per-pax-addon" data-slice="0" data-flightstr="AA402" data-product="Main">+ $5.60</div>
+<span class="show-for-sr hidden-flight-details" data-slice="0" data-flightstr="AA402" data-product="Main">One way Main 27K + $5.60 for SFO to DFW, departing at 5:35 AM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight0-product1" data-slice="0" data-flightstr="AA402" data-product="First">
+<span class="show-for-sr hidden-product-type" data-slice="0" data-flightstr="AA402" data-product="First">First</span>
+<div class="premium" data-slice="0" data-flightstr="AA402" data-product="First">
+</div>
+<div class="trip-type regular" data-slice="0" data-flightstr="AA402" data-product="First">One way</div>
+<app-choose-flights-price-desktop data-slice="0" data-flightstr="AA402" data-product="First">
+<span class="per-pax-amount" data-slice="0" data-flightstr="AA402" data-product="First">37K</span>
+<div class="per-pax-addon" data-slice="0" data-flightstr="AA402" data-product="First">+ $5.60</div>
+<span class="show-for-sr hidden-flight-details" data-slice="0" data-flightstr="AA402" data-product="First">One way First 37K + $5.60 for SFO to DFW, departing at 5:35 AM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+</div>
+</app-available-products-desktop>
+</div>
+<div class="divider margin-bottom-xs margin-top-xxs">
+</div>
+</div>
+<div class="flight-row">
+<div tabindex="-1" class="slice-column" id="flight-details-1">
+<app-slice-info-desktop>
+<div class="slice-info">
+<div class="origin">
+<div class="city-code">SFO</div>
+<div class="flt-times">6:38 AM</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">DFW</div>
+<div class="flt-times"> 12:18 PM </div>
+</div>
+<div class="duration-stops">
+<div class="duration">3h 40m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details flight-number"> AA 3047 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 321-Airbus A321 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="detailsDialogLink btn-link">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 6:38 AM Nonstop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="viewSeatsLink btn-link">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 6:38 AM Nonstop</span>
+</button>
+</div>
+</div>
+</app-slice-info-desktop>
+</div>
+<div class="products-column">
+<app-available-products-desktop>
+<div class="products-row">
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight1-product0" data-slice="1" data-flightstr="AA3047" data-product="Main">
+<span class="show-for-sr hidden-product-type" data-slice="1" data-flightstr="AA3047" data-product="Main">Main</span>
+<div class="premium" data-slice="1" data-flightstr="AA3047" data-product="Main">
+</div>
+<div class="trip-type regular" data-slice="1" data-flightstr="AA3047" data-product="Main">One way</div>
+<app-choose-flights-price-desktop data-slice="1" data-flightstr="AA3047" data-product="Main">
+<span class="per-pax-amount" data-slice="1" data-flightstr="AA3047" data-product="Main">32.5K</span>
+<div class="per-pax-addon" data-slice="1" data-flightstr="AA3047" data-product="Main">+ $5.60</div>
+<span class="show-for-sr hidden-flight-details" data-slice="1" data-flightstr="AA3047" data-product="Main">One way Main 32.5K + $5.60 for SFO to DFW, departing at 6:38 AM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight1-product1" data-slice="1" data-flightstr="AA3047" data-product="First">
+<span class="show-for-sr hidden-product-type" data-slice="1" data-flightstr="AA3047" data-product="First">First</span>
+<div class="premium" data-slice="1" data-flightstr="AA3047" data-product="First">
+</div>
+<div class="trip-type regular" data-slice="1" data-flightstr="AA3047" data-product="First">One way</div>
+<app-choose-flights-price-desktop data-slice="1" data-flightstr="AA3047" data-product="First">
+<span class="per-pax-amount" data-slice="1" data-flightstr="AA3047" data-product="First">101K</span>
+<div class="per-pax-addon" data-slice="1" data-flightstr="AA3047" data-product="First">+ $5.60</div>
+<span class="show-for-sr hidden-flight-details" data-slice="1" data-flightstr="AA3047" data-product="First">One way First 101K + $5.60 for SFO to DFW, departing at 6:38 AM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+</div>
+</app-available-products-desktop>
+</div>
+<div class="divider margin-bottom-xs margin-top-xxs">
+</div>
+</div>
+<div class="flight-row">
+<div tabindex="-1" class="slice-column" id="flight-details-9">
+<app-slice-info-desktop>
+<div class="slice-info">
+<div class="origin">
+<div class="city-code">SFO</div>
+<div class="flt-times">11:23 PM</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">DFW</div>
+<div class="flt-times"> 5:00 AM <span class="next-day">
+<app-next-day-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-next-day">+1 <span class="show-for-sr">, Arrives on November 14</span>
+</button>
+</app-next-day-tooltip>
+</span>
+</div>
+</div>
+<div class="duration-stops">
+<div class="duration">3h 37m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details flight-number"> AA 939 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 321-Airbus A321 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="detailsDialogLink btn-link">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 11:23 PM Nonstop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="viewSeatsLink btn-link">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 11:23 PM Nonstop</span>
+</button>
+</div>
+</div>
+</app-slice-info-desktop>
+</div>
+<div class="products-column">
+<app-available-products-desktop>
+<div class="products-row">
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight9-product0" data-slice="9" data-flightstr="AA939" data-product="Main">
+<span class="show-for-sr hidden-product-type" data-slice="9" data-flightstr="AA939" data-product="Main">Main</span>
+<div class="premium" data-slice="9" data-flightstr="AA939" data-product="Main">
+</div>
+<div class="trip-type regular" data-slice="9" data-flightstr="AA939" data-product="Main">One way</div>
+<app-choose-flights-price-desktop data-slice="9" data-flightstr="AA939" data-product="Main">
+<span class="per-pax-amount" data-slice="9" data-flightstr="AA939" data-product="Main">23.5K</span>
+<div class="per-pax-addon" data-slice="9" data-flightstr="AA939" data-product="Main">+ $5.60</div>
+<span class="show-for-sr hidden-flight-details" data-slice="9" data-flightstr="AA939" data-product="Main">One way Main 23.5K + $5.60 for SFO to DFW, departing at 11:23 PM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight9-product1" data-slice="9" data-flightstr="AA939" data-product="First">
+<span class="show-for-sr hidden-product-type" data-slice="9" data-flightstr="AA939" data-product="First">First</span>
+<div class="premium" data-slice="9" data-flightstr="AA939" data-product="First">
+</div>
+<div class="trip-type regular" data-slice="9" data-flightstr="AA939" data-product="First">One way</div>
+<app-choose-flights-price-desktop data-slice="9" data-flightstr="AA939" data-product="First">
+<span class="per-pax-amount" data-slice="9" data-flightstr="AA939" data-product="First">33.5K</span>
+<div class="per-pax-addon" data-slice="9" data-flightstr="AA939" data-product="First">+ $5.60</div>
+<span class="show-for-sr hidden-flight-details" data-slice="9" data-flightstr="AA939" data-product="First">One way First 33.5K + $5.60 for SFO to DFW, departing at 11:23 PM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+</div>
+</app-available-products-desktop>
+</div>
+<div class="divider margin-bottom-xs margin-top-xxs">
+</div>
+</div>
+<div class="flight-row">
+<div tabindex="-1" class="slice-column" id="flight-details-10">
+<app-slice-info-desktop>
+<div class="slice-info">
+<div class="origin">
+<div class="city-code">SFO</div>
+<div class="flt-times">7:03 AM</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">DFW</div>
+<div class="flt-times"> 9:46 PM </div>
+</div>
+<div class="duration-stops">
+<div class="duration">12h 43m</div>
+<div class="stops">
+<app-stops-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-stops">1 stop<span class="show-for-sr">, LAX, Los Angeles International</span>
+</button>
+</app-stops-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details cities">SFO - LAX</span>
+<span aria-hidden="true" class="icon-square flight-information">
+</span>
+<span class="connecting-flt-details flight-number"> AA 2211 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 738-Boeing 737 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details cities">LAX - DFW</span>
+<span aria-hidden="true" class="icon-square flight-information">
+</span>
+<span class="connecting-flt-details flight-number"> AA 2900 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 32Q-Airbus A321neo </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+<div class="alerts">
+<span class="icon-warning">
+</span>
+<span class="warning-text"> Extended layover</span>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="detailsDialogLink btn-link">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 7:03 AM 1 stop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="viewSeatsLink btn-link">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 7:03 AM 1 stop</span>
+</button>
+</div>
+</div>
+</app-slice-info-desktop>
+</div>
+<div class="products-column">
+<app-available-products-desktop>
+<div class="products-row">
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight10-product0" data-slice="10" data-flightstr="AA2211/AA2900" data-product="Main">
+<span class="show-for-sr hidden-product-type" data-slice="10" data-flightstr="AA2211/AA2900" data-product="Main">Main</span>
+<div class="premium" data-slice="10" data-flightstr="AA2211/AA2900" data-product="Main">
+</div>
+<div class="trip-type regular" data-slice="10" data-flightstr="AA2211/AA2900" data-product="Main">One way</div>
+<app-choose-flights-price-desktop data-slice="10" data-flightstr="AA2211/AA2900" data-product="Main">
+<span class="per-pax-amount" data-slice="10" data-flightstr="AA2211/AA2900" data-product="Main">10K</span>
+<div class="per-pax-addon" data-slice="10" data-flightstr="AA2211/AA2900" data-product="Main">+ $11.20</div>
+<span class="show-for-sr hidden-flight-details" data-slice="10" data-flightstr="AA2211/AA2900" data-product="Main">One way Main 10K + $11.20 for SFO to DFW, departing at 7:03 AM 1 stop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight10-product1" data-slice="10" data-flightstr="AA2211/AA2900" data-product="First">
+<span class="show-for-sr hidden-product-type" data-slice="10" data-flightstr="AA2211/AA2900" data-product="First">First</span>
+<div class="premium" data-slice="10" data-flightstr="AA2211/AA2900" data-product="First">
+</div>
+<div class="trip-type regular" data-slice="10" data-flightstr="AA2211/AA2900" data-product="First">One way</div>
+<app-choose-flights-price-desktop data-slice="10" data-flightstr="AA2211/AA2900" data-product="First">
+<span class="per-pax-amount" data-slice="10" data-flightstr="AA2211/AA2900" data-product="First">43K</span>
+<div class="per-pax-addon" data-slice="10" data-flightstr="AA2211/AA2900" data-product="First">+ $11.20</div>
+<span class="show-for-sr hidden-flight-details" data-slice="10" data-flightstr="AA2211/AA2900" data-product="First">One way First 43K + $11.20 for SFO to DFW, departing at 7:03 AM 1 stop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+</div>
+</app-available-products-desktop>
+</div>
+<div class="divider margin-bottom-xs margin-top-xxs">
+</div>
+</div>
+<div class="flight-row">
+<div tabindex="-1" class="slice-column" id="flight-details-11">
+<app-slice-info-desktop>
+<div class="slice-info">
+<div class="origin">
+<div class="city-code">SFO</div>
+<div class="flt-times">7:04 AM</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">DFW</div>
+<div class="flt-times"> 8:28 PM </div>
+</div>
+<div class="duration-stops">
+<div class="duration">11h 24m</div>
+<div class="stops">
+<app-stops-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-stops">1 stop<span class="show-for-sr">, SAN, San Diego International</span>
+</button>
+</app-stops-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details cities">SFO - SAN</span>
+<span aria-hidden="true" class="icon-square flight-information">
+</span>
+<span class="connecting-flt-details flight-number"> AS 1450 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 7M9-Boeing 737 MAX 9 Passenger </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+<p class="operated-by-desktop">
+<app-operated-by>
+</app-operated-by>
+</p>
+<div class="operated-by"> Operated by Alaska </div>
+<p>
+</p>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details cities">SAN - DFW</span>
+<span aria-hidden="true" class="icon-square flight-information">
+</span>
+<span class="connecting-flt-details flight-number"> AA 2438 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 321-Airbus A321 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+<div class="alerts">
+<span class="icon-warning">
+</span>
+<span class="warning-text"> Extended layover</span>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="detailsDialogLink btn-link">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 7:04 AM 1 stop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="viewSeatsLink btn-link">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 7:04 AM 1 stop</span>
+</button>
+</div>
+</div>
+</app-slice-info-desktop>
+</div>
+<div class="products-column">
+<app-available-products-desktop>
+<div class="products-row">
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight11-product0" data-slice="11" data-flightstr="AS1450/AA2438" data-product="Main">
+<span class="show-for-sr hidden-product-type" data-slice="11" data-flightstr="AS1450/AA2438" data-product="Main">Main</span>
+<div class="premium" data-slice="11" data-flightstr="AS1450/AA2438" data-product="Main">
+</div>
+<div class="trip-type regular" data-slice="11" data-flightstr="AS1450/AA2438" data-product="Main">One way</div>
+<app-choose-flights-price-desktop data-slice="11" data-flightstr="AS1450/AA2438" data-product="Main">
+<span class="per-pax-amount" data-slice="11" data-flightstr="AS1450/AA2438" data-product="Main">12.5K</span>
+<div class="per-pax-addon" data-slice="11" data-flightstr="AS1450/AA2438" data-product="Main">+ $11.20</div>
+<span class="show-for-sr hidden-flight-details" data-slice="11" data-flightstr="AS1450/AA2438" data-product="Main">One way Main 12.5K + $11.20 for SFO to DFW, departing at 7:04 AM 1 stop</span>
+</app-choose-flights-price-desktop>
+<div class="seats-remaining" data-slice="11" data-flightstr="AS1450/AA2438" data-product="Main">
+<span class="show-for-sr" data-slice="11" data-flightstr="AS1450/AA2438" data-product="Main">, </span>1 seat left at this price</div>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<div class="not-available regular" id="flight11-product1">Not available</div>
+</div>
+</div>
+</app-available-products-desktop>
+</div>
+<div class="divider margin-bottom-xs margin-top-xxs">
+</div>
+</div>
+</div>
+</div>
+</app-results-grid-desktop>
+</body>
+</html>

--- a/opencli-plugins/aa/fixtures/award.json
+++ b/opencli-plugins/aa/fixtures/award.json
@@ -1,0 +1,221 @@
+{
+  "origin": "https://www.aa.com",
+  "path": "/booking/choose-flights/1",
+  "language": "en",
+  "width": 1024,
+  "ready": true,
+  "challenge": false,
+  "login_required": false,
+  "expired": false,
+  "error": "",
+  "no_results": false,
+  "loading": false,
+  "expected_count": 5,
+  "search": {
+    "from": "SFO",
+    "to": "DFW",
+    "depart": "11/13/26",
+    "return_date": null,
+    "miles": true,
+    "trip_type": "One way",
+    "passengers": [
+      {
+        "type": "adult",
+        "count": 1
+      }
+    ],
+    "header_from": "SFO",
+    "header_to": "DFW",
+    "header_passengers": "1",
+    "direction": "DEPART",
+    "date_label": "Friday, November 13, 2026"
+  },
+  "rows": [
+    {
+      "id": "flight-details-0",
+      "origin": "SFO",
+      "destination": "DFW",
+      "departure": "5:35 AM",
+      "arrival": "11:14 AM",
+      "duration": "3h 39m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 402",
+          "aircraft": "321-Airbus A321",
+          "operator": ""
+        }
+      ],
+      "alerts": "",
+      "fares": [
+        {
+          "group": false,
+          "name": "Main",
+          "amount": "27K",
+          "addon": "+ $5.60",
+          "scope": "One way",
+          "description": "One way Main 27K + $5.60 for SFO to DFW, departing at 5:35 AM Nonstop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "First",
+          "amount": "37K",
+          "addon": "+ $5.60",
+          "scope": "One way",
+          "description": "One way First 37K + $5.60 for SFO to DFW, departing at 5:35 AM Nonstop",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "flight-details-1",
+      "origin": "SFO",
+      "destination": "DFW",
+      "departure": "6:38 AM",
+      "arrival": "12:18 PM",
+      "duration": "3h 40m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 3047",
+          "aircraft": "321-Airbus A321",
+          "operator": ""
+        }
+      ],
+      "alerts": "",
+      "fares": [
+        {
+          "group": false,
+          "name": "Main",
+          "amount": "32.5K",
+          "addon": "+ $5.60",
+          "scope": "One way",
+          "description": "One way Main 32.5K + $5.60 for SFO to DFW, departing at 6:38 AM Nonstop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "First",
+          "amount": "101K",
+          "addon": "+ $5.60",
+          "scope": "One way",
+          "description": "One way First 101K + $5.60 for SFO to DFW, departing at 6:38 AM Nonstop",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "flight-details-9",
+      "origin": "SFO",
+      "destination": "DFW",
+      "departure": "11:23 PM",
+      "arrival": "5:00 AM +1 , Arrives on November 14",
+      "duration": "3h 37m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 939",
+          "aircraft": "321-Airbus A321",
+          "operator": ""
+        }
+      ],
+      "alerts": "",
+      "fares": [
+        {
+          "group": false,
+          "name": "Main",
+          "amount": "23.5K",
+          "addon": "+ $5.60",
+          "scope": "One way",
+          "description": "One way Main 23.5K + $5.60 for SFO to DFW, departing at 11:23 PM Nonstop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "First",
+          "amount": "33.5K",
+          "addon": "+ $5.60",
+          "scope": "One way",
+          "description": "One way First 33.5K + $5.60 for SFO to DFW, departing at 11:23 PM Nonstop",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "flight-details-10",
+      "origin": "SFO",
+      "destination": "DFW",
+      "departure": "7:03 AM",
+      "arrival": "9:46 PM",
+      "duration": "12h 43m",
+      "stops": "1 stop, LAX, Los Angeles International",
+      "segments": [
+        {
+          "flight_number": "AA 2211",
+          "aircraft": "738-Boeing 737",
+          "operator": ""
+        },
+        {
+          "flight_number": "AA 2900",
+          "aircraft": "32Q-Airbus A321neo",
+          "operator": ""
+        }
+      ],
+      "alerts": "Extended layover",
+      "fares": [
+        {
+          "group": false,
+          "name": "Main",
+          "amount": "10K",
+          "addon": "+ $11.20",
+          "scope": "One way",
+          "description": "One way Main 10K + $11.20 for SFO to DFW, departing at 7:03 AM 1 stop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "First",
+          "amount": "43K",
+          "addon": "+ $11.20",
+          "scope": "One way",
+          "description": "One way First 43K + $11.20 for SFO to DFW, departing at 7:03 AM 1 stop",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "flight-details-11",
+      "origin": "SFO",
+      "destination": "DFW",
+      "departure": "7:04 AM",
+      "arrival": "8:28 PM",
+      "duration": "11h 24m",
+      "stops": "1 stop, SAN, San Diego International",
+      "segments": [
+        {
+          "flight_number": "AS 1450",
+          "aircraft": "7M9-Boeing 737 MAX 9 Passenger",
+          "operator": ""
+        },
+        {
+          "flight_number": "AA 2438",
+          "aircraft": "321-Airbus A321",
+          "operator": ""
+        }
+      ],
+      "alerts": "Extended layover",
+      "fares": [
+        {
+          "group": false,
+          "name": "Main",
+          "amount": "12.5K",
+          "addon": "+ $11.20",
+          "scope": "One way",
+          "description": "One way Main 12.5K + $11.20 for SFO to DFW, departing at 7:04 AM 1 stop",
+          "unavailable": false
+        }
+      ]
+    }
+  ]
+}

--- a/opencli-plugins/aa/fixtures/cash.html
+++ b/opencli-plugins/aa/fixtures/cash.html
@@ -1,0 +1,927 @@
+<html lang="en">
+<head>
+</head>
+<body>
+<app-modify-search>
+<app-modify-search-header>
+<span class="origin">SFO</span>
+<span class="destination"> DFW,</span>
+<span class="passenger-count">1</span>
+</app-modify-search-header>
+<mat-select role="combobox" aria-haspopup="listbox" name="tripType" class="mat-mdc-select ng-untouched ng-pristine ng-valid" aria-labelledby="mat-select-value-0" id="mat-select-0" tabindex="0" aria-expanded="false" aria-required="false" aria-disabled="false" aria-invalid="false">
+<div cdk-overlay-origin="" class="mat-mdc-select-trigger">
+<div class="mat-mdc-select-value" id="mat-select-value-0">
+<span class="mat-mdc-select-value-text">
+<span class="mat-mdc-select-min-line">One way</span>
+</span>
+</div>
+<div class="mat-mdc-select-arrow-wrapper">
+<div class="mat-mdc-select-arrow">
+</div>
+</div>
+</div>
+</mat-select>
+<input type="checkbox" id="redeem-miles" name="redeemMiles" class="ng-untouched ng-pristine ng-valid" value="on">
+<input matinput="" type="text" class="mat-mdc-autocomplete-trigger mat-mdc-input-element ng-untouched ng-pristine ng-valid mat-mdc-form-field-input-control mdc-text-field__input cdk-text-field-autofill-monitored" aria-label="Departure airport" placeholder="City / airport" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="listbox" id="matOriginAirport" name="orig" aria-invalid="false" aria-required="false" value="SFO">
+<input matinput="" type="text" class="mat-mdc-autocomplete-trigger mat-mdc-input-element ng-untouched ng-pristine ng-valid mat-mdc-form-field-input-control mdc-text-field__input cdk-text-field-autofill-monitored" aria-label="Arrival airport" placeholder="City / airport" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="listbox" id="matDestinationAirport" name="dest" aria-invalid="false" aria-required="false" value="DFW">
+<input autocomplete="off" type="text" class="auto-growing-input agc-date-input-has-value agc-date-input-full-date" spellcheck="false" placeholder="mm/dd/yy" id="date-input-first-agc-date-input-0" aria-labelledby="date-accessible-label-first-agc-date-input-0" aria-label="Date, press Enter to open calendar" aria-describedby="date-input-describedby-agc-date-input-0" aria-invalid="false" maxlength="8" style="width: 73px;" value="11/13/26">
+<div data-passengers="[{&quot;type&quot;:&quot;adult&quot;,&quot;count&quot;:1}]">
+</div>
+</app-modify-search>
+<app-depart-return-header-desktop>
+<div class="pad-top-xs hide-for-small-only desktop-only">
+<h2>
+<em>
+<app-depart-return-multicity-text>
+<span id="flight-direction-text">DEPART</span>
+</app-depart-return-multicity-text>
+</em>
+<div class="city-pair"> San Francisco, CA to Dallas/Fort Worth, TX </div>
+</h2>
+<h3 class="date">Friday, November 13, 2026</h3>
+<div class="aa-flight-info">
+<span aria-hidden="true" class="icon-error icon-small">
+</span> American Airlines flights may be listed first. </div>
+</div>
+</app-depart-return-header-desktop>
+<app-results-matrix>
+<div tabindex="-1" class="results-matrix">
+<app-filter-container id="filter-container" tabindex="-1">
+<div class="filter-container">
+<h2 id="flights-by-heading" class="show-for-sr">
+<span>Filter flights by </span>
+<span class="filter-flights-by-stops">Stops, </span>
+</h2>
+<div class="filters-row">
+<div aria-hidden="true" class="filter-by">Filter by:</div>
+<div class="pills">
+<app-filter-stops>
+<div class="pill-container">
+<button type="button" id="btn-stops-filter" class="pill active" aria-haspopup="dialog">
+<div aria-hidden="true" class="pill-text">Stops</div>
+<span class="show-for-sr pill-text">Filter flights by Stops</span>
+<div class="pill-arrow">
+</div>
+</button>
+</div>
+</app-filter-stops>
+<app-filter-airlines>
+<div class="pill-container">
+<button type="button" id="btn-airlines-filter" class="pill inactive" disabled="">
+<div aria-hidden="true" class="pill-text"> American Airlines </div>
+<span class="show-for-sr pill-text">Filter flights by Airlines</span>
+<div class="pill-arrow">
+</div>
+</button>
+</div>
+</app-filter-airlines>
+</div>
+<div class="result-clear">
+<span role="status" aria-live="polite" aria-atomic="true" class="result-count">5 results</span>
+</div>
+<div class="clearfix">
+</div>
+</div>
+</div>
+</app-filter-container>
+<div class="matrix-header">
+<div role="group" aria-label="Sorting options" class="header-row">
+<span id="sort-screen-reader-text" role="status" aria-live="polite" aria-atomic="true" class="show-for-sr">
+</span>
+<div id="sort-by">
+<div id="sort-by-departure">
+<button type="button" id="btn-sort-by-departure">
+<span id="screen-reader-departure" class="show-for-sr"> Sort by depart, not sorted, press to sort early to late </span>
+<div aria-hidden="true" class="sort-text">Depart</div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+<div id="sort-by-arrival">
+<button type="button" id="btn-sort-by-arrival">
+<span id="screen-reader-arrival" class="show-for-sr"> Sort by arrive, not sorted, press to sort early to late </span>
+<div aria-hidden="true" class="sort-text">Arrive</div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+<div id="sort-by-duration">
+<button type="button" id="btn-sort-by-duration">
+<span id="screen-reader-duration" class="show-for-sr"> Sort by duration, not sorted, press to sort short to long </span>
+<div aria-hidden="true" class="sort-text">Duration</div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+</div>
+<div class="groups new-product-line">
+<button type="button" class="group-header group-main" id="sort-by-MAIN">
+<span class="show-for-sr" id="screen-reader-MAIN"> Sort by Main Fare Products, not sorted, press to sort prices low to high </span>
+<div class="group-sort">
+<div class="group-name">Main</div>
+<div class="group-arrows">
+<div class="group-sort-arrows" id="btn-sort-by-MAIN">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</div>
+</div>
+</button>
+<button type="button" class="group-header group-main_extra" id="sort-by-MAIN_EXTRA">
+<span class="show-for-sr" id="screen-reader-MAIN_EXTRA"> Sort by Main Extra Fare Products, not sorted, press to sort prices low to high </span>
+<div class="group-sort">
+<div class="group-name">Main Extra</div>
+<div class="group-arrows">
+<div class="group-sort-arrows" id="btn-sort-by-MAIN_EXTRA">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</div>
+</div>
+</button>
+<button type="button" class="group-header group-premium" id="sort-by-PREMIUM">
+<span class="show-for-sr" id="screen-reader-PREMIUM"> Sort by Premium Fare Products, not sorted, press to sort prices low to high </span>
+<div class="group-sort">
+<div class="group-name">Premium</div>
+<div class="group-arrows">
+<div class="group-sort-arrows" id="btn-sort-by-PREMIUM">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</div>
+</div>
+</button>
+</div>
+</div>
+</div>
+<div class="results-grid-container">
+<app-slice-details id="slice-details-0">
+<div class="slice-details row">
+<div tabindex="-1" class="col-5">
+<app-matrix-flight-card>
+<div class="matrix-flight-card">
+<div class="origin">
+<div class="city-code">SFO</div>
+<div class="time"> 5:35  <span class="meridiem">AM</span>
+</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">DFW</div>
+<div class="time"> 11:14  <span class="meridiem">AM</span>
+</div>
+</div>
+<div class="duration">3h 39m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+<span class="hidden-accessible">Opens Nonstop details for SFO to DFW, departing at 5:35 AM</span>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="flight-number"> AA 402 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> 321-Airbus A321 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="btn-link details">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 5:35 AM Nonstop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="btn-link seats">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 5:35 AM Nonstop</span>
+</button>
+</div>
+</div>
+</app-matrix-flight-card>
+<app-matrix-slice-alerts>
+</app-matrix-slice-alerts>
+</div>
+<div class="col-7">
+<app-product-groups>
+<div class="product-groups" id="slice-0-product-groups">
+<button type="button" id="flight-0-product-group-MAIN" aria-expanded="false" class="btn-flight MAIN">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$206</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main fare list starts at $206 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-0-product-group-MAIN_EXTRA" aria-expanded="false" class="btn-flight MAIN_EXTRA">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main Extra</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$331</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main Extra fare list starts at $331 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-0-product-group-PREMIUM" aria-expanded="false" class="btn-flight PREMIUM">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$569</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium fare list starts at $569 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+</div>
+</app-product-groups>
+</div>
+</div>
+</app-slice-details>
+<app-slice-details id="slice-details-4">
+<div class="slice-details row">
+<div tabindex="-1" class="col-5">
+<app-matrix-flight-card>
+<div class="matrix-flight-card">
+<div class="origin">
+<div class="city-code">SFO</div>
+<div class="time"> 6:38  <span class="meridiem">AM</span>
+</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">DFW</div>
+<div class="time"> 12:18  <span class="meridiem">PM</span>
+</div>
+</div>
+<div class="duration">3h 40m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+<span class="hidden-accessible">Opens Nonstop details for SFO to DFW, departing at 6:38 AM</span>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="flight-number"> AA 3047 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> 321-Airbus A321 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="btn-link details">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 6:38 AM Nonstop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="btn-link seats">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 6:38 AM Nonstop</span>
+</button>
+</div>
+</div>
+</app-matrix-flight-card>
+<app-matrix-slice-alerts>
+</app-matrix-slice-alerts>
+</div>
+<div class="col-7">
+<app-product-groups>
+<div class="product-groups" id="slice-4-product-groups">
+<button type="button" id="flight-4-product-group-MAIN" aria-expanded="false" class="btn-flight MAIN">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$301</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main fare list starts at $301 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-4-product-group-MAIN_EXTRA" aria-expanded="false" class="btn-flight MAIN_EXTRA">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main Extra</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$409</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main Extra fare list starts at $409 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-4-product-group-PREMIUM" aria-expanded="false" class="btn-flight PREMIUM">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$816</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium fare list starts at $816 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+</div>
+</app-product-groups>
+</div>
+</div>
+</app-slice-details>
+<app-slice-details id="slice-details-3">
+<div class="slice-details row">
+<div tabindex="-1" class="col-5">
+<app-matrix-flight-card>
+<div class="matrix-flight-card">
+<div class="origin">
+<div class="city-code">SFO</div>
+<div class="time"> 11:23  <span class="meridiem">PM</span>
+</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">DFW</div>
+<div class="time"> 5:00  <span class="meridiem">AM</span>
+<span class="next-day">
+<app-next-day-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-next-day">+1 <span class="show-for-sr">, Arrives on November 14</span>
+</button>
+</app-next-day-tooltip>
+</span>
+</div>
+</div>
+<div class="duration">3h 37m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+<span class="hidden-accessible">Opens Nonstop details for SFO to DFW, departing at 11:23 PM</span>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="flight-number"> AA 939 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> 321-Airbus A321 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="btn-link details">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 11:23 PM Nonstop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="btn-link seats">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 11:23 PM Nonstop</span>
+</button>
+</div>
+</div>
+</app-matrix-flight-card>
+<app-matrix-slice-alerts>
+</app-matrix-slice-alerts>
+</div>
+<div class="col-7">
+<app-product-groups>
+<div class="product-groups" id="slice-3-product-groups">
+<button type="button" id="flight-3-product-group-MAIN" aria-expanded="false" class="btn-flight MAIN">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$206</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main fare list starts at $206 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-3-product-group-MAIN_EXTRA" aria-expanded="false" class="btn-flight MAIN_EXTRA">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main Extra</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$331</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main Extra fare list starts at $331 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-3-product-group-PREMIUM" aria-expanded="false" class="btn-flight PREMIUM">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$569</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium fare list starts at $569 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+</div>
+</app-product-groups>
+</div>
+</div>
+</app-slice-details>
+<app-slice-details id="slice-details-12">
+<div class="slice-details row">
+<div tabindex="-1" class="col-5">
+<app-matrix-flight-card>
+<div class="matrix-flight-card">
+<div class="origin">
+<div class="city-code">SFO</div>
+<div class="time"> 5:50  <span class="meridiem">AM</span>
+</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">DFW</div>
+<div class="time"> 2:56  <span class="meridiem">PM</span>
+</div>
+</div>
+<div class="duration">7h 6m</div>
+<div class="stops">
+<app-stops-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-stops">1 stop<span class="show-for-sr">, PHX, Phoenix Sky Harbor Intl</span>
+</button>
+</app-stops-tooltip>
+<span class="hidden-accessible">Opens 1 stop details for SFO to DFW, departing at 5:50 AM</span>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="cities">SFO - PHX</span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="flight-number"> AA 6206 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> E75-Embraer 175 </span>
+<p class="operational-disclosure">
+<app-operated-by>
+</app-operated-by>
+</p>
+<div class="operated-by"> Operated by SkyWest Airlines as American Eagle </div>
+<p>
+</p>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="cities">PHX - DFW</span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="flight-number"> AA 2747 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> 32Q-Airbus A321neo </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="btn-link details">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 5:50 AM 1 stop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="btn-link seats">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 5:50 AM 1 stop</span>
+</button>
+</div>
+</div>
+</app-matrix-flight-card>
+<app-matrix-slice-alerts>
+<div class="alerts">
+<span aria-hidden="true" class="icon-warning">
+</span>
+<span class="warning-text"> Extended layover</span>
+</div>
+</app-matrix-slice-alerts>
+</div>
+<div class="col-7">
+<app-product-groups>
+<div class="product-groups" id="slice-12-product-groups">
+<button type="button" id="flight-12-product-group-MAIN" aria-expanded="false" class="btn-flight MAIN">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$311</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main fare list starts at $311 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-12-product-group-MAIN_EXTRA" aria-expanded="false" class="btn-flight MAIN_EXTRA">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main Extra</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$419</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main Extra fare list starts at $419 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-12-product-group-PREMIUM" aria-expanded="false" class="btn-flight PREMIUM">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$826</span>
+</app-choose-flights-price-desktop>
+</div>
+<div class="seats-remaining">
+<span class="show-for-sr">, </span>
+<app-label-tag>
+<div class="seats-remaining">
+<span>3 seats left at this price</span>
+</div>
+</app-label-tag>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium fare list starts at $826 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+</div>
+</app-product-groups>
+</div>
+</div>
+</app-slice-details>
+<app-slice-details id="slice-details-13">
+<div class="slice-details row">
+<div tabindex="-1" class="col-5">
+<app-matrix-flight-card>
+<div class="matrix-flight-card">
+<div class="origin">
+<div class="city-code">SFO</div>
+<div class="time"> 5:50  <span class="meridiem">AM</span>
+</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">DFW</div>
+<div class="time"> 4:20  <span class="meridiem">PM</span>
+</div>
+</div>
+<div class="duration">8h 30m</div>
+<div class="stops">
+<app-stops-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-stops">1 stop<span class="show-for-sr">, PHX, Phoenix Sky Harbor Intl</span>
+</button>
+</app-stops-tooltip>
+<span class="hidden-accessible">Opens 1 stop details for SFO to DFW, departing at 5:50 AM</span>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="cities">SFO - PHX</span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="flight-number"> AA 6206 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> E75-Embraer 175 </span>
+<p class="operational-disclosure">
+<app-operated-by>
+</app-operated-by>
+</p>
+<div class="operated-by"> Operated by SkyWest Airlines as American Eagle </div>
+<p>
+</p>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="cities">PHX - DFW</span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="flight-number"> AA 1999 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> 738-Boeing 737 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="btn-link details">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 5:50 AM 1 stop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="btn-link seats">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for SFO to DFW, departing at 5:50 AM 1 stop</span>
+</button>
+</div>
+</div>
+</app-matrix-flight-card>
+<app-matrix-slice-alerts>
+<div class="alerts">
+<span aria-hidden="true" class="icon-warning">
+</span>
+<span class="warning-text"> Extended layover</span>
+</div>
+</app-matrix-slice-alerts>
+</div>
+<div class="col-7">
+<app-product-groups>
+<div class="product-groups" id="slice-13-product-groups">
+<button type="button" id="flight-13-product-group-MAIN" aria-expanded="false" class="btn-flight MAIN">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$311</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main fare list starts at $311 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-13-product-group-MAIN_EXTRA" aria-expanded="false" class="btn-flight MAIN_EXTRA">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main Extra</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$419</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main Extra fare list starts at $419 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-13-product-group-PREMIUM" aria-expanded="false" class="btn-flight PREMIUM">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium</span>
+<div class="trip-type-row">
+<div class="trip-type">One way from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$826</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium fare list starts at $826 One way, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+</div>
+</app-product-groups>
+</div>
+</div>
+</app-slice-details>
+</div>
+</div>
+</app-results-matrix>
+</body>
+</html>

--- a/opencli-plugins/aa/fixtures/cash.json
+++ b/opencli-plugins/aa/fixtures/cash.json
@@ -1,0 +1,275 @@
+{
+  "origin": "https://www.aa.com",
+  "path": "/booking/choose-flights/1",
+  "language": "en",
+  "width": 1024,
+  "ready": true,
+  "challenge": false,
+  "login_required": false,
+  "expired": false,
+  "error": "",
+  "no_results": false,
+  "loading": false,
+  "expected_count": 5,
+  "search": {
+    "from": "SFO",
+    "to": "DFW",
+    "depart": "11/13/26",
+    "return_date": null,
+    "miles": false,
+    "trip_type": "One way",
+    "passengers": [
+      {
+        "type": "adult",
+        "count": 1
+      }
+    ],
+    "header_from": "SFO",
+    "header_to": "DFW",
+    "header_passengers": "1",
+    "direction": "DEPART",
+    "date_label": "Friday, November 13, 2026"
+  },
+  "rows": [
+    {
+      "id": "slice-details-0",
+      "origin": "SFO",
+      "destination": "DFW",
+      "departure": "5:35 AM",
+      "arrival": "11:14 AM",
+      "duration": "3h 39m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 402",
+          "aircraft": "321-Airbus A321",
+          "operator": ""
+        }
+      ],
+      "alerts": "",
+      "fares": [
+        {
+          "group": true,
+          "name": "Main",
+          "amount": "$206",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Main fare list starts at $206 One way, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Main Extra",
+          "amount": "$331",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Main Extra fare list starts at $331 One way, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium",
+          "amount": "$569",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Premium fare list starts at $569 One way, per person.",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "slice-details-4",
+      "origin": "SFO",
+      "destination": "DFW",
+      "departure": "6:38 AM",
+      "arrival": "12:18 PM",
+      "duration": "3h 40m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 3047",
+          "aircraft": "321-Airbus A321",
+          "operator": ""
+        }
+      ],
+      "alerts": "",
+      "fares": [
+        {
+          "group": true,
+          "name": "Main",
+          "amount": "$301",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Main fare list starts at $301 One way, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Main Extra",
+          "amount": "$409",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Main Extra fare list starts at $409 One way, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium",
+          "amount": "$816",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Premium fare list starts at $816 One way, per person.",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "slice-details-3",
+      "origin": "SFO",
+      "destination": "DFW",
+      "departure": "11:23 PM",
+      "arrival": "5:00 AM +1 , Arrives on November 14",
+      "duration": "3h 37m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 939",
+          "aircraft": "321-Airbus A321",
+          "operator": ""
+        }
+      ],
+      "alerts": "",
+      "fares": [
+        {
+          "group": true,
+          "name": "Main",
+          "amount": "$206",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Main fare list starts at $206 One way, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Main Extra",
+          "amount": "$331",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Main Extra fare list starts at $331 One way, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium",
+          "amount": "$569",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Premium fare list starts at $569 One way, per person.",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "slice-details-12",
+      "origin": "SFO",
+      "destination": "DFW",
+      "departure": "5:50 AM",
+      "arrival": "2:56 PM",
+      "duration": "7h 6m",
+      "stops": "1 stop, PHX, Phoenix Sky Harbor Intl",
+      "segments": [
+        {
+          "flight_number": "AA 6206",
+          "aircraft": "E75-Embraer 175",
+          "operator": ""
+        },
+        {
+          "flight_number": "AA 2747",
+          "aircraft": "32Q-Airbus A321neo",
+          "operator": ""
+        }
+      ],
+      "alerts": "Extended layover",
+      "fares": [
+        {
+          "group": true,
+          "name": "Main",
+          "amount": "$311",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Main fare list starts at $311 One way, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Main Extra",
+          "amount": "$419",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Main Extra fare list starts at $419 One way, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium",
+          "amount": "$826",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Premium fare list starts at $826 One way, per person.",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "slice-details-13",
+      "origin": "SFO",
+      "destination": "DFW",
+      "departure": "5:50 AM",
+      "arrival": "4:20 PM",
+      "duration": "8h 30m",
+      "stops": "1 stop, PHX, Phoenix Sky Harbor Intl",
+      "segments": [
+        {
+          "flight_number": "AA 6206",
+          "aircraft": "E75-Embraer 175",
+          "operator": ""
+        },
+        {
+          "flight_number": "AA 1999",
+          "aircraft": "738-Boeing 737",
+          "operator": ""
+        }
+      ],
+      "alerts": "Extended layover",
+      "fares": [
+        {
+          "group": true,
+          "name": "Main",
+          "amount": "$311",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Main fare list starts at $311 One way, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Main Extra",
+          "amount": "$419",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Main Extra fare list starts at $419 One way, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium",
+          "amount": "$826",
+          "addon": "",
+          "scope": "One way from",
+          "description": "The lowest fare in the Premium fare list starts at $826 One way, per person.",
+          "unavailable": false
+        }
+      ]
+    }
+  ]
+}

--- a/opencli-plugins/aa/fixtures/round-award.html
+++ b/opencli-plugins/aa/fixtures/round-award.html
@@ -1,0 +1,814 @@
+<html lang="en">
+<head>
+</head>
+<body>
+<app-modify-search>
+<app-modify-search-header>
+<span class="origin">JFK</span>
+<span class="destination"> LHR,</span>
+<span class="passenger-count">2</span>
+</app-modify-search-header>
+<mat-select role="combobox" aria-haspopup="listbox" name="tripType" class="mat-mdc-select ng-untouched ng-pristine ng-valid" aria-labelledby="mat-select-value-0" id="mat-select-0" tabindex="0" aria-expanded="false" aria-required="false" aria-disabled="false" aria-invalid="false">
+<div cdk-overlay-origin="" class="mat-mdc-select-trigger">
+<div class="mat-mdc-select-value" id="mat-select-value-0">
+<span class="mat-mdc-select-value-text">
+<span class="mat-mdc-select-min-line">Round trip</span>
+</span>
+</div>
+<div class="mat-mdc-select-arrow-wrapper">
+<div class="mat-mdc-select-arrow">
+</div>
+</div>
+</div>
+</mat-select>
+<input type="checkbox" id="redeem-miles" name="redeemMiles" class="ng-untouched ng-pristine ng-valid" value="on" checked="">
+<input matinput="" type="text" class="mat-mdc-autocomplete-trigger mat-mdc-input-element ng-untouched ng-pristine ng-valid mat-mdc-form-field-input-control mdc-text-field__input cdk-text-field-autofill-monitored" aria-label="Departure airport" placeholder="City / airport" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="listbox" id="matOriginAirport" name="orig" aria-invalid="false" aria-required="false" value="JFK">
+<input matinput="" type="text" class="mat-mdc-autocomplete-trigger mat-mdc-input-element ng-untouched ng-pristine ng-valid mat-mdc-form-field-input-control mdc-text-field__input cdk-text-field-autofill-monitored" aria-label="Arrival airport" placeholder="City / airport" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="listbox" id="matDestinationAirport" name="dest" aria-invalid="false" aria-required="false" value="LHR">
+<input autocomplete="off" type="text" class="auto-growing-input agc-date-input-range-display agc-date-input-full-date" spellcheck="false" placeholder="mm/dd/yy" id="date-input-first-agc-date-input-0" aria-labelledby="date-accessible-label-first-agc-date-input-0" aria-label="Depart date, press Enter to open calendar" aria-describedby="date-input-describedby-agc-date-input-0" aria-invalid="false" maxlength="8" style="width: 69px;" value="11/13/26">
+<input autocomplete="off" type="text" class="auto-growing-input agc-date-input-range-display agc-date-input-full-date" spellcheck="false" placeholder="mm/dd/yy" id="date-input-second-agc-date-input-0" aria-labelledby="date-accessible-label-second-agc-date-input-0" aria-label="Return date, press Enter to open calendar" aria-describedby="date-input-describedby-agc-date-input-0" aria-invalid="false" maxlength="8" style="width: 69px;" value="11/20/26">
+<div data-passengers="[{&quot;type&quot;:&quot;adult&quot;,&quot;count&quot;:2}]">
+</div>
+</app-modify-search>
+<app-depart-return-header-desktop>
+<div class="pad-top-xs hide-for-small-only desktop-only">
+<h2>
+<em>
+<app-depart-return-multicity-text>
+<span id="flight-direction-text">DEPART</span>
+</app-depart-return-multicity-text>
+</em>
+<div class="city-pair"> New York, NY to London, United Kingdom </div>
+</h2>
+<h3 class="date">Friday, November 13, 2026</h3>
+<div class="aa-flight-info">
+<span aria-hidden="true" class="icon-error icon-small">
+</span> American Airlines flights may be listed first. </div>
+</div>
+</app-depart-return-header-desktop>
+
+<app-results-grid-desktop>
+<div tabindex="-1" class="results-desktop">
+<div class="results-header">
+<app-filter-container id="filter-container" tabindex="-1">
+<div class="filter-container">
+<h2 id="flights-by-heading" class="show-for-sr">
+<span>Filter flights by </span>
+<span class="filter-flights-by-stops">Stops, </span>
+<span class="filter-flights-by-airlines">Airlines, </span>
+</h2>
+<div class="filters-row">
+<div aria-hidden="true" class="filter-by">Filter by:</div>
+<div class="pills">
+<app-filter-stops>
+<div class="pill-container">
+<button type="button" id="btn-stops-filter" class="pill active" aria-haspopup="dialog">
+<div aria-hidden="true" class="pill-text">Stops</div>
+<span class="show-for-sr pill-text">Filter flights by Stops</span>
+<div class="pill-arrow">
+</div>
+</button>
+</div>
+</app-filter-stops>
+<app-filter-airlines>
+<div class="pill-container">
+<button type="button" id="btn-airlines-filter" class="pill active" aria-haspopup="dialog">
+<div aria-hidden="true" class="pill-text"> Airlines </div>
+<span class="show-for-sr pill-text">Filter flights by Airlines</span>
+<div class="pill-arrow">
+</div>
+</button>
+</div>
+</app-filter-airlines>
+</div>
+<div class="result-clear">
+<span role="status" aria-live="polite" aria-atomic="true" class="result-count">5 results</span>
+</div>
+<div class="clearfix">
+</div>
+</div>
+</div>
+</app-filter-container>
+<div role="group" aria-label="Sorting options" class="cabin-header-row">
+<span id="sort-screen-reader-text" role="status" aria-live="polite" aria-atomic="true" class="show-for-sr">
+</span>
+<div id="sort-by">
+<div class="sort-columns">
+<div id="sort-by-departure">
+<button type="button" id="btn-sort-by-departure">
+<span id="screen-reader-departure" class="show-for-sr"> Sort by depart, not sorted, press to sort early to late </span>
+<div aria-hidden="true" class="sort-text"> Depart </div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+<div id="sort-by-arrival">
+<button type="button" id="btn-sort-by-arrival">
+<span id="screen-reader-arrival" class="show-for-sr"> Sort by arrive, not sorted, press to sort early to late </span>
+<div aria-hidden="true" class="sort-text"> Arrive </div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+<div id="sort-by-duration">
+<button type="button" id="btn-sort-by-duration">
+<span id="screen-reader-duration" class="show-for-sr"> Sort by duration, not sorted, press to sort short to long </span>
+<div aria-hidden="true" class="sort-text"> Duration </div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+</div>
+</div>
+<div class="cabin-headers">
+<div class="cabin-headers-inner">
+<div class="cabin-header cabin-coach cabin-size-4">
+<div class="product-and-sort">
+<div class="product-tooltip">
+<app-cabin-tooltip>
+<button type="button" apptooltip="" aria-expanded="false" aria-haspopup="dialog" class="cabin-tooltip-button coach text-left">Main</button>
+</app-cabin-tooltip>
+</div>
+<div class="product-arrows">
+<button type="button" id="btn-sort-by-product_price_0">
+<span class="show-for-sr" id="screen-reader-product_price_0"> Sort by Main Cabin, not sorted, press to sort low to high </span>
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</button>
+</div>
+</div>
+</div>
+<div class="cabin-header cabin-premium_economy cabin-size-4">
+<div class="product-and-sort">
+<div class="product-tooltip">
+<app-cabin-tooltip>
+<button type="button" apptooltip="" aria-expanded="false" aria-haspopup="dialog" class="cabin-tooltip-button premium_economy text-left">Premium Economy</button>
+</app-cabin-tooltip>
+</div>
+<div class="product-arrows">
+<button type="button" id="btn-sort-by-product_price_1">
+<span class="show-for-sr" id="screen-reader-product_price_1"> Sort by Premium Economy Fare Products, not sorted, press to sort prices low to high </span>
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</button>
+</div>
+</div>
+</div>
+<div class="cabin-header cabin-business cabin-size-4">
+<div class="product-and-sort">
+<div class="product-tooltip">
+<app-cabin-tooltip>
+<button type="button" apptooltip="" aria-expanded="false" aria-haspopup="dialog" class="business cabin-tooltip-button text-left">Business</button>
+</app-cabin-tooltip>
+</div>
+<div class="product-arrows">
+<button type="button" id="btn-sort-by-product_price_2">
+<span class="show-for-sr" id="screen-reader-product_price_2"> Sort by Business, not sorted, press to sort low to high </span>
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</button>
+</div>
+</div>
+</div>
+<div class="cabin-header cabin-first cabin-size-4">
+<div class="product-and-sort">
+<div class="product-tooltip">
+<app-cabin-tooltip>
+<button type="button" apptooltip="" aria-expanded="false" aria-haspopup="dialog" class="cabin-tooltip-button first text-left">First</button>
+</app-cabin-tooltip>
+</div>
+<div class="product-arrows">
+<button type="button" id="btn-sort-by-product_price_3">
+<span class="show-for-sr" id="screen-reader-product_price_3"> Sort by First, not sorted, press to sort low to high </span>
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</button>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="results-grid-container">
+<div class="flight-row">
+<div tabindex="-1" class="slice-column" id="flight-details-0">
+<app-slice-info-desktop>
+<div class="slice-info">
+<div class="origin">
+<div class="city-code">JFK</div>
+<div class="flt-times">8:05 AM</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">LHR</div>
+<div class="flt-times"> 8:00 PM </div>
+</div>
+<div class="duration-stops">
+<div class="duration">6h 55m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details flight-number"> BA 178 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 777-Boeing 777 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+<p class="operated-by-desktop">
+<app-operated-by>
+</app-operated-by>
+</p>
+<div class="operated-by"> Operated by British Airways </div>
+<p>
+</p>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="detailsDialogLink btn-link">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 8:05 AM Nonstop</span>
+</button>
+</div>
+</div>
+</app-slice-info-desktop>
+</div>
+<div class="products-column">
+<app-available-products-desktop>
+<div class="products-row">
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight0-product0" data-slice="0" data-flightstr="BA178" data-product="Main">
+<span class="show-for-sr hidden-product-type" data-slice="0" data-flightstr="BA178" data-product="Main">Main</span>
+<div class="premium" data-slice="0" data-flightstr="BA178" data-product="Main">
+</div>
+<div class="trip-type regular" data-slice="0" data-flightstr="BA178" data-product="Main">Round trip</div>
+<app-choose-flights-price-desktop data-slice="0" data-flightstr="BA178" data-product="Main">
+<span class="per-pax-amount" data-slice="0" data-flightstr="BA178" data-product="Main">45K</span>
+<div class="per-pax-addon" data-slice="0" data-flightstr="BA178" data-product="Main">+ $549.03</div>
+<span class="show-for-sr hidden-flight-details" data-slice="0" data-flightstr="BA178" data-product="Main">Round trip Main 45K + $549.03 for JFK to LHR, departing at 8:05 AM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<div class="not-available regular" id="flight0-product1">Not available</div>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<div class="not-available regular" id="flight0-product2">Not available</div>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<div class="not-available regular" id="flight0-product3">Not available</div>
+</div>
+</div>
+</app-available-products-desktop>
+</div>
+<div class="divider margin-bottom-xs margin-top-xxs">
+</div>
+</div>
+<div class="flight-row">
+<div tabindex="-1" class="slice-column" id="flight-details-1">
+<app-slice-info-desktop>
+<div class="slice-info">
+<div class="origin">
+<div class="city-code">JFK</div>
+<div class="flt-times">10:10 AM</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">LHR</div>
+<div class="flt-times"> 10:10 PM </div>
+</div>
+<div class="duration-stops">
+<div class="duration">7h 0m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details flight-number"> AA 142 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 772-Boeing 777 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="detailsDialogLink btn-link">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 10:10 AM Nonstop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="viewSeatsLink btn-link">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 10:10 AM Nonstop</span>
+</button>
+</div>
+</div>
+</app-slice-info-desktop>
+</div>
+<div class="products-column">
+<app-available-products-desktop>
+<div class="products-row">
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight1-product0" data-slice="1" data-flightstr="AA142" data-product="Main">
+<span class="show-for-sr hidden-product-type" data-slice="1" data-flightstr="AA142" data-product="Main">Main</span>
+<div class="premium" data-slice="1" data-flightstr="AA142" data-product="Main">
+</div>
+<div class="trip-type regular" data-slice="1" data-flightstr="AA142" data-product="Main">Round trip</div>
+<app-choose-flights-price-desktop data-slice="1" data-flightstr="AA142" data-product="Main">
+<span class="per-pax-amount" data-slice="1" data-flightstr="AA142" data-product="Main">52.5K</span>
+<div class="per-pax-addon" data-slice="1" data-flightstr="AA142" data-product="Main">+ $222.73</div>
+<span class="show-for-sr hidden-flight-details" data-slice="1" data-flightstr="AA142" data-product="Main">Round trip Main 52.5K + $222.73 for JFK to LHR, departing at 10:10 AM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight1-product1" data-slice="1" data-flightstr="AA142" data-product="Premium Economy">
+<span class="show-for-sr hidden-product-type" data-slice="1" data-flightstr="AA142" data-product="Premium Economy">Premium Economy</span>
+<div class="premium" data-slice="1" data-flightstr="AA142" data-product="Premium Economy">
+</div>
+<div class="trip-type regular" data-slice="1" data-flightstr="AA142" data-product="Premium Economy">Round trip</div>
+<app-choose-flights-price-desktop data-slice="1" data-flightstr="AA142" data-product="Premium Economy">
+<span class="per-pax-amount" data-slice="1" data-flightstr="AA142" data-product="Premium Economy">122K</span>
+<div class="per-pax-addon" data-slice="1" data-flightstr="AA142" data-product="Premium Economy">+ $1,000.53</div>
+<span class="show-for-sr hidden-flight-details" data-slice="1" data-flightstr="AA142" data-product="Premium Economy">Round trip Premium Economy 122K + $1,000.53 for JFK to LHR, departing at 10:10 AM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight1-product2" data-slice="1" data-flightstr="AA142" data-product="Business">
+<span class="show-for-sr hidden-product-type" data-slice="1" data-flightstr="AA142" data-product="Business">Business</span>
+<div class="premium" data-slice="1" data-flightstr="AA142" data-product="Business">
+</div>
+<div class="trip-type regular" data-slice="1" data-flightstr="AA142" data-product="Business">Round trip</div>
+<app-choose-flights-price-desktop data-slice="1" data-flightstr="AA142" data-product="Business">
+<span class="per-pax-amount" data-slice="1" data-flightstr="AA142" data-product="Business">407.5K</span>
+<div class="per-pax-addon" data-slice="1" data-flightstr="AA142" data-product="Business">+ $415.13</div>
+<span class="show-for-sr hidden-flight-details" data-slice="1" data-flightstr="AA142" data-product="Business">Round trip Business 407.5K + $415.13 for JFK to LHR, departing at 10:10 AM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<div class="not-available regular" id="flight1-product3">Not available</div>
+</div>
+</div>
+</app-available-products-desktop>
+</div>
+<div class="divider margin-bottom-xs margin-top-xxs">
+</div>
+</div>
+<div class="flight-row">
+<div tabindex="-1" class="slice-column" id="flight-details-2">
+<app-slice-info-desktop>
+<div class="slice-info">
+<div class="origin">
+<div class="city-code">JFK</div>
+<div class="flt-times">5:50 PM</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">LHR</div>
+<div class="flt-times"> 5:50 AM <span class="next-day">
+<app-next-day-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-next-day">+1 <span class="show-for-sr">, Arrives on November 14</span>
+</button>
+</app-next-day-tooltip>
+</span>
+</div>
+</div>
+<div class="duration-stops">
+<div class="duration">7h 0m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details flight-number"> BA 180 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 777-Boeing 777 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+<p class="operated-by-desktop">
+<app-operated-by>
+</app-operated-by>
+</p>
+<div class="operated-by"> Operated by British Airways </div>
+<p>
+</p>
+</div>
+</div>
+<div class="alerts">
+<span class="icon-warning">
+</span>
+<span class="warning-text"> Overnight travel</span>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="detailsDialogLink btn-link">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 5:50 PM Nonstop</span>
+</button>
+</div>
+</div>
+</app-slice-info-desktop>
+</div>
+<div class="products-column">
+<app-available-products-desktop>
+<div class="products-row">
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight2-product0" data-slice="2" data-flightstr="BA180" data-product="Main">
+<span class="show-for-sr hidden-product-type" data-slice="2" data-flightstr="BA180" data-product="Main">Main</span>
+<div class="premium" data-slice="2" data-flightstr="BA180" data-product="Main">
+</div>
+<div class="trip-type regular" data-slice="2" data-flightstr="BA180" data-product="Main">Round trip</div>
+<app-choose-flights-price-desktop data-slice="2" data-flightstr="BA180" data-product="Main">
+<span class="per-pax-amount" data-slice="2" data-flightstr="BA180" data-product="Main">45K</span>
+<div class="per-pax-addon" data-slice="2" data-flightstr="BA180" data-product="Main">+ $549.03</div>
+<span class="show-for-sr hidden-flight-details" data-slice="2" data-flightstr="BA180" data-product="Main">Round trip Main 45K + $549.03 for JFK to LHR, departing at 5:50 PM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<div class="not-available regular" id="flight2-product1">Not available</div>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<div class="not-available regular" id="flight2-product2">Not available</div>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<div class="not-available regular" id="flight2-product3">Not available</div>
+</div>
+</div>
+</app-available-products-desktop>
+</div>
+<div class="divider margin-bottom-xs margin-top-xxs">
+</div>
+</div>
+<div class="flight-row">
+<div tabindex="-1" class="slice-column" id="flight-details-4">
+<app-slice-info-desktop>
+<div class="slice-info">
+<div class="origin">
+<div class="city-code">JFK</div>
+<div class="flt-times">6:25 PM</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">LHR</div>
+<div class="flt-times"> 6:20 AM <span class="next-day">
+<app-next-day-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-next-day">+1 <span class="show-for-sr">, Arrives on November 14</span>
+</button>
+</app-next-day-tooltip>
+</span>
+</div>
+</div>
+<div class="duration-stops">
+<div class="duration">6h 55m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details flight-number"> AA 100 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 77W-Boeing 777 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+<div class="alerts">
+<span class="icon-warning">
+</span>
+<span class="warning-text"> Overnight travel</span>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="detailsDialogLink btn-link">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 6:25 PM Nonstop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="viewSeatsLink btn-link">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 6:25 PM Nonstop</span>
+</button>
+</div>
+</div>
+</app-slice-info-desktop>
+</div>
+<div class="products-column">
+<app-available-products-desktop>
+<div class="products-row">
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight4-product0" data-slice="4" data-flightstr="AA100" data-product="Main">
+<span class="show-for-sr hidden-product-type" data-slice="4" data-flightstr="AA100" data-product="Main">Main</span>
+<div class="premium" data-slice="4" data-flightstr="AA100" data-product="Main">
+</div>
+<div class="trip-type regular" data-slice="4" data-flightstr="AA100" data-product="Main">Round trip</div>
+<app-choose-flights-price-desktop data-slice="4" data-flightstr="AA100" data-product="Main">
+<span class="per-pax-amount" data-slice="4" data-flightstr="AA100" data-product="Main">52.5K</span>
+<div class="per-pax-addon" data-slice="4" data-flightstr="AA100" data-product="Main">+ $222.73</div>
+<span class="show-for-sr hidden-flight-details" data-slice="4" data-flightstr="AA100" data-product="Main">Round trip Main 52.5K + $222.73 for JFK to LHR, departing at 6:25 PM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight4-product1" data-slice="4" data-flightstr="AA100" data-product="Premium Economy">
+<span class="show-for-sr hidden-product-type" data-slice="4" data-flightstr="AA100" data-product="Premium Economy">Premium Economy</span>
+<div class="premium" data-slice="4" data-flightstr="AA100" data-product="Premium Economy">
+</div>
+<div class="trip-type regular" data-slice="4" data-flightstr="AA100" data-product="Premium Economy">Round trip</div>
+<app-choose-flights-price-desktop data-slice="4" data-flightstr="AA100" data-product="Premium Economy">
+<span class="per-pax-amount" data-slice="4" data-flightstr="AA100" data-product="Premium Economy">215.5K</span>
+<div class="per-pax-addon" data-slice="4" data-flightstr="AA100" data-product="Premium Economy">+ $1,000.53</div>
+<span class="show-for-sr hidden-flight-details" data-slice="4" data-flightstr="AA100" data-product="Premium Economy">Round trip Premium Economy 215.5K + $1,000.53 for JFK to LHR, departing at 6:25 PM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight4-product2" data-slice="4" data-flightstr="AA100" data-product="Business">
+<span class="show-for-sr hidden-product-type" data-slice="4" data-flightstr="AA100" data-product="Business">Business</span>
+<div class="premium" data-slice="4" data-flightstr="AA100" data-product="Business">
+</div>
+<div class="trip-type regular" data-slice="4" data-flightstr="AA100" data-product="Business">Round trip</div>
+<app-choose-flights-price-desktop data-slice="4" data-flightstr="AA100" data-product="Business">
+<span class="per-pax-amount" data-slice="4" data-flightstr="AA100" data-product="Business">369K</span>
+<div class="per-pax-addon" data-slice="4" data-flightstr="AA100" data-product="Business">+ $415.13</div>
+<span class="show-for-sr hidden-flight-details" data-slice="4" data-flightstr="AA100" data-product="Business">Round trip Business 369K + $415.13 for JFK to LHR, departing at 6:25 PM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight4-product3" data-slice="4" data-flightstr="AA100" data-product="First">
+<span class="show-for-sr hidden-product-type" data-slice="4" data-flightstr="AA100" data-product="First">First</span>
+<div class="premium" data-slice="4" data-flightstr="AA100" data-product="First">
+</div>
+<div class="trip-type regular" data-slice="4" data-flightstr="AA100" data-product="First">Round trip</div>
+<app-choose-flights-price-desktop data-slice="4" data-flightstr="AA100" data-product="First">
+<span class="per-pax-amount" data-slice="4" data-flightstr="AA100" data-product="First">379K</span>
+<div class="per-pax-addon" data-slice="4" data-flightstr="AA100" data-product="First">+ $415.13</div>
+<span class="show-for-sr hidden-flight-details" data-slice="4" data-flightstr="AA100" data-product="First">Round trip First 379K + $415.13 for JFK to LHR, departing at 6:25 PM Nonstop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+</div>
+</app-available-products-desktop>
+</div>
+<div class="divider margin-bottom-xs margin-top-xxs">
+</div>
+</div>
+<div class="flight-row">
+<div tabindex="-1" class="slice-column" id="flight-details-12">
+<app-slice-info-desktop>
+<div class="slice-info">
+<div class="origin">
+<div class="city-code">JFK</div>
+<div class="flt-times">6:00 AM</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">LHR</div>
+<div class="flt-times"> 12:05 PM <span class="next-day">
+<app-next-day-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-next-day">+1 <span class="show-for-sr">, Arrives on November 14</span>
+</button>
+</app-next-day-tooltip>
+</span>
+</div>
+</div>
+<div class="duration-stops">
+<div class="duration">25h 5m</div>
+<div class="stops">
+<app-stops-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-stops">1 stop<span class="show-for-sr">, MIA, Miami International</span>
+</button>
+</app-stops-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details cities">JFK - MIA</span>
+<span aria-hidden="true" class="icon-square flight-information">
+</span>
+<span class="connecting-flt-details flight-number"> AA 688 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 738-Boeing 737 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<span class="connecting-flt-details cities">MIA - LHR</span>
+<span aria-hidden="true" class="icon-square flight-information">
+</span>
+<span class="connecting-flt-details flight-number"> AA 56 </span>
+<span aria-hidden="true" class="icon-square flight-number-square">
+</span>
+<span class="connecting-flt-details aircraft-name"> 77W-Boeing 777 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+<div class="alerts">
+<span class="icon-warning">
+</span>
+<span class="warning-text"> Overnight travel<span>,</span> Extended layover<span>,</span> The class of service you searched may not be available on one or more flights</span>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="detailsDialogLink btn-link">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 6:00 AM 1 stop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="viewSeatsLink btn-link">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 6:00 AM 1 stop</span>
+</button>
+</div>
+</div>
+</app-slice-info-desktop>
+</div>
+<div class="products-column">
+<app-available-products-desktop>
+<div class="products-row">
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight12-product0" data-slice="12" data-flightstr="AA688/AA56" data-product="Main">
+<span class="show-for-sr hidden-product-type" data-slice="12" data-flightstr="AA688/AA56" data-product="Main">Main</span>
+<div class="premium" data-slice="12" data-flightstr="AA688/AA56" data-product="Main">
+</div>
+<div class="trip-type regular" data-slice="12" data-flightstr="AA688/AA56" data-product="Main">Round trip</div>
+<app-choose-flights-price-desktop data-slice="12" data-flightstr="AA688/AA56" data-product="Main">
+<span class="per-pax-amount" data-slice="12" data-flightstr="AA688/AA56" data-product="Main">52.5K</span>
+<div class="per-pax-addon" data-slice="12" data-flightstr="AA688/AA56" data-product="Main">+ $228.33</div>
+<span class="show-for-sr hidden-flight-details" data-slice="12" data-flightstr="AA688/AA56" data-product="Main">Round trip Main 52.5K + $228.33 for JFK to LHR, departing at 6:00 AM 1 stop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight12-product1" data-slice="12" data-flightstr="AA688/AA56" data-product="Premium Economy">
+<span class="show-for-sr hidden-product-type" data-slice="12" data-flightstr="AA688/AA56" data-product="Premium Economy">Premium Economy</span>
+<div class="premium" data-slice="12" data-flightstr="AA688/AA56" data-product="Premium Economy">
+</div>
+<div class="trip-type regular" data-slice="12" data-flightstr="AA688/AA56" data-product="Premium Economy">Round trip</div>
+<app-choose-flights-price-desktop data-slice="12" data-flightstr="AA688/AA56" data-product="Premium Economy">
+<span class="per-pax-amount" data-slice="12" data-flightstr="AA688/AA56" data-product="Premium Economy">136K</span>
+<div class="per-pax-addon" data-slice="12" data-flightstr="AA688/AA56" data-product="Premium Economy">+ $1,015.93</div>
+<span class="show-for-sr hidden-flight-details" data-slice="12" data-flightstr="AA688/AA56" data-product="Premium Economy">Round trip Premium Economy 136K + $1,015.93 for JFK to LHR, departing at 6:00 AM 1 stop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight12-product2" data-slice="12" data-flightstr="AA688/AA56" data-product="Business">
+<span class="show-for-sr hidden-product-type" data-slice="12" data-flightstr="AA688/AA56" data-product="Business">Business</span>
+<div class="premium" data-slice="12" data-flightstr="AA688/AA56" data-product="Business">
+</div>
+<div class="trip-type regular" data-slice="12" data-flightstr="AA688/AA56" data-product="Business">Round trip</div>
+<app-choose-flights-price-desktop data-slice="12" data-flightstr="AA688/AA56" data-product="Business">
+<span class="per-pax-amount" data-slice="12" data-flightstr="AA688/AA56" data-product="Business">168.5K</span>
+<div class="per-pax-addon" data-slice="12" data-flightstr="AA688/AA56" data-product="Business">+ $420.73</div>
+<span class="show-for-sr hidden-flight-details" data-slice="12" data-flightstr="AA688/AA56" data-product="Business">Round trip Business 168.5K + $420.73 for JFK to LHR, departing at 6:00 AM 1 stop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+<div class="product-cell pad-left-xxs pad-right-xxs">
+<button type="button" class="btn-flight" id="flight12-product3" data-slice="12" data-flightstr="AA688/AA56" data-product="First">
+<span class="show-for-sr hidden-product-type" data-slice="12" data-flightstr="AA688/AA56" data-product="First">First</span>
+<div class="premium" data-slice="12" data-flightstr="AA688/AA56" data-product="First">
+</div>
+<div class="trip-type regular" data-slice="12" data-flightstr="AA688/AA56" data-product="First">Round trip</div>
+<app-choose-flights-price-desktop data-slice="12" data-flightstr="AA688/AA56" data-product="First">
+<span class="per-pax-amount" data-slice="12" data-flightstr="AA688/AA56" data-product="First">517.5K</span>
+<div class="per-pax-addon" data-slice="12" data-flightstr="AA688/AA56" data-product="First">+ $420.73</div>
+<span class="show-for-sr hidden-flight-details" data-slice="12" data-flightstr="AA688/AA56" data-product="First">Round trip First 517.5K + $420.73 for JFK to LHR, departing at 6:00 AM 1 stop</span>
+</app-choose-flights-price-desktop>
+</button>
+</div>
+</div>
+</app-available-products-desktop>
+</div>
+<div class="divider margin-bottom-xs margin-top-xxs">
+</div>
+</div>
+</div>
+</div>
+</app-results-grid-desktop>
+</body>
+</html>

--- a/opencli-plugins/aa/fixtures/round-award.json
+++ b/opencli-plugins/aa/fixtures/round-award.json
@@ -1,0 +1,252 @@
+{
+  "origin": "https://www.aa.com",
+  "path": "/booking/choose-flights/1",
+  "language": "en",
+  "width": 1024,
+  "ready": true,
+  "challenge": false,
+  "login_required": false,
+  "expired": false,
+  "error": "",
+  "no_results": false,
+  "loading": false,
+  "expected_count": 5,
+  "search": {
+    "from": "JFK",
+    "to": "LHR",
+    "depart": "11/13/26",
+    "return_date": "11/20/26",
+    "miles": true,
+    "trip_type": "Round trip",
+    "passengers": [
+      {
+        "type": "adult",
+        "count": 2
+      }
+    ],
+    "header_from": "JFK",
+    "header_to": "LHR",
+    "header_passengers": "2",
+    "direction": "DEPART",
+    "date_label": "Friday, November 13, 2026"
+  },
+  "rows": [
+    {
+      "id": "flight-details-0",
+      "origin": "JFK",
+      "destination": "LHR",
+      "departure": "8:05 AM",
+      "arrival": "8:00 PM",
+      "duration": "6h 55m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "BA 178",
+          "aircraft": "777-Boeing 777",
+          "operator": ""
+        }
+      ],
+      "alerts": "",
+      "fares": [
+        {
+          "group": false,
+          "name": "Main",
+          "amount": "45K",
+          "addon": "+ $549.03",
+          "scope": "Round trip",
+          "description": "Round trip Main 45K + $549.03 for JFK to LHR, departing at 8:05 AM Nonstop",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "flight-details-1",
+      "origin": "JFK",
+      "destination": "LHR",
+      "departure": "10:10 AM",
+      "arrival": "10:10 PM",
+      "duration": "7h 0m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 142",
+          "aircraft": "772-Boeing 777",
+          "operator": ""
+        }
+      ],
+      "alerts": "",
+      "fares": [
+        {
+          "group": false,
+          "name": "Main",
+          "amount": "52.5K",
+          "addon": "+ $222.73",
+          "scope": "Round trip",
+          "description": "Round trip Main 52.5K + $222.73 for JFK to LHR, departing at 10:10 AM Nonstop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "Premium Economy",
+          "amount": "122K",
+          "addon": "+ $1,000.53",
+          "scope": "Round trip",
+          "description": "Round trip Premium Economy 122K + $1,000.53 for JFK to LHR, departing at 10:10 AM Nonstop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "Business",
+          "amount": "407.5K",
+          "addon": "+ $415.13",
+          "scope": "Round trip",
+          "description": "Round trip Business 407.5K + $415.13 for JFK to LHR, departing at 10:10 AM Nonstop",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "flight-details-2",
+      "origin": "JFK",
+      "destination": "LHR",
+      "departure": "5:50 PM",
+      "arrival": "5:50 AM +1 , Arrives on November 14",
+      "duration": "7h 0m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "BA 180",
+          "aircraft": "777-Boeing 777",
+          "operator": ""
+        }
+      ],
+      "alerts": "Overnight travel",
+      "fares": [
+        {
+          "group": false,
+          "name": "Main",
+          "amount": "45K",
+          "addon": "+ $549.03",
+          "scope": "Round trip",
+          "description": "Round trip Main 45K + $549.03 for JFK to LHR, departing at 5:50 PM Nonstop",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "flight-details-4",
+      "origin": "JFK",
+      "destination": "LHR",
+      "departure": "6:25 PM",
+      "arrival": "6:20 AM +1 , Arrives on November 14",
+      "duration": "6h 55m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 100",
+          "aircraft": "77W-Boeing 777",
+          "operator": ""
+        }
+      ],
+      "alerts": "Overnight travel",
+      "fares": [
+        {
+          "group": false,
+          "name": "Main",
+          "amount": "52.5K",
+          "addon": "+ $222.73",
+          "scope": "Round trip",
+          "description": "Round trip Main 52.5K + $222.73 for JFK to LHR, departing at 6:25 PM Nonstop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "Premium Economy",
+          "amount": "215.5K",
+          "addon": "+ $1,000.53",
+          "scope": "Round trip",
+          "description": "Round trip Premium Economy 215.5K + $1,000.53 for JFK to LHR, departing at 6:25 PM Nonstop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "Business",
+          "amount": "369K",
+          "addon": "+ $415.13",
+          "scope": "Round trip",
+          "description": "Round trip Business 369K + $415.13 for JFK to LHR, departing at 6:25 PM Nonstop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "First",
+          "amount": "379K",
+          "addon": "+ $415.13",
+          "scope": "Round trip",
+          "description": "Round trip First 379K + $415.13 for JFK to LHR, departing at 6:25 PM Nonstop",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "flight-details-12",
+      "origin": "JFK",
+      "destination": "LHR",
+      "departure": "6:00 AM",
+      "arrival": "12:05 PM +1 , Arrives on November 14",
+      "duration": "25h 5m",
+      "stops": "1 stop, MIA, Miami International",
+      "segments": [
+        {
+          "flight_number": "AA 688",
+          "aircraft": "738-Boeing 737",
+          "operator": ""
+        },
+        {
+          "flight_number": "AA 56",
+          "aircraft": "77W-Boeing 777",
+          "operator": ""
+        }
+      ],
+      "alerts": "Overnight travel, Extended layover, The class of service you searched may not be available on one or more flights",
+      "fares": [
+        {
+          "group": false,
+          "name": "Main",
+          "amount": "52.5K",
+          "addon": "+ $228.33",
+          "scope": "Round trip",
+          "description": "Round trip Main 52.5K + $228.33 for JFK to LHR, departing at 6:00 AM 1 stop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "Premium Economy",
+          "amount": "136K",
+          "addon": "+ $1,015.93",
+          "scope": "Round trip",
+          "description": "Round trip Premium Economy 136K + $1,015.93 for JFK to LHR, departing at 6:00 AM 1 stop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "Business",
+          "amount": "168.5K",
+          "addon": "+ $420.73",
+          "scope": "Round trip",
+          "description": "Round trip Business 168.5K + $420.73 for JFK to LHR, departing at 6:00 AM 1 stop",
+          "unavailable": false
+        },
+        {
+          "group": false,
+          "name": "First",
+          "amount": "517.5K",
+          "addon": "+ $420.73",
+          "scope": "Round trip",
+          "description": "Round trip First 517.5K + $420.73 for JFK to LHR, departing at 6:00 AM 1 stop",
+          "unavailable": false
+        }
+      ]
+    }
+  ]
+}

--- a/opencli-plugins/aa/fixtures/round-cash.html
+++ b/opencli-plugins/aa/fixtures/round-cash.html
@@ -1,0 +1,968 @@
+<html lang="en">
+<head>
+</head>
+<body>
+<app-modify-search>
+<app-modify-search-header>
+<span class="origin">JFK</span>
+<span class="destination"> LHR,</span>
+<span class="passenger-count">2</span>
+</app-modify-search-header>
+<mat-select role="combobox" aria-haspopup="listbox" name="tripType" class="mat-mdc-select ng-untouched ng-pristine ng-valid" aria-labelledby="mat-select-value-0" id="mat-select-0" tabindex="0" aria-expanded="false" aria-required="false" aria-disabled="false" aria-invalid="false">
+<div cdk-overlay-origin="" class="mat-mdc-select-trigger">
+<div class="mat-mdc-select-value" id="mat-select-value-0">
+<span class="mat-mdc-select-value-text">
+<span class="mat-mdc-select-min-line">Round trip</span>
+</span>
+</div>
+<div class="mat-mdc-select-arrow-wrapper">
+<div class="mat-mdc-select-arrow">
+</div>
+</div>
+</div>
+</mat-select>
+<input type="checkbox" id="redeem-miles" name="redeemMiles" class="ng-untouched ng-pristine ng-valid" value="on">
+<input matinput="" type="text" class="mat-mdc-autocomplete-trigger mat-mdc-input-element ng-untouched ng-pristine ng-valid mat-mdc-form-field-input-control mdc-text-field__input cdk-text-field-autofill-monitored" aria-label="Departure airport" placeholder="City / airport" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="listbox" id="matOriginAirport" name="orig" aria-invalid="false" aria-required="false" value="JFK">
+<input matinput="" type="text" class="mat-mdc-autocomplete-trigger mat-mdc-input-element ng-untouched ng-pristine ng-valid mat-mdc-form-field-input-control mdc-text-field__input cdk-text-field-autofill-monitored" aria-label="Arrival airport" placeholder="City / airport" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-haspopup="listbox" id="matDestinationAirport" name="dest" aria-invalid="false" aria-required="false" value="LHR">
+<input autocomplete="off" type="text" class="auto-growing-input agc-date-input-range-display agc-date-input-full-date" spellcheck="false" placeholder="mm/dd/yy" id="date-input-first-agc-date-input-0" aria-labelledby="date-accessible-label-first-agc-date-input-0" aria-label="Depart date, press Enter to open calendar" aria-describedby="date-input-describedby-agc-date-input-0" aria-invalid="false" maxlength="8" style="width: 69px;" value="11/13/26">
+<input autocomplete="off" type="text" class="auto-growing-input agc-date-input-range-display agc-date-input-full-date" spellcheck="false" placeholder="mm/dd/yy" id="date-input-second-agc-date-input-0" aria-labelledby="date-accessible-label-second-agc-date-input-0" aria-label="Return date, press Enter to open calendar" aria-describedby="date-input-describedby-agc-date-input-0" aria-invalid="false" maxlength="8" style="width: 69px;" value="11/20/26">
+<div data-passengers="[{&quot;type&quot;:&quot;adult&quot;,&quot;count&quot;:2}]">
+</div>
+</app-modify-search>
+<app-depart-return-header-desktop>
+<div class="pad-top-xs hide-for-small-only desktop-only">
+<h2>
+<em>
+<app-depart-return-multicity-text>
+<span id="flight-direction-text">DEPART</span>
+</app-depart-return-multicity-text>
+</em>
+<div class="city-pair"> New York, NY to London, United Kingdom </div>
+</h2>
+<h3 class="date">Friday, November 13, 2026</h3>
+<div class="aa-flight-info">
+<span aria-hidden="true" class="icon-error icon-small">
+</span> American Airlines flights may be listed first. </div>
+</div>
+</app-depart-return-header-desktop>
+<app-results-matrix>
+<div tabindex="-1" class="results-matrix">
+<app-filter-container id="filter-container" tabindex="-1">
+<div class="filter-container">
+<h2 id="flights-by-heading" class="show-for-sr">
+<span>Filter flights by </span>
+<span class="filter-flights-by-stops">Stops, </span>
+<span class="filter-flights-by-airlines">Airlines, </span>
+</h2>
+<div class="filters-row">
+<div aria-hidden="true" class="filter-by">Filter by:</div>
+<div class="pills">
+<app-filter-stops>
+<div class="pill-container">
+<button type="button" id="btn-stops-filter" class="pill active" aria-haspopup="dialog">
+<div aria-hidden="true" class="pill-text">Stops</div>
+<span class="show-for-sr pill-text">Filter flights by Stops</span>
+<div class="pill-arrow">
+</div>
+</button>
+</div>
+</app-filter-stops>
+<app-filter-airlines>
+<div class="pill-container">
+<button type="button" id="btn-airlines-filter" class="pill active" aria-haspopup="dialog">
+<div aria-hidden="true" class="pill-text"> Airlines </div>
+<span class="show-for-sr pill-text">Filter flights by Airlines</span>
+<div class="pill-arrow">
+</div>
+</button>
+</div>
+</app-filter-airlines>
+</div>
+<div class="result-clear">
+<span role="status" aria-live="polite" aria-atomic="true" class="result-count">5 results</span>
+</div>
+<div class="clearfix">
+</div>
+</div>
+</div>
+</app-filter-container>
+<div class="matrix-header">
+<div role="group" aria-label="Sorting options" class="header-row">
+<span id="sort-screen-reader-text" role="status" aria-live="polite" aria-atomic="true" class="show-for-sr">
+</span>
+<div id="sort-by">
+<div id="sort-by-departure">
+<button type="button" id="btn-sort-by-departure">
+<span id="screen-reader-departure" class="show-for-sr"> Sort by depart, not sorted, press to sort early to late </span>
+<div aria-hidden="true" class="sort-text">Depart</div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+<div id="sort-by-arrival">
+<button type="button" id="btn-sort-by-arrival">
+<span id="screen-reader-arrival" class="show-for-sr"> Sort by arrive, not sorted, press to sort early to late </span>
+<div aria-hidden="true" class="sort-text">Arrive</div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+<div id="sort-by-duration">
+<button type="button" id="btn-sort-by-duration">
+<span id="screen-reader-duration" class="show-for-sr"> Sort by duration, not sorted, press to sort short to long </span>
+<div aria-hidden="true" class="sort-text">Duration</div>
+<div class="sort-arrows">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</button>
+</div>
+</div>
+<div class="groups new-product-line">
+<button type="button" class="group-header group-main" id="sort-by-MAIN">
+<span class="show-for-sr" id="screen-reader-MAIN"> Sort by Main Fare Products, not sorted, press to sort prices low to high </span>
+<div class="group-sort">
+<div class="group-name">Main</div>
+<div class="group-arrows">
+<div class="group-sort-arrows" id="btn-sort-by-MAIN">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</div>
+</div>
+</button>
+<button type="button" class="group-header group-main_extra" id="sort-by-MAIN_EXTRA">
+<span class="show-for-sr" id="screen-reader-MAIN_EXTRA"> Sort by Main Extra Fare Products, not sorted, press to sort prices low to high </span>
+<div class="group-sort">
+<div class="group-name">Main Extra</div>
+<div class="group-arrows">
+<div class="group-sort-arrows" id="btn-sort-by-MAIN_EXTRA">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</div>
+</div>
+</button>
+<button type="button" class="group-header group-premium_economy" id="sort-by-PREMIUM_ECONOMY">
+<span class="show-for-sr" id="screen-reader-PREMIUM_ECONOMY"> Sort by Premium Economy Fare Products, not sorted, press to sort prices low to high </span>
+<div class="group-sort">
+<div class="group-name">Premium Economy</div>
+<div class="group-arrows">
+<div class="group-sort-arrows" id="btn-sort-by-PREMIUM_ECONOMY">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</div>
+</div>
+</button>
+<button type="button" class="group-header group-premium" id="sort-by-PREMIUM">
+<span class="show-for-sr" id="screen-reader-PREMIUM"> Sort by Premium Fare Products, not sorted, press to sort prices low to high </span>
+<div class="group-sort">
+<div class="group-name">Premium</div>
+<div class="group-arrows">
+<div class="group-sort-arrows" id="btn-sort-by-PREMIUM">
+<div class="two-arrows up">
+</div>
+<div class="two-arrows down">
+</div>
+<div class="one-arrow down">
+</div>
+<div class="one-arrow up">
+</div>
+</div>
+</div>
+</div>
+</button>
+</div>
+</div>
+</div>
+<div class="results-grid-container">
+<app-slice-details id="slice-details-0">
+<div class="slice-details row">
+<div tabindex="-1" class="col-5">
+<app-matrix-flight-card>
+<div class="matrix-flight-card">
+<div class="origin">
+<div class="city-code">JFK</div>
+<div class="time"> 8:05  <span class="meridiem">AM</span>
+</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">LHR</div>
+<div class="time"> 8:00  <span class="meridiem">PM</span>
+</div>
+</div>
+<div class="duration">6h 55m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+<span class="hidden-accessible">Opens Nonstop details for JFK to LHR, departing at 8:05 AM</span>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="flight-number"> AA 6939 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> 777-Boeing 777 </span>
+<p class="operational-disclosure">
+<app-operated-by>
+</app-operated-by>
+</p>
+<div class="operated-by"> Operated by British Airways </div>
+<p>
+</p>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="btn-link details">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 8:05 AM Nonstop</span>
+</button>
+</div>
+</div>
+</app-matrix-flight-card>
+<app-matrix-slice-alerts>
+</app-matrix-slice-alerts>
+</div>
+<div class="col-7">
+<app-product-groups>
+<div class="product-groups" id="slice-0-product-groups">
+<button type="button" id="flight-0-product-group-MAIN" aria-expanded="false" class="btn-flight MAIN">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$697</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main fare list starts at $697 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<div class="btn-not-available">Not available</div>
+<button type="button" id="flight-0-product-group-PREMIUM_ECONOMY" aria-expanded="false" class="btn-flight PREMIUM_ECONOMY">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium Economy</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$2,391</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium Economy fare list starts at $2,391 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-0-product-group-PREMIUM" aria-expanded="false" class="btn-flight PREMIUM">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$6,416</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium fare list starts at $6,416 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+</div>
+</app-product-groups>
+</div>
+</div>
+</app-slice-details>
+<app-slice-details id="slice-details-1">
+<div class="slice-details row">
+<div tabindex="-1" class="col-5">
+<app-matrix-flight-card>
+<div class="matrix-flight-card">
+<div class="origin">
+<div class="city-code">JFK</div>
+<div class="time"> 10:10  <span class="meridiem">AM</span>
+</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">LHR</div>
+<div class="time"> 10:10  <span class="meridiem">PM</span>
+</div>
+</div>
+<div class="duration">7h 0m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+<span class="hidden-accessible">Opens Nonstop details for JFK to LHR, departing at 10:10 AM</span>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="flight-number"> AA 142 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> 772-Boeing 777 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="btn-link details">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 10:10 AM Nonstop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="btn-link seats">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 10:10 AM Nonstop</span>
+</button>
+</div>
+</div>
+</app-matrix-flight-card>
+<app-matrix-slice-alerts>
+</app-matrix-slice-alerts>
+</div>
+<div class="col-7">
+<app-product-groups>
+<div class="product-groups" id="slice-1-product-groups">
+<button type="button" id="flight-1-product-group-MAIN" aria-expanded="false" class="btn-flight MAIN">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$697</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main fare list starts at $697 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-1-product-group-MAIN_EXTRA" aria-expanded="false" class="btn-flight MAIN_EXTRA">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main Extra</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$1,182</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main Extra fare list starts at $1,182 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-1-product-group-PREMIUM_ECONOMY" aria-expanded="false" class="btn-flight PREMIUM_ECONOMY">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium Economy</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$2,053</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium Economy fare list starts at $2,053 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-1-product-group-PREMIUM" aria-expanded="false" class="btn-flight PREMIUM">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$5,666</span>
+</app-choose-flights-price-desktop>
+</div>
+<div class="flagship">
+<strong>Flagship®</strong> available</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium fare list starts at $5,666 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+</div>
+</app-product-groups>
+</div>
+</div>
+</app-slice-details>
+<app-slice-details id="slice-details-2">
+<div class="slice-details row">
+<div tabindex="-1" class="col-5">
+<app-matrix-flight-card>
+<div class="matrix-flight-card">
+<div class="origin">
+<div class="city-code">JFK</div>
+<div class="time"> 5:50  <span class="meridiem">PM</span>
+</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">LHR</div>
+<div class="time"> 5:50  <span class="meridiem">AM</span>
+<span class="next-day">
+<app-next-day-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-next-day">+1 <span class="show-for-sr">, Arrives on November 14</span>
+</button>
+</app-next-day-tooltip>
+</span>
+</div>
+</div>
+<div class="duration">7h 0m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+<span class="hidden-accessible">Opens Nonstop details for JFK to LHR, departing at 5:50 PM</span>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="flight-number"> AA 6881 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> 777-Boeing 777 </span>
+<p class="operational-disclosure">
+<app-operated-by>
+</app-operated-by>
+</p>
+<div class="operated-by"> Operated by British Airways </div>
+<p>
+</p>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="btn-link details">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 5:50 PM Nonstop</span>
+</button>
+</div>
+</div>
+</app-matrix-flight-card>
+<app-matrix-slice-alerts>
+<div class="alerts">
+<span aria-hidden="true" class="icon-warning">
+</span>
+<span class="warning-text"> Overnight travel</span>
+</div>
+</app-matrix-slice-alerts>
+</div>
+<div class="col-7">
+<app-product-groups>
+<div class="product-groups" id="slice-2-product-groups">
+<button type="button" id="flight-2-product-group-MAIN" aria-expanded="false" class="btn-flight MAIN">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$697</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main fare list starts at $697 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<div class="btn-not-available">Not available</div>
+<button type="button" id="flight-2-product-group-PREMIUM_ECONOMY" aria-expanded="false" class="btn-flight PREMIUM_ECONOMY">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium Economy</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$2,391</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium Economy fare list starts at $2,391 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-2-product-group-PREMIUM" aria-expanded="false" class="btn-flight PREMIUM">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$4,816</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium fare list starts at $4,816 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+</div>
+</app-product-groups>
+</div>
+</div>
+</app-slice-details>
+<app-slice-details id="slice-details-4">
+<div class="slice-details row">
+<div tabindex="-1" class="col-5">
+<app-matrix-flight-card>
+<div class="matrix-flight-card">
+<div class="origin">
+<div class="city-code">JFK</div>
+<div class="time"> 6:25  <span class="meridiem">PM</span>
+</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">LHR</div>
+<div class="time"> 6:20  <span class="meridiem">AM</span>
+<span class="next-day">
+<app-next-day-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-next-day">+1 <span class="show-for-sr">, Arrives on November 14</span>
+</button>
+</app-next-day-tooltip>
+</span>
+</div>
+</div>
+<div class="duration">6h 55m</div>
+<div class="stops">
+<app-stops-tooltip>
+<span class="nonstop">Nonstop</span>
+</app-stops-tooltip>
+<span class="hidden-accessible">Opens Nonstop details for JFK to LHR, departing at 6:25 PM</span>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="flight-number"> AA 100 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> 77W-Boeing 777 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="btn-link details">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 6:25 PM Nonstop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="btn-link seats">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 6:25 PM Nonstop</span>
+</button>
+</div>
+</div>
+</app-matrix-flight-card>
+<app-matrix-slice-alerts>
+<div class="alerts">
+<span aria-hidden="true" class="icon-warning">
+</span>
+<span class="warning-text"> Overnight travel</span>
+</div>
+</app-matrix-slice-alerts>
+</div>
+<div class="col-7">
+<app-product-groups>
+<div class="product-groups" id="slice-4-product-groups">
+<button type="button" id="flight-4-product-group-MAIN" aria-expanded="false" class="btn-flight MAIN">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$697</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main fare list starts at $697 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-4-product-group-MAIN_EXTRA" aria-expanded="false" class="btn-flight MAIN_EXTRA">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main Extra</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$1,182</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main Extra fare list starts at $1,182 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-4-product-group-PREMIUM_ECONOMY" aria-expanded="false" class="btn-flight PREMIUM_ECONOMY">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium Economy</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$2,391</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium Economy fare list starts at $2,391 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-4-product-group-PREMIUM" aria-expanded="false" class="btn-flight PREMIUM">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$5,666</span>
+</app-choose-flights-price-desktop>
+</div>
+<div class="flagship">
+<strong>Flagship®</strong> available</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium fare list starts at $5,666 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+</div>
+</app-product-groups>
+</div>
+</div>
+</app-slice-details>
+<app-slice-details id="slice-details-12">
+<div class="slice-details row">
+<div tabindex="-1" class="col-5">
+<app-matrix-flight-card>
+<div class="matrix-flight-card">
+<div class="origin">
+<div class="city-code">JFK</div>
+<div class="time"> 12:30  <span class="meridiem">PM</span>
+</div>
+</div>
+<div aria-hidden="true" class="arrow-icon">
+<span class="icon-arrow-right">
+</span>
+</div>
+<div class="destination">
+<div class="city-code">LHR</div>
+<div class="time"> 7:20  <span class="meridiem">AM</span>
+<span class="next-day">
+<app-next-day-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-next-day">+1 <span class="show-for-sr">, Arrives on November 14</span>
+</button>
+</app-next-day-tooltip>
+</span>
+</div>
+</div>
+<div class="duration">13h 50m</div>
+<div class="stops">
+<app-stops-tooltip>
+<button type="button" apptooltip="" class="btn-link btn-stops">1 stop<span class="show-for-sr">, CLT, Charlotte Douglas International Airport</span>
+</button>
+</app-stops-tooltip>
+<span class="hidden-accessible">Opens 1 stop details for JFK to LHR, departing at 12:30 PM</span>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="cities">JFK - CLT</span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="flight-number"> AA 2680 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> 738-Boeing 737 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+<span>Free Wi-Fi for AAdvantage® members</span>
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="segment-info">
+<div class="leg-info">
+<div class="transportation-type">
+<span aria-hidden="true" class="plane">
+</span>
+</div>
+<div class="flight-details">
+<span class="cities">CLT - LHR</span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="flight-number"> AA 730 </span>
+<span aria-hidden="true" class="bullet">
+</span>
+<span class="aircraft"> 77W-Boeing 777 </span>
+<app-amenities-tooltip>
+<div class="amenities">
+<div class="amenities-wrapper">
+<button type="button" aria-haspopup="dialog" aria-label="Onboard amenities">
+</button>
+</div>
+</div>
+</app-amenities-tooltip>
+</div>
+</div>
+</div>
+<div class="actions">
+<button type="button" aria-haspopup="dialog" class="btn-link details">
+<span class="detailsDialogText">Details</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 12:30 PM 1 stop</span>
+</button>
+<span aria-hidden="true" class="icon-pipe">
+</span>
+<button type="button" aria-haspopup="dialog" class="btn-link seats">
+<span class="seatsDialogText">Seats (view only)</span>
+<span class="hidden-accessible">, for JFK to LHR, departing at 12:30 PM 1 stop</span>
+</button>
+</div>
+</div>
+</app-matrix-flight-card>
+<app-matrix-slice-alerts>
+<div class="alerts">
+<span aria-hidden="true" class="icon-warning">
+</span>
+<span class="warning-text"> Overnight travel<span>,</span> Extended layover<span>,</span> The class of service you searched may not be available on one or more flights</span>
+</div>
+</app-matrix-slice-alerts>
+</div>
+<div class="col-7">
+<app-product-groups>
+<div class="product-groups" id="slice-12-product-groups">
+<button type="button" id="flight-12-product-group-MAIN" aria-expanded="false" class="btn-flight MAIN">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$701</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main fare list starts at $701 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-12-product-group-MAIN_EXTRA" aria-expanded="false" class="btn-flight MAIN_EXTRA">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Main Extra</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$1,186</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Main Extra fare list starts at $1,186 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-12-product-group-PREMIUM_ECONOMY" aria-expanded="false" class="btn-flight PREMIUM_ECONOMY">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium Economy</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$2,396</span>
+</app-choose-flights-price-desktop>
+</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium Economy fare list starts at $2,396 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+<button type="button" id="flight-12-product-group-PREMIUM" aria-expanded="false" class="btn-flight PREMIUM">
+<div class="btn-contents">
+<span class="show-for-sr hidden-product-group">Premium</span>
+<div class="trip-type-row">
+<div class="trip-type">Round trip from</div>
+<div class="chevron">
+</div>
+</div>
+<div class="price">
+<app-choose-flights-price-desktop>
+<span class="per-pax-amount">$4,820</span>
+</app-choose-flights-price-desktop>
+</div>
+<div class="flagship">
+<strong>Flagship®</strong> available</div>
+</div>
+<span class="show-for-sr a11y-drawer-button-text">The lowest fare in the Premium fare list starts at $4,820 Round trip, per person.</span>
+<span class="show-for-sr a11y-dynamic-button-text"> Click here for more fare options </span>
+</button>
+</div>
+</app-product-groups>
+</div>
+</div>
+</app-slice-details>
+</div>
+</div>
+</app-results-matrix>
+</body>
+</html>

--- a/opencli-plugins/aa/fixtures/round-cash.json
+++ b/opencli-plugins/aa/fixtures/round-cash.json
@@ -1,0 +1,297 @@
+{
+  "origin": "https://www.aa.com",
+  "path": "/booking/choose-flights/1",
+  "language": "en",
+  "width": 1024,
+  "ready": true,
+  "challenge": false,
+  "login_required": false,
+  "expired": false,
+  "error": "",
+  "no_results": false,
+  "loading": false,
+  "expected_count": 5,
+  "search": {
+    "from": "JFK",
+    "to": "LHR",
+    "depart": "11/13/26",
+    "return_date": "11/20/26",
+    "miles": false,
+    "trip_type": "Round trip",
+    "passengers": [
+      {
+        "type": "adult",
+        "count": 2
+      }
+    ],
+    "header_from": "JFK",
+    "header_to": "LHR",
+    "header_passengers": "2",
+    "direction": "DEPART",
+    "date_label": "Friday, November 13, 2026"
+  },
+  "rows": [
+    {
+      "id": "slice-details-0",
+      "origin": "JFK",
+      "destination": "LHR",
+      "departure": "8:05 AM",
+      "arrival": "8:00 PM",
+      "duration": "6h 55m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 6939",
+          "aircraft": "777-Boeing 777",
+          "operator": ""
+        }
+      ],
+      "alerts": "",
+      "fares": [
+        {
+          "group": true,
+          "name": "Main",
+          "amount": "$697",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Main fare list starts at $697 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium Economy",
+          "amount": "$2,391",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Premium Economy fare list starts at $2,391 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium",
+          "amount": "$6,416",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Premium fare list starts at $6,416 Round trip, per person.",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "slice-details-1",
+      "origin": "JFK",
+      "destination": "LHR",
+      "departure": "10:10 AM",
+      "arrival": "10:10 PM",
+      "duration": "7h 0m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 142",
+          "aircraft": "772-Boeing 777",
+          "operator": ""
+        }
+      ],
+      "alerts": "",
+      "fares": [
+        {
+          "group": true,
+          "name": "Main",
+          "amount": "$697",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Main fare list starts at $697 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Main Extra",
+          "amount": "$1,182",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Main Extra fare list starts at $1,182 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium Economy",
+          "amount": "$2,053",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Premium Economy fare list starts at $2,053 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium",
+          "amount": "$5,666",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Premium fare list starts at $5,666 Round trip, per person.",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "slice-details-2",
+      "origin": "JFK",
+      "destination": "LHR",
+      "departure": "5:50 PM",
+      "arrival": "5:50 AM +1 , Arrives on November 14",
+      "duration": "7h 0m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 6881",
+          "aircraft": "777-Boeing 777",
+          "operator": ""
+        }
+      ],
+      "alerts": "Overnight travel",
+      "fares": [
+        {
+          "group": true,
+          "name": "Main",
+          "amount": "$697",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Main fare list starts at $697 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium Economy",
+          "amount": "$2,391",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Premium Economy fare list starts at $2,391 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium",
+          "amount": "$4,816",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Premium fare list starts at $4,816 Round trip, per person.",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "slice-details-4",
+      "origin": "JFK",
+      "destination": "LHR",
+      "departure": "6:25 PM",
+      "arrival": "6:20 AM +1 , Arrives on November 14",
+      "duration": "6h 55m",
+      "stops": "Nonstop",
+      "segments": [
+        {
+          "flight_number": "AA 100",
+          "aircraft": "77W-Boeing 777",
+          "operator": ""
+        }
+      ],
+      "alerts": "Overnight travel",
+      "fares": [
+        {
+          "group": true,
+          "name": "Main",
+          "amount": "$697",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Main fare list starts at $697 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Main Extra",
+          "amount": "$1,182",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Main Extra fare list starts at $1,182 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium Economy",
+          "amount": "$2,391",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Premium Economy fare list starts at $2,391 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium",
+          "amount": "$5,666",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Premium fare list starts at $5,666 Round trip, per person.",
+          "unavailable": false
+        }
+      ]
+    },
+    {
+      "id": "slice-details-12",
+      "origin": "JFK",
+      "destination": "LHR",
+      "departure": "12:30 PM",
+      "arrival": "7:20 AM +1 , Arrives on November 14",
+      "duration": "13h 50m",
+      "stops": "1 stop, CLT, Charlotte Douglas International Airport",
+      "segments": [
+        {
+          "flight_number": "AA 2680",
+          "aircraft": "738-Boeing 737",
+          "operator": ""
+        },
+        {
+          "flight_number": "AA 730",
+          "aircraft": "77W-Boeing 777",
+          "operator": ""
+        }
+      ],
+      "alerts": "Overnight travel, Extended layover, The class of service you searched may not be available on one or more flights",
+      "fares": [
+        {
+          "group": true,
+          "name": "Main",
+          "amount": "$701",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Main fare list starts at $701 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Main Extra",
+          "amount": "$1,186",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Main Extra fare list starts at $1,186 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium Economy",
+          "amount": "$2,396",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Premium Economy fare list starts at $2,396 Round trip, per person.",
+          "unavailable": false
+        },
+        {
+          "group": true,
+          "name": "Premium",
+          "amount": "$4,820",
+          "addon": "",
+          "scope": "Round trip from",
+          "description": "The lowest fare in the Premium fare list starts at $4,820 Round trip, per person.",
+          "unavailable": false
+        }
+      ]
+    }
+  ]
+}

--- a/opencli-plugins/aa/flights.js
+++ b/opencli-plugins/aa/flights.js
@@ -1,0 +1,131 @@
+import { ArgumentError, AuthRequiredError, CommandExecutionError } from "@jackwener/opencli/errors";
+import { cli, Strategy } from "@jackwener/opencli/registry";
+import { AaLoginRequiredError, loadAaFlights } from "./aa-browser.mjs";
+import { FARES, STOPS, SORTS, normalizeResults, normalizeSearch } from "./aa-helpers.mjs";
+
+cli({
+  site: "aa",
+  name: "flights",
+  access: "read",
+  description:
+    "Search American Airlines cash fares or AAdvantage miles (outbound choices for round trips)",
+  example: "opencli aa flights SFO DFW 2026-11-13 --miles --stops nonstop -f json",
+  domain: "aa.com",
+  strategy: Strategy.COOKIE,
+  browser: true,
+  siteSession: "persistent",
+  navigateBefore: false,
+  args: [
+    {
+      name: "from",
+      type: "string",
+      positional: true,
+      required: true,
+      help: "Origin airport code, e.g. SFO",
+    },
+    {
+      name: "to",
+      type: "string",
+      positional: true,
+      required: true,
+      help: "Destination airport code, e.g. DFW",
+    },
+    {
+      name: "depart",
+      type: "string",
+      positional: true,
+      required: true,
+      help: "Departure date, YYYY-MM-DD",
+    },
+    {
+      name: "return",
+      type: "string",
+      help: "Return date. Returns outbound choices with starting round-trip prices, not finalized itineraries",
+    },
+    {
+      name: "miles",
+      type: "bool",
+      default: false,
+      help: "Search AAdvantage miles plus cash taxes instead of cash fares",
+    },
+    {
+      name: "adults",
+      type: "int",
+      default: 1,
+      help: "Adult passengers (1-9). Prices remain per person",
+    },
+    {
+      name: "fare",
+      type: "string",
+      choices: FARES,
+      default: "all",
+      help: "Filter displayed cash fare group or award cabin. Cash Business/First uses premium",
+    },
+    {
+      name: "stops",
+      type: "string",
+      choices: STOPS,
+      default: "any",
+      help: "Maximum outbound stops",
+    },
+    { name: "max-price", type: "string", help: "Maximum displayed USD fare per person. Cash only" },
+    {
+      name: "max-miles",
+      type: "int",
+      help: "Maximum displayed miles per person. Requires --miles",
+    },
+    { name: "max-duration", type: "int", help: "Maximum outbound duration in minutes" },
+    {
+      name: "sort",
+      type: "string",
+      choices: SORTS,
+      default: "best",
+      help: "AA order, price (miles then taxes for awards), duration, or departure",
+    },
+    {
+      name: "limit",
+      type: "int",
+      default: 20,
+      help: "Maximum fare rows (1-500), after filtering and sorting the displayed flights",
+    },
+    {
+      name: "timeout",
+      type: "int",
+      default: 90,
+      help: "Result-loading deadline in seconds (5-180)",
+    },
+  ],
+  columns: [
+    "rank",
+    "origin",
+    "destination",
+    "departure_date",
+    "departure",
+    "arrival_date",
+    "arrival",
+    "duration_minutes",
+    "stops",
+    "fare_product",
+    "price",
+    "miles",
+    "taxes",
+    "currency",
+    "price_basis",
+  ],
+  func: async (page, args) => {
+    let search;
+    try {
+      search = normalizeSearch(args);
+    } catch (error) {
+      throw new ArgumentError(error.message);
+    }
+    if (!page) throw new CommandExecutionError("Browser session required for aa flights");
+    try {
+      return normalizeResults(await loadAaFlights(page, search), search);
+    } catch (error) {
+      if (error instanceof AaLoginRequiredError)
+        throw new AuthRequiredError("aa.com", error.message);
+      throw new CommandExecutionError(error.message);
+    }
+  },
+});

--- a/opencli-plugins/aa/opencli-plugin.json
+++ b/opencli-plugins/aa/opencli-plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "rome-aa",
+  "description": "American Airlines cash fares and AAdvantage awards with separate taxes",
+  "version": "0.1.0",
+  "opencli": ">=1.8.0"
+}

--- a/opencli-plugins/aa/package.json
+++ b/opencli-plugins/aa/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "rome-opencli-aa",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "../../scripts/test-env.sh node --test *.test.mjs"
+  }
+}

--- a/opencli-plugins/aa/test-fixtures.mjs
+++ b/opencli-plugins/aa/test-fixtures.mjs
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { normalizeSearch } from "./aa-helpers.mjs";
+
+export const fixture = (mode = "cash") =>
+  JSON.parse(readFileSync(new URL(`./fixtures/${mode}.json`, import.meta.url), "utf8"));
+export const argsFor = (mode = "cash", extra = {}) => ({
+  from: mode.startsWith("round") ? "JFK" : "SFO",
+  to: mode.startsWith("round") ? "LHR" : "DFW",
+  depart: "2026-11-13",
+  miles: mode.includes("award"),
+  ...(mode.startsWith("round") ? { return: "2026-11-20", adults: 2 } : {}),
+  ...extra,
+});
+export const searchFor = (mode = "cash", extra = {}) => normalizeSearch(argsFor(mode, extra));
+export function mockPage(frames) {
+  let reads = 0;
+  let time = 0;
+  const urls = [];
+  return {
+    urls,
+    now: () => time,
+    async goto(url) {
+      urls.push(url);
+    },
+    async wait() {
+      time += 1000;
+    },
+    async evaluate(fn) {
+      if (fn.name !== "readAaPage") throw new Error("Unexpected browser mutation");
+      return structuredClone(frames[Math.min(reads++, frames.length - 1)]);
+    },
+  };
+}


### PR DESCRIPTION
## What this PR does

Rome has no aa.com flight-price command. `opencli aa flights FROM TO DATE` searches American Airlines cash fares, and `--miles` searches AAdvantage awards with separate cash taxes and charges.

The command supports return dates, 1–9 adults, fare-group or award-cabin filters, stop and duration limits, price ceilings, and sorting. The local plugin is installed as `rome-aa`.

## Design & Invariants

The command contract lives in [opencli-plugins/aa/README.md](opencli-plugins/aa/README.md).

- Use AA's public search deep link and read its rendered Angular result components. Do not handle authentication material or call private pricing APIs.
- Verify the rendered airport codes, dates, adult count, trip type, and miles checkbox. Wait for date controls to hydrate and the displayed result count to stabilize.
- Cash results expose fare-group minima. Award results expose cabin offers. Do not infer Business or First from AA's cash Premium group.
- Keep miles and cash taxes separate. Prices stay per person, including searches for multiple adults.
- Round-trip rows describe outbound choices with starting round-trip totals. They are not finalized itineraries or outbound-only prices.
- Fail on challenges, expired sessions, search changes, incomplete rows, or unknown prices. Never substitute cash results for an award request.
- Return a reproducible search link without AA search-session identifiers. Never click a fare or create a booking.

## Test plan

- [x] `pnpm -C opencli-plugins/aa test` — 134 helper, DOM, loader, and command tests.
- [x] `TZ=Pacific/Kiritimati node --test opencli-plugins/aa/aa-dom.test.mjs` — 14 DOM tests pass in UTC+14.
- [x] `opencli validate aa` — one command, no errors or warnings.
- [x] Biome and `git diff --check` pass. CI runs the AA plugin suite.
- [x] Southwest, Delta, and United regression suites pass: 109, 92, and 72 tests.
- [x] Live signed-out CLI cash search: SFO–DFW, 2026-11-13, Main fares sorted by price. Returned displayed $206 fare-group minima.
- [x] Live signed-out CLI award search: the same route and date, Main awards sorted by miles and taxes. Returned 10,000-mile choices with separate $5.60 cash components.
- [x] Live browser inspection of JFK–LHR round-trip cash and awards for two adults. Sanitized one-way and round-trip fixtures replay correctly in real Chromium.
- [x] Regression coverage for delayed award `data-product` attributes, date-control hydration, transient navigation contexts, hidden prices, unavailable cabins, overnight arrivals, and validation before result limits.
- [ ] Successful end-to-end round-trip CLI revalidation. AA intermittently returned Access Denied or stalled on a blank result page after repeated searches. The command failed explicitly without returning partial fares.
- [ ] Full repository checks. `pnpm typecheck` and `pnpm test:unit` cannot run with the checkout's missing workspace toolchain. `pnpm dev:all` reports an unreachable Docker daemon. No Nix dev shell is available here.

## Not in this PR

- Fare selection, booking, or finalized return choices. The command only reads the initial search results.
- Multi-city and mixed-age passenger searches. The interface accepts one airport pair and adult passengers.
- Anti-bot bypasses. The command reports AA's challenge and leaves authentication and access resolution to the browser user.
