### PR TITLE
fix(codex): preserve the OpenCLI CDP endpoint in agent subprocesses

### DIFF
--- a/packages/core/src/core/codex/app-server-manager.test.ts
+++ b/packages/core/src/core/codex/app-server-manager.test.ts
@@ -96,6 +96,39 @@ function binding(label: string): CodexThreadBinding & {
 }
 
 describe("CodexAppServerManager", () => {
+  it.each([
+    "http://127.0.0.1:9222",
+    "http://chrome:9333",
+    undefined,
+  ])("passes through the OpenCLI endpoint (%s) and filters unrelated env vars", async (endpoint) => {
+    rs.stubEnv("OPENCLI_CDP_ENDPOINT", endpoint as string);
+    rs.stubEnv("ROME_TEST_UNLISTED_ENV", "not-for-child-processes");
+    const clients: FakeConnection[] = [];
+    const manager = new CodexAppServerManager({
+      createClient: (options) => {
+        const client = new FakeConnection(options, () => "thread-env");
+        clients.push(client);
+        return client;
+      },
+    });
+
+    try {
+      await manager.warmup();
+
+      expect(clients).toHaveLength(1);
+      const env = clients[0].options.env;
+      if (endpoint === undefined) {
+        expect(env).not.toHaveProperty("OPENCLI_CDP_ENDPOINT");
+      } else {
+        expect(env.OPENCLI_CDP_ENDPOINT).toBe(endpoint);
+      }
+      expect(env).not.toHaveProperty("ROME_TEST_UNLISTED_ENV");
+    } finally {
+      manager.close();
+      rs.unstubAllEnvs();
+    }
+  });
+
   it("initializes once and isolates concurrent thread notifications and dynamic calls", async () => {
     const clients: FakeConnection[] = [];
     let threadSequence = 0;

--- a/packages/core/src/core/codex/common.ts
+++ b/packages/core/src/core/codex/common.ts
@@ -18,7 +18,7 @@ export type Usage = {
   reasoning_output_tokens: number;
 };
 
-// Env vars the codex Rust binary actually needs. Everything else stays in
+// Env vars Codex and its child commands need. Everything else stays in
 // Rome's process so we don't leak secrets into the subprocess.
 export const CODEX_ENV_ALLOWLIST = [
   "HOME",
@@ -29,6 +29,7 @@ export const CODEX_ENV_ALLOWLIST = [
   "LANG",
   "LC_ALL",
   "TERM",
+  "OPENCLI_CDP_ENDPOINT",
 ] as const;
 
 export function stripLegacyReasoningSuffix(model: string): string {


### PR DESCRIPTION
## What this PR does

Codex drops `OPENCLI_CDP_ENDPOINT` when it builds the app-server environment. OpenCLI commands then fall back to Browser Bridge instead of the configured browser. The shell alias does not cover noninteractive agent shells because Bash alias expansion is disabled there.

Allow the configured endpoint through the existing environment filter. Preserve custom endpoint values and leave the variable absent when the parent has not set it. Keep unrelated environment variables out of the child process.

## Test plan

- [x] Run `scripts/test-env.sh /app/node_modules/.bin/rstest src/core/codex/app-server-manager.test.ts src/core/codex/common.test.ts` from `packages/core` (using `../../scripts/test-env.sh`): 10 tests pass.
- [x] Confirm regression sensitivity: removing the allowlist entry fails both configured-endpoint cases.
- [x] Cover the local endpoint, a custom host and port, an unset endpoint, and filtering of an unrelated variable.
- [x] Run Biome on both changed files, `git diff --check`, and `scripts/check-pr-title.sh`.
- [ ] Run the full `pnpm typecheck` and `pnpm test:unit` checks. Both were attempted but fail on missing workspace dependencies, including Statsig and jsonwebtoken. Focused tests used the installed `/app` dependencies through temporary symlinks, removed after testing. Nix is unavailable here.
- [ ] Run `pnpm dev:all` and check startup. Attempted, but the Docker daemon is unreachable.

## Not in this PR

- Configure a runtime default for `OPENCLI_CDP_ENDPOINT`. This PR only preserves an existing value, so deployments must still set it.
- Replace the interactive shell alias. The change stays scoped to Codex environment propagation.
