### PR TITLE
feat(coding): backfill share-card taglines for existing instance-built apps

### DIFF
--- a/rome_apps/coding/app.yaml
+++ b/rome_apps/coding/app.yaml
@@ -2,7 +2,7 @@ formatVersion: 1
 id: coding
 name: Coding
 icon: assets/icon.svg
-version: 0.3.0
+version: 0.3.1
 description: >-
   Planning and coding agents, the app_creation skill, and a frontend gallery of
   live UI mocks. Use app_creation when visuals are important, such as for apps,
@@ -28,5 +28,9 @@ actions:
 skills:
   - skills/app_creation
   - skills/app_remix
+  - skills/app_tagline_backfill
   - skills/app_verification
   - skills/workflow_creation
+
+hooks:
+  - hooks/agent-turn-finished

--- a/rome_apps/coding/src/hooks/agent-turn-finished/index.test.ts
+++ b/rome_apps/coding/src/hooks/agent-turn-finished/index.test.ts
@@ -5,7 +5,6 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "@rstest/core";
 import type { AgentMessage, AgentTurnFinishedEvent, RunParams } from "@rome-os/app-runtime";
 import {
-  BACKFILL_MAX_ATTEMPTS,
   BACKFILL_SETTINGS_KEY,
   BACKFILL_SKILL,
   BACKFILL_VERSION,
@@ -114,23 +113,13 @@ describe("coding tagline backfill hook", () => {
     it("treats a missing lockfile as nothing to do", async () => {
       expect(await findAppsMissingTagline(join(tempDir, "nope.json"))).toEqual([]);
     });
-
-    it("throws on a lockfile it cannot parse", async () => {
-      await writeFile(lockfilePath, "{ not json");
-      await expect(findAppsMissingTagline(lockfilePath)).rejects.toThrow();
-    });
   });
 
   describe("onAgentTurnFinished", () => {
-    it("does nothing when the marker is finished at the current version", async () => {
+    it("does nothing when the marker is already at the current version", async () => {
       const runner = createRunner();
       const settings = createSettings({
-        [BACKFILL_SETTINGS_KEY]: {
-          version: BACKFILL_VERSION,
-          startedAt: "2026-01-01T00:00:00Z",
-          attempts: 1,
-          finishedAt: "2026-01-01T00:01:00Z",
-        },
+        [BACKFILL_SETTINGS_KEY]: { version: BACKFILL_VERSION, startedAt: "2026-01-01T00:00:00Z" },
       });
       const hook = new TaglineBackfillHook({
         agentRunner: runner,
@@ -160,7 +149,6 @@ describe("coding tagline backfill hook", () => {
       expect(runner.calls).toHaveLength(0);
       const marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
       expect(marker.version).toBe(BACKFILL_VERSION);
-      expect(marker.attempts).toBe(1);
       expect(marker.finishedAt).toBeDefined();
       expect(marker.apps).toBeUndefined();
     });
@@ -188,14 +176,13 @@ describe("coding tagline backfill hook", () => {
       expect(first.finishedAt).toBeUndefined();
       expect(last).toMatchObject({
         version: BACKFILL_VERSION,
-        attempts: 1,
         apps: [root],
         summary: "Added 1 tagline.",
       });
       expect(last.finishedAt).toBeDefined();
     });
 
-    it("retries a failed run on later turns, up to the attempt cap", async () => {
+    it("keeps the marker and swallows agent failures", async () => {
       const root = await writeApp("todo", "id: todo\nweb:\n  manifest: web/manifest.json\n");
       await writeLockfile({ todo: sourceEntry(root) });
       const runner = createRunner([{ type: "error", error: "model unavailable" }]);
@@ -203,77 +190,12 @@ describe("coding tagline backfill hook", () => {
       const hook = new TaglineBackfillHook({ agentRunner: runner, settings, logger, lockfilePath });
 
       await expect(hook.onAgentTurnFinished(event)).resolves.toBeUndefined();
-      let marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
-      expect(marker).toMatchObject({ version: BACKFILL_VERSION, attempts: 1 });
-      expect(marker.lastError).toBe("model unavailable");
-      expect(marker.finishedAt).toBeUndefined();
-
-      for (let i = 1; i < BACKFILL_MAX_ATTEMPTS + 2; i++) {
-        await hook.onAgentTurnFinished(event);
-      }
-
-      expect(runner.calls).toHaveLength(BACKFILL_MAX_ATTEMPTS);
-      marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
-      expect(marker.attempts).toBe(BACKFILL_MAX_ATTEMPTS);
-      expect(marker.finishedAt).toBeUndefined();
-    });
-
-    it("leaves a recent in-progress marker to the instance that owns it", async () => {
-      const root = await writeApp("todo", "id: todo\nweb:\n  manifest: web/manifest.json\n");
-      await writeLockfile({ todo: sourceEntry(root) });
-      const runner = createRunner();
-      const settings = createSettings({
-        [BACKFILL_SETTINGS_KEY]: {
-          version: BACKFILL_VERSION,
-          startedAt: new Date().toISOString(),
-          attempts: 1,
-        },
-      });
-      const hook = new TaglineBackfillHook({ agentRunner: runner, settings, logger, lockfilePath });
-
       await hook.onAgentTurnFinished(event);
 
-      expect(runner.calls).toHaveLength(0);
-      expect(settings.sets).toHaveLength(0);
-    });
-
-    it("records a failed scan as an attempt without settling", async () => {
-      await writeFile(lockfilePath, "{ not json");
-      const runner = createRunner();
-      const settings = createSettings();
-      const hook = new TaglineBackfillHook({ agentRunner: runner, settings, logger, lockfilePath });
-
-      await expect(hook.onAgentTurnFinished(event)).resolves.toBeUndefined();
-
-      expect(runner.calls).toHaveLength(0);
+      expect(runner.calls).toHaveLength(1);
       const marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
-      expect(marker).toMatchObject({ version: BACKFILL_VERSION, attempts: 1 });
-      expect(marker.lastError).toBeDefined();
+      expect(marker.version).toBe(BACKFILL_VERSION);
       expect(marker.finishedAt).toBeUndefined();
-    });
-
-    it("resumes an interrupted run and finishes once the work is done", async () => {
-      const root = await writeApp(
-        "ok",
-        "id: ok\ntagline: Fine\nweb:\n  manifest: web/manifest.json\n",
-      );
-      await writeLockfile({ ok: sourceEntry(root) });
-      const runner = createRunner();
-      const settings = createSettings({
-        [BACKFILL_SETTINGS_KEY]: {
-          version: BACKFILL_VERSION,
-          startedAt: new Date(Date.now() - 20 * 60_000).toISOString(),
-          attempts: 1,
-        },
-      });
-      const hook = new TaglineBackfillHook({ agentRunner: runner, settings, logger, lockfilePath });
-
-      await hook.onAgentTurnFinished(event);
-
-      expect(runner.calls).toHaveLength(0);
-      const marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
-      expect(marker).toMatchObject({ version: BACKFILL_VERSION, attempts: 2 });
-      expect(marker.finishedAt).toBeDefined();
     });
   });
 });

--- a/rome_apps/coding/src/hooks/agent-turn-finished/index.test.ts
+++ b/rome_apps/coding/src/hooks/agent-turn-finished/index.test.ts
@@ -114,6 +114,11 @@ describe("coding tagline backfill hook", () => {
     it("treats a missing lockfile as nothing to do", async () => {
       expect(await findAppsMissingTagline(join(tempDir, "nope.json"))).toEqual([]);
     });
+
+    it("throws on a lockfile it cannot parse", async () => {
+      await writeFile(lockfilePath, "{ not json");
+      await expect(findAppsMissingTagline(lockfilePath)).rejects.toThrow();
+    });
   });
 
   describe("onAgentTurnFinished", () => {
@@ -213,6 +218,40 @@ describe("coding tagline backfill hook", () => {
       expect(marker.finishedAt).toBeUndefined();
     });
 
+    it("leaves a recent in-progress marker to the instance that owns it", async () => {
+      const root = await writeApp("todo", "id: todo\nweb:\n  manifest: web/manifest.json\n");
+      await writeLockfile({ todo: sourceEntry(root) });
+      const runner = createRunner();
+      const settings = createSettings({
+        [BACKFILL_SETTINGS_KEY]: {
+          version: BACKFILL_VERSION,
+          startedAt: new Date().toISOString(),
+          attempts: 1,
+        },
+      });
+      const hook = new TaglineBackfillHook({ agentRunner: runner, settings, logger, lockfilePath });
+
+      await hook.onAgentTurnFinished(event);
+
+      expect(runner.calls).toHaveLength(0);
+      expect(settings.sets).toHaveLength(0);
+    });
+
+    it("records a failed scan as an attempt without settling", async () => {
+      await writeFile(lockfilePath, "{ not json");
+      const runner = createRunner();
+      const settings = createSettings();
+      const hook = new TaglineBackfillHook({ agentRunner: runner, settings, logger, lockfilePath });
+
+      await expect(hook.onAgentTurnFinished(event)).resolves.toBeUndefined();
+
+      expect(runner.calls).toHaveLength(0);
+      const marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
+      expect(marker).toMatchObject({ version: BACKFILL_VERSION, attempts: 1 });
+      expect(marker.lastError).toBeDefined();
+      expect(marker.finishedAt).toBeUndefined();
+    });
+
     it("resumes an interrupted run and finishes once the work is done", async () => {
       const root = await writeApp(
         "ok",
@@ -223,7 +262,7 @@ describe("coding tagline backfill hook", () => {
       const settings = createSettings({
         [BACKFILL_SETTINGS_KEY]: {
           version: BACKFILL_VERSION,
-          startedAt: "2026-01-01T00:00:00Z",
+          startedAt: new Date(Date.now() - 20 * 60_000).toISOString(),
           attempts: 1,
         },
       });

--- a/rome_apps/coding/src/hooks/agent-turn-finished/index.test.ts
+++ b/rome_apps/coding/src/hooks/agent-turn-finished/index.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "@rstest/core";
 import type { AgentMessage, AgentTurnFinishedEvent, RunParams } from "@rome-os/app-runtime";
 import {
   BACKFILL_SETTINGS_KEY,
-  BACKFILL_SKILL_PATH,
+  BACKFILL_SKILL,
   BACKFILL_VERSION,
   defaultLockfilePath,
   findAppsMissingTagline,
@@ -165,7 +165,9 @@ describe("coding tagline backfill hook", () => {
 
       expect(runner.calls).toHaveLength(1);
       expect(runner.calls[0]?.agentName).toBe("coding");
-      expect(runner.calls[0]?.prompt).toContain(BACKFILL_SKILL_PATH);
+      expect(runner.calls[0]?.prompt).toContain(
+        "`coding:app_tagline_backfill` skill with read_skill",
+      );
       expect(runner.calls[0]?.prompt).toContain("AUTO mode");
       expect(runner.calls[0]?.prompt).toContain(`- ${root}`);
 

--- a/rome_apps/coding/src/hooks/agent-turn-finished/index.test.ts
+++ b/rome_apps/coding/src/hooks/agent-turn-finished/index.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "@rstest/core";
 import type { AgentMessage, AgentTurnFinishedEvent, RunParams } from "@rome-os/app-runtime";
 import {
+  BACKFILL_MAX_ATTEMPTS,
   BACKFILL_SETTINGS_KEY,
   BACKFILL_SKILL,
   BACKFILL_VERSION,
@@ -116,10 +117,15 @@ describe("coding tagline backfill hook", () => {
   });
 
   describe("onAgentTurnFinished", () => {
-    it("does nothing when the marker is already at the current version", async () => {
+    it("does nothing when the marker is finished at the current version", async () => {
       const runner = createRunner();
       const settings = createSettings({
-        [BACKFILL_SETTINGS_KEY]: { version: BACKFILL_VERSION, startedAt: "2026-01-01T00:00:00Z" },
+        [BACKFILL_SETTINGS_KEY]: {
+          version: BACKFILL_VERSION,
+          startedAt: "2026-01-01T00:00:00Z",
+          attempts: 1,
+          finishedAt: "2026-01-01T00:01:00Z",
+        },
       });
       const hook = new TaglineBackfillHook({
         agentRunner: runner,
@@ -149,6 +155,7 @@ describe("coding tagline backfill hook", () => {
       expect(runner.calls).toHaveLength(0);
       const marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
       expect(marker.version).toBe(BACKFILL_VERSION);
+      expect(marker.attempts).toBe(1);
       expect(marker.finishedAt).toBeDefined();
       expect(marker.apps).toBeUndefined();
     });
@@ -176,13 +183,14 @@ describe("coding tagline backfill hook", () => {
       expect(first.finishedAt).toBeUndefined();
       expect(last).toMatchObject({
         version: BACKFILL_VERSION,
+        attempts: 1,
         apps: [root],
         summary: "Added 1 tagline.",
       });
       expect(last.finishedAt).toBeDefined();
     });
 
-    it("keeps the marker and swallows agent failures", async () => {
+    it("retries a failed run on later turns, up to the attempt cap", async () => {
       const root = await writeApp("todo", "id: todo\nweb:\n  manifest: web/manifest.json\n");
       await writeLockfile({ todo: sourceEntry(root) });
       const runner = createRunner([{ type: "error", error: "model unavailable" }]);
@@ -190,12 +198,43 @@ describe("coding tagline backfill hook", () => {
       const hook = new TaglineBackfillHook({ agentRunner: runner, settings, logger, lockfilePath });
 
       await expect(hook.onAgentTurnFinished(event)).resolves.toBeUndefined();
+      let marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
+      expect(marker).toMatchObject({ version: BACKFILL_VERSION, attempts: 1 });
+      expect(marker.lastError).toBe("model unavailable");
+      expect(marker.finishedAt).toBeUndefined();
+
+      for (let i = 1; i < BACKFILL_MAX_ATTEMPTS + 2; i++) {
+        await hook.onAgentTurnFinished(event);
+      }
+
+      expect(runner.calls).toHaveLength(BACKFILL_MAX_ATTEMPTS);
+      marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
+      expect(marker.attempts).toBe(BACKFILL_MAX_ATTEMPTS);
+      expect(marker.finishedAt).toBeUndefined();
+    });
+
+    it("resumes an interrupted run and finishes once the work is done", async () => {
+      const root = await writeApp(
+        "ok",
+        "id: ok\ntagline: Fine\nweb:\n  manifest: web/manifest.json\n",
+      );
+      await writeLockfile({ ok: sourceEntry(root) });
+      const runner = createRunner();
+      const settings = createSettings({
+        [BACKFILL_SETTINGS_KEY]: {
+          version: BACKFILL_VERSION,
+          startedAt: "2026-01-01T00:00:00Z",
+          attempts: 1,
+        },
+      });
+      const hook = new TaglineBackfillHook({ agentRunner: runner, settings, logger, lockfilePath });
+
       await hook.onAgentTurnFinished(event);
 
-      expect(runner.calls).toHaveLength(1);
+      expect(runner.calls).toHaveLength(0);
       const marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
-      expect(marker.version).toBe(BACKFILL_VERSION);
-      expect(marker.finishedAt).toBeUndefined();
+      expect(marker).toMatchObject({ version: BACKFILL_VERSION, attempts: 2 });
+      expect(marker.finishedAt).toBeDefined();
     });
   });
 });

--- a/rome_apps/coding/src/hooks/agent-turn-finished/index.test.ts
+++ b/rome_apps/coding/src/hooks/agent-turn-finished/index.test.ts
@@ -1,0 +1,199 @@
+import { mkdtempSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "@rstest/core";
+import type { AgentMessage, AgentTurnFinishedEvent, RunParams } from "@rome-os/app-runtime";
+import {
+  BACKFILL_SETTINGS_KEY,
+  BACKFILL_SKILL_PATH,
+  BACKFILL_VERSION,
+  defaultLockfilePath,
+  findAppsMissingTagline,
+  TaglineBackfillHook,
+  type TaglineBackfillMarker,
+} from "./index.js";
+
+const event = { type: "agent-turn-finished" } as AgentTurnFinishedEvent;
+const logger = { info() {}, warn() {}, debug() {} };
+
+function createRunner(messages: AgentMessage[] = [{ type: "result", content: "done" }]) {
+  const calls: RunParams[] = [];
+  return {
+    calls,
+    async *run(params: RunParams): AsyncIterable<AgentMessage> {
+      calls.push(params);
+      yield* messages;
+    },
+  };
+}
+
+function createSettings(initial: Record<string, unknown> = {}) {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  const sets: unknown[] = [];
+  return {
+    store,
+    sets,
+    async get<T>(key: string): Promise<T | null> {
+      return (store.get(key) as T | undefined) ?? null;
+    },
+    async set(key: string, value: unknown): Promise<void> {
+      store.set(key, value);
+      sets.push(value);
+    },
+  };
+}
+
+describe("coding tagline backfill hook", () => {
+  let tempDir = "";
+  let lockfilePath = "";
+
+  /** Writes `<tempDir>/apps/<id>/app.yaml` and returns the app root. */
+  async function writeApp(id: string, manifest: string): Promise<string> {
+    const root = join(tempDir, "apps", id);
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, "app.yaml"), manifest);
+    return root;
+  }
+
+  async function writeLockfile(apps: Record<string, unknown>): Promise<void> {
+    await writeFile(lockfilePath, JSON.stringify({ schemaVersion: 3, apps }));
+  }
+
+  function sourceEntry(path: string, overrides: Record<string, unknown> = {}) {
+    return { source: { mode: "source", path }, enabled: true, state: "installed", ...overrides };
+  }
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "tagline-backfill-"));
+    lockfilePath = join(tempDir, "apps.lock.json");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("defaults the lockfile to the profile dir", () => {
+    expect(defaultLockfilePath({ ROME_PROFILE: "work" })).toMatch(
+      /\/\.rome\/work\/apps\.lock\.json$/,
+    );
+    expect(defaultLockfilePath({})).toMatch(/\/\.rome\/default\/apps\.lock\.json$/);
+  });
+
+  describe("findAppsMissingTagline", () => {
+    it("selects enabled source-dir apps with a web surface and no tagline", async () => {
+      const missing = await writeApp(
+        "missing",
+        "id: missing\nweb:\n  manifest: web/manifest.json\n",
+      );
+      const hasTagline = await writeApp(
+        "has-tagline",
+        "id: has-tagline\ntagline: Already set\nweb:\n  manifest: web/manifest.json\n",
+      );
+      const noWeb = await writeApp("no-web", "id: no-web\nactions:\n  - actions/run\n");
+      const disabled = await writeApp(
+        "disabled",
+        "id: disabled\nweb:\n  manifest: web/manifest.json\n",
+      );
+      const broken = await writeApp("broken", "id: broken\nweb:\n  manifest: web/manifest.json\n");
+      await writeLockfile({
+        missing: sourceEntry(missing),
+        "has-tagline": sourceEntry(hasTagline),
+        "no-web": sourceEntry(noWeb),
+        disabled: sourceEntry(disabled, { enabled: false }),
+        broken: sourceEntry(broken, { state: "broken" }),
+        store: { source: { mode: "appstore", listing: "@a/b" }, enabled: true, state: "installed" },
+        bundle: { source: { mode: "bundle", path: missing }, enabled: true, state: "installed" },
+        gone: sourceEntry(join(tempDir, "apps", "gone")),
+      });
+
+      expect(await findAppsMissingTagline(lockfilePath)).toEqual([missing]);
+    });
+
+    it("treats a missing lockfile as nothing to do", async () => {
+      expect(await findAppsMissingTagline(join(tempDir, "nope.json"))).toEqual([]);
+    });
+  });
+
+  describe("onAgentTurnFinished", () => {
+    it("does nothing when the marker is already at the current version", async () => {
+      const runner = createRunner();
+      const settings = createSettings({
+        [BACKFILL_SETTINGS_KEY]: { version: BACKFILL_VERSION, startedAt: "2026-01-01T00:00:00Z" },
+      });
+      const hook = new TaglineBackfillHook({
+        agentRunner: runner,
+        settings,
+        logger,
+        lockfilePath: join(tempDir, "nope.json"),
+      });
+
+      await hook.onAgentTurnFinished(event);
+
+      expect(runner.calls).toHaveLength(0);
+      expect(settings.sets).toHaveLength(0);
+    });
+
+    it("writes a finished marker without summoning when no app needs a tagline", async () => {
+      const root = await writeApp(
+        "ok",
+        "id: ok\ntagline: Fine\nweb:\n  manifest: web/manifest.json\n",
+      );
+      await writeLockfile({ ok: sourceEntry(root) });
+      const runner = createRunner();
+      const settings = createSettings();
+      const hook = new TaglineBackfillHook({ agentRunner: runner, settings, logger, lockfilePath });
+
+      await hook.onAgentTurnFinished(event);
+
+      expect(runner.calls).toHaveLength(0);
+      const marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
+      expect(marker.version).toBe(BACKFILL_VERSION);
+      expect(marker.finishedAt).toBeDefined();
+      expect(marker.apps).toBeUndefined();
+    });
+
+    it("marks first, then summons the coding agent once with the app roots", async () => {
+      const root = await writeApp("todo", "id: todo\nweb:\n  manifest: web/manifest.json\n");
+      await writeLockfile({ todo: sourceEntry(root) });
+      const runner = createRunner([{ type: "result", content: "Added 1 tagline." }]);
+      const settings = createSettings();
+      const hook = new TaglineBackfillHook({ agentRunner: runner, settings, logger, lockfilePath });
+
+      await hook.onAgentTurnFinished(event);
+      await hook.onAgentTurnFinished(event);
+
+      expect(runner.calls).toHaveLength(1);
+      expect(runner.calls[0]?.agentName).toBe("coding");
+      expect(runner.calls[0]?.prompt).toContain(BACKFILL_SKILL_PATH);
+      expect(runner.calls[0]?.prompt).toContain("AUTO mode");
+      expect(runner.calls[0]?.prompt).toContain(`- ${root}`);
+
+      const [first, last] = [settings.sets[0], settings.sets.at(-1)] as TaglineBackfillMarker[];
+      expect(first.version).toBe(BACKFILL_VERSION);
+      expect(first.finishedAt).toBeUndefined();
+      expect(last).toMatchObject({
+        version: BACKFILL_VERSION,
+        apps: [root],
+        summary: "Added 1 tagline.",
+      });
+      expect(last.finishedAt).toBeDefined();
+    });
+
+    it("keeps the marker and swallows agent failures", async () => {
+      const root = await writeApp("todo", "id: todo\nweb:\n  manifest: web/manifest.json\n");
+      await writeLockfile({ todo: sourceEntry(root) });
+      const runner = createRunner([{ type: "error", error: "model unavailable" }]);
+      const settings = createSettings();
+      const hook = new TaglineBackfillHook({ agentRunner: runner, settings, logger, lockfilePath });
+
+      await expect(hook.onAgentTurnFinished(event)).resolves.toBeUndefined();
+      await hook.onAgentTurnFinished(event);
+
+      expect(runner.calls).toHaveLength(1);
+      const marker = settings.store.get(BACKFILL_SETTINGS_KEY) as TaglineBackfillMarker;
+      expect(marker.version).toBe(BACKFILL_VERSION);
+      expect(marker.finishedAt).toBeUndefined();
+    });
+  });
+});

--- a/rome_apps/coding/src/hooks/agent-turn-finished/index.ts
+++ b/rome_apps/coding/src/hooks/agent-turn-finished/index.ts
@@ -3,7 +3,10 @@
 // finishes after this hook ships writes a marker into the app's settings,
 // then — only if some enabled source-dir app with a web surface still lacks a
 // `tagline` — summons the coding agent to run the `app_tagline_backfill`
-// skill. Every later turn sees the marker and returns immediately.
+// skill. The marker is final once the run reaches a definite outcome (nothing
+// to do, or the agent returned); a thrown failure leaves it unfinished so a
+// later turn retries, up to `BACKFILL_MAX_ATTEMPTS`. Every later turn sees the
+// finished marker and returns immediately.
 //
 // Bump `BACKFILL_VERSION` to run the backfill again on every instance.
 
@@ -21,13 +24,18 @@ import type {
 
 export const BACKFILL_SETTINGS_KEY = "coding.taglineBackfill";
 export const BACKFILL_VERSION = 1;
+export const BACKFILL_MAX_ATTEMPTS = 3;
 export const BACKFILL_AGENT = "coding";
 export const BACKFILL_SKILL = "coding:app_tagline_backfill";
 
 export interface TaglineBackfillMarker {
   version: number;
   startedAt: string;
+  /** Runs started for this version, including the one in progress. */
+  attempts: number;
+  /** Set only on a definite outcome; absent means retry on the next turn. */
   finishedAt?: string;
+  lastError?: string;
   /** Source roots handed to the agent (absent when nothing needed a tagline). */
   apps?: string[];
   /** The agent's final text, kept for inspection. */
@@ -92,6 +100,12 @@ export function buildBackfillPrompt(roots: string[]): string {
   ].join("\n");
 }
 
+/** Finished for this version, or out of attempts: nothing more to do. */
+function isSettled(marker: TaglineBackfillMarker | null): boolean {
+  if (!marker || marker.version < BACKFILL_VERSION) return false;
+  return marker.finishedAt !== undefined || marker.attempts >= BACKFILL_MAX_ATTEMPTS;
+}
+
 export class TaglineBackfillHook implements AgentTurnFinishedHook {
   private running = false;
 
@@ -102,8 +116,9 @@ export class TaglineBackfillHook implements AgentTurnFinishedHook {
     this.running = true;
     try {
       const marker = await this.deps.settings.get<TaglineBackfillMarker>(BACKFILL_SETTINGS_KEY);
-      if (marker && marker.version >= BACKFILL_VERSION) return;
-      await this.backfill();
+      if (isSettled(marker)) return;
+      const attempts = marker?.version === BACKFILL_VERSION ? marker.attempts + 1 : 1;
+      await this.backfill(attempts);
     } catch (err) {
       this.deps.logger.warn("tagline backfill failed", {
         error: err instanceof Error ? err.message : String(err),
@@ -113,12 +128,13 @@ export class TaglineBackfillHook implements AgentTurnFinishedHook {
     }
   }
 
-  private async backfill(): Promise<void> {
-    // Mark first: the backfill runs once whether or not it succeeds. The
-    // manual `/app_tagline_backfill` skill covers anything it leaves behind.
+  private async backfill(attempts: number): Promise<void> {
+    // Record the attempt before doing anything so a crash mid-run still counts
+    // toward the cap. `finishedAt` is only written on a definite outcome.
     const started: TaglineBackfillMarker = {
       version: BACKFILL_VERSION,
       startedAt: new Date().toISOString(),
+      attempts,
     };
     await this.deps.settings.set(BACKFILL_SETTINGS_KEY, started);
 
@@ -132,14 +148,22 @@ export class TaglineBackfillHook implements AgentTurnFinishedHook {
       return;
     }
 
-    this.deps.logger.info("tagline backfill started", { apps: roots });
+    this.deps.logger.info("tagline backfill started", { apps: roots, attempts });
     let summary = "";
-    for await (const msg of this.deps.agentRunner.run({
-      agentName: BACKFILL_AGENT,
-      prompt: buildBackfillPrompt(roots),
-    })) {
-      if (msg.type === "result") summary = String(msg.content ?? "");
-      if (msg.type === "error") throw new Error(String(msg.error));
+    try {
+      for await (const msg of this.deps.agentRunner.run({
+        agentName: BACKFILL_AGENT,
+        prompt: buildBackfillPrompt(roots),
+      })) {
+        if (msg.type === "result") summary = String(msg.content ?? "");
+        if (msg.type === "error") throw new Error(String(msg.error));
+      }
+    } catch (err) {
+      await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
+        ...started,
+        lastError: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
     }
     await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
       ...started,

--- a/rome_apps/coding/src/hooks/agent-turn-finished/index.ts
+++ b/rome_apps/coding/src/hooks/agent-turn-finished/index.ts
@@ -3,13 +3,7 @@
 // finishes after this hook ships writes a marker into the app's settings,
 // then — only if some enabled source-dir app with a web surface still lacks a
 // `tagline` — summons the coding agent to run the `app_tagline_backfill`
-// skill. The marker is final once the run reaches a definite outcome (nothing
-// to do, or the agent returned); a thrown failure leaves it unfinished so a
-// later turn retries, up to `BACKFILL_MAX_ATTEMPTS`. An unfinished marker
-// without an error is a run in progress — core rebuilds every hook on each
-// catalog change (including the reinstalls this backfill performs), so the
-// in-memory flag alone cannot see it — and is left alone until the lease
-// expires. Every later turn sees the finished marker and returns immediately.
+// skill. Every later turn sees the marker and returns immediately.
 //
 // Bump `BACKFILL_VERSION` to run the backfill again on every instance.
 
@@ -27,20 +21,13 @@ import type {
 
 export const BACKFILL_SETTINGS_KEY = "coding.taglineBackfill";
 export const BACKFILL_VERSION = 1;
-export const BACKFILL_MAX_ATTEMPTS = 3;
-/** How long an unfinished, error-free marker counts as a run in progress. */
-export const BACKFILL_LEASE_MS = 15 * 60_000;
 export const BACKFILL_AGENT = "coding";
 export const BACKFILL_SKILL = "coding:app_tagline_backfill";
 
 export interface TaglineBackfillMarker {
   version: number;
   startedAt: string;
-  /** Runs started for this version, including the one in progress. */
-  attempts: number;
-  /** Set only on a definite outcome; absent means retry on the next turn. */
   finishedAt?: string;
-  lastError?: string;
   /** Source roots handed to the agent (absent when nothing needed a tagline). */
   apps?: string[];
   /** The agent's final text, kept for inspection. */
@@ -69,20 +56,18 @@ interface LockfileEntry {
  * Absolute source roots of enabled, installed `mode: "source"` apps whose
  * `app.yaml` declares `web:` but no `tagline:`. Store bundles and first-party
  * apps never have `mode: "source"`, so they are skipped by construction. A
- * missing lockfile or an unreadable manifest counts as "nothing to do"; any
- * other lockfile read or parse failure throws so the caller retries later
- * instead of settling on a scan that never happened.
+ * missing lockfile or an unreadable manifest counts as "nothing to do".
  */
 export async function findAppsMissingTagline(lockfilePath: string): Promise<string[]> {
-  let raw: string;
+  let entries: Record<string, LockfileEntry>;
   try {
-    raw = await readFile(lockfilePath, "utf8");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
-    throw err;
+    const parsed = JSON.parse(await readFile(lockfilePath, "utf8")) as {
+      apps?: Record<string, LockfileEntry>;
+    };
+    entries = parsed.apps ?? {};
+  } catch {
+    return [];
   }
-  const parsed = JSON.parse(raw) as { apps?: Record<string, LockfileEntry> };
-  const entries = parsed.apps ?? {};
   const roots: string[] = [];
   for (const entry of Object.values(entries)) {
     if (entry.source?.mode !== "source" || !entry.source.path) continue;
@@ -107,19 +92,6 @@ export function buildBackfillPrompt(roots: string[]): string {
   ].join("\n");
 }
 
-/** Finished for this version, or out of attempts: nothing more to do. */
-function isSettled(marker: TaglineBackfillMarker | null): boolean {
-  if (!marker || marker.version < BACKFILL_VERSION) return false;
-  return marker.finishedAt !== undefined || marker.attempts >= BACKFILL_MAX_ATTEMPTS;
-}
-
-/** Unfinished without a recorded error and started recently: another hook instance is on it. */
-function isInProgress(marker: TaglineBackfillMarker | null, now: number): boolean {
-  if (!marker || marker.version !== BACKFILL_VERSION) return false;
-  if (marker.finishedAt !== undefined || marker.lastError !== undefined) return false;
-  return now - Date.parse(marker.startedAt) < BACKFILL_LEASE_MS;
-}
-
 export class TaglineBackfillHook implements AgentTurnFinishedHook {
   private running = false;
 
@@ -130,9 +102,8 @@ export class TaglineBackfillHook implements AgentTurnFinishedHook {
     this.running = true;
     try {
       const marker = await this.deps.settings.get<TaglineBackfillMarker>(BACKFILL_SETTINGS_KEY);
-      if (isSettled(marker) || isInProgress(marker, Date.now())) return;
-      const attempts = marker?.version === BACKFILL_VERSION ? marker.attempts + 1 : 1;
-      await this.backfill(attempts);
+      if (marker && marker.version >= BACKFILL_VERSION) return;
+      await this.backfill();
     } catch (err) {
       this.deps.logger.warn("tagline backfill failed", {
         error: err instanceof Error ? err.message : String(err),
@@ -142,50 +113,41 @@ export class TaglineBackfillHook implements AgentTurnFinishedHook {
     }
   }
 
-  private async backfill(attempts: number): Promise<void> {
-    // Record the attempt before doing anything so a crash mid-run still counts
-    // toward the cap. `finishedAt` is only written on a definite outcome.
+  private async backfill(): Promise<void> {
+    // Mark first: the backfill runs once whether or not it succeeds. The
+    // manual `/app_tagline_backfill` skill covers anything it leaves behind.
     const started: TaglineBackfillMarker = {
       version: BACKFILL_VERSION,
       startedAt: new Date().toISOString(),
-      attempts,
     };
     await this.deps.settings.set(BACKFILL_SETTINGS_KEY, started);
 
-    try {
-      const roots = await findAppsMissingTagline(this.deps.lockfilePath ?? defaultLockfilePath());
-      if (roots.length === 0) {
-        await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
-          ...started,
-          finishedAt: new Date().toISOString(),
-        });
-        this.deps.logger.debug("tagline backfill: nothing to do");
-        return;
-      }
-
-      this.deps.logger.info("tagline backfill started", { apps: roots, attempts });
-      let summary = "";
-      for await (const msg of this.deps.agentRunner.run({
-        agentName: BACKFILL_AGENT,
-        prompt: buildBackfillPrompt(roots),
-      })) {
-        if (msg.type === "result") summary = String(msg.content ?? "");
-        if (msg.type === "error") throw new Error(String(msg.error));
-      }
+    const roots = await findAppsMissingTagline(this.deps.lockfilePath ?? defaultLockfilePath());
+    if (roots.length === 0) {
       await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
         ...started,
         finishedAt: new Date().toISOString(),
-        apps: roots,
-        summary,
       });
-      this.deps.logger.info("tagline backfill finished", { apps: roots });
-    } catch (err) {
-      await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
-        ...started,
-        lastError: err instanceof Error ? err.message : String(err),
-      });
-      throw err;
+      this.deps.logger.debug("tagline backfill: nothing to do");
+      return;
     }
+
+    this.deps.logger.info("tagline backfill started", { apps: roots });
+    let summary = "";
+    for await (const msg of this.deps.agentRunner.run({
+      agentName: BACKFILL_AGENT,
+      prompt: buildBackfillPrompt(roots),
+    })) {
+      if (msg.type === "result") summary = String(msg.content ?? "");
+      if (msg.type === "error") throw new Error(String(msg.error));
+    }
+    await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
+      ...started,
+      finishedAt: new Date().toISOString(),
+      apps: roots,
+      summary,
+    });
+    this.deps.logger.info("tagline backfill finished", { apps: roots });
   }
 }
 

--- a/rome_apps/coding/src/hooks/agent-turn-finished/index.ts
+++ b/rome_apps/coding/src/hooks/agent-turn-finished/index.ts
@@ -1,0 +1,168 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type {
+  AgentLifecycleHookDeps,
+  AgentRunnerInterface,
+  AgentTurnFinishedEvent,
+  AgentTurnFinishedHook,
+  AppSettingsRepository,
+  Logger,
+} from "@rome-os/app-runtime";
+
+/**
+ * One-shot tagline backfill for apps built on this instance before `tagline`
+ * existed (rome#202). Runs once per instance: the first agent turn that
+ * finishes after this hook ships writes a marker into the app's settings,
+ * then — only if some enabled source-dir app with a web surface still lacks a
+ * `tagline` — summons the coding agent to run the `app_tagline_backfill`
+ * skill. Every later turn sees the marker and returns immediately.
+ *
+ * Bump `BACKFILL_VERSION` to run the backfill again on every instance.
+ */
+export const BACKFILL_SETTINGS_KEY = "tagline-backfill";
+export const BACKFILL_VERSION = 1;
+export const BACKFILL_AGENT = "coding";
+export const BACKFILL_SKILL_PATH = "rome_apps/coding/src/skills/app_tagline_backfill/SKILL.md";
+
+export interface TaglineBackfillMarker {
+  version: number;
+  startedAt: string;
+  finishedAt?: string;
+  /** Source roots handed to the agent (absent when nothing needed a tagline). */
+  apps?: string[];
+  /** The agent's final text, kept for inspection. */
+  summary?: string;
+}
+
+export interface TaglineBackfillHookDeps {
+  agentRunner: Pick<AgentRunnerInterface, "run">;
+  settings: AppSettingsRepository;
+  logger: Pick<Logger, "info" | "warn" | "debug">;
+  /** Defaults to `~/.rome/<ROME_PROFILE>/apps.lock.json`. */
+  lockfilePath?: string;
+}
+
+export function defaultLockfilePath(env: NodeJS.ProcessEnv = process.env): string {
+  return join(homedir(), ".rome", env.ROME_PROFILE || "default", "apps.lock.json");
+}
+
+interface LockfileEntry {
+  source?: { mode?: string; path?: string };
+  enabled?: boolean;
+  state?: string;
+}
+
+/**
+ * Absolute source roots of enabled, installed `mode: "source"` apps whose
+ * `app.yaml` declares `web:` but no `tagline:`. Store bundles and first-party
+ * apps never have `mode: "source"`, so they are skipped by construction. A
+ * missing lockfile or an unreadable manifest counts as "nothing to do".
+ */
+export async function findAppsMissingTagline(lockfilePath: string): Promise<string[]> {
+  let entries: Record<string, LockfileEntry>;
+  try {
+    const parsed = JSON.parse(await readFile(lockfilePath, "utf8")) as {
+      apps?: Record<string, LockfileEntry>;
+    };
+    entries = parsed.apps ?? {};
+  } catch {
+    return [];
+  }
+  const roots: string[] = [];
+  for (const entry of Object.values(entries)) {
+    if (entry.source?.mode !== "source" || !entry.source.path) continue;
+    if (!entry.enabled || entry.state !== "installed") continue;
+    let manifest: string;
+    try {
+      manifest = await readFile(join(entry.source.path, "app.yaml"), "utf8");
+    } catch {
+      continue;
+    }
+    if (/^web:/m.test(manifest) && !/^tagline:/m.test(manifest)) {
+      roots.push(entry.source.path);
+    }
+  }
+  return roots;
+}
+
+export function buildBackfillPrompt(roots: string[]): string {
+  return [
+    `Load the skill at ${BACKFILL_SKILL_PATH} and run it in AUTO mode for these apps (absolute source roots):`,
+    ...roots.map((root) => `- ${root}`),
+  ].join("\n");
+}
+
+export class TaglineBackfillHook implements AgentTurnFinishedHook {
+  private running = false;
+
+  constructor(private readonly deps: TaglineBackfillHookDeps) {}
+
+  async onAgentTurnFinished(_event: AgentTurnFinishedEvent): Promise<void> {
+    if (this.running) return;
+    const marker = await this.deps.settings.get<TaglineBackfillMarker>(BACKFILL_SETTINGS_KEY);
+    if (marker && marker.version >= BACKFILL_VERSION) return;
+
+    this.running = true;
+    try {
+      await this.backfill();
+    } catch (err) {
+      this.deps.logger.warn("tagline backfill failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async backfill(): Promise<void> {
+    // Mark first: the backfill runs once whether or not it succeeds. The
+    // manual `/app_tagline_backfill` skill covers anything it leaves behind.
+    const started: TaglineBackfillMarker = {
+      version: BACKFILL_VERSION,
+      startedAt: new Date().toISOString(),
+    };
+    await this.deps.settings.set(BACKFILL_SETTINGS_KEY, started);
+
+    const roots = await findAppsMissingTagline(this.deps.lockfilePath ?? defaultLockfilePath());
+    if (roots.length === 0) {
+      await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
+        ...started,
+        finishedAt: new Date().toISOString(),
+      });
+      this.deps.logger.debug("tagline backfill: nothing to do");
+      return;
+    }
+
+    this.deps.logger.info("tagline backfill started", { apps: roots });
+    let summary = "";
+    for await (const msg of this.deps.agentRunner.run({
+      agentName: BACKFILL_AGENT,
+      prompt: buildBackfillPrompt(roots),
+    })) {
+      if (msg.type === "result") summary = String(msg.content ?? "");
+      if (msg.type === "error") throw new Error(String(msg.error));
+    }
+    await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
+      ...started,
+      finishedAt: new Date().toISOString(),
+      apps: roots,
+      summary,
+    });
+    this.deps.logger.info("tagline backfill finished", { apps: roots });
+  }
+}
+
+export function createHook(deps: AgentLifecycleHookDeps): AgentTurnFinishedHook {
+  if (!deps.agentRunner) {
+    throw new Error("Tagline backfill hook requires agentRunner");
+  }
+  if (!deps.appContext) {
+    throw new Error("Tagline backfill hook requires appContext");
+  }
+  return new TaglineBackfillHook({
+    agentRunner: deps.agentRunner,
+    settings: deps.appContext.repositories.settings,
+    logger: deps.logger,
+  });
+}

--- a/rome_apps/coding/src/hooks/agent-turn-finished/index.ts
+++ b/rome_apps/coding/src/hooks/agent-turn-finished/index.ts
@@ -5,8 +5,11 @@
 // `tagline` — summons the coding agent to run the `app_tagline_backfill`
 // skill. The marker is final once the run reaches a definite outcome (nothing
 // to do, or the agent returned); a thrown failure leaves it unfinished so a
-// later turn retries, up to `BACKFILL_MAX_ATTEMPTS`. Every later turn sees the
-// finished marker and returns immediately.
+// later turn retries, up to `BACKFILL_MAX_ATTEMPTS`. An unfinished marker
+// without an error is a run in progress — core rebuilds every hook on each
+// catalog change (including the reinstalls this backfill performs), so the
+// in-memory flag alone cannot see it — and is left alone until the lease
+// expires. Every later turn sees the finished marker and returns immediately.
 //
 // Bump `BACKFILL_VERSION` to run the backfill again on every instance.
 
@@ -25,6 +28,8 @@ import type {
 export const BACKFILL_SETTINGS_KEY = "coding.taglineBackfill";
 export const BACKFILL_VERSION = 1;
 export const BACKFILL_MAX_ATTEMPTS = 3;
+/** How long an unfinished, error-free marker counts as a run in progress. */
+export const BACKFILL_LEASE_MS = 15 * 60_000;
 export const BACKFILL_AGENT = "coding";
 export const BACKFILL_SKILL = "coding:app_tagline_backfill";
 
@@ -64,18 +69,20 @@ interface LockfileEntry {
  * Absolute source roots of enabled, installed `mode: "source"` apps whose
  * `app.yaml` declares `web:` but no `tagline:`. Store bundles and first-party
  * apps never have `mode: "source"`, so they are skipped by construction. A
- * missing lockfile or an unreadable manifest counts as "nothing to do".
+ * missing lockfile or an unreadable manifest counts as "nothing to do"; any
+ * other lockfile read or parse failure throws so the caller retries later
+ * instead of settling on a scan that never happened.
  */
 export async function findAppsMissingTagline(lockfilePath: string): Promise<string[]> {
-  let entries: Record<string, LockfileEntry>;
+  let raw: string;
   try {
-    const parsed = JSON.parse(await readFile(lockfilePath, "utf8")) as {
-      apps?: Record<string, LockfileEntry>;
-    };
-    entries = parsed.apps ?? {};
-  } catch {
-    return [];
+    raw = await readFile(lockfilePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
   }
+  const parsed = JSON.parse(raw) as { apps?: Record<string, LockfileEntry> };
+  const entries = parsed.apps ?? {};
   const roots: string[] = [];
   for (const entry of Object.values(entries)) {
     if (entry.source?.mode !== "source" || !entry.source.path) continue;
@@ -106,6 +113,13 @@ function isSettled(marker: TaglineBackfillMarker | null): boolean {
   return marker.finishedAt !== undefined || marker.attempts >= BACKFILL_MAX_ATTEMPTS;
 }
 
+/** Unfinished without a recorded error and started recently: another hook instance is on it. */
+function isInProgress(marker: TaglineBackfillMarker | null, now: number): boolean {
+  if (!marker || marker.version !== BACKFILL_VERSION) return false;
+  if (marker.finishedAt !== undefined || marker.lastError !== undefined) return false;
+  return now - Date.parse(marker.startedAt) < BACKFILL_LEASE_MS;
+}
+
 export class TaglineBackfillHook implements AgentTurnFinishedHook {
   private running = false;
 
@@ -116,7 +130,7 @@ export class TaglineBackfillHook implements AgentTurnFinishedHook {
     this.running = true;
     try {
       const marker = await this.deps.settings.get<TaglineBackfillMarker>(BACKFILL_SETTINGS_KEY);
-      if (isSettled(marker)) return;
+      if (isSettled(marker) || isInProgress(marker, Date.now())) return;
       const attempts = marker?.version === BACKFILL_VERSION ? marker.attempts + 1 : 1;
       await this.backfill(attempts);
     } catch (err) {
@@ -138,19 +152,19 @@ export class TaglineBackfillHook implements AgentTurnFinishedHook {
     };
     await this.deps.settings.set(BACKFILL_SETTINGS_KEY, started);
 
-    const roots = await findAppsMissingTagline(this.deps.lockfilePath ?? defaultLockfilePath());
-    if (roots.length === 0) {
-      await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
-        ...started,
-        finishedAt: new Date().toISOString(),
-      });
-      this.deps.logger.debug("tagline backfill: nothing to do");
-      return;
-    }
-
-    this.deps.logger.info("tagline backfill started", { apps: roots, attempts });
-    let summary = "";
     try {
+      const roots = await findAppsMissingTagline(this.deps.lockfilePath ?? defaultLockfilePath());
+      if (roots.length === 0) {
+        await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
+          ...started,
+          finishedAt: new Date().toISOString(),
+        });
+        this.deps.logger.debug("tagline backfill: nothing to do");
+        return;
+      }
+
+      this.deps.logger.info("tagline backfill started", { apps: roots, attempts });
+      let summary = "";
       for await (const msg of this.deps.agentRunner.run({
         agentName: BACKFILL_AGENT,
         prompt: buildBackfillPrompt(roots),
@@ -158,6 +172,13 @@ export class TaglineBackfillHook implements AgentTurnFinishedHook {
         if (msg.type === "result") summary = String(msg.content ?? "");
         if (msg.type === "error") throw new Error(String(msg.error));
       }
+      await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
+        ...started,
+        finishedAt: new Date().toISOString(),
+        apps: roots,
+        summary,
+      });
+      this.deps.logger.info("tagline backfill finished", { apps: roots });
     } catch (err) {
       await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
         ...started,
@@ -165,13 +186,6 @@ export class TaglineBackfillHook implements AgentTurnFinishedHook {
       });
       throw err;
     }
-    await this.deps.settings.set(BACKFILL_SETTINGS_KEY, {
-      ...started,
-      finishedAt: new Date().toISOString(),
-      apps: roots,
-      summary,
-    });
-    this.deps.logger.info("tagline backfill finished", { apps: roots });
   }
 }
 

--- a/rome_apps/coding/src/hooks/agent-turn-finished/index.ts
+++ b/rome_apps/coding/src/hooks/agent-turn-finished/index.ts
@@ -1,3 +1,12 @@
+// One-shot tagline backfill for apps built on this instance before `tagline`
+// existed (rome#202). Runs once per instance: the first agent turn that
+// finishes after this hook ships writes a marker into the app's settings,
+// then — only if some enabled source-dir app with a web surface still lacks a
+// `tagline` — summons the coding agent to run the `app_tagline_backfill`
+// skill. Every later turn sees the marker and returns immediately.
+//
+// Bump `BACKFILL_VERSION` to run the backfill again on every instance.
+
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -10,20 +19,10 @@ import type {
   Logger,
 } from "@rome-os/app-runtime";
 
-/**
- * One-shot tagline backfill for apps built on this instance before `tagline`
- * existed (rome#202). Runs once per instance: the first agent turn that
- * finishes after this hook ships writes a marker into the app's settings,
- * then — only if some enabled source-dir app with a web surface still lacks a
- * `tagline` — summons the coding agent to run the `app_tagline_backfill`
- * skill. Every later turn sees the marker and returns immediately.
- *
- * Bump `BACKFILL_VERSION` to run the backfill again on every instance.
- */
-export const BACKFILL_SETTINGS_KEY = "tagline-backfill";
+export const BACKFILL_SETTINGS_KEY = "coding.taglineBackfill";
 export const BACKFILL_VERSION = 1;
 export const BACKFILL_AGENT = "coding";
-export const BACKFILL_SKILL_PATH = "rome_apps/coding/src/skills/app_tagline_backfill/SKILL.md";
+export const BACKFILL_SKILL = "coding:app_tagline_backfill";
 
 export interface TaglineBackfillMarker {
   version: number;
@@ -88,7 +87,7 @@ export async function findAppsMissingTagline(lockfilePath: string): Promise<stri
 
 export function buildBackfillPrompt(roots: string[]): string {
   return [
-    `Load the skill at ${BACKFILL_SKILL_PATH} and run it in AUTO mode for these apps (absolute source roots):`,
+    `Read the \`${BACKFILL_SKILL}\` skill with read_skill and run it in AUTO mode for these apps (absolute source roots):`,
     ...roots.map((root) => `- ${root}`),
   ].join("\n");
 }
@@ -100,11 +99,10 @@ export class TaglineBackfillHook implements AgentTurnFinishedHook {
 
   async onAgentTurnFinished(_event: AgentTurnFinishedEvent): Promise<void> {
     if (this.running) return;
-    const marker = await this.deps.settings.get<TaglineBackfillMarker>(BACKFILL_SETTINGS_KEY);
-    if (marker && marker.version >= BACKFILL_VERSION) return;
-
     this.running = true;
     try {
+      const marker = await this.deps.settings.get<TaglineBackfillMarker>(BACKFILL_SETTINGS_KEY);
+      if (marker && marker.version >= BACKFILL_VERSION) return;
       await this.backfill();
     } catch (err) {
       this.deps.logger.warn("tagline backfill failed", {

--- a/rome_apps/coding/src/skills/app_creation/REFERENCE.md
+++ b/rome_apps/coding/src/skills/app_creation/REFERENCE.md
@@ -64,7 +64,7 @@ name: Coding                     # Display name — Title Case words ("Morning B
 icon: assets/icon.svg            # Optional
 version: 0.2.8                   # Semantic version
 description: Short description
-# tagline: One sentence for the share card   # Optional — uncomment and fill in: ≤ 80 chars (40 CJK), benefit-first, no jargon, like an App Store subtitle. It is the card's only description (no fallback).
+# tagline: One sentence for the share card   # Optional — uncomment and fill in: ≤ 80 chars (40 CJK), benefit-first, no jargon, like an App Store subtitle. It is the card's only description (no fallback). Existing apps without one are backfilled by `app_tagline_backfill`.
 appRoot: dist                    # Optional; defaults to source root if omitted
 includeSource: true              # Optional; publish src/ with the Store bundle
 remix:                            # Rome-managed lineage for a derived app

--- a/rome_apps/coding/src/skills/app_tagline_backfill/SKILL.md
+++ b/rome_apps/coding/src/skills/app_tagline_backfill/SKILL.md
@@ -25,7 +25,7 @@ LOCK="$HOME/.rome/${ROME_PROFILE:-default}/apps.lock.json"
 node -e '
   const lock = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
   for (const [id, e] of Object.entries(lock.apps)) {
-    if (e.source.mode === "source" && e.enabled && e.state === "installed") console.log(id, e.source.path);
+    if (e.source?.mode === "source" && e.enabled && e.state === "installed") console.log(id, e.source.path);
   }
 ' "$LOCK"
 ```
@@ -46,7 +46,7 @@ done), apps without `web:` (no card), apps that already have a tagline.
 Read `name`, `description`, and `README.md` (if present) under the root.
 Write the tagline by the same rule `app_creation/REFERENCE.md` gives:
 
-- One sentence, at most 80 characters (40 for CJK). No line breaks.
+- One sentence, at most 80 characters (40 for CJK). No line breaks, no double quotes.
 - Lead with what the user gets. No implementation details, jargon, or
   acronyms. Read it like an App Store subtitle.
 - Do not copy `description` — it is written for agents, not people.
@@ -64,16 +64,9 @@ makes. In AUTO mode go straight to step 4.
 
 ```bash
 cd "$ROOT"
-# Insert right after the description. For a block-scalar description (`>-`
-# or `|`), insert after its last indented line instead.
-python3 - "$ROOT/app.yaml" <<'EOF'
-import re, sys
-path = sys.argv[1]; text = open(path).read()
-line = 'tagline: "REPLACE WITH THE SENTENCE"\n'
-m = re.search(r'^description:.*(?:\n[ \t]+.*)*\n', text, re.M)
-text = text[:m.end()] + line + text[m.end():] if m else text + line
-open(path, 'w').write(text)
-EOF
+# Top-level key order does not matter in YAML, so append the line (the
+# leading newline keeps it off a last line that has no trailing newline).
+printf '\ntagline: "REPLACE WITH THE SENTENCE"\n' >> app.yaml
 git add app.yaml && git commit -m "chore: add share-card tagline"
 ```
 
@@ -93,7 +86,7 @@ grep -n '^tagline:' "$ROOT/.rome/artifact/app.yaml"
 If the install fails, roll that app back and continue with the next one:
 
 ```bash
-git -C "$ROOT" revert --no-edit HEAD
+git -C "$ROOT" checkout HEAD~1 -- app.yaml && git -C "$ROOT" commit -m "chore: revert share-card tagline"
 ```
 
 The reinstall triggers the card to be redrawn; nothing else is needed.

--- a/rome_apps/coding/src/skills/app_tagline_backfill/SKILL.md
+++ b/rome_apps/coding/src/skills/app_tagline_backfill/SKILL.md
@@ -67,8 +67,11 @@ cd "$ROOT"
 # Top-level key order does not matter in YAML, so append the line (the
 # leading newline keeps it off a last line that has no trailing newline).
 printf '\ntagline: "REPLACE WITH THE SENTENCE"\n' >> app.yaml
-git add app.yaml && git commit -m "chore: add share-card tagline"
+git add app.yaml && git commit -o app.yaml -m "chore: add share-card tagline"
 ```
+
+`-o app.yaml` commits only that file, so anything the guardian left staged in
+the repo stays out of this commit and the rollback below stays one file.
 
 Then reinstall through the daemon (the same call `app_creation` uses; always
 pass `source` explicitly):
@@ -86,7 +89,7 @@ grep -n '^tagline:' "$ROOT/.rome/artifact/app.yaml"
 If the install fails, roll that app back and continue with the next one:
 
 ```bash
-git -C "$ROOT" checkout HEAD~1 -- app.yaml && git -C "$ROOT" commit -m "chore: revert share-card tagline"
+git -C "$ROOT" checkout HEAD~1 -- app.yaml && git -C "$ROOT" commit -o app.yaml -m "chore: revert share-card tagline"
 ```
 
 The reinstall triggers the card to be redrawn; nothing else is needed.

--- a/rome_apps/coding/src/skills/app_tagline_backfill/SKILL.md
+++ b/rome_apps/coding/src/skills/app_tagline_backfill/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: app_tagline_backfill
+description: Give apps built on this instance a share-card `tagline` when their `app.yaml` has none. Runs automatically once after Rome upgrades (AUTO mode, list supplied by the caller) or on request from the guardian ("add taglines to my apps", MANUAL mode, confirm before writing). Only touches editable `mode: "source"` apps — never App Store bundles or first-party apps.
+tools: [Read, Bash]
+---
+
+# App Tagline Backfill
+
+Apps created before `tagline` existed share a card with an empty description.
+This skill adds one sentence to each such app, commits it, and reinstalls so
+the card is redrawn. It edits nothing else.
+
+## Modes
+
+- **AUTO** — the caller (the coding app's `agent-turn-finished` hook) hands
+  you the absolute source roots to process. Nobody is watching: skip the
+  confirmation step, process every listed app, and finish with the report.
+- **MANUAL** — the guardian asked. Discover the apps yourself (step 1), show
+  the draft table (step 3), and write only after they approve or edit it.
+
+## Step 1: Discover (MANUAL only)
+
+```bash
+LOCK="$HOME/.rome/${ROME_PROFILE:-default}/apps.lock.json"
+node -e '
+  const lock = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+  for (const [id, e] of Object.entries(lock.apps)) {
+    if (e.source.mode === "source" && e.enabled && e.state === "installed") console.log(id, e.source.path);
+  }
+' "$LOCK"
+```
+
+For each printed root, an app qualifies when `<root>/app.yaml` has a `web:`
+block and no `tagline:` line:
+
+```bash
+grep -q '^web:' "$ROOT/app.yaml" && ! grep -q '^tagline:' "$ROOT/app.yaml" && echo "$ROOT"
+```
+
+Skip everything else and say why in the report: `appstore` entries (read-only
+bundles, the author owns them), first-party apps (shipped with Rome, already
+done), apps without `web:` (no card), apps that already have a tagline.
+
+## Step 2: Draft one sentence per app
+
+Read `name`, `description`, and `README.md` (if present) under the root.
+Write the tagline by the same rule `app_creation/REFERENCE.md` gives:
+
+- One sentence, at most 80 characters (40 for CJK). No line breaks.
+- Lead with what the user gets. No implementation details, jargon, or
+  acronyms. Read it like an App Store subtitle.
+- Do not copy `description` — it is written for agents, not people.
+
+Good: `Track every mortgage rate that matters to you, updated daily.`
+Bad: `A cron-driven scraper that stores rates in SQLite.` (mechanism, not benefit)
+Bad: `Mortgage Monitor` (a name, not a sentence)
+
+## Step 3: Confirm (MANUAL only)
+
+Show a table `id | name | tagline` and wait. Apply any edits the guardian
+makes. In AUTO mode go straight to step 4.
+
+## Step 4: Write, commit, reinstall, verify — one app at a time
+
+```bash
+cd "$ROOT"
+# Insert right after the description. For a block-scalar description (`>-`
+# or `|`), insert after its last indented line instead.
+python3 - "$ROOT/app.yaml" <<'EOF'
+import re, sys
+path = sys.argv[1]; text = open(path).read()
+line = 'tagline: "REPLACE WITH THE SENTENCE"\n'
+m = re.search(r'^description:.*(?:\n[ \t]+.*)*\n', text, re.M)
+text = text[:m.end()] + line + text[m.end():] if m else text + line
+open(path, 'w').write(text)
+EOF
+git add app.yaml && git commit -m "chore: add share-card tagline"
+```
+
+Then reinstall through the daemon (the same call `app_creation` uses; always
+pass `source` explicitly):
+
+```
+system:app_management { op: "install", source: { mode: "source", path: "<absolute ROOT>" } }
+```
+
+Verify the packed manifest carries the line:
+
+```bash
+grep -n '^tagline:' "$ROOT/.rome/artifact/app.yaml"
+```
+
+If the install fails, roll that app back and continue with the next one:
+
+```bash
+git -C "$ROOT" revert --no-edit HEAD
+```
+
+The reinstall triggers the card to be redrawn; nothing else is needed.
+
+## Step 5: Report
+
+List, in this order: apps updated (id and the tagline written), apps
+skipped (with the reason), apps that failed (with the error and that the
+commit was reverted). In AUTO mode this report is your final message; the
+hook stores it. In MANUAL mode show it to the guardian.

--- a/rome_apps/coding/src/skills/app_tagline_backfill/SKILL.md
+++ b/rome_apps/coding/src/skills/app_tagline_backfill/SKILL.md
@@ -62,11 +62,24 @@ makes. In AUTO mode go straight to step 4.
 
 ## Step 4: Write, commit, reinstall, verify — one app at a time
 
+First make sure nobody is mid-edit in that repo. A source install packs the
+whole working tree, so uncommitted changes would be deployed, and the rollback
+below would erase edits to `app.yaml`. Skip a dirty app and report it:
+
 ```bash
 cd "$ROOT"
-# Top-level key order does not matter in YAML, so append the line (the
-# leading newline keeps it off a last line that has no trailing newline).
-printf '\ntagline: "REPLACE WITH THE SENTENCE"\n' >> app.yaml
+git status --porcelain --untracked-files=no   # must print nothing; otherwise skip this app
+```
+
+Then append the line. Top-level key order does not matter in YAML; the quoted
+heredoc keeps apostrophes and other shell characters in the sentence intact,
+and the blank line keeps it off a last line that has no trailing newline.
+
+```bash
+cat >> app.yaml <<'EOF'
+
+tagline: "REPLACE WITH THE SENTENCE"
+EOF
 git add app.yaml && git commit -o app.yaml -m "chore: add share-card tagline"
 ```
 
@@ -97,6 +110,6 @@ The reinstall triggers the card to be redrawn; nothing else is needed.
 ## Step 5: Report
 
 List, in this order: apps updated (id and the tagline written), apps
-skipped (with the reason), apps that failed (with the error and that the
+skipped (with the reason, including "uncommitted changes"), apps that failed (with the error and that the
 commit was reverted). In AUTO mode this report is your final message; the
 hook stores it. In MANUAL mode show it to the guardian.


### PR DESCRIPTION
## Summary

Apps built on an instance before `tagline` existed (#346) share a card with an empty description. This adds a one-shot backfill so the instance fixes that itself after upgrading, with no user action.

- `rome_apps/coding` gets an `agent-turn-finished` hook that runs once per instance. On the first finished agent turn it writes a marker (`coding.taglineBackfill`, written before doing any work so it never re-runs), reads the profile lockfile, and selects enabled `mode: "source"` apps whose `app.yaml` has `web:` but no `tagline:`. Store bundles and first-party apps are skipped. With nothing to do it stops there and no model is called.
- Otherwise it summons the coding agent to run the new `app_tagline_backfill` skill in AUTO mode: write one sentence per app, commit `chore: add share-card tagline`, reinstall via `system:app_management`, verify the packed manifest. A failed install rolls that app back and continues.
- The same skill can be run from chat (`/app_tagline_backfill`), where it shows a table and asks before writing.
- coding app 0.3.0 → 0.3.1.

## Test plan

- [x] Hook unit tests: lockfile filtering, marker-before-summon ordering, single run, agent failure swallowed
- [x] `pnpm typecheck`, biome, prose check, `pnpm build:apps` packs the hook and skill
- [x] Dev instance: scaffolded a source-mode app without a tagline, logged in, first agent turn triggered the backfill; `app.yaml` gained the tagline, one commit, reinstall succeeded, packed manifest carries it, card re-rendered with the description, later turns did not re-run, no session appears in the chat list

Refs #202