### PR TITLE
fix(docker): default OpenCLI to the Rome browser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -342,6 +342,7 @@ RUN find /opt/rome/node_modules /usr/local/lib/node_modules \
 # backend runs without one.
 RUN install -m 0755 /opt/rome/scripts/docker/rome-open-in-server-browser.sh /usr/local/bin/rome-open-in-server-browser
 ENV BROWSER=/usr/local/bin/rome-open-in-server-browser
+ENV OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9222
 
 RUN test ! -e /opt/rome/packages/desktop && \
     test ! -e /opt/rome/packages/pantheon && \

--- a/infra/rome/Dockerfile
+++ b/infra/rome/Dockerfile
@@ -70,6 +70,7 @@ RUN --mount=type=cache,target=/root/.npm \
 COPY scripts/docker/rome-open-in-server-browser.sh /usr/local/bin/rome-open-in-server-browser
 RUN chmod 0755 /usr/local/bin/rome-open-in-server-browser
 ENV BROWSER=/usr/local/bin/rome-open-in-server-browser
+ENV OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9222
 
 RUN curl -fsSL https://composio.dev/install | COMPOSIO_INSTALL_DIR=/usr/local/lib/composio bash -s -- "$COMPOSIO_CLI_VERSION" \
     && ln -sf /usr/local/lib/composio/composio /usr/local/bin/composio \

--- a/opencli-plugins/README.md
+++ b/opencli-plugins/README.md
@@ -41,6 +41,12 @@ directory is its own standalone plugin rather than one plugin holding `<site>/<c
 
 ## Install points (all idempotent)
 
+Both container images set `OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9222`, so OpenCLI uses
+Rome's browser without a shell alias or an extra flag. Codex passes this variable to
+agent subprocesses. Set `OPENCLI_CDP_ENDPOINT` in the container environment to use another
+browser, including deployments with a custom Chrome host or port. Recreate the container
+after changing the image or its environment. An explicit `--cdp-endpoint` overrides the variable.
+
 - **Production image**: `docker-entrypoint.sh` installs every `/app/opencli-plugins/*/` dir for
   the `rome` user after the `/app` sync. The symlinks survive image upgrades; rsync updates the
   plugin source in place.

--- a/packages/core/src/channels/linkedin-cli.ts
+++ b/packages/core/src/channels/linkedin-cli.ts
@@ -42,8 +42,7 @@ function cdpEndpoint(): string {
 
 /**
  * The production runner: `opencli --cdp-endpoint <server-chrome> <args> -f json`.
- * Resolution mirrors the in-container shell alias (scripts/docker/
- * rome-shell-aliases.sh) so the channel sees the same browser agents do.
+ * Uses Rome's configured Chrome host and port.
  * A non-zero exit is NOT a rejection here — callers classify via the parsers
  * below, which need the captured output either way.
  */

--- a/scripts/bundle-docker-core.test.mjs
+++ b/scripts/bundle-docker-core.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -11,6 +11,38 @@ import { dockerBundleOptions } from "./bundle-docker-core.mjs";
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const require = createRequire(import.meta.url);
 const { build } = createRequire(require.resolve("tsx/package.json"))("esbuild");
+
+for (const dockerfile of ["Dockerfile", "infra/rome/Dockerfile"]) {
+  test(`${dockerfile} sets the OpenCLI endpoint for processes that skip shell startup`, async () => {
+    const source = await readFile(join(root, dockerfile), "utf8");
+    assert.match(source, /^ENV OPENCLI_CDP_ENDPOINT=http:\/\/127\.0\.0\.1:9222$/m);
+  });
+}
+
+for (const endpoint of [undefined, "http://chrome:9333"]) {
+  test(`the OpenCLI shell default preserves overrides (${endpoint ?? "unset"})`, () => {
+    const output = execFileSync(
+      "bash",
+      [
+        "--noprofile",
+        "--norc",
+        "-c",
+        'source "$1"; if alias opencli >/dev/null 2>&1; then exit 1; fi; exec "$2" -e "process.stdout.write(process.env.OPENCLI_CDP_ENDPOINT)"',
+        "opencli-env-test",
+        join(root, "scripts/docker/rome-shell-aliases.sh"),
+        process.execPath,
+      ],
+      {
+        env: {
+          PATH: process.env.PATH,
+          ...(endpoint === undefined ? {} : { OPENCLI_CDP_ENDPOINT: endpoint }),
+        },
+        encoding: "utf8",
+      },
+    );
+    assert.equal(output, endpoint ?? "http://127.0.0.1:9222");
+  });
+}
 
 test("the relocated Caddy generator runs without Core workspace dependencies", async (t) => {
   const directory = await mkdtemp(join(tmpdir(), "rome-compiled-caddy-"));

--- a/scripts/docker/rome-shell-aliases.sh
+++ b/scripts/docker/rome-shell-aliases.sh
@@ -1,2 +1,2 @@
 # shellcheck shell=bash  # sourced into the in-container rome shell, no shebang
-alias opencli='opencli --cdp-endpoint http://127.0.0.1:9222'
+export OPENCLI_CDP_ENDPOINT="${OPENCLI_CDP_ENDPOINT:-http://127.0.0.1:9222}"


### PR DESCRIPTION
## What this PR does

OpenCLI falls back to Browser Bridge because Rome never sets `OPENCLI_CDP_ENDPOINT`. PR #360 preserves the variable in Codex subprocesses but leaves it unset by default.

Set `OPENCLI_CDP_ENDPOINT=http://127.0.0.1:9222` in both the production and development Docker images. Processes inherit the default even when they skip shell startup files. Replace the shell alias with an exported fallback so interactive shells respect a deployment override too.

The OpenCLI README documents the default, custom endpoints, and container recreation. The LinkedIn runner keeps its explicit host and port arguments.

## Design & Invariants

- Set the default in image metadata rather than only in an entrypoint or shell file. The development image has no entrypoint, and Docker exec also needs the default.
- Preserve deployment-provided endpoint values. OpenCLI keeps its explicit `--cdp-endpoint` precedence.
- Keep the environment allowlist from #360. This change does not pass other environment variables into Codex.
- Deploy a rebuilt image and recreate the container to apply the default to Rome and its agent processes. A source-only update does not change image environment metadata.

## Test plan

- [x] `scripts/test-env.sh node --test scripts/bundle-docker-core.test.mjs`: six tests pass, including defaults in both Dockerfiles and noninteractive child-process inheritance with unset and custom endpoints.
- [x] From `packages/core`, `../../scripts/test-env.sh /app/node_modules/.bin/rstest src/core/codex/app-server-manager.test.ts src/core/codex/common.test.ts`: ten tests pass, including the allowlist regressions from #360.
- [x] Source the changed shell fallback, then run `opencli google flights SFO IAH 2026-09-28 --return 2026-10-02 --stops nonstop --limit 1 -f json` without `--cdp-endpoint`: live results returned.
- [x] Biome on the changed JavaScript and TypeScript files, `bash -n scripts/docker/rome-shell-aliases.sh`, `git diff --check`, and the PR title check pass.
- [ ] Full `pnpm typecheck` and `pnpm test:unit`: attempted but blocked by missing workspace dependencies, including Statsig, jsonwebtoken, and Drizzle. Focused tests used temporary links to installed `/app` dependencies. The links were removed after testing. Nix is unavailable here.
- [ ] Rebuild both images, start the stack, and verify plain OpenCLI from a new agent process. `pnpm dev:all` was attempted but the Docker daemon is unreachable here. The Dockerfile tests check the declarations, not built images.
